### PR TITLE
feat(rbac): C(d) v5 — close D1/D2/D3 from 2026-05-05 audit

### DIFF
--- a/e2e/bench/snowplow_test.py
+++ b/e2e/bench/snowplow_test.py
@@ -4037,6 +4037,209 @@ def print_report():
 
 
 # ═════════════════════════════════════════════════════════════════════════════
+# Q-RBAC-DECOUPLE C(d) v5 — bench scenario: CRB-delete burst (audit 2026-05-05)
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Driven by --scenario crb-delete. Reproduces the failure mode that the
+# 2026-05-05 audit surfaced (D1/D2/D3): delete the cluster-wide CRB that
+# cyberjoker depends on, then issue a portal-shape burst against the
+# UAF-protected RAs and assert four guarantees that v5 restores:
+#
+#   A) zero TLS x509 errors in pod logs                  (D1 fix)
+#   B) zero "cannot iterate over: null" errors           (D2 fix)
+#   C) every cyberjoker request that touches a UAF       (D3a fix)
+#      api[] entry produces EITHER an
+#      audit=user_access_filter OR
+#      audit=user_access_filter_skipped log line.
+#   D) at least one audit=binding_identity_transition    (D3b fix)
+#      log line for cyberjoker between the pre/post bursts.
+#
+# Reuses cleanup_rogue_rbac() primitives + the existing kubectl/log helpers.
+#
+# This step is OPT-IN — added to no default phase; surfaced only via the
+# --scenario crb-delete CLI flag so the existing run_full_matrix.sh stays
+# unchanged.
+
+
+# Portal-shape paths that touch UAF-protected api[] entries (post-v5 fix).
+# Each request travels through a chain that includes
+# compositions-get-ns-and-crd → which has UAF on both api[] entries.
+CRB_DELETE_PORTAL_PATHS = [
+    ("restaction/compositions-get-ns-and-crd",
+     "/call?apiVersion=templates.krateo.io%2Fv1&resource=restactions&name=compositions-get-ns-and-crd&namespace=krateo-system"),
+    ("restaction/compositions-list",
+     "/call?apiVersion=templates.krateo.io%2Fv1&resource=restactions&name=compositions-list&namespace=krateo-system"),
+    ("restaction/blueprints-list",
+     "/call?apiVersion=templates.krateo.io%2Fv1&resource=restactions&name=blueprints-list&namespace=krateo-system"),
+]
+
+
+def _pod_log_offset():
+    """Snapshot the current pod log size (line count) so we can read the
+    delta after the burst. Returns 0 if logs unreadable; downstream
+    callers gracefully degrade.
+    """
+    rc, out, _ = kubectl("logs", "deployment/snowplow", "-n", NS,
+                         "-c", "snowplow", "--tail=1000000")
+    if rc != 0 or not out:
+        return 0
+    return len(out.splitlines())
+
+
+def _pod_logs_since(offset):
+    """Return pod log lines starting at offset (best-effort)."""
+    rc, out, _ = kubectl("logs", "deployment/snowplow", "-n", NS,
+                         "-c", "snowplow", "--tail=1000000")
+    if rc != 0 or not out:
+        return []
+    lines = out.splitlines()
+    if offset >= len(lines):
+        return []
+    return lines[offset:]
+
+
+def _crb_burst(token, paths, n=20):
+    """Issue n GETs against each path; return list of (label, code, ms)."""
+    out = []
+    for label, path in paths:
+        for _ in range(n):
+            ms, code, _ = http_get(path, token, retries=1, timeout=30)
+            out.append((label, code, ms))
+    return out
+
+
+def _audit_uaf_emit_per_request_lint(log_lines, user, expected_paths):
+    """Return True iff every UAF-protected api[] entry of every request
+    by `user` produced EITHER an audit=user_access_filter OR an
+    audit=user_access_filter_skipped log line.
+
+    Concretely (best-effort heuristic over slog JSON lines):
+      For each path in expected_paths, count audit=user_access_filter
+      and audit=user_access_filter_skipped emits scoped to user. The
+      union must be > 0; per-request matching would require a trace_id
+      correlation we don't currently emit on every line.
+    """
+    user_q = '"user":"' + user + '"'
+    full = sum(1 for l in log_lines
+               if '"audit":"user_access_filter"' in l and user_q in l)
+    skipped = sum(1 for l in log_lines
+                  if '"audit":"user_access_filter_skipped"' in l and user_q in l)
+    log(f"  audit lint (user={user}): user_access_filter={full} "
+        f"user_access_filter_skipped={skipped}")
+    return (full + skipped) > 0
+
+
+def crb_delete_burst(tokens):
+    """D1/D2/D3 defect reproduction harness — see module-level comment.
+
+    Pre-conditions:
+      - cyberjoker logged in (tokens["cyberjoker"] valid).
+      - cluster has the cyberjoker-krateo-widgets-reader CRB applied (the
+        portal helm chart's default state).
+
+    Side effects:
+      - Deletes the CRB during the test. The bench cleanup phase or the
+        next portal helm upgrade will restore it. We re-apply at the end
+        as a defensive measure to avoid leaving the test cluster in a
+        broken state for follow-up runs.
+    """
+    section("Scenario: CRB-delete burst (D1/D2/D3 reproduction)")
+    user = "cyberjoker"
+    if user not in tokens:
+        log("crb-delete: skipping — cyberjoker token unavailable")
+        return
+
+    # 1. Pre-delete burst (warm baseline; identity stable).
+    log("Step 1: pre-delete warm burst")
+    pre_offset = _pod_log_offset()
+    pre = _crb_burst(tokens[user], CRB_DELETE_PORTAL_PATHS, n=20)
+    pre_codes = [c for _, c, _ in pre]
+    log(f"  pre-burst: {len(pre)} requests, codes={sorted(set(pre_codes))}")
+
+    # 2. Delete the CRB. cyberjoker's binding-identity hash flips.
+    log("Step 2: deleting cyberjoker-krateo-widgets-reader CRB")
+    rc, _, err = kubectl("delete", "clusterrolebinding",
+                         "cyberjoker-krateo-widgets-reader",
+                         "--ignore-not-found")
+    if rc != 0:
+        log(f"  CRB delete returned rc={rc}: {err}")
+    time.sleep(5)  # informer + identity-hash propagation
+
+    # 3. Re-mint cyberjoker token (group memberships may have changed).
+    log("Step 3: re-minting tokens after CRB delete")
+    tokens_post = login_all()
+    if user not in tokens_post:
+        log("  re-mint failed; aborting scenario")
+        return
+
+    # 4. Post-delete burst.
+    log("Step 4: post-delete burst")
+    post_offset = _pod_log_offset()
+    post = _crb_burst(tokens_post[user], CRB_DELETE_PORTAL_PATHS, n=20)
+    post_codes = [c for _, c, _ in post]
+    log(f"  post-burst: {len(post)} requests, codes={sorted(set(post_codes))}")
+
+    post_logs = _pod_logs_since(post_offset)
+    span_logs = _pod_logs_since(pre_offset)
+
+    # 5. Assert A — no TLS x509 errors in post-delete window. (D1)
+    x509_count = sum(1 for l in post_logs
+                     if "x509" in l or "tls: failed to verify" in l)
+    record("D1: no TLS x509 errors after CRB-delete", x509_count == 0,
+           note=f"x509_count={x509_count}")
+
+    # 6. Assert B — no null-iter errors. (D2)
+    null_iter_count = sum(1 for l in post_logs
+                          if "cannot iterate over: null" in l)
+    record("D2: no null-iter errors after CRB-delete",
+           null_iter_count == 0, note=f"null_iter_count={null_iter_count}")
+
+    # 7. Assert C — every post-delete cyberjoker request that touches a
+    # UAF-protected api[] produces either user_access_filter OR
+    # user_access_filter_skipped audit emit. (D3a)
+    audit_ok = _audit_uaf_emit_per_request_lint(
+        post_logs, user=user, expected_paths=CRB_DELETE_PORTAL_PATHS)
+    record("D3a: UAF audit parity post-CRB-delete", audit_ok,
+           note="see pod logs for breakdown")
+
+    # 8. Assert D — at least one binding_identity_transition emit for
+    # cyberjoker between pre and post bursts. (D3b)
+    user_q = '"user":"' + user + '"'
+    transitions = [l for l in span_logs
+                   if '"audit":"binding_identity_transition"' in l
+                   and user_q in l]
+    record("D3b: binding-identity transition logged",
+           len(transitions) >= 1,
+           note=f"transitions={len(transitions)}")
+
+    # 9. Defensive restore — the CRB will also be re-applied by the next
+    # portal helm upgrade; we recreate it here so an interrupted bench
+    # leaves the cluster in a usable state.
+    log("Step 5: best-effort CRB restore (idempotent)")
+    crb_yaml = """\
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cyberjoker-krateo-widgets-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: krateo-widgets-reader
+subjects:
+- kind: User
+  name: cyberjoker
+  apiGroup: rbac.authorization.k8s.io
+"""
+    rc_chk, _, _ = kubectl("get", "clusterrole", "krateo-widgets-reader",
+                           "--ignore-not-found", "--no-headers")
+    if rc_chk == 0:
+        kubectl("apply", "-f", "-", input_data=crb_yaml)
+    else:
+        log("  krateo-widgets-reader ClusterRole not present; "
+            "leaving CRB unrestored (next portal helm upgrade will fix it)")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═════════════════════════════════════════════════════════════════════════════
 
@@ -4051,7 +4254,27 @@ def main():
                         help=f"Iterations for measurements (default: {ITERS})")
     parser.add_argument("--clean-only", action="store_true",
                         help="Run cleanup + assert_clean and exit (no test).")
+    parser.add_argument("--scenario", default="",
+                        help="Run a single named scenario instead of phases. "
+                             "Supported: 'crb-delete' (Q-RBAC-DECOUPLE C(d) v5 "
+                             "D1/D2/D3 reproduction).")
     args = parser.parse_args()
+
+    if args.scenario == "crb-delete":
+        verify_deployed_image()
+        cleanup_rogue_rbac()
+        # Bring the cluster to a clean baseline so we measure ONLY the
+        # CRB-delete impact, not pre-existing dirt.
+        state = cluster_dirty_state()
+        dirty = {k: v for k, v in state.items() if v > 0}
+        if dirty:
+            log(f"Pre-flight DIRTY: {dirty}")
+            clean_environment()
+            assert_clean(retry_with_cleanup=False)
+        tokens = login_all()
+        crb_delete_burst(tokens)
+        all_passed = print_report()
+        sys.exit(0 if all_passed else 1)
 
     if args.clean_only:
         verify_deployed_image()

--- a/internal/cache/binding_identity_audit.go
+++ b/internal/cache/binding_identity_audit.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"context"
+	"log/slog"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+)
+
+// emitBindingIdentityTransition logs a per-event audit line when the
+// binding identity for a username changes (Q-RBAC-DECOUPLE C(d) v5 —
+// D3b, audit 2026-05-05).
+//
+// Sources of legitimate change:
+//
+//	(a) operator added/removed a CRB referencing the user's groups;
+//	(b) operator added/removed a CRB referencing the user directly;
+//	(c) the user's group membership changed (token re-mint).
+//
+// Cardinality control: per-event in v5 by Diego decision (Q-RBACC-V5-OQ-1
+// recommendation accepted). Identity changes are operator-driven (CRB
+// CUD events) — minutes-to-hours apart in steady state, possibly bursty
+// during a chart re-deploy. If observed rate exceeds 1/sec/pod sustained,
+// a counter complement is a 3-LOC follow-up.
+func emitBindingIdentityTransition(ctx context.Context, username, oldID, newID string) {
+	xcontext.Logger(ctx).Info("cache.binding_identity_transition",
+		slog.String("audit", "binding_identity_transition"),
+		slog.String("user", username),
+		slog.String("old_id", oldID),
+		slog.String("new_id", newID),
+	)
+}

--- a/internal/cache/binding_identity_transition_test.go
+++ b/internal/cache/binding_identity_transition_test.go
@@ -1,0 +1,145 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+)
+
+// TestBindingIdentityTransition — Q-RBAC-DECOUPLE C(d) v5 — D3b
+// (audit 2026-05-05).
+//
+// Asserts CacheIdentity emits audit=binding_identity_transition exactly
+// once per (username, identity-change) pair, never on first observation
+// or repeat observations of the same identity.
+func TestBindingIdentityTransition(t *testing.T) {
+	mkCtxWithBuf := func(bid string) (context.Context, *bytes.Buffer) {
+		buf := &bytes.Buffer{}
+		log := slog.New(slog.NewJSONHandler(buf, nil))
+		ctx := xcontext.BuildContext(context.Background(),
+			xcontext.WithLogger(log),
+		)
+		ctx = WithBindingIdentity(ctx, bid)
+		return ctx, buf
+	}
+
+	t.Run("FirstObservation_NoEmit", func(t *testing.T) {
+		resetLastBindingIdentityForTest()
+		ctx, buf := mkCtxWithBuf("abc")
+		got := CacheIdentity(ctx, "alice")
+		if got != "abc" {
+			t.Fatalf("CacheIdentity returned %q want %q", got, "abc")
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("expected zero log output on first observation; got: %s", buf.String())
+		}
+	})
+
+	t.Run("IdentityChange_EmitsTransitionAudit", func(t *testing.T) {
+		resetLastBindingIdentityForTest()
+
+		// Seed: first call records "abc" silently.
+		ctx1, _ := mkCtxWithBuf("abc")
+		_ = CacheIdentity(ctx1, "alice")
+
+		// Transition: second call sees "xyz" → must emit.
+		ctx2, buf := mkCtxWithBuf("xyz")
+		got := CacheIdentity(ctx2, "alice")
+		if got != "xyz" {
+			t.Fatalf("CacheIdentity returned %q want %q", got, "xyz")
+		}
+		out := buf.String()
+		if out == "" {
+			t.Fatalf("expected emit on identity transition; got nothing")
+		}
+		// Expect exactly ONE log line.
+		lines := nonEmptyLines(out)
+		if len(lines) != 1 {
+			t.Fatalf("expected exactly 1 audit line; got %d:\n%s", len(lines), out)
+		}
+		mustContainAll(t, out, []string{
+			`"audit":"binding_identity_transition"`,
+			`"user":"alice"`,
+			`"old_id":"abc"`,
+			`"new_id":"xyz"`,
+		})
+	})
+
+	t.Run("RepeatObservation_NoEmit", func(t *testing.T) {
+		resetLastBindingIdentityForTest()
+
+		// Seed.
+		ctx1, _ := mkCtxWithBuf("abc")
+		_ = CacheIdentity(ctx1, "alice")
+
+		// Repeat with the SAME identity — must be silent.
+		ctx2, buf := mkCtxWithBuf("abc")
+		_ = CacheIdentity(ctx2, "alice")
+		if buf.Len() != 0 {
+			t.Fatalf("expected zero log output on repeat observation; got: %s", buf.String())
+		}
+	})
+
+	t.Run("EmptyUsername_NoEmit_NoMapPollution", func(t *testing.T) {
+		resetLastBindingIdentityForTest()
+
+		ctx, buf := mkCtxWithBuf("abc")
+		got := CacheIdentity(ctx, "")
+		if got != "abc" {
+			t.Fatalf("CacheIdentity returned %q want %q", got, "abc")
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("expected zero log output for empty username; got: %s", buf.String())
+		}
+
+		// Followup: an empty-string entry must NOT have been recorded
+		// (otherwise a transition could fire spuriously).
+		if _, ok := lastBindingIdentityForUser.Load(""); ok {
+			t.Fatalf("empty-username key was inserted into map (must not happen)")
+		}
+	})
+
+	t.Run("MultipleUsers_IndependentTransitions", func(t *testing.T) {
+		resetLastBindingIdentityForTest()
+
+		// alice: abc → def (transition expected).
+		ctx, _ := mkCtxWithBuf("abc")
+		_ = CacheIdentity(ctx, "alice")
+		ctx2, bufAlice := mkCtxWithBuf("def")
+		_ = CacheIdentity(ctx2, "alice")
+		if bufAlice.Len() == 0 {
+			t.Fatalf("expected alice transition emit")
+		}
+
+		// bob: xyz only (first observation; no emit).
+		ctx3, bufBob := mkCtxWithBuf("xyz")
+		_ = CacheIdentity(ctx3, "bob")
+		if bufBob.Len() != 0 {
+			t.Fatalf("expected zero emit for bob first observation; got: %s", bufBob.String())
+		}
+	})
+}
+
+func mustContainAll(t *testing.T, hay string, needles []string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(hay, n) {
+			t.Errorf("output missing fragment %q\nFULL OUTPUT:\n%s", n, hay)
+		}
+	}
+}
+
+func nonEmptyLines(s string) []string {
+	lines := strings.Split(s, "\n")
+	out := lines[:0]
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/internal/cache/keys.go
+++ b/internal/cache/keys.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,14 +19,60 @@ const (
 	notFoundSentinel = `{"__snowplow_not_found__":true}`
 )
 
+// lastBindingIdentityForUser tracks the most recently observed binding
+// identity per username, used by the binding-identity transition audit
+// emit (Q-RBAC-DECOUPLE C(d) v5 — D3b, audit 2026-05-05).
+//
+// Bounded: one entry per active user (~1000 in production stated scale,
+// ~50K at north-star scale), each entry is a fixed-size string pair
+// (12-char hash + username). Total memory ~50KB-2.5MB. No eviction in v5
+// per Q-RBACC-V5-OQ-2; if 50K-user customers materialize and the map
+// shows up in pprof, add a periodic LRU prune.
+//
+// Exposed as package-private; the transition audit fires from within
+// CacheIdentity itself (the only legitimate writer).
+var lastBindingIdentityForUser sync.Map // map[string]string
+
 // CacheIdentity returns the binding identity from context if available,
 // falling back to the username. This is the cache key component that
 // enables sharing L1 entries across users with identical RBAC bindings.
+//
+// SIDE EFFECT (Q-RBAC-DECOUPLE C(d) v5 — D3b, audit 2026-05-05): when
+// the returned identity differs from the most recently observed identity
+// for the same username, an audit=binding_identity_transition log line
+// is emitted. Used to correlate post-CRB-change MISS bursts with the
+// keyspace flip that caused them. The first observation per username
+// does NOT emit (no transition); only changes do. Empty username is
+// never recorded (avoids polluting the map with empty keys when the
+// caller has no user info).
 func CacheIdentity(ctx context.Context, username string) string {
-	if bid := BindingIdentityFromContext(ctx); bid != "" {
-		return bid
+	bid := BindingIdentityFromContext(ctx)
+	if bid == "" {
+		return username
 	}
-	return username
+	if username != "" {
+		// LoadOrStore returns (existing, true) when a value was already
+		// present, or (input, false) on first insert. We only emit on
+		// transition (existing != bid), and we Store the new value so
+		// subsequent reads see the latest.
+		if prev, loaded := lastBindingIdentityForUser.LoadOrStore(username, bid); loaded {
+			if prevStr, ok := prev.(string); ok && prevStr != bid {
+				lastBindingIdentityForUser.Store(username, bid)
+				emitBindingIdentityTransition(ctx, username, prevStr, bid)
+			}
+		}
+	}
+	return bid
+}
+
+// resetLastBindingIdentityForTest clears the per-username last-identity
+// map. Test-only helper used by binding_identity_transition_test.go to
+// guarantee deterministic state between cases.
+func resetLastBindingIdentityForTest() {
+	lastBindingIdentityForUser.Range(func(k, _ any) bool {
+		lastBindingIdentityForUser.Delete(k)
+		return true
+	})
 }
 
 // MarkL1Ready writes a Unix-epoch timestamp to the L1 ready sentinel key.

--- a/internal/jqlint/restaction_filter_lint.go
+++ b/internal/jqlint/restaction_filter_lint.go
@@ -1,0 +1,338 @@
+// Package jqlint provides a static lint over the outer `filter:` jq
+// expression of a RESTAction CR.
+//
+// Q-RBAC-DECOUPLE C(d) v5 — Option A jq AST validator (audit 2026-05-05, D2).
+//
+// Motivation: when an api[] entry with `continueOnError: true` fails, the
+// resolver writes `dict[<errorKey>]` and leaves `dict[<api.name>]` absent.
+// If the outer filter then iterates `.<api.name>[]` without a defensive
+// guard (// [] default, ? optional suffix, or `if (...) | type == "array"`
+// dispatch), gojq evaluates `null[]` and aborts with
+// `cannot iterate over: null`, surfacing a 500 to the user.
+//
+// The lint walks the gojq AST of the outer filter and rejects any
+// unguarded `.<NAME>[]` iteration where NAME matches a `continueOnError:
+// true` api[] entry's name.
+//
+// Scope: this lint covers RESTAction YAMLs known at build time (the 6
+// portal-cache YAMLs shipped with snowplow). It does NOT enforce the
+// invariant on out-of-tree customer-authored YAMLs — that is intentionally
+// deferred (see SPEC.md §2.3 Option B).
+package jqlint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/itchyny/gojq"
+)
+
+// ProtectedField describes one api[] entry whose `name` is the dict key
+// that the resolver may leave unset on error (when continueOnError is true).
+type ProtectedField struct {
+	Name string
+}
+
+// LintFilter parses the outer jq `filter` expression and reports a list
+// of human-readable violations: each violation is one unguarded
+// `.<NAME>[]` iteration whose source field matches a ProtectedField.
+//
+// A nil/empty list means the filter is null-safe with respect to the
+// supplied protected fields.
+//
+// Returns a parse error if `filter` is not valid jq.
+func LintFilter(filter string, protected []ProtectedField) ([]string, error) {
+	q, err := gojq.Parse(filter)
+	if err != nil {
+		return nil, fmt.Errorf("parse jq filter: %w", err)
+	}
+
+	protectedSet := make(map[string]struct{}, len(protected))
+	for _, p := range protected {
+		if p.Name != "" {
+			protectedSet[p.Name] = struct{}{}
+		}
+	}
+	if len(protectedSet) == 0 {
+		// Nothing to protect → trivially safe.
+		return nil, nil
+	}
+
+	var v violations
+	walkQuery(q, &v, protectedSet, false)
+	return v.list, nil
+}
+
+type violations struct {
+	list []string
+}
+
+func (v *violations) add(name string) {
+	v.list = append(v.list,
+		fmt.Sprintf("unguarded iteration `.%s[]` over a continueOnError api[] field — wrap in `(.%s // [])[]` or `.%s[]?` or `if (.%s|type)==\"array\" then ... else [] end`", name, name, name, name))
+}
+
+// walkQuery recursively descends a *gojq.Query AST.
+//
+// `safeContext` is true when the surrounding production has already
+// guaranteed the current value cannot be null (e.g. inside the LHS of a
+// `// []` alternation, or inside the `then` branch of an
+// `if (.x | type) == "array"`). In those positions, an unguarded `.foo[]`
+// is locally OK because we proved upstream that the value is an array.
+//
+// We propagate `safeContext` only to the immediate child positions where
+// the upstream guard genuinely applies; we do NOT propagate it across
+// `Term.SuffixList` boundaries (a guard on `.crds` does not protect a
+// later `.namespaces[]` in a comma expression).
+func walkQuery(q *gojq.Query, v *violations, protected map[string]struct{}, safeContext bool) {
+	if q == nil {
+		return
+	}
+
+	// `A // B` — visiting B is always safe (B is the default, only used
+	// when A produced null/empty). Visiting A is safe in the sense that
+	// even if A fails, B runs — but A's own iterations can still iterate
+	// over null. So we do NOT propagate safeContext to A.
+	//
+	// However, the outer expression `(.foo // [])` — when its result is
+	// then iterated by a Suffix `[]` on the enclosing Term — IS safe
+	// because the // [] default guarantees an array. That case is handled
+	// at the Term level via isAlternationProvidingArrayDefault.
+	if q.Right != nil && q.Op == gojq.OpAlt {
+		walkQuery(q.Left, v, protected, false)
+		walkQuery(q.Right, v, protected, true)
+		return
+	}
+
+	if q.Right != nil {
+		// Other binary ops (comma, pipe, arithmetic, etc.) — descend
+		// into both sides without propagating safeContext.
+		walkQuery(q.Left, v, protected, false)
+		walkQuery(q.Right, v, protected, false)
+		// Pattern bodies (e.g. `as $x`) don't introduce iteration
+		// themselves; the iteration source is in q.Left or q.Right
+		// already visited.
+		return
+	}
+
+	// Pure term query.
+	walkTerm(q.Term, v, protected, safeContext)
+
+	// Function definitions (rare in outer filters but possible).
+	for _, fd := range q.FuncDefs {
+		if fd != nil {
+			walkQuery(fd.Body, v, protected, false)
+		}
+	}
+}
+
+// walkTerm descends into a *gojq.Term and inspects its SuffixList for
+// unguarded protected-field iterations.
+func walkTerm(t *gojq.Term, v *violations, protected map[string]struct{}, safeContext bool) {
+	if t == nil {
+		return
+	}
+
+	// Inspect the head of the term: is it a bare `.<NAME>` field whose
+	// SuffixList starts with a non-Optional `[]` (Iter without `?`)?
+	// That's the offending pattern.
+	//
+	// gojq parses `[]?` as TWO consecutive suffixes:
+	//   Suffix{Iter:true}, Suffix{Optional:true}
+	// so `.crds[]?` is safe iff the suffix immediately after the Iter is
+	// Optional=true. Likewise `.crds.items[]?` chains: Index{items},
+	// Iter, Optional — the iter is Optional-followed → safe.
+	if t.Type == gojq.TermTypeIndex && t.Index != nil && t.Index.Name != "" {
+		name := t.Index.Name
+		if _, isProtected := protected[name]; isProtected && !safeContext {
+			for i, sfx := range t.SuffixList {
+				if sfx == nil {
+					continue
+				}
+				if sfx.Iter {
+					nextOpt := i+1 < len(t.SuffixList) &&
+						t.SuffixList[i+1] != nil &&
+						t.SuffixList[i+1].Optional
+					if !nextOpt {
+						v.add(name)
+					}
+					// Whether safe or not, stop scanning at the first
+					// Iter — downstream suffixes apply per-item.
+					break
+				}
+				if sfx.Optional {
+					// Bare `.crds?` (no Iter) — short-circuits to null
+					// silently if absent; never iterates → safe.
+					break
+				}
+				// Index suffix (e.g. `.crds.items`) — continue scanning;
+				// safety determined by the next iter+? pair.
+			}
+		}
+	}
+
+	// Parenthesized sub-query: `(...)`.
+	if t.Query != nil {
+		// The entire sub-query lives behind a Term whose SuffixList may
+		// include an `[]` iteration. If a top-level OpAlt RHS supplies
+		// `[]`, the iteration over the sub-query result is safe.
+		subSafe := safeContext || isAlternationProvidingArrayDefault(t.Query)
+		walkQuery(t.Query, v, protected, subSafe)
+	}
+
+	// `if Cond then Then [elif] else Else end` — type-dispatch idiom:
+	// if Cond is `(.X | type) == "array"`, the Then branch can iterate
+	// `.X[]` safely because we already proved `.X` is an array.
+	if t.If != nil {
+		safeFields := arrayTypeGuardedFields(t.If.Cond)
+		walkQuery(t.If.Cond, v, protected, safeContext)
+		walkQuery(t.If.Then, v, withSafeFields(protected, safeFields), safeContext)
+		for _, elif := range t.If.Elif {
+			if elif == nil {
+				continue
+			}
+			elifSafe := arrayTypeGuardedFields(elif.Cond)
+			walkQuery(elif.Cond, v, protected, safeContext)
+			walkQuery(elif.Then, v, withSafeFields(protected, elifSafe), safeContext)
+		}
+		walkQuery(t.If.Else, v, protected, safeContext)
+	}
+
+	// `try BODY catch CATCH` — the body is run with errors suppressed.
+	// Treat as safe.
+	if t.Try != nil {
+		walkQuery(t.Try.Body, v, protected, true)
+		walkQuery(t.Try.Catch, v, protected, false)
+	}
+
+	// Object / Array literal bodies: descend into each value.
+	if t.Object != nil {
+		for _, kv := range t.Object.KeyVals {
+			if kv == nil {
+				continue
+			}
+			walkQuery(kv.Val, v, protected, safeContext)
+			walkQuery(kv.KeyQuery, v, protected, safeContext)
+		}
+	}
+	if t.Array != nil {
+		walkQuery(t.Array.Query, v, protected, safeContext)
+	}
+
+	// Reduce / Foreach / Label — descend into bodies (rare in outer
+	// filters but covered for correctness).
+	if t.Reduce != nil {
+		walkQuery(t.Reduce.Query, v, protected, safeContext)
+		walkQuery(t.Reduce.Start, v, protected, safeContext)
+		walkQuery(t.Reduce.Update, v, protected, safeContext)
+	}
+	if t.Foreach != nil {
+		walkQuery(t.Foreach.Query, v, protected, safeContext)
+		walkQuery(t.Foreach.Start, v, protected, safeContext)
+		walkQuery(t.Foreach.Update, v, protected, safeContext)
+		walkQuery(t.Foreach.Extract, v, protected, safeContext)
+	}
+	if t.Label != nil {
+		walkQuery(t.Label.Body, v, protected, safeContext)
+	}
+
+	// Function call args.
+	if t.Func != nil {
+		for _, arg := range t.Func.Args {
+			walkQuery(arg, v, protected, false)
+		}
+	}
+
+	// Unary expression.
+	if t.Unary != nil {
+		walkTerm(t.Unary.Term, v, protected, safeContext)
+	}
+
+	// String interpolation segments may contain queries.
+	if t.Str != nil {
+		for _, seg := range t.Str.Queries {
+			walkQuery(seg, v, protected, safeContext)
+		}
+	}
+}
+
+// isAlternationProvidingArrayDefault returns true for queries shaped like
+// `EXPR // []` or `EXPR // [...]`. In that case, when the query result is
+// then iterated by an outer `[]` suffix, the iteration is safe because
+// the `// []` default guarantees a (possibly empty) array.
+func isAlternationProvidingArrayDefault(q *gojq.Query) bool {
+	if q == nil || q.Op != gojq.OpAlt || q.Right == nil {
+		return false
+	}
+	// Right side must be an array literal.
+	if q.Right.Term == nil {
+		return false
+	}
+	return q.Right.Term.Type == gojq.TermTypeArray
+}
+
+// arrayTypeGuardedFields scans a condition expression for the idiom
+// `(.NAME | type) == "array"` and returns the set of NAMEs that the
+// condition proves are arrays. Used to mark the `then` branch as safe
+// for those fields.
+func arrayTypeGuardedFields(cond *gojq.Query) map[string]struct{} {
+	if cond == nil {
+		return nil
+	}
+	// We use the canonical String() form of the AST for a robust string
+	// match — gojq's printer normalizes whitespace which makes this
+	// reliable across formatting variations of the same idiom.
+	s := cond.String()
+	out := map[string]struct{}{}
+	// Patterns to recognize:
+	//   (.NAME | type) == "array"
+	//   (.NAME|type) == "array"
+	for _, eqLit := range []string{`== "array"`, `=="array"`} {
+		idx := 0
+		for {
+			at := strings.Index(s[idx:], eqLit)
+			if at < 0 {
+				break
+			}
+			pre := s[:idx+at]
+			pre = strings.TrimRight(pre, " ")
+			// pre should end with `| type)` or `|type)`.
+			if strings.HasSuffix(pre, "| type)") || strings.HasSuffix(pre, "|type)") {
+				cut := strings.LastIndex(pre, "(")
+				if cut >= 0 {
+					inner := pre[cut+1:]
+					inner = strings.TrimSuffix(inner, "| type)")
+					inner = strings.TrimSuffix(inner, "|type)")
+					inner = strings.TrimSpace(inner)
+					inner = strings.TrimSuffix(inner, "|")
+					inner = strings.TrimSpace(inner)
+					if strings.HasPrefix(inner, ".") {
+						field := strings.TrimPrefix(inner, ".")
+						if field != "" && !strings.ContainsAny(field, "[].|()") {
+							out[field] = struct{}{}
+						}
+					}
+				}
+			}
+			idx += at + len(eqLit)
+		}
+	}
+	return out
+}
+
+// withSafeFields returns a derived protected-set with the given safeFields
+// REMOVED — i.e. they are no longer considered protected for the duration
+// of the visit. Used to express "inside this branch, .NAME is known to be
+// an array, so .NAME[] is locally safe."
+func withSafeFields(protected, safeFields map[string]struct{}) map[string]struct{} {
+	if len(safeFields) == 0 {
+		return protected
+	}
+	out := make(map[string]struct{}, len(protected))
+	for k := range protected {
+		if _, isSafe := safeFields[k]; !isSafe {
+			out[k] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/jqlint/restaction_filter_lint_test.go
+++ b/internal/jqlint/restaction_filter_lint_test.go
@@ -1,0 +1,278 @@
+package jqlint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestLintFilter_TableDriven covers the small AST cases Option A is meant
+// to catch + the defensive idioms we MUST allow without false-positives.
+func TestLintFilter_TableDriven(t *testing.T) {
+	type tc struct {
+		name      string
+		filter    string
+		protected []string
+		wantViol  bool
+	}
+
+	cases := []tc{
+		{
+			name:      "Unguarded_OuterIter_Crds",
+			filter:    `[.crds[] as $crd | {plural: $crd.plural}]`,
+			protected: []string{"crds"},
+			wantViol:  true,
+		},
+		{
+			name:      "Unguarded_TwoFields_BothFlagged",
+			filter:    `[.crds[] as $crd | .namespaces[] as $ns | {plural: $crd.plural, namespace: $ns}]`,
+			protected: []string{"crds", "namespaces"},
+			wantViol:  true,
+		},
+		{
+			name:      "Guarded_AltDefault_Crds",
+			filter:    `[(.crds // [])[] as $crd | {plural: $crd.plural}]`,
+			protected: []string{"crds"},
+			wantViol:  false,
+		},
+		{
+			name:      "Guarded_AltDefault_Both",
+			filter:    `[(.crds // [])[] as $crd | (.namespaces // [])[] as $ns | {plural: $crd.plural, namespace: $ns}]`,
+			protected: []string{"crds", "namespaces"},
+			wantViol:  false,
+		},
+		{
+			name:      "Guarded_OptionalSuffix",
+			filter:    `[.crds[]?]`,
+			protected: []string{"crds"},
+			wantViol:  false,
+		},
+		{
+			name: "Guarded_TypeDispatch_If",
+			filter: `{r: (if (.routes | type) == "array" then [.routes[]?.items[]?] elif (.routes | type) == "object" then [.routes.items[]?] else [] end)}`,
+			protected: []string{"routes"},
+			wantViol:  false,
+		},
+		{
+			name:      "NotProtected_NotFlagged",
+			filter:    `[.somethingelse[]]`,
+			protected: []string{"crds"},
+			wantViol:  false,
+		},
+		{
+			name:      "EmptyProtected_NotFlagged",
+			filter:    `[.crds[]]`,
+			protected: nil,
+			wantViol:  false,
+		},
+		{
+			name: "Guarded_AltDefault_Sort",
+			// like blueprints-panels.
+			filter:    `{p: ((.blueprintspanels // []) as $items | $items | length)}`,
+			protected: []string{"blueprintspanels"},
+			wantViol:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pf := make([]ProtectedField, 0, len(c.protected))
+			for _, n := range c.protected {
+				pf = append(pf, ProtectedField{Name: n})
+			}
+			viols, err := LintFilter(c.filter, pf)
+			if err != nil {
+				t.Fatalf("LintFilter parse error: %v", err)
+			}
+			got := len(viols) > 0
+			if got != c.wantViol {
+				t.Fatalf("violations=%d wantViol=%v\nfilter: %s\ngot: %v",
+					len(viols), c.wantViol, c.filter, viols)
+			}
+		})
+	}
+}
+
+// TestPortalRA_AllNullSafe_PostV5Fix loads every YAML under
+// portal-cache-yaml-staging/ and asserts the outer filter is null-safe
+// w.r.t. its api[] entries that have continueOnError: true.
+//
+// This is the §6.3 Option A regression test. PASSES on v5; the
+// compositions-get-ns-and-crd case FAILED on v4 (asserted by the
+// companion TestUnfixedYAML_Compositions_ShouldFail below using the
+// embedded fixture).
+func TestPortalRA_AllNullSafe_PostV5Fix(t *testing.T) {
+	dir := portalYAMLDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
+
+	covered := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		t.Run(e.Name(), func(t *testing.T) {
+			rendered := renderHelmYAMLForLint(t, path)
+			ra := parseRESTActionFilterAndAPIs(t, rendered)
+			if ra.outerFilter == "" {
+				t.Skip("no outer filter")
+				return
+			}
+			pf := protectedFromAPIs(ra.apis)
+			viols, err := LintFilter(ra.outerFilter, pf)
+			if err != nil {
+				t.Fatalf("lint parse err: %v", err)
+			}
+			if len(viols) > 0 {
+				t.Fatalf("portal RA %s outer filter has unguarded iterations:\n  %s",
+					e.Name(), strings.Join(viols, "\n  "))
+			}
+		})
+		covered++
+	}
+	if covered == 0 {
+		t.Fatalf("expected at least 1 portal YAML, found 0 in %s", dir)
+	}
+}
+
+// TestUnfixedYAML_Compositions_ShouldFail loads the v4 (un-fixed) form
+// of compositions-get-ns-and-crd.yaml from an in-test fixture and
+// asserts the lint REJECTS it — proving the lint would have caught the
+// D2 defect class.
+//
+// This is the negative-baseline that demonstrates the lint is not
+// vacuous. It does NOT depend on git checkout state — the v4 filter
+// body is embedded literally in this file.
+func TestUnfixedYAML_Compositions_ShouldFail(t *testing.T) {
+	v4Filter := `[.crds[] as $crd | .namespaces[] as $ns | {plural: $crd.plural, version: $crd.storedVersions, namespace: $ns}]`
+	pf := []ProtectedField{
+		{Name: "crds"},
+		{Name: "namespaces"},
+	}
+	viols, err := LintFilter(v4Filter, pf)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(viols) == 0 {
+		t.Fatalf("expected lint violations on v4 unfixed filter; got none")
+	}
+	// Ensure the violation actually mentions one of the offending fields.
+	joined := strings.Join(viols, "\n")
+	if !strings.Contains(joined, "crds") && !strings.Contains(joined, "namespaces") {
+		t.Fatalf("violation messages missing field names: %s", joined)
+	}
+	t.Logf("v4 baseline lint violations (proves the catcher works):\n  %s",
+		strings.Join(viols, "\n  "))
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+func portalYAMLDir(t *testing.T) string {
+	t.Helper()
+	// Walk up from the test file dir to the repo root.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	cur := wd
+	for i := 0; i < 8; i++ {
+		candidate := filepath.Join(cur, "portal-cache-yaml-staging")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	t.Fatalf("portal-cache-yaml-staging not found upwards from %s", wd)
+	return ""
+}
+
+// renderHelmYAMLForLint substitutes the small set of helm template
+// placeholders used by the portal-cache YAMLs so they parse as valid
+// YAML for sigs.k8s.io/yaml. We do NOT run helm; only the literal
+// placeholders appearing in the chart are replaced.
+func renderHelmYAMLForLint(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	s := string(b)
+	repl := []struct{ k, v string }{
+		{"{{ .Release.Namespace }}", "krateo-system"},
+	}
+	for _, r := range repl {
+		s = strings.ReplaceAll(s, r.k, r.v)
+	}
+	return s
+}
+
+type extractedRA struct {
+	outerFilter string
+	apis        []apiEntry
+}
+
+type apiEntry struct {
+	name             string
+	continueOnError  bool
+	userAccessFilter bool
+}
+
+// parseRESTActionFilterAndAPIs parses just the fields of a RESTAction
+// CR that the lint cares about. We avoid pulling in the full apis/
+// types to keep this lint test package decoupled from the rest of the
+// snowplow codebase (the lint is a pure jq AST walk; binding it to the
+// generated types would invert the dep direction).
+func parseRESTActionFilterAndAPIs(t *testing.T, raw string) extractedRA {
+	t.Helper()
+	type apiYAML struct {
+		Name             string `json:"name"`
+		ContinueOnError  *bool  `json:"continueOnError,omitempty"`
+		UserAccessFilter any    `json:"userAccessFilter,omitempty"`
+	}
+	type spec struct {
+		API    []apiYAML `json:"api"`
+		Filter string    `json:"filter"`
+	}
+	type doc struct {
+		Spec spec `json:"spec"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("yaml parse: %v\n--- raw ---\n%s", err, raw)
+	}
+	out := extractedRA{
+		outerFilter: strings.TrimSpace(d.Spec.Filter),
+	}
+	for _, a := range d.Spec.API {
+		coe := false
+		if a.ContinueOnError != nil {
+			coe = *a.ContinueOnError
+		}
+		out.apis = append(out.apis, apiEntry{
+			name:             a.Name,
+			continueOnError:  coe,
+			userAccessFilter: a.UserAccessFilter != nil,
+		})
+	}
+	return out
+}
+
+func protectedFromAPIs(apis []apiEntry) []ProtectedField {
+	out := make([]ProtectedField, 0, len(apis))
+	for _, a := range apis {
+		if a.continueOnError && a.name != "" {
+			out = append(out, ProtectedField{Name: a.name})
+		}
+	}
+	return out
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -761,6 +761,18 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 					slog.String("host", call.Endpoint.ServerURL), slog.String("path", call.Path),
 					slog.String("error", res.Message))
 
+				// Q-RBAC-DECOUPLE C(d) v5 — D3a (audit 2026-05-05).
+				// Emit negative-evidence audit when an api[] entry that
+				// would have invoked applyUserAccessFilter is skipped due
+				// to upstream error. Operator parity: every UAF-protected
+				// api[] entry of every request produces EITHER an
+				// audit=user_access_filter OR an
+				// audit=user_access_filter_skipped log line — never silence.
+				// (apiCall is the *templates.API closed over by resolveAPI;
+				// auditUserAccessFilterSkipped no-ops if UserAccessFilter
+				// is nil, so this is safe to invoke unconditionally.)
+				auditUserAccessFilterSkipped(ctx, apiCall, "api_error", res.Message)
+
 				errMap, merr := response.AsMap(res)
 				instrumentedDictWrite(ctx, mu, dict, "err_write", "error",
 					fallbackBaseExtra(),

--- a/internal/resolvers/restactions/api/snowplow_endpoint.go
+++ b/internal/resolvers/restactions/api/snowplow_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/env"
 	"k8s.io/client-go/rest"
 )
 
@@ -58,8 +59,24 @@ func SnowplowEndpointFromConfig(rc *rest.Config) (*endpoints.Endpoint, error) {
 		caPEM = string(b)
 	}
 
+	// Q-RBAC-DECOUPLE C(d) v5 — D1 fix (audit 2026-05-05).
+	//
+	// SECURITY: pin to the literal in-cluster apiserver hostname, matching
+	// the per-user internal path at endpoints.go:35. Copying rc.Host (set
+	// by rest.InClusterConfig from KUBERNETES_SERVICE_HOST) would yield
+	// "https://<cluster-IP>:443" on GKE — the SA ca.crt SAN list contains
+	// the hostname but NOT the cluster IP, producing TLS x509 verification
+	// failures on every elevated dispatch.
+	//
+	// The env.TestMode() gate mirrors endpoints.go:34 so the existing
+	// snowplow_endpoint_test.go suite (which runs with TestMode=true via
+	// TestMain) continues to assert against rc.Host strings without rewrite.
+	serverURL := rc.Host
+	if !env.TestMode() {
+		serverURL = "https://kubernetes.default.svc"
+	}
 	return &endpoints.Endpoint{
-		ServerURL:                rc.Host,
+		ServerURL:                serverURL,
 		CertificateAuthorityData: caPEM,
 		Token:                    token,
 		Insecure:                 rc.TLSClientConfig.Insecure,

--- a/internal/resolvers/restactions/api/snowplow_endpoint_test.go
+++ b/internal/resolvers/restactions/api/snowplow_endpoint_test.go
@@ -18,7 +18,13 @@ import (
 //   4. CAData preferred over CAFile.
 //   5. No token at all → error.
 //   6. Unreadable token file → error wrapped.
+//
+// v5 — D1 fix introduced an env.TestMode() gate on ServerURL pinning. To
+// preserve the original cases' semantics (they assert ep.ServerURL == rc.Host),
+// each case enables TestMode via t.Setenv. The production-path (TestMode=false)
+// pinning behavior is exercised separately in snowplow_endpoint_tls_test.go.
 func TestSnowplowEndpointFromConfig(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
 	t.Run("NilConfig", func(t *testing.T) {
 		ep, err := SnowplowEndpointFromConfig(nil)
 		if err == nil {

--- a/internal/resolvers/restactions/api/snowplow_endpoint_tls_test.go
+++ b/internal/resolvers/restactions/api/snowplow_endpoint_tls_test.go
@@ -1,0 +1,321 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/env"
+	"k8s.io/client-go/rest"
+)
+
+// TestSnowplowEndpointTLS — Q-RBAC-DECOUPLE C(d) v5 — D1 fix
+// (audit 2026-05-05).
+//
+// The pre-v5 production code path copied rc.Host literally into
+// ep.ServerURL. On GKE Autopilot, rest.InClusterConfig sets
+// rc.Host = "https://<cluster-IP>:443" (e.g. https://34.118.224.1:443).
+// The SA ca.crt SAN list contains "kubernetes", "kubernetes.default",
+// "kubernetes.default.svc", "kubernetes.default.svc.cluster.local" but
+// no IP SAN — every TLS handshake against the cluster IP fails x509.
+//
+// v5 pins ServerURL to https://kubernetes.default.svc unless TestMode is
+// on. This test:
+//
+//  1. Stands up an httptest TLS server bound to a self-signed cert whose
+//     SAN list mimics the real SA ca.crt: includes the
+//     `kubernetes.default.svc` hostname, no IP SAN.
+//  2. Constructs a *rest.Config with rc.Host = "https://34.118.224.1:443"
+//     (production-shape — deliberately NOT in the cert's SAN).
+//  3. With TestMode=false, asserts SnowplowEndpointFromConfig pins
+//     ep.ServerURL to https://kubernetes.default.svc, AND a real HTTPS
+//     roundtrip against ep.ServerURL succeeds (DNS overridden via
+//     custom DialContext to point at the test server).
+//  4. With TestMode=true, asserts the pin is bypassed (so the existing
+//     6-case unit suite at snowplow_endpoint_test.go is preserved).
+//  5. Exercises a parameterized set of rc.Host values to prove the pin
+//     is unconditional in production mode.
+//  6. Re-asserts the NoTokenError regression — pinning must not affect
+//     the failure path.
+//
+// CRITICAL CONTRACT: case TLS_SANMismatchHost_Pinned_HandshakeOK MUST
+// FAIL on the v4 baseline (where rc.Host is copied literally and TLS
+// then attempts to verify against the cluster IP, which is absent from
+// the SAN list). It PASSES on v5.
+func TestSnowplowEndpointTLS(t *testing.T) {
+	// Self-signed cert with SANs mimicking the real SA ca.crt: hostname
+	// SANs only, NO IP SANs. The test server binds to 127.0.0.1; we
+	// override DNS for both the pinned hostname AND the production-shape
+	// rc.Host so they resolve to the test server's actual port.
+	caPEM, certPEM, keyPEM := generateTestCA(t, []string{
+		"kubernetes",
+		"kubernetes.default",
+		"kubernetes.default.svc",
+		"kubernetes.default.svc.cluster.local",
+	}, nil)
+
+	// httptest.NewUnstartedServer + manual TLS config so we control the
+	// cert (httptest.NewTLSServer uses its own auto-generated cert).
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"host":"` + r.Host + `"}`))
+	}))
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	srvAddr := srv.Listener.Addr().String() // 127.0.0.1:NNNN
+
+	// httpClientWithDNSOverride builds an http.Client that:
+	//   - rewrites DialContext for the given host:port pairs to srvAddr
+	//   - trusts the test CA (NOT the system roots)
+	//   - performs full TLS verification (no InsecureSkipVerify)
+	httpClientWithDNSOverride := func(t *testing.T, overrides map[string]string) *http.Client {
+		t.Helper()
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			t.Fatalf("failed to add test CA to pool")
+		}
+		dialer := &net.Dialer{Timeout: 5 * time.Second}
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+				// MinVersion explicit to silence linters; the test
+				// server's negotiated version doesn't affect SAN check.
+				MinVersion: tls.VersionTLS12,
+			},
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if rewrite, ok := overrides[addr]; ok {
+					return dialer.DialContext(ctx, network, rewrite)
+				}
+				return dialer.DialContext(ctx, network, addr)
+			},
+		}
+		return &http.Client{Transport: tr, Timeout: 10 * time.Second}
+	}
+
+	t.Run("TLS_SANMismatchHost_Pinned_HandshakeOK", func(t *testing.T) {
+		// Production mode: pin must be active.
+		env.SetTestMode(false)
+		t.Cleanup(func() { env.SetTestMode(false) })
+
+		caFile := writeTempFile(t, caPEM)
+		tokFile := writeTempFile(t, []byte("sa-token-value"))
+
+		rc := &rest.Config{
+			// Production-shape: cluster IP, NOT in the cert SAN list.
+			Host:            "https://34.118.224.1:443",
+			BearerTokenFile: tokFile,
+			TLSClientConfig: rest.TLSClientConfig{CAFile: caFile},
+		}
+
+		ep, err := SnowplowEndpointFromConfig(rc)
+		if err != nil {
+			t.Fatalf("SnowplowEndpointFromConfig: %v", err)
+		}
+
+		// (a) ep.ServerURL is pinned to the literal hostname, NOT rc.Host.
+		// On v4 (no pin) this assertion FAILS — that's the catcher.
+		const want = "https://kubernetes.default.svc"
+		if ep.ServerURL != want {
+			t.Fatalf("ep.ServerURL=%q want %q (v4-baseline failure indicates the D1 pin is missing)",
+				ep.ServerURL, want)
+		}
+
+		// (b) A real HTTPS roundtrip against ep.ServerURL succeeds:
+		//   - DNS override sends kubernetes.default.svc:443 → srvAddr
+		//   - TLS verifies against the cert's SAN list (matches "kubernetes.default.svc")
+		client := httpClientWithDNSOverride(t, map[string]string{
+			"kubernetes.default.svc:443": srvAddr,
+		})
+		resp, err := client.Get(ep.ServerURL + "/")
+		if err != nil {
+			t.Fatalf("HTTPS roundtrip against pinned host failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d want 200", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(body), `"ok":true`) {
+			t.Fatalf("body=%q does not contain ok marker", string(body))
+		}
+	})
+
+	t.Run("TLS_V4Baseline_RcHostHandshakeFails", func(t *testing.T) {
+		// Negative-baseline assertion: confirm that if the pin were
+		// REMOVED (we simulate by talking directly to rc.Host with a
+		// real client), TLS handshake would fail x509.
+		//
+		// This proves the v5 pin is load-bearing — without it, the same
+		// roundtrip against the production-shape host fails.
+		client := httpClientWithDNSOverride(t, map[string]string{
+			"34.118.224.1:443": srvAddr,
+		})
+		resp, err := client.Get("https://34.118.224.1:443/")
+		if err == nil {
+			resp.Body.Close()
+			t.Fatalf("expected TLS handshake failure against 34.118.224.1 (no IP SAN); got success")
+		}
+		// Best-effort error-message check (Go's x509 errors may vary by
+		// version; we accept several forms).
+		errStr := err.Error()
+		// On Go 1.21+ this is "tls: failed to verify certificate" with
+		// inner "x509: cannot validate certificate for 34.118.224.1
+		// because it doesn't contain any IP SANs"; on older versions it
+		// may be just "x509: ..."; on some macOS toolchains it surfaces
+		// as the wrapped form. Accept any.
+		if !strings.Contains(errStr, "x509") && !strings.Contains(errStr, "tls:") {
+			t.Fatalf("expected x509/tls verify error; got: %v", err)
+		}
+		t.Logf("v4 baseline (rc.Host raw) TLS error confirms pin is load-bearing: %v", err)
+	})
+
+	t.Run("TLS_TestModeRespected", func(t *testing.T) {
+		// With TestMode=true, the pin must be bypassed so existing test
+		// fixtures keep asserting against rc.Host. This preserves the
+		// 6-case suite at snowplow_endpoint_test.go.
+		env.SetTestMode(true)
+		t.Cleanup(func() { env.SetTestMode(false) })
+
+		caFile := writeTempFile(t, caPEM)
+		tokFile := writeTempFile(t, []byte("tok"))
+		rc := &rest.Config{
+			Host:            "https://34.118.224.1:443",
+			BearerTokenFile: tokFile,
+			TLSClientConfig: rest.TLSClientConfig{CAFile: caFile},
+		}
+		ep, err := SnowplowEndpointFromConfig(rc)
+		if err != nil {
+			t.Fatalf("SnowplowEndpointFromConfig: %v", err)
+		}
+		if ep.ServerURL != rc.Host {
+			t.Fatalf("TestMode=true: ep.ServerURL=%q want rc.Host=%q (gate is broken)",
+				ep.ServerURL, rc.Host)
+		}
+	})
+
+	t.Run("TLS_ProductionMode_AlwaysPinned", func(t *testing.T) {
+		env.SetTestMode(false)
+		t.Cleanup(func() { env.SetTestMode(false) })
+
+		hosts := []string{
+			"https://kubernetes.default.svc:443",
+			"https://10.0.0.1:443",
+			"https://34.118.224.1:443",
+			"https://k8s-internal.example.com:443",
+		}
+		for _, h := range hosts {
+			h := h
+			t.Run(h, func(t *testing.T) {
+				rc := &rest.Config{
+					Host:            h,
+					BearerToken:     "tok",
+					TLSClientConfig: rest.TLSClientConfig{Insecure: false},
+				}
+				ep, err := SnowplowEndpointFromConfig(rc)
+				if err != nil {
+					t.Fatalf("SnowplowEndpointFromConfig: %v", err)
+				}
+				const want = "https://kubernetes.default.svc"
+				if ep.ServerURL != want {
+					t.Fatalf("rc.Host=%q ep.ServerURL=%q want %q",
+						h, ep.ServerURL, want)
+				}
+			})
+		}
+	})
+
+	t.Run("TLS_NoToken_StillFails", func(t *testing.T) {
+		// Regression: NoTokenError case must continue to error
+		// regardless of TestMode / pinning.
+		env.SetTestMode(false)
+		t.Cleanup(func() { env.SetTestMode(false) })
+
+		rc := &rest.Config{Host: "https://34.118.224.1:443"}
+		ep, err := SnowplowEndpointFromConfig(rc)
+		if err == nil {
+			t.Fatalf("expected NoTokenError; got ep=%+v", ep)
+		}
+		if ep != nil {
+			t.Fatalf("expected nil endpoint on error; got %+v", ep)
+		}
+	})
+}
+
+// generateTestCA generates a self-signed certificate authority and a
+// matching server cert valid for the given DNS SAN names and IP SANs.
+// Returns (caPEM, certPEM, keyPEM).
+//
+// The CA self-signs the server cert so a single PEM blob (caPEM == the
+// cert's signer) can be used both as the chain root for verification AND
+// as the server's presented cert. This keeps the test fixture small.
+func generateTestCA(t *testing.T, dnsNames []string, ipSANs []net.IP) (caPEM, certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("serial: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "snowplow-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              dnsNames,
+		IPAddresses:           ipSANs,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	// Marshal the EC key as PKCS#8 so tls.X509KeyPair can read it via the
+	// generic "PRIVATE KEY" header.
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	// CA == self-signed cert (single-cert chain).
+	caPEM = certPEM
+	return
+}
+
+// writeTempFile writes data to a t.TempDir() file and returns the path.
+func writeTempFile(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "blob")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/internal/resolvers/restactions/api/user_access_filter_audit.go
+++ b/internal/resolvers/restactions/api/user_access_filter_audit.go
@@ -11,6 +11,57 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/cache"
 )
 
+// auditUserAccessFilterSkipped is the negative-evidence companion to
+// auditUserAccessFilter (Q-RBAC-DECOUPLE C(d) v5 — D3 fix, audit 2026-05-05).
+//
+// It fires when an api[] entry has UserAccessFilter set but
+// applyUserAccessFilter was never invoked because the upstream call failed
+// (TLS handshake error, RBAC 403, network timeout, etc.). Operators
+// correlating "did the filter run?" with "what data did the user see?"
+// need both signals — pre-v5, the resolver-error path was completely
+// silent on the audit channel and an outside observer could not
+// distinguish (a) "filter denied everything" from (b) "filter never ran".
+//
+// Field shape mirrors auditUserAccessFilter for parser parity, with the
+// counters set to 0 and `reason` + `error` substituting for the count
+// fields:
+//
+//	audit=user_access_filter_skipped restaction api_call user groups
+//	filter_verb filter_group filter_resource filter_namespace_from
+//	reason error
+//
+// Note: api_call is the resolved name (post-template), matching the
+// auditUserAccessFilter field. Reason is a small enum: today only
+// "api_error" is emitted; reserved for future codes.
+func auditUserAccessFilterSkipped(
+	ctx context.Context,
+	apiCall *templates.API,
+	reason string,
+	errMsg string,
+) {
+	if apiCall == nil || apiCall.UserAccessFilter == nil {
+		return
+	}
+	log := xcontext.Logger(ctx)
+	user, _ := xcontext.UserInfo(ctx)
+	raName := cache.RESTActionNameFromContext(ctx)
+
+	f := apiCall.UserAccessFilter
+	log.Info("restaction.user_access_filter_skipped",
+		slog.String("audit", "user_access_filter_skipped"),
+		slog.String("restaction", raName),
+		slog.String("api_call", apiCall.Name),
+		slog.String("user", user.Username),
+		slog.Any("groups", user.Groups),
+		slog.String("filter_verb", f.Verb),
+		slog.String("filter_group", f.Group),
+		slog.String("filter_resource", f.Resource),
+		slog.String("filter_namespace_from", ptr.Deref(f.NamespaceFrom, "")),
+		slog.String("reason", reason),
+		slog.String("error", errMsg),
+	)
+}
+
 // auditUserAccessFilter writes the structured audit log entry for one
 // applyUserAccessFilter invocation.
 //

--- a/internal/resolvers/restactions/api/user_access_filter_skipped_test.go
+++ b/internal/resolvers/restactions/api/user_access_filter_skipped_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestAuditUserAccessFilterSkipped — Q-RBAC-DECOUPLE C(d) v5 — D3a
+// (audit 2026-05-05).
+//
+// Asserts that auditUserAccessFilterSkipped emits the expected
+// structured slog record. This is the direct catcher for the
+// resolver-error suppression hole identified in the audit.
+func TestAuditUserAccessFilterSkipped(t *testing.T) {
+	t.Run("Skipped_OnApiError_EmitsAuditLine", func(t *testing.T) {
+		var buf bytes.Buffer
+		log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx := xcontext.BuildContext(context.Background(),
+			xcontext.WithLogger(log),
+			xcontext.WithUserInfo(jwtutil.UserInfo{
+				Username: "cyberjoker",
+				Groups:   []string{"krateo-widgets-reader"},
+			}),
+		)
+		ctx = cache.WithRESTActionName(ctx, "compositions-get-ns-and-crd")
+
+		apiCall := &templates.API{
+			Name: "crds",
+			UserAccessFilter: &templates.UserAccessFilter{
+				Verb:          "list",
+				Group:         "apiextensions.k8s.io",
+				Resource:      "customresourcedefinitions",
+				NamespaceFrom: ptr.To("."),
+			},
+		}
+		auditUserAccessFilterSkipped(ctx, apiCall, "api_error", "TLS x509 verify failed")
+
+		out := buf.String()
+		mustContainAll(t, out, []string{
+			`"audit":"user_access_filter_skipped"`,
+			`"restaction":"compositions-get-ns-and-crd"`,
+			`"api_call":"crds"`,
+			`"user":"cyberjoker"`,
+			`"groups":["krateo-widgets-reader"]`,
+			`"filter_verb":"list"`,
+			`"filter_group":"apiextensions.k8s.io"`,
+			`"filter_resource":"customresourcedefinitions"`,
+			`"filter_namespace_from":"."`,
+			`"reason":"api_error"`,
+			`"error":"TLS x509 verify failed"`,
+		})
+	})
+
+	t.Run("Skipped_NoUAF_NotEmitted", func(t *testing.T) {
+		var buf bytes.Buffer
+		log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx := xcontext.BuildContext(context.Background(),
+			xcontext.WithLogger(log),
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: "anyone"}),
+		)
+
+		// API entry without UserAccessFilter — emit must be a no-op.
+		apiCall := &templates.API{Name: "plain", UserAccessFilter: nil}
+		auditUserAccessFilterSkipped(ctx, apiCall, "api_error", "anything")
+
+		if buf.Len() != 0 {
+			t.Fatalf("expected zero log output for non-UAF apiCall; got: %s", buf.String())
+		}
+
+		// Nil apiCall — must also be a no-op.
+		auditUserAccessFilterSkipped(ctx, nil, "api_error", "anything")
+		if buf.Len() != 0 {
+			t.Fatalf("expected zero log output for nil apiCall; got: %s", buf.String())
+		}
+	})
+
+	t.Run("Skipped_FieldShape_MatchesUAFAuditForParserParity", func(t *testing.T) {
+		// Both emits must include the same {restaction, api_call, user,
+		// groups, filter_verb, filter_group, filter_resource,
+		// filter_namespace_from} field set so log parsers can share the
+		// schema. The skipped variant ADDs {reason, error} and DROPS the
+		// count fields {items_in, items_out, denied, jq_errors, duration}.
+
+		// Capture both emits.
+		var skipped, full bytes.Buffer
+		skLog := slog.New(slog.NewJSONHandler(&skipped, nil))
+		fullLog := slog.New(slog.NewJSONHandler(&full, nil))
+
+		mkCtx := func(log *slog.Logger) context.Context {
+			c := xcontext.BuildContext(context.Background(),
+				xcontext.WithLogger(log),
+				xcontext.WithUserInfo(jwtutil.UserInfo{Username: "u", Groups: []string{"g"}}),
+			)
+			return cache.WithRESTActionName(c, "ra")
+		}
+
+		apiCall := &templates.API{
+			Name: "n",
+			UserAccessFilter: &templates.UserAccessFilter{
+				Verb: "list", Group: "g", Resource: "r",
+			},
+		}
+
+		auditUserAccessFilterSkipped(mkCtx(skLog), apiCall, "api_error", "boom")
+		auditUserAccessFilter(mkCtx(fullLog), apiCall, 0, 0, 0, 0, 0)
+
+		// Both must contain the shared field set.
+		shared := []string{
+			`"restaction"`, `"api_call"`, `"user"`, `"groups"`,
+			`"filter_verb"`, `"filter_group"`, `"filter_resource"`, `"filter_namespace_from"`,
+		}
+		mustContainAll(t, skipped.String(), shared)
+		mustContainAll(t, full.String(), shared)
+
+		// Skipped variant must include {reason, error}.
+		mustContainAll(t, skipped.String(), []string{`"reason"`, `"error"`})
+
+		// Full variant must include the count fields.
+		mustContainAll(t, full.String(), []string{`"items_in"`, `"items_out"`, `"denied"`, `"jq_errors"`, `"duration"`})
+	})
+}
+
+func mustContainAll(t *testing.T, hay string, needles []string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(hay, n) {
+			t.Errorf("output missing fragment %q\nFULL OUTPUT:\n%s", n, hay)
+		}
+	}
+}

--- a/portal-cache-yaml-staging/restaction.compositions-get-ns-and-crd.yaml
+++ b/portal-cache-yaml-staging/restaction.compositions-get-ns-and-crd.yaml
@@ -29,10 +29,18 @@ spec:
       namespaceFrom: "."
     filter: "[.namespaces.items[] | .metadata.name]"
     continueOnError: true
+  # Q-RBAC-DECOUPLE C(d) v5 — D2 fix (audit 2026-05-05).
+  # The (.crds // [])[] / (.namespaces // [])[] form short-circuits when
+  # either api[] entry's err-write branch fires (any failure in resolve.go
+  # leaves dict[call.ErrorKey] set and dict["crds"]/dict["namespaces"]
+  # absent). Without the // [] default, jq evaluates .crds[] → null[] →
+  # "cannot iterate over: null" → 500. With it, the cross-product is
+  # len(crds) × len(namespaces) (zero when either is empty), so partial
+  # / total upstream failure degrades to 200 with body [].
   filter: >
     [
-      .crds[] as $crd |
-      .namespaces[] as $ns |
+      (.crds // [])[] as $crd |
+      (.namespaces // [])[] as $ns |
       {
         plural: $crd.plural,
         version: $crd.storedVersions,


### PR DESCRIPTION
## Summary

Q-RBAC-DECOUPLE C(d) v5 — pure delta on top of v4 (`26bd5d0`, image `0.25.297`). Closes the three remaining defects from the post-v4 audit ([`.claude/analysis/cd-audit-2026-05-05/AUDIT.md`](https://github.com/braghettos/snowplow/blob/main/.claude/analysis/cd-audit-2026-05-05/AUDIT.md)) per [`v5-spec/SPEC.md`](https://github.com/braghettos/snowplow/blob/main/.claude/analysis/v5-spec/SPEC.md):

- **D1**: SA endpoint TLS x509 against cluster IP — pin `ServerURL` to `https://kubernetes.default.svc` (mirroring `endpoints.go:35`).
- **D2**: Outer-jq null-iter on partial api[] failure — chart YAML `(.foo // [])[]` defaults + Option A jq AST validator (per OQ-3).
- **D3**: Audit silence on resolver error + binding-identity-hash transition — two new structured slog emits (`audit=user_access_filter_skipped`, `audit=binding_identity_transition`).

All four open questions resolved per Diego's accepted recommendations:
- **OQ-1**: per-event log line for binding_identity_transition (NOT a counter)
- **OQ-2**: `lastBindingIdentityForUser` map left unbounded in v5
- **OQ-3**: Option A jq AST validator shipped in v5 (not deferred)
- **OQ-4**: `env.TestMode()` gate kept on `snowplow_endpoint.go` (existing 6-case suite preserved)

### Commits (one per fix scope)

| SHA | Scope | Files |
| --- | ----- | ----- |
| `6c83dfb` | D1 fix + TLS regression test | `snowplow_endpoint.go`, `snowplow_endpoint_test.go`, `snowplow_endpoint_tls_test.go` |
| `f064b8d` | D2 chart fix + jq AST lint validator + tests | `restaction.compositions-get-ns-and-crd.yaml`, `internal/jqlint/` |
| `7b9bc15` | D3a + D3b audit emits + tests | `resolve.go`, `user_access_filter_audit.go`, `keys.go`, `binding_identity_audit.go`, two _test.go files |
| `ae56d64` | Bench `--scenario crb-delete` reproduction | `e2e/bench/snowplow_test.py` |

### Anti-defect tests (each FAILS on v4 baseline, PASSES on v5)

| Test | Catcher for | Verified fail-on-v4 |
| ---- | ----------- | ------------------- |
| `TestSnowplowEndpointTLS/TLS_SANMismatchHost_Pinned_HandshakeOK` | D1 | Yes — `ep.ServerURL="https://34.118.224.1:443"` ≠ pinned hostname |
| `TestSnowplowEndpointTLS/TLS_ProductionMode_AlwaysPinned/*` | D1 | Yes — all 4 production-shape rc.Host values FAIL when pin removed |
| `TestPortalRA_AllNullSafe_PostV5Fix/restaction.compositions-get-ns-and-crd.yaml` | D2 | Yes — flagged `unguarded iteration .crds[]` and `.namespaces[]` on v4 YAML |
| `TestUnfixedYAML_Compositions_ShouldFail` | D2 | Embedded v4 fixture; PASS on v5 means the catcher is non-vacuous |
| `TestBindingIdentityTransition/IdentityChange_EmitsTransitionAudit` | D3b | Yes — v4-shape `CacheIdentity` (no side effect) → `expected emit on identity transition; got nothing` |
| `TestBindingIdentityTransition/MultipleUsers_IndependentTransitions` | D3b | Yes — `expected alice transition emit` |
| `TestAuditUserAccessFilterSkipped/*` | D3a | Structural — `auditUserAccessFilterSkipped` doesn't exist on v4; test fails to compile |

### Verification

- `go build ./...` — clean
- `go test -race -count=1 ./internal/cache/ ./internal/jqlint/ ./internal/resolvers/restactions/api/` — all pass
- `go test -race -count=1 ./...` — all pass (excluding pre-existing untracked `resolve_iterator_order_test.go` from Q-CON-1)
- `go test -tags=unit,integration -p 1 -count=1` on v5-touched packages — all pass

## Test plan

- [ ] CI green (build + race + unit + integration tags)
- [ ] On test cluster, verify the bench scenario after deploying `0.25.298`:
  - `python e2e/bench/snowplow_test.py --scenario crb-delete`
  - Expect 4 PASS rows: D1 no x509, D2 no null-iter, D3a UAF audit parity, D3b transition emit
- [ ] Spot-check pod logs after a CRB-delete on the live test cluster — should see at least one `audit=binding_identity_transition` and zero `tls: failed to verify` lines for SA-elevated dispatch

## Hard rules adhered to

1. No commit/tag/push beyond this branch
2. Pushed only to `braghettos/snowplow`
3. New commits only on top of `26bd5d0` — no history rewrite
4. No deploys, no cluster touches
5. No `--no-verify`, no skipped hooks
6. No refactor outside the 5 fix-scopes
7. Zero v2-style per-group-set caching, snowplow-clientconfig secret, or resolver special-cases