### PR TITLE
feat(rbac): C(d) v4 — Fix-2b + Fix-3a + Fix-W (Q-RBACC-DEFECT-2/3/4)

### DIFF
--- a/internal/cache/context.go
+++ b/internal/cache/context.go
@@ -299,3 +299,77 @@ func BindingIdentityFromContext(ctx context.Context) string {
 	id, _ := ctx.Value(bindingIdentityKey{}).(string)
 	return id
 }
+
+// systemIdentityKey is the context key that flags a context as carrying a
+// synthesized system identity (today: the snowplow ServiceAccount used by
+// the L1 refresh path). Q-RBAC-DECOUPLE C(d) v4 §2.2 (Fix-3a for
+// Q-RBACC-DEFECT-3).
+type systemIdentityKey struct{}
+
+// WithSystemIdentity marks ctx as carrying a synthesized system identity
+// (e.g., the snowplow ServiceAccount built by MakeL1Refresher). The api
+// dispatch fork at internal/resolvers/restactions/api/resolve.go uses
+// this to route ALL api[] entries through the snowplow elevated endpoint
+// regardless of UserAccessFilter — because the per-user clientconfig
+// fallback at internal/resolvers/restactions/endpoints/endpoints.go
+// cannot resolve a Secret named after the synthesized SA identity (which
+// would attempt `systemserviceaccountkrateo-systemsnowplow-clientconfig`
+// — a non-existent Secret — and ERROR out).
+//
+// SECURITY (NON-NEGOTIABLE per spec §11 rule 2): this flag is RESERVED
+// for the L1 refresh path (and any future system-only resolver path).
+// It MUST NEVER be set on contexts that carry a real user identity.
+// Doing so would route real-user traffic through the snowplow SA token
+// — equivalent to bypassing per-user clientconfig and silently elevating
+// every request to cluster-admin equivalence. The §6.8 negative test
+// (restactions_systemidentity_negative_test.go) asserts the invariant.
+func WithSystemIdentity(ctx context.Context) context.Context {
+	return context.WithValue(ctx, systemIdentityKey{}, true)
+}
+
+// IsSystemIdentity returns true iff WithSystemIdentity was set on ctx.
+// Single read site today: the dispatch-fork predicate in
+// internal/resolvers/restactions/api/resolve.go.
+func IsSystemIdentity(ctx context.Context) bool {
+	v, _ := ctx.Value(systemIdentityKey{}).(bool)
+	return v
+}
+
+// testRestConfigKey is a TEST-ONLY context key used by the v4 envtest
+// fixtures (Q-RBAC-DECOUPLE C(d) v4 §6.4 - §6.6) to inject a stub
+// rest.Config so the api.Resolve `if opts.RC == nil` early guard does
+// not try (and fail) to call rest.InClusterConfig() outside an
+// in-cluster environment.
+//
+// PRODUCTION CALLERS: zero. This key is set ONLY by *_test.go files
+// in internal/handlers/dispatchers/. Production wiring relies on the
+// dispatcher's l1cache.Input.SArc being nil and the resolver falling
+// back to rest.InClusterConfig(), exactly as it does today. Reading
+// the key as an additive fallback inside l1cache.ResolveAndCache keeps
+// the change strictly additive — the production execution path is
+// bit-for-bit identical with the v3 baseline.
+//
+// Why this is acceptable scaffolding under the v4 spec §11 (no out-of-
+// scope refactor): the §6.4 envtest is load-bearing — the architect's
+// §6.10 lesson is that dispatcher-level invariants MUST be exercised
+// via the real handler. Without an SArc injection the real handler
+// cannot run outside a kubelet-mounted SA pod, defeating §6.4's intent.
+type testRestConfigKey struct{}
+
+// WithTestRestConfig is a TEST-ONLY helper. The value type is `any`
+// to avoid a cache→client-go import cycle; callers pass *rest.Config
+// and l1cache asserts the type back at the read site.
+func WithTestRestConfig(ctx context.Context, rc any) context.Context {
+	if rc == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, testRestConfigKey{}, rc)
+}
+
+// TestRestConfigFromContext returns the test-injected rest.Config (as
+// `any`) or nil. Read by l1cache.ResolveAndCache as an additive
+// fallback when in.SArc is nil — does NOT change production behavior
+// because production never calls WithTestRestConfig.
+func TestRestConfigFromContext(ctx context.Context) any {
+	return ctx.Value(testRestConfigKey{})
+}

--- a/internal/cache/tracker.go
+++ b/internal/cache/tracker.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -20,11 +21,22 @@ type ResourceRef struct {
 // DependencyTracker records the GVRs and specific resources accessed during a
 // single resolution pass. It is safe for concurrent use (inner HTTP fan-out
 // calls run in parallel).
+//
+// Q-RBAC-DECOUPLE C(d) v4 §2.3 (Fix-W) — adds an atomic UAFTouching flag.
+// Set to true by the widget apiref resolver when it observes that the
+// resolved RESTAction CR has at least one api[] entry with UserAccessFilter
+// configured. Read by the widget dispatcher to gate the L1 write: when
+// true, the widget body would inline a per-user-filtered apiref view that
+// must NOT be shared across users in the same binding-identity group, so
+// the L1 write is SKIPPED. atomic.Bool gives us the cheapest read on the
+// hot widget HIT path with zero contention against the AddGVR /
+// AddResource mutex critical section.
 type DependencyTracker struct {
-	mu        sync.Mutex
-	gvrs      map[string]bool
-	resources []ResourceRef
-	resSeen   map[string]bool
+	mu          sync.Mutex
+	gvrs        map[string]bool
+	resources   []ResourceRef
+	resSeen     map[string]bool
+	uafTouching atomic.Bool
 }
 
 func NewDependencyTracker() *DependencyTracker {
@@ -77,6 +89,24 @@ func (t *DependencyTracker) ResourceRefs() []ResourceRef {
 	out := make([]ResourceRef, len(t.resources))
 	copy(out, t.resources)
 	return out
+}
+
+// MarkUAFTouching records that the resolution pass touched (transitively
+// or directly) at least one RESTAction whose api[] declares a
+// UserAccessFilter. The widget dispatcher reads this via UAFTouching()
+// to decide whether to skip the L1 write — see Q-RBAC-DECOUPLE C(d) v4
+// §2.3 (Fix-W for the widget L1 transitive leak).
+//
+// Idempotent: repeated calls are no-ops. Safe for concurrent invocation
+// from multiple apiref resolution goroutines (atomic.Bool.Store).
+func (t *DependencyTracker) MarkUAFTouching() {
+	t.uafTouching.Store(true)
+}
+
+// UAFTouching returns true iff MarkUAFTouching() was invoked at least
+// once during this resolution pass.
+func (t *DependencyTracker) UAFTouching() bool {
+	return t.uafTouching.Load()
 }
 
 func WithDependencyTracker(ctx context.Context, t *DependencyTracker) context.Context {

--- a/internal/handlers/dispatchers/l1_refresh.go
+++ b/internal/handlers/dispatchers/l1_refresh.go
@@ -102,6 +102,20 @@ func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rb
 	}
 
 	return func(ctx context.Context, triggerGVR schema.GroupVersionResource, l1Keys []string) []string {
+		// Q-RBAC-DECOUPLE C(d) v4 §2.2 (Fix-3a) — flag the refresh ctx as
+		// system-identity. Read site: the dispatch-fork predicate in
+		// internal/resolvers/restactions/api/resolve.go. With the flag
+		// set, ALL api[] entries (UAF and non-UAF alike) route through
+		// the snowplow elevated endpoint instead of attempting the
+		// per-user clientconfig lookup at endpoints.go — which would
+		// otherwise try to resolve a non-existent Secret named after the
+		// synthesized SA identity and error out (Q-RBACC-DEFECT-3).
+		//
+		// MUST be set BEFORE WithSnowplowEndpoint and BEFORE the closure
+		// hands ctx to refreshSingleL1, so every downstream propagation
+		// inherits the flag. NEVER set this flag on a real-user ctx.
+		ctx = cache.WithSystemIdentity(ctx)
+
 		// Inject RBACWatcher for local RBAC evaluation during background refresh.
 		// Without this, UserCan falls back to SSAR (K8s API), which saturates
 		// the rate limiter with 345K calls at 50K scale.

--- a/internal/handlers/dispatchers/l1_refresh_envtest_test.go
+++ b/internal/handlers/dispatchers/l1_refresh_envtest_test.go
@@ -1,0 +1,323 @@
+// Q-RBAC-DECOUPLE C(d) v4 §6.6 — anti-defect test for Q-RBACC-DEFECT-3
+// (L1 refresh under SA breaks per-user clientconfig fallback for non-UAF
+// api[] entries).
+//
+// CRITICAL CONTRACT (per the v4 spec §6.6): this test MUST FAIL on the
+// v3 implementation tagged 0.25.296 (proves it catches the defect) and
+// PASS on the v4 implementation. The v3 path was:
+//
+//   MakeL1Refresher → refreshSingleL1 (under SA identity) → ResolveAndCache
+//                  → restactions.Resolve → api.Resolve
+//                  → for each api[] entry:
+//                      - UAF set        → snowplow endpoint (correct)
+//                      - UAF NOT set    → mapper.resolveOne(ctx, nil)
+//                                       → endpoints.FromSecret(
+//                                            "<sanitize(saUser)>-clientconfig")
+//                                       → secret doesn't exist → ERROR
+//
+//   The error fires on every L1 refresh for every non-UAF api[] entry —
+//   ~150 lines per refresh cycle at 50 NS scale, the production failure
+//   mode that caused the rollback at 0.25.296.
+//
+// In v4 (Fix-3a):
+//
+//   MakeL1Refresher sets cache.WithSystemIdentity on the refresh ctx.
+//   api.Resolve's dispatch fork now treats system-identity ctx + nil
+//   EndpointRef as "use snowplow endpoint" — regardless of UserAccessFilter.
+//   Result: all api[] entries route through the snowplow endpoint during
+//   L1 refresh. Real-user contexts (which never set the system-identity
+//   flag) preserve the original per-user clientconfig path.
+//
+// Test design: drive `MakeL1Refresher`'s refresh closure directly with a
+// pre-seeded L1 key for a NON-UAF RESTAction. Capture log output via a
+// custom slog handler; fail if any line contains
+// `clientconfig not found`. Assert the L1 entry was overwritten.
+
+package dispatchers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/client-go/rest"
+)
+
+// captureSlogHandler buffers all emitted log lines so the test can scan
+// for the Q-RBACC-DEFECT-3 signature `clientconfig not found`. Thread-
+// safe — the L1 refresh closure may emit logs from background
+// goroutines.
+type captureSlogHandler struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (h *captureSlogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler        { return h }
+func (h *captureSlogHandler) WithGroup(_ string) slog.Handler             { return h }
+func (h *captureSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	parts := []string{r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		parts = append(parts, a.Key+"="+a.Value.String())
+		return true
+	})
+	h.lines = append(h.lines, strings.Join(parts, " "))
+	return nil
+}
+func (h *captureSlogHandler) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.lines))
+	copy(out, h.lines)
+	return out
+}
+func (h *captureSlogHandler) hasLineContaining(substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, l := range h.lines {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestL1Refresh_SystemIdentity_NonUAF_NoClientConfigError is the §6.6
+// anti-defect contract for Q-RBACC-DEFECT-3.
+//
+// Invariant: on L1 refresh under the synthesized snowplow SA identity,
+// NO api[] entry should attempt to load a `<sa-username>-clientconfig`
+// Secret. The dispatch fork in api.Resolve must route ALL entries
+// through the snowplow endpoint when cache.IsSystemIdentity(ctx) is
+// true.
+//
+// On v3 (0.25.296), the test FAILS at the
+// `secrets "...snowplow-clientconfig" not found` log line — the per-
+// user clientconfig fallback fires for non-UAF entries even under SA
+// identity.
+//
+// On v4 (Fix-3a), the test PASSES: the system-identity flag routes
+// non-UAF entries through the snowplow endpoint and the L1 entry is
+// overwritten cleanly.
+func TestL1Refresh_SystemIdentity_NonUAF_NoClientConfigError(t *testing.T) {
+	env.SetTestMode(true)
+	t.Cleanup(func() { env.SetTestMode(false) })
+
+	// Capture all log lines emitted during refresh — the failure mode
+	// is observable as a log line, not as a returned error.
+	cap := &captureSlogHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	upstreamCt := &atomic.Int32{}
+	upstreamPaths := &sync.Map{}
+	upstreamAuth := &sync.Map{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCt.Add(1)
+		upstreamPaths.Store(r.URL.Path, true)
+		upstreamAuth.Store(r.Header.Get("Authorization"), true)
+		w.Header().Set("Content-Type", "application/json")
+		// Mirror the K8s namespaces list shape — the same upstream is
+		// used both for the api[] entry and any opportunistic discovery
+		// the test harness might trigger. The path doesn't matter for
+		// the §6.6 assertion (we only care about which auth scheme the
+		// resolver used to reach us).
+		_, _ = w.Write([]byte(k8sNamespacesListBody([]string{"default", "kube-system"})))
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Pre-seed the L1 entry for a NON-UAF RESTAction. The refresher
+	// re-resolves it; if Fix-3a is missing, the resolver tries to load
+	// `system:serviceaccount:...-clientconfig` for the (non-UAF)
+	// api[] entry and errors out.
+	//
+	// IMPORTANT: the api[] entry must have NO UserAccessFilter so the
+	// dispatch fork's v3 condition (UAF set → snowplow endpoint) does
+	// NOT fire. Only the v4 Fix-3a system-identity branch should route
+	// this entry to the snowplow endpoint.
+	cr := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{{
+				Name: "ns",
+				Path: "/api/v1/namespaces",
+				// UserAccessFilter intentionally NIL — this is the
+				// shape that exposes Q-RBACC-DEFECT-3 in production.
+				Filter: ptr.To(`[.ns.items[].metadata.name]`),
+			}},
+			Filter: ptr.To(`{namespaces: .ns}`),
+		},
+	}
+	cr.Name = "non-uaf-restaction"
+	cr.Namespace = "krateo-system"
+	cr.APIVersion = "templates.krateo.io/v1"
+	cr.Kind = "RESTAction"
+
+	c := cache.NewMem(0)
+	if err := c.Set(context.Background(),
+		cache.GetKey(restActionGVRForTest, cr.Namespace, cr.Name),
+		mustToUnstructured(t, cr)); err != nil {
+		t.Fatalf("seed RESTAction in L2: %v", err)
+	}
+
+	// Pre-seed the L1 entry with placeholder bytes so refreshSingleL1
+	// has something to refresh. The bytes will be overwritten by the
+	// refresh. The "identity" segment in the key is the production
+	// binding-identity hash for some real user-or-group set; refresh
+	// re-resolves under the SA identity (set on ctx via Fix-3a) but
+	// keys remain stable across the cycle.
+	identity := "binding-id-H-real-user-group"
+	l1Key := cache.ResolvedKey(identity, restActionGVRForTest,
+		cr.Namespace, cr.Name, -1, -1)
+	if err := c.SetResolvedRaw(context.Background(), l1Key,
+		[]byte(`{"placeholder":true}`)); err != nil {
+		t.Fatalf("seed L1 entry: %v", err)
+	}
+
+	snowplowEndpointFn := func() (*endpoints.Endpoint, error) {
+		return &endpoints.Endpoint{
+			ServerURL: upstream.URL,
+			Token:     "SNOWPLOW-SA-TEST",
+		}, nil
+	}
+
+	// MakeL1Refresher: production wires rbacWatcher; the test omits it
+	// (the L1 refresh closure tolerates nil — the dispatch fork's
+	// system-identity check is the load-bearing v4 logic and runs
+	// independently).
+	refresh := MakeL1Refresher(c, &rest.Config{Host: upstream.URL},
+		cr.Namespace, "test-jwt-key", nil, snowplowEndpointFn)
+
+	// Drive the refresh. Pass our test's rest.Config via the v4 ctx
+	// fallback so api.Resolve's nil-RC guard finds it (production sets
+	// SArc=nil, falls back to InClusterConfig in-cluster — tests
+	// substitute via WithTestRestConfig).
+	ctx := cache.WithTestRestConfig(context.Background(),
+		&rest.Config{Host: upstream.URL})
+	_ = refresh(ctx, restActionGVRForTest.GroupVersion().WithResource(restActionGVRForTest.Resource), []string{l1Key})
+
+	// Assertion 1 (the load-bearing one): NO log line should contain
+	// `unable to resolve api endpoint reference`. This is what the v3
+	// dispatch path emits when mapper.resolveOne errors out for a
+	// non-UAF api[] entry under SA identity (the production signature
+	// of Q-RBACC-DEFECT-3 is the deeper `clientconfig not found` Secret
+	// lookup error; in this test the upstream mock surfaces a different
+	// decode error but the dispatcher-level signal is the same).
+	for _, sig := range []string{
+		"clientconfig not found",
+		"unable to resolve api endpoint reference",
+		"snowplow-clientconfig",
+	} {
+		if cap.hasLineContaining(sig) {
+			var matched string
+			for _, l := range cap.snapshot() {
+				if strings.Contains(l, sig) {
+					matched = l
+					break
+				}
+			}
+			t.Errorf("Q-RBACC-DEFECT-3: refresh emitted v3-dispatch error containing %q — non-UAF api[] entry hit the per-user clientconfig fallback under SA identity (Fix-3a not in effect)\nfirst match: %s", sig, matched)
+		}
+	}
+
+	// Diagnostic dump (always): surface captured logs so the
+	// dispatch path is always visible for debugging.
+	t.Cleanup(func() {
+		lines := cap.snapshot()
+		t.Logf("captured %d log line(s):", len(lines))
+		for i, l := range lines {
+			t.Logf("  [%d] %s", i, l)
+		}
+	})
+
+	// Assertion 2: the upstream MUST have been called at least once.
+	// On v3 (pre-Fix-3a), the non-UAF entry would error out at
+	// endpoints.FromSecret BEFORE reaching httpcall.Do, so the
+	// upstream count would be 0. On v4 the system-identity branch
+	// routes the entry through the snowplow endpoint and we see at
+	// least one hit.
+	//
+	// NB: the bearerAuthRoundTripper does NOT overwrite an existing
+	// Authorization header (see plumbing/http/request/transport.go),
+	// so the user-JWT injected via shouldInjectUserJWT for non-UAF
+	// entries WINS over the snowplow Endpoint.Token. The presence of
+	// the call (regardless of which auth header was sent) is the
+	// load-bearing evidence that the dispatch fork picked the
+	// snowplow endpoint URL.
+	if upstreamCt.Load() == 0 {
+		t.Errorf("Fix-3a: upstream NOT called — the system-identity branch did not route the non-UAF entry through the snowplow endpoint\nexpected at least one HTTP call to %s", upstream.URL)
+	}
+	// Diagnostic: assert the entry reached the upstream at the api[]
+	// path (not just at endpoints.FromSecret's secret-GET path which
+	// also hits our upstream mock and would falsely satisfy a substring
+	// check). On v3 (pre-Fix-3a), the only upstream hit is the secret
+	// GET; on v4 the api[] entry itself reaches the upstream after the
+	// system-identity dispatch fork.
+	pathSeen := false
+	upstreamPaths.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok && s == "/api/v1/namespaces" {
+			pathSeen = true
+			return false
+		}
+		return true
+	})
+	if !pathSeen {
+		var paths []string
+		upstreamPaths.Range(func(k, _ any) bool {
+			if s, ok := k.(string); ok {
+				paths = append(paths, s)
+			}
+			return true
+		})
+		t.Errorf("Fix-3a: expected upstream call to exact path /api/v1/namespaces (the api[] entry path); saw paths=%v\nThis means the dispatch fork did NOT route the non-UAF entry through the snowplow endpoint — Q-RBACC-DEFECT-3 active.", paths)
+	}
+
+	// Assertion 3: the L1 entry was overwritten with the resolved CR
+	// wrapper (proves the refresh ran end-to-end and produced output).
+	cached, hit, err := c.GetRaw(context.Background(), l1Key)
+	if err != nil || !hit {
+		t.Fatalf("L1 entry should still exist after refresh; hit=%v err=%v", hit, err)
+	}
+	if string(cached) == `{"placeholder":true}` {
+		t.Errorf("L1 entry NOT overwritten by refresh; still holds the placeholder bytes")
+	}
+	if !strings.Contains(string(cached), `"schema_version":"v3"`) {
+		t.Errorf("L1 entry should be the v3 wrapper after a successful refresh; got\n%s", truncate(cached, 600))
+	}
+}
+
+// TestL1Refresh_SystemIdentity_FlagSetOnRefreshCtxOnly is the §6.3 §6.8
+// negative invariant: WithSystemIdentity must be set ONLY on the L1
+// refresh closure's ctx. Real HTTP request flows must NOT carry the
+// flag.
+func TestL1Refresh_SystemIdentity_FlagSetOnRefreshCtxOnly(t *testing.T) {
+	// 1. Real-user ctx — flag MUST be false.
+	realCtx := context.Background()
+	if cache.IsSystemIdentity(realCtx) {
+		t.Errorf("default context unexpectedly carries system-identity flag")
+	}
+	// 2. Set the flag. Confirm IsSystemIdentity reads true.
+	sysCtx := cache.WithSystemIdentity(realCtx)
+	if !cache.IsSystemIdentity(sysCtx) {
+		t.Errorf("WithSystemIdentity did not produce a system-identity ctx")
+	}
+	// 3. The system-identity flag is TRUE only inside the chain that
+	//    SET it. A child ctx derived from realCtx via context.WithValue
+	//    or other operations does NOT inherit it.
+	derivedFromReal := context.WithValue(realCtx, struct{ k string }{"foo"}, "bar")
+	if cache.IsSystemIdentity(derivedFromReal) {
+		t.Errorf("ctx derived from real-user parent unexpectedly carries system-identity flag")
+	}
+}

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -219,7 +219,27 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		response.InternalError(wri, errEmptyResolveResult)
 		return
 	}
-	raw := result.Raw
+
+	// Q-RBAC-DECOUPLE C(d) v4 §2.1 (Fix-2b) — TRUST BOUNDARY:
+	// `cacheBody` (formerly `raw`) is the v3 wrapper held in L1; it
+	// carries the UNFILTERED ProtectedDict and MUST NEVER be written to
+	// the HTTP response. The HTTP response sink is `result.Refiltered`,
+	// which holds the per-user-refiltered CR JSON computed inside
+	// l1cache.ResolveAndCache. Renamed for clarity so a future reviewer
+	// cannot accidentally route the wrong field to wri.Write.
+	cacheBody := result.Raw
+	_ = cacheBody // referenced only by the cache write inside ResolveAndCache; kept as a named binding for grep/audit visibility.
+
+	if result.Refiltered == nil {
+		// Refilter failed inside ResolveAndCache (it logged the cause).
+		// FAIL-CLOSED: do NOT serve `cacheBody` — that would re-introduce
+		// Q-RBACC-DEFECT-2 (silent RBAC leak on cache MISS).
+		log.Error("RESTAction MISS: refilter unavailable; refusing to serve unfiltered wrapper",
+			slog.String("key", resolvedKey))
+		response.InternalError(wri, errRefilterMissingOnMiss)
+		return
+	}
+	body := result.Refiltered
 
 	// Touch the key so it starts HOT for refresh priority.
 	if resolvedKey != "" {
@@ -242,9 +262,9 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		trace.WithAttributes(
 			attribute.Bool("cache.hit", false),
 			attribute.String("path", pathAttr),
-			attribute.Int("http.response.body.size", len(raw)),
+			attribute.Int("http.response.body.size", len(body)),
 		))
-	_, _ = wri.Write(raw)
+	_, _ = wri.Write(body)
 	writeSpan.End()
 }
 
@@ -258,6 +278,20 @@ type errEmptyResolve struct{}
 
 func (errEmptyResolve) Error() string {
 	return "l1cache.ResolveAndCache returned empty result with no error"
+}
+
+// errRefilterMissingOnMiss indicates the dispatcher MISS path observed
+// `result.Refiltered == nil` after l1cache.ResolveAndCache returned
+// successfully — the refilter call inside ResolveAndCache failed (logged
+// at WARN), and FAIL-CLOSED demands HTTP 500 instead of serving the
+// unfiltered wrapper. Q-RBAC-DECOUPLE C(d) v4 §2.1 (Fix-2b for
+// Q-RBACC-DEFECT-2).
+var errRefilterMissingOnMiss = errRefilterMissing{}
+
+type errRefilterMissing struct{}
+
+func (errRefilterMissing) Error() string {
+	return "l1cache.ResolveAndCache produced no refiltered bytes (refilter error); refusing to serve unfiltered wrapper"
 }
 
 // ResolveRESTActionBackground is the entry point for the L1 refresh

--- a/internal/handlers/dispatchers/restactions_miss_envtest_test.go
+++ b/internal/handlers/dispatchers/restactions_miss_envtest_test.go
@@ -1,0 +1,525 @@
+// Q-RBAC-DECOUPLE C(d) v4 §6.4 — anti-defect test for Q-RBACC-DEFECT-2.
+//
+// CRITICAL CONTRACT (per the v4 spec §6.4): this test MUST FAIL on the
+// v3 implementation tagged 0.25.296 (proves it catches the defect) and
+// PASS on the v4 implementation. The v3 path on cache MISS was:
+//
+//   first request (L1 miss) → l1cache.ResolveAndCache runs the resolver,
+//                             marshals the v3 wrapper, calls
+//                             api.RefilterRESTAction internally to populate
+//                             Result.Status (apiref-safe shape) — but the
+//                             refiltered BYTES were silently DISCARDED.
+//   dispatcher returns       → wri.Write(result.Raw) → user receives the
+//                             v3 wrapper with the UNFILTERED ProtectedDict
+//                             (every namespace visible). Silent RBAC leak.
+//
+// In v4 (Fix-2b):
+//
+//   first request (L1 miss) → l1cache.ResolveAndCache populates BOTH
+//                             Result.Raw (the wrapper, written to L1) AND
+//                             Result.Refiltered (the per-user-refiltered CR).
+//   dispatcher returns       → wri.Write(result.Refiltered) → user receives
+//                             ONLY their RBAC-permitted view.
+//
+// This test exercises the REAL `restActionHandler.ServeHTTP` via
+// httptest.NewServer — it does NOT use the simulator pattern that the
+// v3 envtest at internal/resolvers/restactions/api/dispatcher_refilter
+// _envtest_test.go uses. The test-design lesson (§6.10) is that the v3
+// simulator BYPASSED the dispatcher MISS path entirely, which is why the
+// v3 anti-defect test PASSED while the real MISS path leaked. v4 envtests
+// use the real handler so dispatcher-level integration bugs cannot hide.
+//
+// PLACEMENT NOTE: spec §10 lists this test under
+// internal/resolvers/restactions/api/dispatcher_miss_envtest_test.go,
+// but that path creates an import cycle (dispatchers → api). The
+// architect's INTENT is "real-handler test, not simulator" — placement
+// in this package is the only valid way to honor that intent.
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// restActionGVR is the canonical RESTAction GVR — the dispatcher reads
+// it from the request query parameters; the test seeds the L2 cache
+// (cache.GetKey) under the same GVR so objects.Get hits L2 and returns
+// the unstructured CR without needing a real K8s apiserver.
+var restActionGVRForTest = schema.GroupVersionResource{
+	Group:    "templates.krateo.io",
+	Version:  "v1",
+	Resource: "restactions",
+}
+
+// missTestStubRBAC is a minimal RBACEvaluator: allow[user][ns] == true
+// grants list access on namespaces. Mirrors the stub used by the api
+// package's refilter_test.go and dispatcher_refilter_envtest_test.go,
+// duplicated here because Go's `internal/...` linkage rules forbid
+// importing test-only types across packages.
+type missTestStubRBAC struct {
+	allow map[string]map[string]bool
+}
+
+func (s *missTestStubRBAC) EvaluateRBAC(username string, _ []string, _ string, _ schema.GroupResource, ns string) bool {
+	if s == nil {
+		return false
+	}
+	if u, ok := s.allow[username]; ok {
+		return u[ns]
+	}
+	return false
+}
+
+// k8sNamespacesListBody returns a serialized K8s NamespaceList containing
+// the given names. Shape matches what kube-apiserver returns for
+// `GET /api/v1/namespaces`.
+func k8sNamespacesListBody(names []string) string {
+	items := make([]map[string]any, 0, len(names))
+	for _, n := range names {
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": n},
+		})
+	}
+	body := map[string]any{
+		"kind":       "NamespaceList",
+		"apiVersion": "v1",
+		"items":      items,
+	}
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+// missTestEnv stands up a fake K8s upstream (httptest.NewServer that
+// returns a NamespaceList), a snowplow ServeHTTP server wrapping
+// restActionHandler with a per-request middleware that installs ctx
+// values, and a NewMem cache pre-seeded with the unstructured RESTAction
+// CR. Returns a tear-down func.
+type missTestEnv struct {
+	t          *testing.T
+	c          *cache.MemCache
+	upstream   *httptest.Server
+	server     *httptest.Server
+	upstreamCt *atomic.Int32
+	identityH  string
+	cr         *templates.RESTAction
+	authnNS    string
+	stopFns    []func()
+}
+
+func (e *missTestEnv) close() {
+	for _, fn := range e.stopFns {
+		fn()
+	}
+}
+
+func newMissTestEnv(t *testing.T, namespacesInUpstream []string) *missTestEnv {
+	t.Helper()
+
+	// env.SetTestMode(true) preserves the endpoint ServerURL chosen by
+	// our snowplow callback — production code rewrites unknown URLs to
+	// https://kubernetes.default.svc which would break the httptest hop.
+	env.SetTestMode(true)
+	t.Cleanup(func() { env.SetTestMode(false) })
+
+	upstreamCt := &atomic.Int32{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCt.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(k8sNamespacesListBody(namespacesInUpstream)))
+	}))
+
+	// Build the RESTAction CR: a single api[] entry with UAF on
+	// namespaces. The per-api filter extracts a flat array of names
+	// from the K8s NamespaceList response — applyUserAccessFilter
+	// requires an array shape to gate items per-user (it skips with a
+	// "response not an array" warning otherwise). The outer filter
+	// surfaces the array under `status.namespaces` for assertion
+	// clarity. Mirrors the production `compositions-get-ns-and-crd`
+	// shape (the one that leaked in production at 0.25.296) and the
+	// pattern the v3 envtest at user_access_filter_envtest_test.go
+	// uses.
+	cr := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{{
+				Name: "ns",
+				Path: "/api/v1/namespaces",
+				UserAccessFilter: &templates.UserAccessFilter{
+					Verb:          "list",
+					Resource:      "namespaces",
+					NamespaceFrom: ptr.To("."),
+				},
+				// Per-api filter: produce an array of NS names.
+				// applyUserAccessFilter then iterates this array and
+				// drops items the requesting user can't list.
+				Filter: ptr.To(`[.ns.items[].metadata.name]`),
+			}},
+			// Outer filter: lift dict["ns"] (now an array of strings)
+			// under `status.namespaces` for the wire shape.
+			Filter: ptr.To(`{namespaces: .ns}`),
+		},
+	}
+	cr.Name = "compositions-get-ns-and-crd"
+	cr.Namespace = "krateo-system"
+	cr.APIVersion = "templates.krateo.io/v1"
+	cr.Kind = "RESTAction"
+
+	// Seed L2 cache with the unstructured CR so `objects.Get(ctx, ref)`
+	// returns it without a real K8s apiserver.
+	c := cache.NewMem(0)
+	crUnstructured := mustToUnstructured(t, cr)
+	cacheKey := cache.GetKey(restActionGVRForTest, cr.Namespace, cr.Name)
+	if err := c.Set(context.Background(), cacheKey, crUnstructured); err != nil {
+		t.Fatalf("seed L2 cache: %v", err)
+	}
+
+	// Forced binding-identity collision — both users' requests build the
+	// same L1 key. Production reproduces this when two users in the same
+	// group-set share a binding-identity hash.
+	const identityH = "shared-binding-id-H"
+
+	// snowplowEndpointFn points at our upstream httptest server with a
+	// dummy SA token. The dispatcher routes UAF entries through this
+	// callback (independent of the requesting user's RBAC).
+	snowplowEndpointFn := func() (*endpoints.Endpoint, error) {
+		return &endpoints.Endpoint{
+			ServerURL: upstream.URL,
+			Token:     "SNOWPLOW-SA-TEST",
+		}, nil
+	}
+
+	authnNS := "krateo-system"
+	handler := RESTAction(snowplowEndpointFn)
+
+	// Per-request middleware: install ctx values that production
+	// middleware would. Reads (user, rbac) from request headers so each
+	// test request can carry its own identity.
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username := r.Header.Get("X-Test-User")
+		var rbac cache.RBACEvaluator
+		switch r.Header.Get("X-Test-RBAC") {
+		case "user-a":
+			rbac = &missTestStubRBAC{allow: map[string]map[string]bool{
+				"user-a": {"default": true, "shared-ns": true},
+			}}
+		case "user-b":
+			rbac = &missTestStubRBAC{allow: map[string]map[string]bool{
+				"user-b": {"kube-system": true, "shared-ns": true},
+			}}
+		}
+
+		ctx := xcontext.BuildContext(r.Context(),
+			xcontext.WithLogger(slog.Default()),
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: []string{"devs"}}),
+			// Empty UserConfig satisfies objects.Get's UserConfig
+			// requirement; the L2 cache hit short-circuits before the
+			// actual K8s call needs the endpoint.
+			xcontext.WithUserConfig(endpoints.Endpoint{ServerURL: upstream.URL}),
+		)
+		ctx = cache.WithCache(ctx, c)
+		ctx = cache.WithRBACEvaluator(ctx, rbac)
+		ctx = cache.WithBindingIdentity(ctx, identityH)
+		// Provide the snowplow endpoint via context fallback as well, so
+		// the dispatch fork in resolve.go can resolve UAF entries
+		// regardless of whether opts.SnowplowEndpoint was set.
+		ctx = cache.WithSnowplowEndpoint(ctx, func() (any, error) {
+			return snowplowEndpointFn()
+		})
+		// Inject a stub rest.Config via the v4 test-only ctx fallback
+		// so api.Resolve's `if opts.RC == nil` branch picks it up
+		// instead of calling rest.InClusterConfig() (which fails outside
+		// an in-cluster pod). The Host points at the upstream
+		// httptest.Server so any non-UAF entry that fell back to the
+		// per-user clientconfig path would also reach our mock — but
+		// our test scenario uses UAF on every entry, so this Config is
+		// only used to satisfy the early nil-check.
+		ctx = cache.WithTestRestConfig(ctx, &rest.Config{Host: upstream.URL})
+
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	server := httptest.NewServer(wrapped)
+
+	return &missTestEnv{
+		t:          t,
+		c:          c,
+		upstream:   upstream,
+		server:     server,
+		upstreamCt: upstreamCt,
+		identityH:  identityH,
+		cr:         cr,
+		authnNS:    authnNS,
+		stopFns: []func(){
+			upstream.Close,
+			server.Close,
+		},
+	}
+}
+
+// mustToUnstructured converts the typed RESTAction to an
+// unstructured.Unstructured suitable for L2 cache seeding.
+func mustToUnstructured(t *testing.T, cr *templates.RESTAction) *unstructured.Unstructured {
+	t.Helper()
+	b, err := json.Marshal(cr)
+	if err != nil {
+		t.Fatalf("marshal CR: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal CR: %v", err)
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+// missTestRequest issues a GET to the snowplow test server for the seeded
+// RESTAction CR with the given user identity headers. Returns
+// (statusCode, body).
+func missTestRequest(t *testing.T, e *missTestEnv, user string, rbac string) (int, []byte) {
+	t.Helper()
+	q := fmt.Sprintf(
+		"%s/call?apiVersion=%s/%s&resource=%s&namespace=%s&name=%s",
+		e.server.URL,
+		restActionGVRForTest.Group, restActionGVRForTest.Version,
+		restActionGVRForTest.Resource,
+		e.cr.Namespace, e.cr.Name,
+	)
+	req, err := http.NewRequest(http.MethodGet, q, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Test-User", user)
+	req.Header.Set("X-Test-RBAC", rbac)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+// extractMissNS unmarshals the per-user response body and returns
+// status.namespaces as a string slice. Returns nil on any decode failure
+// so callers can assert "no leaked items" cleanly.
+func extractMissNS(body []byte) []string {
+	var top map[string]any
+	if err := json.Unmarshal(body, &top); err != nil {
+		return nil
+	}
+	st, ok := top["status"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	arr, ok := st["namespaces"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestDispatcherMissPath_PerUserFilteredBytes_NoLeak is the §6.4 anti-
+// defect contract for Q-RBACC-DEFECT-2.
+//
+// Invariant: on cache MISS, the dispatcher MUST write per-user-refiltered
+// bytes (NOT the v3 wrapper) to the HTTP response. The wrapper must
+// remain in L1 for the next refilter-on-HIT to consume.
+//
+// On v3 (0.25.296) this test FAILS at the "wrapper marker" assertion:
+// the response body contains `"schema_version":"v3"` and `"protected_dict"`
+// because the dispatcher writes `result.Raw` (the wrapper) instead of
+// `result.Refiltered`.
+//
+// On v4 (Fix-2b) it PASSES: the response body parses as the per-user
+// filtered RESTAction CR and contains ONLY the requesting user's
+// RBAC-permitted namespaces.
+func TestDispatcherMissPath_PerUserFilteredBytes_NoLeak(t *testing.T) {
+	upstreamNS := []string{"default", "kube-system", "shared-ns", "tenant-a", "tenant-b"}
+	e := newMissTestEnv(t, upstreamNS)
+	defer e.close()
+
+	// First MISS: user-a (RBAC: default + shared-ns).
+	codeA, bodyA := missTestRequest(t, e, "user-a", "user-a")
+	if codeA != http.StatusOK {
+		t.Fatalf("user-a MISS: status %d, body=%s, upstream_calls=%d", codeA, string(bodyA), e.upstreamCt.Load())
+	}
+	// Step 1: response body must be the per-user filtered shape, NOT the
+	// v3 wrapper. The wrapper carries `"schema_version":"v3"` and
+	// `"protected_dict"`. Their presence in the response is the
+	// DEFECT-2 signature.
+	if bytes.Contains(bodyA, []byte(`"schema_version"`)) {
+		t.Errorf("Q-RBACC-DEFECT-2: response body contains v3 wrapper marker `\"schema_version\"`; dispatcher MISS path is leaking the unfiltered wrapper to HTTP\nbody=%s", truncate(bodyA, 600))
+	}
+	if bytes.Contains(bodyA, []byte(`"protected_dict"`)) {
+		t.Errorf("Q-RBACC-DEFECT-2: response body contains `\"protected_dict\"`; the unfiltered ProtectedDict was served verbatim\nbody=%s", truncate(bodyA, 600))
+	}
+	// Step 2: status.namespaces must be exactly user-a's permitted set.
+	gotA := extractMissNS(bodyA)
+	if !equalUnordered(gotA, []string{"default", "shared-ns"}) {
+		t.Errorf("user-a MISS: expected namespaces=[default shared-ns], got %v\nbody=%s", gotA, truncate(bodyA, 600))
+	}
+
+	// Step 3: L1 should now hold the v3 wrapper for the shared
+	// binding-identity key. Subsequent reads must HIT and refilter
+	// per-user (Path A — already covered by the v3 envtest, asserted
+	// here as a regression guard for Path A under the v4 fix).
+	l1Key := cache.ResolvedKey(e.identityH, restActionGVRForTest,
+		e.cr.Namespace, e.cr.Name, -1, -1)
+	rawCached, hit, err := e.c.GetRaw(context.Background(), l1Key)
+	if err != nil {
+		t.Fatalf("L1 GetRaw: %v", err)
+	}
+	if !hit {
+		t.Fatalf("L1 should hold the v3 wrapper after the MISS, got hit=false (key=%s)", l1Key)
+	}
+	if !bytes.Contains(rawCached, []byte(`"schema_version":"v3"`)) {
+		t.Errorf("L1 entry should be the v3 wrapper (with schema_version=v3) but the cached bytes do not contain that marker\ncached=%s", truncate(rawCached, 600))
+	}
+
+	// Second request: user-b in the same binding-identity group. This
+	// time L1 HITs (Path A) and must refilter per user-b. Both v3 and
+	// v4 should pass this; we keep it as a sanity check.
+	codeB, bodyB := missTestRequest(t, e, "user-b", "user-b")
+	if codeB != http.StatusOK {
+		t.Fatalf("user-b HIT: status %d, body=%s", codeB, string(bodyB))
+	}
+	if bytes.Contains(bodyB, []byte(`"schema_version"`)) {
+		t.Errorf("user-b HIT: response body unexpectedly contains v3 wrapper marker\nbody=%s", truncate(bodyB, 600))
+	}
+	gotB := extractMissNS(bodyB)
+	if !equalUnordered(gotB, []string{"kube-system", "shared-ns"}) {
+		t.Errorf("user-b HIT: expected namespaces=[kube-system shared-ns], got %v\nbody=%s", gotB, truncate(bodyB, 600))
+	}
+
+	// Cross-leak: bytes returned to A and B MUST differ.
+	if bytes.Equal(bodyA, bodyB) {
+		t.Errorf("user-a and user-b received byte-identical responses; per-user filtering is not running on the dispatcher MISS+HIT pair")
+	}
+}
+
+// TestDispatcherMissPath_TwoUsersDisjointRBAC_AlwaysIsolated bombards
+// the same L1 key from two users in alternating MISS/HIT pattern (with
+// a forced cache flush between iterations to keep MISSes coming) and
+// asserts strict per-user isolation throughout.
+//
+// On v3, an alternating burst would show one of the two users receiving
+// the OTHER user's view inside the wrapper on every MISS that fires
+// after a cache flush.
+func TestDispatcherMissPath_TwoUsersDisjointRBAC_AlwaysIsolated(t *testing.T) {
+	upstreamNS := []string{"default", "kube-system", "shared-ns"}
+	e := newMissTestEnv(t, upstreamNS)
+	defer e.close()
+
+	l1Key := cache.ResolvedKey(e.identityH, restActionGVRForTest,
+		e.cr.Namespace, e.cr.Name, -1, -1)
+
+	// Flush the L1 entry between iterations to keep the dispatcher on
+	// the MISS path. Each MISS exercises the Fix-2b code path.
+	for i := 0; i < 20; i++ {
+		// Erase any existing L1 entry.
+		_ = e.c.Delete(context.Background(), l1Key)
+
+		var (
+			user, rbac string
+			want       []string
+		)
+		if i%2 == 0 {
+			user, rbac, want = "user-a", "user-a", []string{"default", "shared-ns"}
+		} else {
+			user, rbac, want = "user-b", "user-b", []string{"kube-system", "shared-ns"}
+		}
+		code, body := missTestRequest(t, e, user, rbac)
+		if code != http.StatusOK {
+			t.Fatalf("iter %d (%s): status %d body=%s", i, user, code, string(body))
+		}
+		if bytes.Contains(body, []byte(`"schema_version"`)) {
+			t.Fatalf("iter %d (%s): wrapper leaked to HTTP body\nbody=%s", i, user, truncate(body, 600))
+		}
+		got := extractMissNS(body)
+		if !equalUnordered(got, want) {
+			t.Fatalf("iter %d (%s): expected %v, got %v\nbody=%s", i, user, want, got, truncate(body, 600))
+		}
+	}
+}
+
+// TestDispatcherMissPath_AfterMiss_L1HoldsV3Wrapper asserts that on
+// MISS, the dispatcher writes the v3 wrapper to L1 (so subsequent HITs
+// on Path A find a cache-shape-correct entry to refilter). The Fix-2b
+// change MUST NOT alter the L1 wire shape.
+func TestDispatcherMissPath_AfterMiss_L1HoldsV3Wrapper(t *testing.T) {
+	upstreamNS := []string{"default", "kube-system"}
+	e := newMissTestEnv(t, upstreamNS)
+	defer e.close()
+
+	code, _ := missTestRequest(t, e, "user-a", "user-a")
+	if code != http.StatusOK {
+		t.Fatalf("status %d", code)
+	}
+	l1Key := cache.ResolvedKey(e.identityH, restActionGVRForTest,
+		e.cr.Namespace, e.cr.Name, -1, -1)
+	cached, hit, err := e.c.GetRaw(context.Background(), l1Key)
+	if err != nil || !hit {
+		t.Fatalf("expected L1 hit after MISS, got hit=%v err=%v key=%s", hit, err, l1Key)
+	}
+	if !bytes.Contains(cached, []byte(`"schema_version":"v3"`)) {
+		t.Errorf("L1 cached entry must hold v3 wrapper; got\n%s", truncate(cached, 600))
+	}
+	if !bytes.Contains(cached, []byte(`"protected_dict"`)) {
+		t.Errorf("L1 cached entry must hold protected_dict (unfiltered); got\n%s", truncate(cached, 600))
+	}
+}
+
+// equalUnordered is a small set-equality helper duplicated from the
+// api package's test (Go's package-test linkage prevents importing it).
+func equalUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]int, len(a))
+	for _, s := range a {
+		m[s]++
+	}
+	for _, s := range b {
+		m[s]--
+		if m[s] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// truncate returns at most n bytes of s, appending an ellipsis on truncation.
+func truncate(s []byte, n int) string {
+	if len(s) <= n {
+		return string(s)
+	}
+	return string(s[:n]) + "...[truncated]"
+}
+

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
 )
 
 var widgetTracer = otel.Tracer("snowplow/dispatchers")
@@ -196,8 +197,21 @@ func resolveWidgetFromObject(ctx context.Context, c cache.Cache, got objects.Res
 	tracker := cache.NewDependencyTracker()
 	tctx := cache.WithDependencyTracker(xcontext.BuildContext(ctx), tracker)
 
+	// Q-RBAC-DECOUPLE C(d) v4 — strictly-additive test-only RC
+	// fallback. Production NEVER sets cache.WithTestRestConfig; the
+	// widget resolver continues to work with opts.RC=nil exactly as
+	// before (ValidateObjectStatus's nil-rc + non-TestMode path falls
+	// back to InClusterConfig). The fallback is reserved for the
+	// §6.5 envtest fixture so it can drive the real widgetsHandler
+	// without an in-cluster SA mount.
+	var resolveRC *rest.Config
+	if rc, ok := cache.TestRestConfigFromContext(ctx).(*rest.Config); ok {
+		resolveRC = rc
+	}
+
 	res, err := widgets.Resolve(tctx, widgets.ResolveOptions{
 		In:      got.Unstructured,
+		RC:      resolveRC,
 		AuthnNS: authnNS,
 		PerPage: perPage,
 		Page:    page,
@@ -236,7 +250,18 @@ func resolveWidgetFromObject(ctx context.Context, c cache.Cache, got objects.Res
 	// Only write deps from the tracker's ResourceRefs that are RESTAction
 	// refs (from apiRef resolution). Container widgets without apiRef
 	// have no RESTAction refs in the tracker, so nothing is registered.
-	if c != nil && resolvedKey != "" {
+	//
+	// Q-RBAC-DECOUPLE C(d) v4 §2.3 (Fix-W) — SKIP the L1 write when the
+	// widget transitively depends on a UAF-protected RESTAction. The
+	// widget body inlines the FIRST resolving user's apiref view; widget
+	// L1 keys are per binding-identity (NOT per-user), so caching the
+	// body would silently leak the first user's RBAC-filtered data to
+	// every other user in the same binding-identity group. Affected
+	// widgets fall through to Path D on every request (per-user
+	// correct). Cascade dep registration + child prewarm are also
+	// skipped because they depend on the L1 key that we did not write.
+	uafSkip := tracker.UAFTouching()
+	if c != nil && resolvedKey != "" && !uafSkip {
 		_ = c.SetResolvedRaw(ctx, resolvedKey, raw)
 		// Touch the key so it starts HOT for refresh priority.
 		if rki, ok := cache.ParseResolvedKey(resolvedKey); ok {
@@ -265,6 +290,9 @@ func resolveWidgetFromObject(ctx context.Context, c cache.Cache, got objects.Res
 		_, preWarmSpan := widgetTracer.Start(ctx, "widget.prewarm_children")
 		preWarmChildWidgets(ctx, c, res, authnNS)
 		preWarmSpan.End()
+	} else if c != nil && resolvedKey != "" && uafSkip {
+		log.Debug("widget L1 write skipped: UAF-touching",
+			slog.String("key", resolvedKey))
 	}
 
 	return &ResolveWidgetResult{Raw: raw, Resolved: res}, nil

--- a/internal/handlers/dispatchers/widgets_uaf_envtest_test.go
+++ b/internal/handlers/dispatchers/widgets_uaf_envtest_test.go
@@ -1,0 +1,506 @@
+//go:build envtest
+// +build envtest
+
+// Q-RBAC-DECOUPLE C(d) v4 §6.5 — anti-defect envtest for the NEW
+// widget-L1 transitive leak (Q-RBACC-DEFECT-4).
+//
+// CRITICAL CONTRACT (per the v4 spec §6.5): this test MUST FAIL on the
+// v3 implementation tagged 0.25.296 (proves it catches the defect) and
+// PASS on the v4 implementation. The v3 / v3-pre-Fix-W path was:
+//
+//   first request (widget L1 miss) → widgets.Resolve runs the widget
+//                                    pipeline; the apiref slot is resolved
+//                                    via apiref.Resolve which (on its own
+//                                    L1 miss) returns the FIRST user's
+//                                    refiltered view. The widget body
+//                                    inlines that view and is written to
+//                                    widget L1 keyed by binding identity.
+//   second request (widget L1 hit, same identity, different user) →
+//                                    dispatcher serves the FIRST user's
+//                                    cached widget body verbatim. The
+//                                    second user receives the FIRST user's
+//                                    apiref data inside the widget shell.
+//                                    Silent RBAC leak.
+//
+// In v4 (Fix-W):
+//
+//   widget L1 write is GATED by tracker.UAFTouching. apiref.Resolve
+//   marks the parent (widget) tracker UAFTouching when the resolved
+//   RESTAction has any api[] entry with userAccessFilter. With the
+//   flag set, the widget dispatcher SKIPS the L1 write — every request
+//   for the widget falls through to Path D and resolves per-user.
+//
+// Build/run:
+//
+//   export KUBEBUILDER_ASSETS=$(setup-envtest use --bin-dir ~/.envtest -p path)
+//   go test -tags envtest -timeout 120s -run TestWidgetDispatcher_UAFTransitiveLeak ./internal/handlers/dispatchers/
+//
+// The envtest binaries provide a real K8s apiserver so the widget
+// dispatcher's ValidateObjectStatus + dynamic discovery succeed against
+// a real Panel CRD installed by the test setup. The snowplow service
+// is exposed via httptest.NewServer wrapping the real widgetsHandler.
+
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// widgetGVRForTest is the canonical Widget GVR. envtest installs this
+// CRD before the test runs.
+var widgetGVRForTest = schema.GroupVersionResource{
+	Group:    "widgets.templates.krateo.io",
+	Version:  "v1beta1",
+	Resource: "panels",
+}
+
+// widgetUAFTestEnv bundles the envtest control plane + the snowplow
+// httptest service so the test can drive widgetsHandler.ServeHTTP via
+// a real client over HTTP.
+type widgetUAFTestEnv struct {
+	t          *testing.T
+	cfg        *rest.Config
+	c          *cache.MemCache
+	upstream   *httptest.Server // serves the K8s namespaces list shape
+	server     *httptest.Server // wraps widgetsHandler
+	upstreamCt *atomic.Int32
+	identityH  string
+	cr         *templates.RESTAction
+	widget     *unstructured.Unstructured
+	authnNS    string
+	stopFns    []func()
+}
+
+func (e *widgetUAFTestEnv) close() {
+	for i := len(e.stopFns) - 1; i >= 0; i-- {
+		e.stopFns[i]()
+	}
+}
+
+const widgetUAFEnvtestHint = `
+KUBEBUILDER_ASSETS not set or empty.
+
+Run the following once on this machine:
+
+  go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+  setup-envtest use --bin-dir ~/.envtest -p path
+  export KUBEBUILDER_ASSETS=$(setup-envtest use --bin-dir ~/.envtest -p path)
+
+Then re-run:
+  go test -tags envtest -timeout 120s -run TestWidgetDispatcher_UAFTransitiveLeak ./internal/handlers/dispatchers/
+`
+
+// startWidgetUAFEnvtest brings up etcd + kube-apiserver. Returns the
+// rest.Config and a teardown func.
+func startWidgetUAFEnvtest(t *testing.T) (*rest.Config, func()) {
+	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip(widgetUAFEnvtestHint)
+	}
+	envt := &envtest.Environment{ErrorIfCRDPathMissing: false}
+	cfg, err := envt.Start()
+	if err != nil {
+		t.Fatalf("envtest.Start: %v", err)
+	}
+	return cfg, func() {
+		if err := envt.Stop(); err != nil {
+			t.Logf("envtest.Stop: %v", err)
+		}
+	}
+}
+
+// installPanelCRD registers a minimal Panel CRD against envtest's
+// apiserver. The schema is permissive — the dispatcher's
+// ValidateObjectStatus only needs a real CRD to look up via discovery
+// + apiextensions GET; it then validates `status.widgetData` against
+// a permissive object schema.
+func installPanelCRD(t *testing.T, cfg *rest.Config) {
+	t.Helper()
+	cli, err := apiextclientset.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("apiext client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: widgetGVRForTest.Resource + "." + widgetGVRForTest.Group,
+		},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: widgetGVRForTest.Group,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Plural:   widgetGVRForTest.Resource,
+				Singular: "panel",
+				Kind:     "Panel",
+				ListKind: "PanelList",
+			},
+			Scope: apiextv1.NamespaceScoped,
+			Versions: []apiextv1.CustomResourceDefinitionVersion{{
+				Name:    widgetGVRForTest.Version,
+				Served:  true,
+				Storage: true,
+				Schema: &apiextv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+						Properties: map[string]apiextv1.JSONSchemaProps{
+							"spec": {
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+							},
+							"status": {
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+								Properties: map[string]apiextv1.JSONSchemaProps{
+									"widgetData": {
+										Type:                   "object",
+										XPreserveUnknownFields: ptr.To(true),
+									},
+								},
+							},
+						},
+					},
+				},
+				Subresources: &apiextv1.CustomResourceSubresources{
+					Status: &apiextv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	}
+	if _, err := cli.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("create Panel CRD: %v", err)
+		}
+	}
+	// envtest needs a moment to register the new CRD with discovery.
+	time.Sleep(500 * time.Millisecond)
+}
+
+func newWidgetUAFTestEnv(t *testing.T, namespacesInUpstream []string) *widgetUAFTestEnv {
+	t.Helper()
+	cfg, stopEnvt := startWidgetUAFEnvtest(t)
+	installPanelCRD(t, cfg)
+
+	env.SetTestMode(true)
+	t.Cleanup(func() { env.SetTestMode(false) })
+
+	upstreamCt := &atomic.Int32{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCt.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(k8sNamespacesListBody(namespacesInUpstream)))
+	}))
+
+	cr := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{{
+				Name: "ns",
+				Path: "/api/v1/namespaces",
+				UserAccessFilter: &templates.UserAccessFilter{
+					Verb:          "list",
+					Resource:      "namespaces",
+					NamespaceFrom: ptr.To("."),
+				},
+				Filter: ptr.To(`[.ns.items[].metadata.name]`),
+			}},
+			Filter: ptr.To(`{namespaces: .ns}`),
+		},
+	}
+	cr.Name = "ns-restaction"
+	cr.Namespace = "krateo-system"
+	cr.APIVersion = "templates.krateo.io/v1"
+	cr.Kind = "RESTAction"
+
+	c := cache.NewMem(0)
+	if err := c.Set(context.Background(),
+		cache.GetKey(restActionGVRForTest, cr.Namespace, cr.Name),
+		mustToUnstructured(t, cr)); err != nil {
+		t.Fatalf("seed RESTAction in L2: %v", err)
+	}
+
+	widget := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": widgetGVRForTest.GroupVersion().String(),
+		"kind":       "Panel",
+		"metadata": map[string]any{
+			"name":      "ns-panel",
+			"namespace": "krateo-system",
+		},
+		"spec": map[string]any{
+			"apiRef": map[string]any{
+				"name":      cr.Name,
+				"namespace": cr.Namespace,
+			},
+			// widgetData is needed by ValidateObjectStatus (line 67 of
+			// schema.go) — provide a placeholder; widgetDataTemplate
+			// fills `namespaces` from the apiref's `.namespaces`
+			// status subtree (the per-user-filtered list).
+			"widgetData": map[string]any{
+				"namespaces": []any{},
+			},
+			// widgetDataTemplate flows the apiref-resolved data source
+			// into status.widgetData. The dispatcher's writeup calls
+			// widgetdatatemplate.Resolve which evaluates each item's
+			// expression against `ds` (the apiref output map) and
+			// writes the result at the given path.
+			"widgetDataTemplate": []any{
+				map[string]any{
+					"forPath":    "namespaces",
+					"expression": "${.namespaces}",
+				},
+			},
+		},
+	}}
+	if err := c.Set(context.Background(),
+		cache.GetKey(widgetGVRForTest, "krateo-system", "ns-panel"),
+		widget); err != nil {
+		t.Fatalf("seed Widget in L2: %v", err)
+	}
+
+	const identityH = "shared-binding-id-widget-H"
+
+	snowplowEndpointFn := func() (*endpoints.Endpoint, error) {
+		return &endpoints.Endpoint{
+			ServerURL: upstream.URL,
+			Token:     "SNOWPLOW-SA-TEST",
+		}, nil
+	}
+
+	authnNS := "krateo-system"
+	handler := Widgets()
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username := r.Header.Get("X-Test-User")
+		var rbac cache.RBACEvaluator
+		switch r.Header.Get("X-Test-RBAC") {
+		case "user-a":
+			rbac = &missTestStubRBAC{allow: map[string]map[string]bool{
+				"user-a": {"default": true, "shared-ns": true},
+			}}
+		case "user-b":
+			rbac = &missTestStubRBAC{allow: map[string]map[string]bool{
+				"user-b": {"kube-system": true, "shared-ns": true},
+			}}
+		}
+
+		ctx := xcontext.BuildContext(r.Context(),
+			xcontext.WithLogger(slog.Default()),
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: []string{"devs"}}),
+			xcontext.WithUserConfig(endpoints.Endpoint{ServerURL: upstream.URL}),
+		)
+		ctx = cache.WithCache(ctx, c)
+		ctx = cache.WithRBACEvaluator(ctx, rbac)
+		ctx = cache.WithBindingIdentity(ctx, identityH)
+		ctx = cache.WithSnowplowEndpoint(ctx, func() (any, error) {
+			return snowplowEndpointFn()
+		})
+		// Inject the envtest cfg as the SArc + RC so api.Resolve and
+		// widgets.Resolve's ValidateObjectStatus path can both run
+		// without requiring an in-cluster mount.
+		ctx = cache.WithTestRestConfig(ctx, cfg)
+
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	})
+	server := httptest.NewServer(wrapped)
+
+	return &widgetUAFTestEnv{
+		t:          t,
+		cfg:        cfg,
+		c:          c,
+		upstream:   upstream,
+		server:     server,
+		upstreamCt: upstreamCt,
+		identityH:  identityH,
+		cr:         cr,
+		widget:     widget,
+		authnNS:    authnNS,
+		stopFns:    []func(){upstream.Close, server.Close, stopEnvt},
+	}
+}
+
+// widgetUAFRequest issues a GET to the snowplow widgets dispatcher.
+func widgetUAFRequest(t *testing.T, e *widgetUAFTestEnv, user, rbac string) (int, []byte) {
+	t.Helper()
+	q := fmt.Sprintf(
+		"%s/call?apiVersion=%s/%s&resource=%s&namespace=%s&name=%s",
+		e.server.URL,
+		widgetGVRForTest.Group, widgetGVRForTest.Version,
+		widgetGVRForTest.Resource,
+		"krateo-system", "ns-panel",
+	)
+	req, err := http.NewRequest(http.MethodGet, q, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Test-User", user)
+	req.Header.Set("X-Test-RBAC", rbac)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+// extractWidgetNS extracts the namespace list embedded in the widget
+// body's apiRef-resolved data source. The widget pipeline flows the
+// apiref status into status.widgetData via apiRef → widgetData merge;
+// the array we want lives at status.widgetData.namespaces (or a
+// flatter path for the minimal Panel shape).
+func extractWidgetNS(body []byte) []string {
+	var top map[string]any
+	if err := json.Unmarshal(body, &top); err != nil {
+		return nil
+	}
+	st, ok := top["status"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if wd, ok := st["widgetData"].(map[string]any); ok {
+		if arr, ok := wd["namespaces"].([]any); ok {
+			out := make([]string, 0, len(arr))
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					out = append(out, s)
+				}
+			}
+			return out
+		}
+	}
+	if arr, ok := st["namespaces"].([]any); ok {
+		out := make([]string, 0, len(arr))
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// TestWidgetDispatcher_UAFTransitiveLeak_NoCrossUser is the §6.5 anti-
+// defect contract for Q-RBACC-DEFECT-4.
+func TestWidgetDispatcher_UAFTransitiveLeak_NoCrossUser(t *testing.T) {
+	upstreamNS := []string{"default", "kube-system", "shared-ns", "tenant-a"}
+	e := newWidgetUAFTestEnv(t, upstreamNS)
+	defer e.close()
+
+	codeA, bodyA := widgetUAFRequest(t, e, "user-a", "user-a")
+	if codeA != http.StatusOK {
+		t.Fatalf("user-a widget request: status %d, body=%s", codeA, string(bodyA))
+	}
+	if bytes.Contains(bodyA, []byte(`"schema_version"`)) {
+		t.Errorf("user-a widget body contains v3 wrapper marker; defense-in-depth assertion failed\nbody=%s", truncate(bodyA, 800))
+	}
+
+	widgetL1Key := cache.ResolvedKey(e.identityH, widgetGVRForTest,
+		"krateo-system", "ns-panel", -1, -1)
+	if _, hit, _ := e.c.GetRaw(context.Background(), widgetL1Key); hit {
+		t.Errorf("Q-RBACC-DEFECT-4: widget L1 entry was written despite UAF-touching apiref; v4 Fix-W should have skipped the write\nkey=%s", widgetL1Key)
+	}
+
+	codeB, bodyB := widgetUAFRequest(t, e, "user-b", "user-b")
+	if codeB != http.StatusOK {
+		t.Fatalf("user-b widget request: status %d, body=%s", codeB, string(bodyB))
+	}
+	if bytes.Equal(bodyA, bodyB) {
+		t.Errorf("Q-RBACC-DEFECT-4: user-a and user-b received byte-identical widget bodies despite disjoint RBAC; widget L1 served first user's body to second user")
+	}
+
+	gotA := extractWidgetNS(bodyA)
+	gotB := extractWidgetNS(bodyB)
+	if !equalUnordered(gotA, []string{"default", "shared-ns"}) {
+		t.Errorf("user-a widget: expected namespaces=[default shared-ns], got %v\nbody=%s", gotA, truncate(bodyA, 800))
+	}
+	if !equalUnordered(gotB, []string{"kube-system", "shared-ns"}) {
+		t.Errorf("user-b widget: expected namespaces=[kube-system shared-ns], got %v\nbody=%s", gotB, truncate(bodyB, 800))
+	}
+
+	if bytes.Contains(bodyA, []byte(`"kube-system"`)) {
+		t.Errorf("user-a widget body leaks `kube-system` (user-b's RBAC); cross-user contamination\nbody=%s", truncate(bodyA, 800))
+	}
+	if bytes.Contains(bodyB, []byte(`"default"`)) {
+		t.Errorf("user-b widget body leaks `default` (user-a's RBAC); cross-user contamination\nbody=%s", truncate(bodyB, 800))
+	}
+
+	raL1Key := cache.ResolvedKey(e.identityH, restActionGVRForTest,
+		e.cr.Namespace, e.cr.Name, -1, -1)
+	cachedRA, raHit, _ := e.c.GetRaw(context.Background(), raL1Key)
+	if !raHit {
+		t.Errorf("RESTAction L1 entry expected to be written by apiref.Resolve; got hit=false (key=%s)", raL1Key)
+	}
+	if !bytes.Contains(cachedRA, []byte(`"schema_version":"v3"`)) {
+		t.Errorf("RESTAction L1 entry should be the v3 wrapper; got\n%s", truncate(cachedRA, 600))
+	}
+}
+
+// TestWidgetDispatcher_NonUAF_WidgetL1WriteAllowed asserts the
+// negative case: a widget whose apiref points at a NON-UAF
+// RESTAction must still write to widget L1 (the Fix-W gate must NOT
+// trip when no UAF is involved).
+func TestWidgetDispatcher_NonUAF_WidgetL1WriteAllowed(t *testing.T) {
+	upstreamNS := []string{"default", "kube-system"}
+	e := newWidgetUAFTestEnv(t, upstreamNS)
+	defer e.close()
+
+	e.cr.Spec.API[0].UserAccessFilter = nil
+	if err := e.c.Set(context.Background(),
+		cache.GetKey(restActionGVRForTest, e.cr.Namespace, e.cr.Name),
+		mustToUnstructured(t, e.cr)); err != nil {
+		t.Fatalf("re-seed RESTAction: %v", err)
+	}
+
+	codeA, bodyA := widgetUAFRequest(t, e, "user-a", "user-a")
+	if codeA != http.StatusOK {
+		t.Fatalf("widget request: status %d, body=%s", codeA, string(bodyA))
+	}
+	_ = bodyA
+
+	widgetL1Key := cache.ResolvedKey(e.identityH, widgetGVRForTest,
+		"krateo-system", "ns-panel", -1, -1)
+	if _, hit, _ := e.c.GetRaw(context.Background(), widgetL1Key); !hit {
+		t.Errorf("widget L1 entry MUST be written when the apiref RESTAction has NO UAF (Fix-W should not trip); got hit=false\nkey=%s", widgetL1Key)
+	}
+}
+
+// _ = filepath, runtime — placeholders so the imports survive minor
+// future tweaks; remove if unused after stabilization.
+var (
+	_ = filepath.Join
+	_ = runtime.GOOS
+)

--- a/internal/resolvers/restactions/api/dispatcher_refilter_envtest_test.go
+++ b/internal/resolvers/restactions/api/dispatcher_refilter_envtest_test.go
@@ -1,5 +1,36 @@
 // Q-RBAC-DECOUPLE C(d) v3 — anti-defect test for Q-RBACC-DEFECT-1.
 //
+// === v4 ANNOTATION (Q-RBAC-DECOUPLE C(d) v4 §6.10 / §9 IMPL-4) ===
+//
+// SCOPE: this file tests the `RefilterRESTAction` HELPER's L1-HIT-path
+// behaviour via the `dispatcherSimulator` stub at line ~64 below. It
+// does NOT exercise the real `restActionHandler.ServeHTTP` and therefore
+// does NOT cover the dispatcher MISS path or the widget-L1 transitive
+// surface. The simulator's design hole is precisely what hid
+// Q-RBACC-DEFECT-2 in v3 — the simulator returns refiltered bytes
+// directly, bypassing the dispatcher MISS code that incorrectly wrote
+// `result.Raw` (the unfiltered wrapper) to the HTTP response.
+//
+// v4 anti-defect tests for the dispatcher integration live in:
+//
+//   - internal/handlers/dispatchers/restactions_miss_envtest_test.go
+//     (§6.4 — dispatcher MISS path leak / Q-RBACC-DEFECT-2)
+//   - internal/handlers/dispatchers/widgets_uaf_envtest_test.go
+//     (§6.5 — widget-L1 transitive leak / Q-RBACC-DEFECT-4)
+//   - internal/handlers/dispatchers/l1_refresh_envtest_test.go
+//     (§6.6 — L1 refresh under SA / Q-RBACC-DEFECT-3)
+//
+// Those v4 tests exercise the REAL `restActionHandler.ServeHTTP` (and
+// `widgetsHandler.ServeHTTP`) via `httptest.NewServer`. The v4 spec's
+// §6.10 codifies the lesson: every anti-defect test for a dispatcher-
+// level invariant MUST go through the real handler, NOT a simulator.
+//
+// Per spec §9 Q-RBACC-V4-IMPL-4: this v3 test is KEPT (not deleted)
+// because the simulator-based form remains a useful, fast HIT-path
+// regression for `RefilterRESTAction` itself.
+//
+// === ORIGINAL v3 CONTEXT ===
+//
 // CRITICAL CONTRACT (per the v3 spec §6.4): this test MUST FAIL on the v2
 // implementation tagged 0.25.295 (proves it catches the defect) and PASS on
 // the v3 implementation that ships in 0.25.296. The v2 path was:

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -249,10 +249,22 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 		//   the projected SA token is re-read on every call.
 		// - EndpointRef wins (operator escape hatch). The filter still
 		//   applies to the response if userAccessFilter is set.
+		// - Q-RBAC-DECOUPLE C(d) v4 §2.2 (Fix-3a) — system-identity ctx
+		//   (set by MakeL1Refresher) → snowplow-SA dispatch for ALL api
+		//   entries, regardless of UserAccessFilter. Reason: the per-user
+		//   clientconfig fallback below would attempt to load a Secret
+		//   named after the synthesized SA identity (which doesn't exist)
+		//   and ERROR out — Q-RBACC-DEFECT-3. The flag is set ONLY in
+		//   MakeL1Refresher's closure; real-user contexts never set it,
+		//   so the user-clientconfig path is preserved for HTTP requests.
 		// - Otherwise: the original mapper handles the user-secret /
 		//   internal-clientconfig lookup unchanged.
 		var ep endpoints.Endpoint
-		if apiCall.UserAccessFilter != nil && apiCall.EndpointRef == nil {
+		useSystemEndpoint := apiCall.UserAccessFilter != nil && apiCall.EndpointRef == nil
+		if !useSystemEndpoint && apiCall.EndpointRef == nil && cache.IsSystemIdentity(ctx) {
+			useSystemEndpoint = true
+		}
+		if useSystemEndpoint {
 			// Resolve the snowplow-SA endpoint provider. opts.SnowplowEndpoint
 			// (set explicitly by the dispatcher constructors per Q-RBACC-IMPL-7)
 			// wins; otherwise fall back to the context-stored provider that

--- a/internal/resolvers/restactions/l1cache/l1cache.go
+++ b/internal/resolvers/restactions/l1cache/l1cache.go
@@ -95,13 +95,26 @@ type Input struct {
 }
 
 // Result is what both HTTP and widget callers need from one resolution.
-// Raw is the marshaled + bulky-annotations-stripped CR (written to L1
-// and to the HTTP response body). Status is the decoded status subtree
-// of the CR, which is what the widget apiref path returns to its own
-// callers.
+//
+// Raw is the v3 wrapper bytes — written to L1, NEVER served to an HTTP
+// response. The wrapper carries the unfiltered ProtectedDict; serving
+// it to a real user would re-introduce Q-RBACC-DEFECT-2 (silent RBAC
+// leak on cache MISS).
+//
+// Refiltered is the per-user-refiltered CR JSON computed inside
+// ResolveAndCache via api.RefilterRESTAction. The dispatcher MISS path
+// MUST write Refiltered (not Raw) to the HTTP response. May be nil only
+// if the refilter call itself errored — callers detect nil and respond
+// HTTP 500 (no cached bytes are served on a refilter error). Q-RBAC-
+// DECOUPLE C(d) v4 §2.1 (Fix-2b).
+//
+// Status is the decoded status subtree of the per-user-refiltered CR —
+// the apiref-path consumer surface. Populated from Refiltered via a
+// single json.Unmarshal so Status and Refiltered cannot drift.
 type Result struct {
-	Raw    []byte
-	Status map[string]any
+	Raw        []byte
+	Refiltered []byte
+	Status     map[string]any
 }
 
 // ResolveAndCache runs the full RESTAction resolution:
@@ -141,9 +154,24 @@ func resolveAndCacheInner(ctx context.Context, in Input) (*Result, error) {
 
 	tracker := cache.NewDependencyTracker()
 	tctx := cache.WithDependencyTracker(xcontext.BuildContext(ctx), tracker)
+
+	// Q-RBAC-DECOUPLE C(d) v4 — strictly-additive test-only SArc
+	// fallback. Production NEVER sets cache.WithTestRestConfig; the
+	// fallback is a no-op there and api.Resolve continues to call
+	// rest.InClusterConfig() when in.SArc == nil, exactly as in v3.
+	// The fallback is reserved for the §6.4-§6.6 envtest fixtures so
+	// they can exercise the real dispatcher.ServeHTTP path without an
+	// in-cluster SA mount.
+	sArc := in.SArc
+	if sArc == nil {
+		if rc, ok := cache.TestRestConfigFromContext(ctx).(*rest.Config); ok {
+			sArc = rc
+		}
+	}
+
 	_, dict, err := restactions.Resolve(tctx, restactions.ResolveOptions{
 		In:               &cr,
-		SArc:             in.SArc,
+		SArc:             sArc,
 		AuthnNS:          in.AuthnNS,
 		PerPage:          in.PerPage,
 		Page:             in.Page,
@@ -218,10 +246,17 @@ func resolveAndCacheInner(ctx context.Context, in Input) (*Result, error) {
 	// applies on L1 hit).
 	refiltered, refErr := api.RefilterRESTAction(ctx, in.Cache, raw)
 	if refErr != nil {
-		log.Warn("resolveAndCacheInner: refilter failed; returning raw without status",
+		log.Warn("resolveAndCacheInner: refilter failed; returning raw without status or refiltered bytes",
 			slog.String("name", cr.Name),
 			slog.String("ns", cr.Namespace),
 			slog.Any("err", refErr))
+		// SECURITY (Q-RBAC-DECOUPLE C(d) v4 §2.1 Fix-2b): do NOT populate
+		// Result.Refiltered on error. The dispatcher MISS path inspects
+		// Refiltered==nil and returns HTTP 500 (no fallback to Raw, which
+		// would leak the unfiltered wrapper to the user). Result.Raw is
+		// still returned so the cache-write inspection / debug paths see
+		// what was committed to L1, but no HTTP response sink should ever
+		// dereference it.
 		return &Result{Raw: raw}, nil
 	}
 
@@ -249,7 +284,13 @@ func resolveAndCacheInner(ctx context.Context, in Input) (*Result, error) {
 		}
 	}
 
-	return &Result{Raw: raw, Status: status}, nil
+	// Q-RBAC-DECOUPLE C(d) v4 §2.1 (Fix-2b): expose the refiltered bytes
+	// alongside Raw + Status. The dispatcher MISS path writes Refiltered
+	// to the HTTP response (NEVER Raw) so the user receives the per-user-
+	// filtered shape the cache-HIT path already serves. ZERO new CPU cost
+	// — the bytes are produced by the RefilterRESTAction call above and
+	// were silently discarded in v3.
+	return &Result{Raw: raw, Refiltered: refiltered, Status: status}, nil
 }
 
 // extractAPIRequests extracts the "apiRequests" string array from the

--- a/internal/resolvers/widgets/apiref/resolve.go
+++ b/internal/resolvers/widgets/apiref/resolve.go
@@ -69,7 +69,7 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 			// on ANY error from refilter, fall through to the miss path
 			// (resolveViaL1Cache below). NEVER return the unfiltered
 			// status to the caller.
-			if status, ok := lookupL1Refiltered(ctx, c, l1Key); ok {
+			if status, hasUAF, ok := lookupL1Refiltered(ctx, c, l1Key); ok {
 				// Record the restaction GVR in the dependency tracker
 				// even on L1 hit. The widget dispatcher uses the
 				// tracker to register deps (widgets.go:267). Without
@@ -79,11 +79,22 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 				if tracker := cache.TrackerFromContext(ctx); tracker != nil {
 					tracker.AddGVR(restActionGVR)
 					tracker.AddResource(restActionGVR, opts.ApiRef.Namespace, opts.ApiRef.Name)
+					// Q-RBAC-DECOUPLE C(d) v4 §2.3 (Fix-W) — propagate
+					// UAF-touching to the parent (widget) tracker on the
+					// HIT path. The widget dispatcher reads this flag to
+					// SKIP the widget L1 write when the widget's body
+					// inlines a per-user-filtered apiref view that must
+					// not be shared across users in the same binding-
+					// identity group.
+					if hasUAF {
+						tracker.MarkUAFTouching()
+					}
 					slog.Debug("apiref: L1 hit, added restaction dep to tracker",
 						slog.String("l1Key", l1Key),
 						slog.String("apiRef", opts.ApiRef.Name),
 						slog.Int("page", opts.Page),
-						slog.Int("perPage", opts.PerPage))
+						slog.Int("perPage", opts.PerPage),
+						slog.Bool("uafTouching", hasUAF))
 				} else {
 					slog.Warn("apiref: L1 hit but NO tracker in context",
 						slog.String("l1Key", l1Key))
@@ -105,7 +116,7 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 
 	// L1 miss: fall through to shared resolver.
 	if l1Key != "" {
-		status, err := resolveViaL1Cache(ctx, c, opts, l1Key)
+		status, hasUAF, err := resolveViaL1Cache(ctx, c, opts, l1Key)
 		// Register the restaction dep in the CALLER's tracker even on
 		// L1 miss. l1cache.ResolveAndCache creates its own tracker, so
 		// the widget's tracker doesn't get the restaction ref automatically.
@@ -115,6 +126,15 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 			if tracker := cache.TrackerFromContext(ctx); tracker != nil {
 				tracker.AddGVR(restActionGVR)
 				tracker.AddResource(restActionGVR, opts.ApiRef.Namespace, opts.ApiRef.Name)
+				// Q-RBAC-DECOUPLE C(d) v4 §2.3 (Fix-W) — propagate
+				// UAF-touching to the parent (widget) tracker on the
+				// MISS path so the widget dispatcher's L1-write gate
+				// trips correctly on the very first request that
+				// resolves a UAF-protected RESTAction through the
+				// widget pipeline.
+				if hasUAF {
+					tracker.MarkUAFTouching()
+				}
 			}
 		}
 		return status, err
@@ -127,11 +147,24 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 // resolveViaL1Cache fetches the RESTAction CR and hands it off to
 // l1cache.ResolveAndCache, which runs inside the shared foreground
 // singleflight.Group and writes the L1 entry.
-func resolveViaL1Cache(ctx context.Context, c cache.Cache, opts ResolveOptions, l1Key string) (map[string]any, error) {
+//
+// Returns (status, hasUAF, err). hasUAF is true iff the resolved RESTAction
+// CR has at least one api[] entry with UserAccessFilter configured — used
+// by the caller (Resolve) to set the parent tracker's UAFTouching flag
+// (Q-RBAC-DECOUPLE C(d) v4 §2.3 / Fix-W).
+func resolveViaL1Cache(ctx context.Context, c cache.Cache, opts ResolveOptions, l1Key string) (map[string]any, bool, error) {
 	res := objects.Get(ctx, opts.ApiRef)
 	if res.Err != nil {
-		return map[string]any{}, fmt.Errorf("%s", res.Err.Message)
+		return map[string]any{}, false, fmt.Errorf("%s", res.Err.Message)
 	}
+
+	// Compute hasUAF from the unstructured CR BEFORE handing it off to
+	// l1cache.ResolveAndCache. The check is a single linear scan over
+	// cr.Spec.API (≤ 4 entries per RESTAction), cheap and unconditional
+	// (we always need the truth value for the caller). Done on the
+	// unstructured map shape to avoid a duplicate full conversion to
+	// templatesv1.RESTAction (which l1cache does internally).
+	hasUAF := unstructuredHasUAF(res.Unstructured.Object)
 
 	result, err := l1cache.ResolveAndCache(ctx, l1cache.Input{
 		Cache:       c,
@@ -144,12 +177,47 @@ func resolveViaL1Cache(ctx context.Context, c cache.Cache, opts ResolveOptions, 
 		Extras:      opts.Extras,
 	})
 	if err != nil {
-		return map[string]any{}, err
+		return map[string]any{}, hasUAF, err
 	}
 	if result == nil || result.Status == nil {
-		return map[string]any{}, nil
+		return map[string]any{}, hasUAF, nil
 	}
-	return result.Status, nil
+	return result.Status, hasUAF, nil
+}
+
+// unstructuredHasUAF returns true iff at least one api[] entry in the
+// unstructured RESTAction CR has a non-nil userAccessFilter. The check
+// runs against the raw map shape (`spec.api[*].userAccessFilter`) so we
+// avoid a duplicate full conversion to templatesv1.RESTAction (which
+// l1cache.ResolveAndCache does internally). Q-RBAC-DECOUPLE C(d) v4
+// §2.3 (Fix-W) — used by resolveViaL1Cache and by lookupL1Refiltered's
+// HIT path.
+func unstructuredHasUAF(obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	spec, ok := obj["spec"].(map[string]any)
+	if !ok {
+		return false
+	}
+	apis, ok := spec["api"].([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range apis {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if uaf, present := entry["userAccessFilter"]; present && uaf != nil {
+			// Defensive: a JSON null could decode as untyped nil — only
+			// report true when the field carries a structured value.
+			if m, ok := uaf.(map[string]any); ok && len(m) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // resolveInline is the no-cache fast path: no L1 lookup, no L1 write,
@@ -187,17 +255,23 @@ func resolveInline(ctx context.Context, opts ResolveOptions) (map[string]any, er
 
 // lookupL1Refiltered reads a RESTAction L1 entry, runs the v3 per-user
 // refilter against the cached wrapper, and extracts the resulting status
-// map. Returns (status, true) on hit + successful refilter; (nil, false)
-// on miss, on any refilter error, or on decode failure.
+// map. Returns (status, hasUAF, true) on hit + successful refilter;
+// (nil, false, false) on miss, on any refilter error, or on decode
+// failure.
+//
+// hasUAF reports whether the cached RESTAction CR has at least one api[]
+// entry with userAccessFilter configured — used by the caller to set the
+// parent (widget) tracker's UAFTouching flag (Q-RBAC-DECOUPLE C(d) v4
+// §2.3 / Fix-W).
 //
 // SECURITY: refilter failures are treated as misses — the caller falls
 // through to a fresh resolve under the requesting user. NEVER return the
 // raw cached status; the cached wrapper holds the unfiltered ProtectedDict
 // shape and would leak items to a user lacking the corresponding RBAC.
-func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[string]any, bool) {
+func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[string]any, bool, bool) {
 	raw, hit, err := c.GetRaw(ctx, l1Key)
 	if err != nil || !hit || len(raw) == 0 {
-		return nil, false
+		return nil, false, false
 	}
 	refiltered, refErr := func() (out []byte, ferr error) {
 		defer func() {
@@ -217,15 +291,38 @@ func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[s
 		slog.Warn("apiref: L1 refilter failed; treating as miss",
 			slog.String("l1Key", l1Key),
 			slog.Any("err", refErr))
-		return nil, false
+		return nil, false, false
 	}
 	var cached map[string]any
 	if json.Unmarshal(refiltered, &cached) != nil {
-		return nil, false
+		return nil, false, false
 	}
 	status, ok := cached["status"].(map[string]any)
 	if !ok {
-		return nil, false
+		return nil, false, false
 	}
-	return status, true
+	// Q-RBAC-DECOUPLE C(d) v4 §2.3 (Fix-W) — derive hasUAF from the
+	// cached wrapper bytes (NOT from `refiltered`, which has the
+	// per-user-projected shape via the outer JQ). The wrapper holds
+	// `cr.spec.api[*].userAccessFilter` verbatim.
+	hasUAF := wrapperHasUAF(raw)
+	return status, hasUAF, true
+}
+
+// wrapperHasUAF decodes only enough of the v3 cached wrapper to know
+// whether `cr.spec.api[*].userAccessFilter` is set on at least one
+// entry. Does NOT verify schema_version (callers do that via the
+// refilter call). Returns false on any decode failure (defensive: a
+// false-negative here just causes a per-request resolve cost; never a
+// security regression).
+func wrapperHasUAF(raw []byte) bool {
+	var top map[string]any
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return false
+	}
+	cr, ok := top["cr"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return unstructuredHasUAF(cr)
 }


### PR DESCRIPTION
## Summary

v4 fixes the THREE design defects uncovered after the v3 deploy at `0.25.296`:

- **Fix-2b** (Q-RBACC-DEFECT-2): dispatcher MISS path was writing `result.Raw` (the v3 wrapper) to HTTP responses, leaking the unfiltered ProtectedDict. Surface the already-computed refiltered bytes via `Result.Refiltered`; dispatcher writes those.
- **Fix-3a** (Q-RBACC-DEFECT-3): L1 refresh under SA tried to load `<sa-username>-clientconfig` for non-UAF api[] entries — Secret never exists. Add a `cache.WithSystemIdentity` flag set in `MakeL1Refresher`'s closure; extend the dispatch fork at `resolve.go:255` so all api[] entries route through the snowplow endpoint when the flag is set.
- **Fix-W** (Q-RBACC-DEFECT-4, NEW): widget L1 entries are keyed by binding-identity hash, NOT username. Widgets transitively touching UAF restactions inline the FIRST resolving user's apiref view; subsequent users in the same group hit widget L1 and see the wrong data. Add `tracker.UAFTouching` flag set inside `apiref.Resolve`; widget dispatcher SKIPS the L1 write when set.

Spec: `/tmp/snowplow-runs/q-rbac-decouple-cd-v4-spec-2026-05-05/SPEC.md`. Fork point: `37b7bce` (v3 baseline).

## Commits (4)

1. `74ce760` — Fix-2b: `Result.Refiltered` + dispatcher MISS write (~30 LOC).
2. `369c565` — Fix-3a: system-identity context flag (~25 LOC).
3. `69f3717` — Fix-W: widget L1 transitive gate (~80 LOC; UAF scan helpers + tracker flag).
4. `e52e16c` — Three new envtests + v3 envtest annotation (~1385 LOC, all tests).

## What changes (production code, ~135 LOC)

| File | Lines | Purpose |
|---|---|---|
| `internal/resolvers/restactions/l1cache/l1cache.go` | +33 | Add `Result.Refiltered`; populate from existing refilter call. Test-only SArc fallback (additive, no production effect). |
| `internal/handlers/dispatchers/restactions.go` | +28 | MISS path writes `result.Refiltered` (NOT `result.Raw`). FAIL-CLOSED 500 if Refiltered nil. New `errRefilterMissingOnMiss`. |
| `internal/cache/context.go` | +35 | `WithSystemIdentity` / `IsSystemIdentity`. (Plus `WithTestRestConfig` test scaffolding.) |
| `internal/handlers/dispatchers/l1_refresh.go` | +14 | `ctx = cache.WithSystemIdentity(ctx)` as first line in refresh closure. |
| `internal/resolvers/restactions/api/resolve.go` | +14 | Extend dispatch-fork predicate: `useSystemEndpoint` true also when `IsSystemIdentity(ctx) && EndpointRef == nil`. |
| `internal/cache/tracker.go` | +35 | `UAFTouching` atomic.Bool + `MarkUAFTouching()` + `UAFTouching()` on `DependencyTracker`. |
| `internal/resolvers/widgets/apiref/resolve.go` | +110 | Propagate UAFTouching to parent tracker on HIT + MISS paths. Helpers `unstructuredHasUAF`, `wrapperHasUAF`. |
| `internal/handlers/dispatchers/widgets.go` | +30 | Gate widget L1 write on `!tracker.UAFTouching()`. Test-only RC fallback (additive). |

Plus new test infrastructure (~1385 LOC of *_test.go files).

## Defect catch evidence (3-of-3)

Each new envtest was verified to FAIL on a 0.25.296-equivalent baseline by temporarily reverting just the corresponding fix and re-running.

### §6.4 — `TestDispatcherMissPath_PerUserFilteredBytes_NoLeak` (catches Q-RBACC-DEFECT-2)

Failure on v3-equivalent (dispatcher reverts to `body := result.Raw`):

```
restactions_miss_envtest_test.go:378: Q-RBACC-DEFECT-2: response body contains v3 wrapper marker `"schema_version"`; dispatcher MISS path is leaking the unfiltered wrapper to HTTP
    body={"schema_version":"v3","cr":{...,"status":{"namespaces":["default","kube-system","shared-ns","tenant-a","tenant-b"]}},"protected_dict":{...,"ns":["default","kube-system","shared-ns","tenant-a","tenant-b"]...
restactions_miss_envtest_test.go:381: Q-RBACC-DEFECT-2: response body contains `"protected_dict"`; the unfiltered ProtectedDict was served verbatim
restactions_miss_envtest_test.go:386: user-a MISS: expected namespaces=[default shared-ns], got []
```

cyberjoker user-a (RBAC: only `default` + `shared-ns`) RECEIVES ALL 5 NSes. Audit log showed RBAC IS being computed (`items_in=5 items_out=2 denied=3`) but those filtered bytes are silently DISCARDED.

PASSES on v4 in ~0.5s. Three sub-tests cover MISS shape, alternating MISS burst (20 iters with cache flush), and the L1 wire-shape regression check.

### §6.5 — `TestWidgetDispatcher_UAFTransitiveLeak_NoCrossUser` (catches Q-RBACC-DEFECT-4)

Failure on v3-pre-Fix-W (widget L1 write gate disabled):

```
widgets_uaf_envtest_test.go:434: Q-RBACC-DEFECT-4: widget L1 entry was written despite UAF-touching apiref; v4 Fix-W should have skipped the write
widgets_uaf_envtest_test.go:442: Q-RBACC-DEFECT-4: user-a and user-b received byte-identical widget bodies despite disjoint RBAC; widget L1 served first user's body to second user
widgets_uaf_envtest_test.go:451: user-b widget: expected namespaces=[kube-system shared-ns], got [default shared-ns]
widgets_uaf_envtest_test.go:458: user-b widget body leaks `default` (user-a's RBAC); cross-user contamination
```

Smoking-gun log: `Widget resolved from cache user=user-b source=L1-cache` — user-b literally hit user-a's cached widget body.

PASSES on v4 in ~4s with envtest. Negative case (`TestWidgetDispatcher_NonUAF_WidgetL1WriteAllowed`) confirms the gate does NOT trip when no UAF is involved (preserves widget cache hit rate for the bulk of widgets).

### §6.6 — `TestL1Refresh_SystemIdentity_NonUAF_NoClientConfigError` (catches Q-RBACC-DEFECT-3)

Failure on v3-pre-Fix-3a (no `WithSystemIdentity` set on refresh ctx):

```
l1_refresh_envtest_test.go:231: Q-RBACC-DEFECT-3: refresh emitted v3-dispatch error containing "unable to resolve api endpoint reference" — non-UAF api[] entry hit the per-user clientconfig fallback under SA identity (Fix-3a not in effect)
    first match: unable to resolve api endpoint reference name=ns ref=<nil> error=no kind "NamespaceList" is registered for version "v1" in scheme "pkg/runtime/scheme.go:111"
l1_refresh_envtest_test.go:284: Fix-3a: expected upstream call to exact path /api/v1/namespaces (the api[] entry path); saw paths=[/api/v1/namespaces/krateo-system/secrets/systemserviceaccountkrateo-systemsnowplow-clientconfig]
```

The path the upstream ACTUALLY saw on v3 — `/api/v1/namespaces/krateo-system/secrets/systemserviceaccountkrateo-systemsnowplow-clientconfig` — is exactly the production failure mode that filled the pod logs at `0.25.296`. PASSES on v4: the api[] entry reaches the upstream at `/api/v1/namespaces` directly, L1 entry is overwritten with the v3 wrapper.

Plus `TestL1Refresh_SystemIdentity_FlagSetOnRefreshCtxOnly` asserts the §6.8-style negative invariant: real-user contexts NEVER carry the system-identity flag.

## v3 envtest test annotation

`internal/resolvers/restactions/api/dispatcher_refilter_envtest_test.go` gets a top-of-file annotation explaining that it tests `RefilterRESTAction` via `dispatcherSimulator` and does NOT exercise the real handler. Points readers to the three v4 envtests above. Per spec §9 Q-RBACC-V4-IMPL-4 the v3 simulator test is KEPT as a fast HIT-path regression.

## Hard rules respected (per spec §11)

1. NEVER write `result.Raw` to an HTTP response from the dispatcher MISS path. — Enforced; renamed to `cacheBody`; SECURITY comment at the assignment site.
2. NEVER set `WithSystemIdentity` on a real-user ctx. — Single setter site (`MakeL1Refresher`'s closure); negative test asserts the invariant.
3. NEVER cache widget bodies that transitively depend on UAF-protected restactions. — Skip-write gate at `widgets.go:264`.
4. NO commit/tag/push beyond the branch. — This is the deliverable.
5. Push only to `braghettos/snowplow`. — Confirmed via `git remote -v`.
6. NO `--no-verify`. — All commits via the standard signed (or unsigned, per local config) commit path.
7. NO Phase 2 aggregates / no snowplow-clientconfig secret / no Fix-3c. — Out of scope per spec §11.10.
8. The 8-step rollout is a deploy-time concern; this PR ships code + tests. — No deploys triggered.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` — green except pre-existing `TestIteratorOrderDistribution_Today` which fails identically on `37b7bce` baseline (untracked file, unrelated to v4)
- [x] §6.4 envtest — PASS on v4, FAIL on v3-equivalent (proven by reverting Fix-2b)
- [x] §6.5 envtest (build-tag `envtest`) — PASS on v4 with `setup-envtest` binaries, FAIL on v3-pre-Fix-W
- [x] §6.6 envtest — PASS on v4, FAIL on v3-pre-Fix-3a
- [x] System-identity flag negative test — PASS
- [x] All existing v3 unit tests still pass (refilter_test, dispatcher_refilter_envtest, refilter_singleflight_test, refilter_bench_test)

Run commands:

```
go test -race -count=1 ./internal/handlers/dispatchers/  # §6.4 + §6.6 + flag-negative
KUBEBUILDER_ASSETS=$(setup-envtest use --bin-dir ~/.envtest -p path) \
  go test -tags envtest -count=1 ./internal/handlers/dispatchers/  # adds §6.5
```

## What this PR does NOT do

- No deploys. Cluster stays on V0/`0.25.293`.
- No tag. The fix becomes `0.25.297` AFTER review + merge — Diego's separate decision.
- No CRD changes (v3 UAF shape unchanged).
- No Helm changes (no new env vars, no new Secrets).
- No L1 wire shape change (still v3 wrapper).
- No history rewrite — 4 new commits on top of `37b7bce` (v3 PR merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)