### PR TITLE
feat(rbac): C(d) v6 — Path B SA dispatch via client-go

### DIFF
--- a/e2e/bench/snowplow_test.py
+++ b/e2e/bench/snowplow_test.py
@@ -4115,7 +4115,8 @@ def print_report():
 
 
 # ═════════════════════════════════════════════════════════════════════════════
-# Q-RBAC-DECOUPLE C(d) v5 — bench scenario: CRB-delete burst (audit 2026-05-05)
+# Q-RBAC-DECOUPLE C(d) v5/v6 — bench scenario: CRB-delete burst
+# (audit 2026-05-05; v6 update 2026-05-04)
 # ═════════════════════════════════════════════════════════════════════════════
 #
 # Driven by --scenario crb-delete. Reproduces the failure mode that the
@@ -4131,6 +4132,15 @@ def print_report():
 #      audit=user_access_filter_skipped log line.
 #   D) at least one audit=binding_identity_transition    (D3b fix)
 #      log line for cyberjoker between the pre/post bursts.
+#
+# Q-RBAC-DECOUPLE C(d) v6 — Path B (audit 2026-05-04): assertion A is
+# strengthened from "v5 host-pin closes the host-string half" to "v6
+# Path B closes the bug class structurally" — the SA dispatch now goes
+# through client-go's dynamic client (which uses rest.TLSConfigFor with
+# correct CA loading) instead of httpcall.Do (which hit plumbing's
+# tlsConfigFor early-return on token-auth+CA endpoints, the v5 D1
+# residual). On v6, assertion A passes because the failing TLS code
+# path is no longer reachable from the SA dispatch.
 #
 # Reuses cleanup_rogue_rbac() primitives + the existing kubectl/log helpers.
 #

--- a/internal/cache/context.go
+++ b/internal/cache/context.go
@@ -261,6 +261,41 @@ func SnowplowEndpointFromContext(ctx context.Context) func() (any, error) {
 	return fn
 }
 
+// snowplowK8sKey carries the snowplow-SA dynamic K8s client used by the
+// SA-elevated dispatch path (Q-RBAC-DECOUPLE C(d) v6 — Path B). The value
+// type is intentionally `any` to avoid a cache→internal/dynamic import
+// cycle; the api package re-asserts it back to dynamic.Client.
+//
+// This is a sibling to snowplowEndpointKey: the same set of context
+// installation sites (main.go withCache, prewarm, l1_refresh) install
+// both, so every dispatch path that previously had access to the SA
+// endpoint now also has access to a client-go-backed dynamic client. The
+// SA branch of api.Resolve uses this client INSTEAD of httpcall.Do +
+// SnowplowEndpoint, structurally bypassing plumbing's tlsConfigFor bug
+// that silently drops CertificateAuthorityData on token-auth endpoints
+// (the v5 D1 defect that v6 closes).
+type snowplowK8sKey struct{}
+
+// WithSnowplowK8s returns a context carrying the snowplow-SA dynamic K8s
+// client. The value type is `any` to avoid an import cycle; the api
+// package type-asserts it back to dynamic.Client.
+//
+// nil-safe: if c is nil, returns ctx unchanged so callers don't have to
+// guard the install site.
+func WithSnowplowK8s(ctx context.Context, c any) context.Context {
+	if c == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, snowplowK8sKey{}, c)
+}
+
+// SnowplowK8sFromContext extracts the snowplow-SA dynamic K8s client from
+// ctx as `any`. Returns nil when not set. Callers re-assert to the
+// concrete dynamic.Client type.
+func SnowplowK8sFromContext(ctx context.Context) any {
+	return ctx.Value(snowplowK8sKey{})
+}
+
 type restActionNameKey struct{}
 
 // WithRESTActionName returns a context carrying the RESTAction name being

--- a/internal/handlers/dispatchers/dispatchers.go
+++ b/internal/handlers/dispatchers/dispatchers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 )
 
 // All returns the GVR → http.Handler dispatcher table used by handlers.Call.
@@ -11,9 +12,13 @@ import (
 // snowplowEndpointFn is the elevated-call provider plumbed to the
 // restactions dispatcher (Q-RBAC-DECOUPLE C(d)). May be nil; that disables
 // userAccessFilter dispatch with an explicit log line at resolve time.
-func All(snowplowEndpointFn func() (*endpoints.Endpoint, error)) map[string]http.Handler {
+//
+// Q-RBAC-DECOUPLE C(d) v6 — Path B: snowplowK8sClient is the in-cluster
+// dynamic client used for SA dispatch (replaces httpcall.Do for the SA
+// branch). Either field is sufficient to enable UAF dispatch.
+func All(snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) map[string]http.Handler {
 	return map[string]http.Handler{
-		"restactions.templates.krateo.io": RESTAction(snowplowEndpointFn),
+		"restactions.templates.krateo.io": RESTAction(snowplowEndpointFn, snowplowK8sClient),
 		"widgets.templates.krateo.io":     Widgets(),
 	}
 }

--- a/internal/handlers/dispatchers/l1_refresh.go
+++ b/internal/handlers/dispatchers/l1_refresh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/krateoplatformops/plumbing/jwtutil"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/objects"
 	"github.com/krateoplatformops/snowplow/internal/observability"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/l1cache"
@@ -47,7 +48,11 @@ type userContext struct {
 // snowplowEndpointFn is the elevated-call provider for api[] entries that
 // declare userAccessFilter (Q-RBAC-DECOUPLE C(d)). May be nil; that disables
 // elevated dispatch during background refresh.
-func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error)) cache.L1RefreshFunc {
+//
+// Q-RBAC-DECOUPLE C(d) v6 — Path B: snowplowK8sClient is the in-cluster
+// dynamic K8s client used for SA dispatch, replacing httpcall.Do for the
+// elevated path. Threaded down to ResolveRESTActionBackground.
+func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) cache.L1RefreshFunc {
 	// Q-RBAC-DECOUPLE C(d) v3 — L1 refresh runs under the snowplow
 	// ServiceAccount identity exclusively. Per §4.6 of the v3 spec:
 	// "L1 refresh CAN run under the snowplow SA identity (no userconfig
@@ -130,6 +135,12 @@ func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rb
 				return snowplowEndpointFn()
 			})
 		}
+		// Q-RBAC-DECOUPLE C(d) v6 — Path B: install the dynamic K8s
+		// client so the SA dispatch in api.Resolve uses client-go
+		// directly, bypassing plumbing's TLS handshake bug.
+		if snowplowK8sClient != nil {
+			ctx = cache.WithSnowplowK8s(ctx, snowplowK8sClient)
+		}
 
 		ctx, span := l1RefreshTracer.Start(ctx, "l1.refresh",
 			trace.WithAttributes(
@@ -170,7 +181,7 @@ func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rb
 			}
 
 			for _, k := range keys {
-				ok, cascade := refreshSingleL1(ctx, c, uc.user, uc.endpoint, uc.accessToken, k.info, k.raw, authnNS, snowplowEndpointFn)
+				ok, cascade := refreshSingleL1(ctx, c, uc.user, uc.endpoint, uc.accessToken, k.info, k.raw, authnNS, snowplowEndpointFn, snowplowK8sClient)
 				if ok {
 					totalRefreshed++
 					allCascade = append(allCascade, cascade...)
@@ -222,8 +233,8 @@ func MakeL1Refresher(c cache.Cache, rc *rest.Config, authnNS, signKey string, rb
 //
 // snowplowEndpointFn is forwarded to ResolveRESTActionBackground so api[]
 // entries that declare userAccessFilter resolve correctly during the
-// background refresh path.
-func refreshSingleL1(ctx context.Context, c cache.Cache, user jwtutil.UserInfo, ep endpoints.Endpoint, accessToken string, info cache.ResolvedKeyInfo, rawKey, authnNS string, snowplowEndpointFn func() (*endpoints.Endpoint, error)) (bool, []string) {
+// background refresh path. snowplowK8sClient is the v6 Path B equivalent.
+func refreshSingleL1(ctx context.Context, c cache.Cache, user jwtutil.UserInfo, ep endpoints.Endpoint, accessToken string, info cache.ResolvedKeyInfo, rawKey, authnNS string, snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) (bool, []string) {
 	rctx := xcontext.BuildContext(ctx,
 		xcontext.WithUserConfig(ep),
 		xcontext.WithUserInfo(user),
@@ -249,6 +260,11 @@ func refreshSingleL1(ctx context.Context, c cache.Cache, user jwtutil.UserInfo, 
 	// directly into ctx for parity (see MakeL1Refresher.refreshFn).
 	if snEp := cache.SnowplowEndpointFromContext(ctx); snEp != nil {
 		rctx = cache.WithSnowplowEndpoint(rctx, snEp)
+	}
+	// Q-RBAC-DECOUPLE C(d) v6 — Path B: propagate the dynamic K8s client
+	// so nested SA dispatches use client-go (no plumbing TLS bug).
+	if snK8s := cache.SnowplowK8sFromContext(ctx); snK8s != nil {
+		rctx = cache.WithSnowplowK8s(rctx, snK8s)
 	}
 
 	// Propagate DirtySet so nested resolution bypasses stale API result cache.
@@ -327,7 +343,7 @@ func refreshSingleL1(ctx context.Context, c cache.Cache, user jwtutil.UserInfo, 
 		return true, nil
 
 	case info.GVR.Group == templatesGroup && info.GVR.Resource == restactionResource:
-		_, err := ResolveRESTActionBackground(rctx, c, got.Unstructured.Object, rawKey, authnNS, info.PerPage, info.Page, snowplowEndpointFn)
+		_, err := ResolveRESTActionBackground(rctx, c, got.Unstructured.Object, rawKey, authnNS, info.PerPage, info.Page, snowplowEndpointFn, snowplowK8sClient)
 		if err != nil {
 			slog.Info("refreshSingleL1: RESTAction resolve failed",
 				slog.String("key", rawKey), slog.Any("err", err))

--- a/internal/handlers/dispatchers/l1_refresh_envtest_test.go
+++ b/internal/handlers/dispatchers/l1_refresh_envtest_test.go
@@ -198,7 +198,7 @@ func TestL1Refresh_SystemIdentity_NonUAF_NoClientConfigError(t *testing.T) {
 	// system-identity check is the load-bearing v4 logic and runs
 	// independently).
 	refresh := MakeL1Refresher(c, &rest.Config{Host: upstream.URL},
-		cr.Namespace, "test-jwt-key", nil, snowplowEndpointFn)
+		cr.Namespace, "test-jwt-key", nil, snowplowEndpointFn, nil)
 
 	// Drive the refresh. Pass our test's rest.Config via the v4 ctx
 	// fallback so api.Resolve's nil-RC guard finds it (production sets

--- a/internal/handlers/dispatchers/prewarm.go
+++ b/internal/handlers/dispatchers/prewarm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/krateoplatformops/plumbing/endpoints"
 	"github.com/krateoplatformops/plumbing/jwtutil"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/l1cache"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -298,8 +299,13 @@ func FilterWidgetGVRs(cfg *cache.WarmupConfig) []schema.GroupVersionResource {
 // snowplowEndpointFn is the elevated-call provider for api[] entries that
 // declare userAccessFilter. Injected into prewarm contexts so the warmup
 // path also resolves cyberjoker-class RESTActions correctly.
+//
+// Q-RBAC-DECOUPLE C(d) v6 — Path B: snowplowK8sClient is the in-cluster
+// dynamic client used for SA dispatch (replaces httpcall.Do for the
+// elevated path). Injected into the warmup ctx so prewarm-time resolution
+// also avoids the plumbing TLS bug.
 func WarmL1FromEntryPoints(ctx context.Context, c cache.Cache, rc *rest.Config,
-	authnNS, signKey string, entryPoints []cache.EntryPoint, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error)) {
+	authnNS, signKey string, entryPoints []cache.EntryPoint, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) {
 	log := slog.Default()
 	if len(entryPoints) == 0 || authnNS == "" {
 		log.Info("L1 entry-point warmup: skipped (no entry points or authn namespace)")
@@ -313,6 +319,10 @@ func WarmL1FromEntryPoints(ctx context.Context, c cache.Cache, rc *rest.Config,
 		ctx = cache.WithSnowplowEndpoint(ctx, func() (any, error) {
 			return snowplowEndpointFn()
 		})
+	}
+	// Q-RBAC-DECOUPLE C(d) v6 — Path B install for warmup ctx.
+	if snowplowK8sClient != nil {
+		ctx = cache.WithSnowplowK8s(ctx, snowplowK8sClient)
 	}
 
 	users, err := discoverUsers(ctx, rc, authnNS)

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/krateoplatformops/plumbing/env"
 	"github.com/krateoplatformops/plumbing/http/response"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/handlers/util"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/l1cache"
@@ -39,18 +40,27 @@ var restactionTracer = otel.Tracer("snowplow/dispatchers")
 // l1cache.Input.SnowplowEndpoint; pass nil when not running in-cluster
 // (userAccessFilter calls will be rejected at the resolver with an explicit
 // log line).
-func RESTAction(snowplowEndpointFn func() (*endpoints.Endpoint, error)) http.Handler {
+//
+// Q-RBAC-DECOUPLE C(d) v6 — Path B (audit 2026-05-04): snowplowK8sClient
+// is the in-cluster dynamic K8s client used for SA dispatch. Replaces
+// httpcall.Do for the SA branch, structurally avoiding plumbing's
+// tlsConfigFor TLS handshake bug. Both fields are nil-safe; the resolver
+// emits a runtime error log if neither is configured but a UAF api[]
+// entry tries to dispatch.
+func RESTAction(snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) http.Handler {
 	return &restActionHandler{
-		authnNS:          env.String("AUTHN_NAMESPACE", ""),
-		verbose:          env.True("DEBUG"),
-		snowplowEndpoint: snowplowEndpointFn,
+		authnNS:           env.String("AUTHN_NAMESPACE", ""),
+		verbose:           env.True("DEBUG"),
+		snowplowEndpoint:  snowplowEndpointFn,
+		snowplowK8sClient: snowplowK8sClient,
 	}
 }
 
 type restActionHandler struct {
-	authnNS          string
-	verbose          bool
-	snowplowEndpoint func() (*endpoints.Endpoint, error)
+	authnNS           string
+	verbose           bool
+	snowplowEndpoint  func() (*endpoints.Endpoint, error)
+	snowplowK8sClient dynamic.Client
 }
 
 var _ http.Handler = (*restActionHandler)(nil)
@@ -202,14 +212,15 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		sfCtx = context.WithoutCancel(req.Context())
 	}
 	result, resolveErr := l1cache.ResolveAndCache(sfCtx, l1cache.Input{
-		Cache:            c,
-		Obj:              got.Unstructured.Object,
-		ResolvedKey:      resolvedKey,
-		AuthnNS:          r.authnNS,
-		PerPage:          perPage,
-		Page:             page,
-		Extras:           extras,
-		SnowplowEndpoint: r.snowplowEndpoint,
+		Cache:             c,
+		Obj:               got.Unstructured.Object,
+		ResolvedKey:       resolvedKey,
+		AuthnNS:           r.authnNS,
+		PerPage:           perPage,
+		Page:              page,
+		Extras:            extras,
+		SnowplowEndpoint:  r.snowplowEndpoint,
+		SnowplowK8sClient: r.snowplowK8sClient,
 	})
 	if resolveErr != nil {
 		response.InternalError(wri, resolveErr)
@@ -306,15 +317,21 @@ func (errRefilterMissing) Error() string {
 // during background refresh (the warm cache will only contain entries
 // resolvable without elevated access). Production wiring threads it from
 // MakeL1Refresher / WarmL1FromEntryPoints.
-func ResolveRESTActionBackground(ctx context.Context, c cache.Cache, obj map[string]interface{}, resolvedKey, authnNS string, perPage, page int, snowplowEndpointFn func() (*endpoints.Endpoint, error)) ([]byte, error) {
+//
+// Q-RBAC-DECOUPLE C(d) v6 — Path B: snowplowK8sClient is the in-cluster
+// dynamic client used for SA dispatch. Either field (endpoint or k8s
+// client) is sufficient to enable UAF dispatch — typically both are
+// passed in production wiring.
+func ResolveRESTActionBackground(ctx context.Context, c cache.Cache, obj map[string]interface{}, resolvedKey, authnNS string, perPage, page int, snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) ([]byte, error) {
 	result, err := l1cache.ResolveAndCache(ctx, l1cache.Input{
-		Cache:            c,
-		Obj:              obj,
-		ResolvedKey:      resolvedKey,
-		AuthnNS:          authnNS,
-		PerPage:          perPage,
-		Page:             page,
-		SnowplowEndpoint: snowplowEndpointFn,
+		Cache:             c,
+		Obj:               obj,
+		ResolvedKey:       resolvedKey,
+		AuthnNS:           authnNS,
+		PerPage:           perPage,
+		Page:              page,
+		SnowplowEndpoint:  snowplowEndpointFn,
+		SnowplowK8sClient: snowplowK8sClient,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/handlers/dispatchers/restactions_miss_envtest_test.go
+++ b/internal/handlers/dispatchers/restactions_miss_envtest_test.go
@@ -207,7 +207,7 @@ func newMissTestEnv(t *testing.T, namespacesInUpstream []string) *missTestEnv {
 	}
 
 	authnNS := "krateo-system"
-	handler := RESTAction(snowplowEndpointFn)
+	handler := RESTAction(snowplowEndpointFn, nil)
 
 	// Per-request middleware: install ctx values that production
 	// middleware would. Reads (user, rbac) from request headers so each

--- a/internal/httpcall/do_tls_test.go
+++ b/internal/httpcall/do_tls_test.go
@@ -1,0 +1,384 @@
+// Q-RBAC-DECOUPLE C(d) v6 — TLS handshake regression test
+// (audit 2026-05-04).
+//
+// This test drives the production codepath that produced the v5 D1
+// failure (`tls: failed to verify certificate: x509: certificate signed
+// by unknown authority`) and asserts:
+//
+//  1. THE BUG IS REAL on v5 baseline: `httpcall.Do(token-auth + CA)`
+//     fails the TLS handshake against a server whose cert is signed by
+//     the CA in the endpoint's `CertificateAuthorityData`. Plumbing's
+//     `tlsConfigFor` early-returns at `if !ep.HasCertAuth()` and never
+//     wires `RootCAs`; the distroless system pool is effectively empty;
+//     verification fails. Live evidence on `0.25.298`:
+//     "Get https://kubernetes.default.svc/...: tls: failed to verify
+//     certificate: x509: certificate signed by unknown authority"
+//
+//  2. THE BUG IS ABSENT on the v6 client-go path (`Path B`): the
+//     equivalent dispatch via `dynamic.Client` from a `rest.Config`
+//     carrying the same `CAData` + `BearerToken` succeeds the TLS
+//     handshake. Client-go's `rest.TLSConfigFor` correctly consumes
+//     `CAData` regardless of whether `CertData/KeyData` are set —
+//     there's no `HasCertAuth()` early-return bug. So the same trust
+//     material that plumbing silently dropped, client-go honors.
+//
+// Test names use the `OnV5Baseline` / `OnV6` suffixes so the failure
+// messages explicitly cite which codepath the assertion is for.
+//
+// CRITICAL CONTRACT: case `TestHttpcallDo_TokenAuthWithCA_FailsOnV5Baseline`
+// MUST FAIL on a *future* fix to plumbing's `tlsConfigFor` — at which
+// point this test becomes a positive assertion that v6 is no longer
+// load-bearing. Today, both cases together prove the bug is structurally
+// bypassed by Path B even though plumbing remains buggy.
+
+package httpcall_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
+	"github.com/krateoplatformops/snowplow/internal/httpcall"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// generateTLSFixture builds a self-signed CA + server cert with SAN
+// entries DNS=["kubernetes.default.svc"] and IP=[127.0.0.1]. The DNS SAN
+// matches the production-shape SA ca.crt; the IP SAN lets the test bind
+// to localhost without needing DNS overrides at the OS level.
+//
+// Returns (caPEM, certPEM, keyPEM, *tls.Certificate-for-server).
+func generateTLSFixture(t *testing.T) (caPEM, certPEM, keyPEM []byte, srvCert tls.Certificate) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("serial: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "snowplow-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              []string{"kubernetes.default.svc", "localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	caPEM = certPEM
+	srvCert, err = tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return
+}
+
+// startTestTLSServer spins up an httptest.Server bound to a self-signed
+// cert with the SAN list above. Returns the server URL.
+func startTestTLSServer(t *testing.T, srvCert tls.Certificate, h http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(h)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{srvCert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHttpcallDo_TokenAuthWithCA_FailsOnV5Baseline asserts the v5 D1 bug
+// is still present in the unchanged `httpcall.Do` codepath: a token-auth
+// + CA endpoint cannot complete the TLS handshake against a server whose
+// cert is signed by the endpoint's CA, because plumbing's tlsConfigFor
+// silently drops CertificateAuthorityData when HasCertAuth() returns
+// false (token-auth has no client cert).
+//
+// This test is a NEGATIVE-BASELINE assertion: when this test FAILS in
+// the future (e.g. plumbing ships a fix), v6's Path B becomes
+// non-load-bearing for the SA dispatch case — that's a green-light to
+// remove the v6 plumbing entirely. Until then, this test proves Path B
+// is structurally necessary.
+//
+// The test does NOT assert a specific error string (Go's TLS error
+// messages vary across versions), only that:
+//   - the dispatch returns response.StatusFailure
+//   - the message contains "tls" or "x509" (any verification failure is
+//     evidence of the CA-drop bug)
+func TestHttpcallDo_TokenAuthWithCA_FailsOnV5Baseline(t *testing.T) {
+	caPEM, _, _, srvCert := generateTLSFixture(t)
+
+	// Server returns a small JSON body so the request would succeed if
+	// the TLS handshake passed. We never expect to reach this handler on
+	// v5 baseline — TLS fails first.
+	srv := startTestTLSServer(t, srvCert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	ep := &endpoints.Endpoint{
+		// Use the test server's actual URL (e.g. https://127.0.0.1:NNN)
+		// so DNS resolution doesn't mask the TLS-layer assertion.
+		ServerURL:                srv.URL,
+		Token:                    "test-bearer-token",
+		CertificateAuthorityData: string(caPEM),
+		Insecure:                 false,
+	}
+
+	verb := http.MethodGet
+	res := httpcall.Do(context.Background(), httpcall.RequestOptions{
+		Endpoint: ep,
+		RequestInfo: httpcall.RequestInfo{
+			Path: "/",
+			Verb: ptr.To(verb),
+		},
+	})
+
+	if res == nil {
+		t.Fatalf("expected non-nil response.Status from httpcall.Do")
+	}
+	if res.Status != response.StatusFailure {
+		t.Fatalf("v5 baseline FAILED to reproduce: expected StatusFailure (TLS handshake should fail because plumbing drops CA on token-auth), got Status=%q Code=%d Message=%q.\n"+
+			"If this test starts passing, plumbing's tlsConfigFor likely shipped a fix and v6 Path B may no longer be load-bearing for SA dispatch.",
+			res.Status, res.Code, res.Message)
+	}
+	msg := strings.ToLower(res.Message)
+	if !strings.Contains(msg, "tls") && !strings.Contains(msg, "x509") && !strings.Contains(msg, "certificate") {
+		t.Fatalf("v5 baseline reproduced a failure but not the expected TLS/x509 shape: Message=%q", res.Message)
+	}
+	t.Logf("v5 baseline reproduced: TLS handshake fails through httpcall.Do → plumbing/tlsConfigFor on token-auth+CA endpoint.\nMessage: %s", res.Message)
+}
+
+// TestHttpcallDo_TokenAuthWithCA_PoolPreserves verifies that the failure
+// is reproducible on a fresh pool entry too — guards against accidental
+// future caching of a working transport that would mask the bug.
+func TestHttpcallDo_TokenAuthWithCA_PoolPreserves(t *testing.T) {
+	caPEM, _, _, srvCert := generateTLSFixture(t)
+	srv := startTestTLSServer(t, srvCert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	ep := &endpoints.Endpoint{
+		ServerURL:                srv.URL,
+		Token:                    "tok-pool-test",
+		CertificateAuthorityData: string(caPEM),
+	}
+	verb := http.MethodGet
+	for i := 0; i < 3; i++ {
+		res := httpcall.Do(context.Background(), httpcall.RequestOptions{
+			Endpoint: ep,
+			RequestInfo: httpcall.RequestInfo{
+				Path: "/",
+				Verb: ptr.To(verb),
+			},
+		})
+		if res.Status != response.StatusFailure {
+			t.Fatalf("iteration %d: expected StatusFailure (v5 plumbing CA-drop bug), got %q", i, res.Status)
+		}
+	}
+}
+
+// TestPathBSADispatch_TokenAuthWithCA_HandshakeOK asserts the v6 Path B
+// codepath structurally bypasses the v5 D1 bug. Building a `rest.Config`
+// from the SAME materials (token + CA) that the v5 endpoint carries and
+// dispatching via `dynamic.Client` (the production v6 path) succeeds the
+// TLS handshake.
+//
+// We can't run a full `dynamic.Client.List()` against a non-K8s server
+// because the dynamic client needs to discover REST mappings first. So
+// instead we drive `rest.RESTClientFor` directly with the same rest.Config
+// — that's the layer that plumbing's tlsConfigFor was supposed to mirror,
+// and the layer that client-go's dynamic client builds on top of.
+//
+// The TLS handshake assertion fires inside `rest.HTTPClientFor` via
+// `transport.New(config)` → `transport.TLSConfigFor(config)`. If CAData
+// is loaded correctly, the test request returns either HTTP 404 (the
+// test server doesn't implement K8s API verbs) or any non-TLS error.
+// Critically: it does NOT return a TLS x509 error.
+func TestPathBSADispatch_TokenAuthWithCA_HandshakeOK(t *testing.T) {
+	caPEM, _, _, srvCert := generateTLSFixture(t)
+
+	srv := startTestTLSServer(t, srvCert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mimic apiserver-style 404 for unknown paths.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","code":404}`))
+	}))
+
+	rc := &rest.Config{
+		Host:        srv.URL,
+		BearerToken: "test-bearer-token",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: caPEM,
+		},
+	}
+
+	// rest.HTTPClientFor builds the same TLS config that dynamic.NewClient
+	// uses. If RootCAs is loaded correctly, the handshake succeeds.
+	cli, err := rest.HTTPClientFor(rc)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor failed (BUG): %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		// An error here that mentions tls/x509 means the CA pool failed
+		// to load — i.e., the v6 fix is broken. Any other error is fine.
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "x509") || strings.Contains(errStr, "tls: failed to verify") {
+			t.Fatalf("v6 Path B BROKEN: TLS handshake failed via rest.HTTPClientFor: %v", err)
+		}
+		// Other errors (timeout, server hang up) are fine for this test —
+		// the TLS handshake completed, which is what we're asserting.
+		t.Logf("non-TLS error (acceptable): %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	t.Logf("v6 Path B succeeded: TLS handshake OK, server responded with HTTP %d", resp.StatusCode)
+}
+
+// TestPathBSADispatch_DynamicClientHandshakeOK adds a stronger assertion
+// driven through `dynamic.NewClient` — the actual v6 production code
+// path used by `dispatchSAViaClientGo`. We don't expect List() to
+// succeed (no real K8s API on the test server), but we DO expect the
+// failure mode NOT to be a TLS verification error. Any client-go error
+// that surfaces means the TLS handshake completed — which is the v6
+// regression catcher.
+func TestPathBSADispatch_DynamicClientHandshakeOK(t *testing.T) {
+	caPEM, _, _, srvCert := generateTLSFixture(t)
+
+	// Server pretends to be an apiserver: respond to discovery with
+	// minimal valid shape so dynamic.Client can move past discovery.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[]}`))
+	})
+	mux.HandleFunc("/api/v1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","list"]}]}`))
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"APIGroupList","groups":[]}`))
+	})
+	mux.HandleFunc("/api/v1/namespaces", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"NamespaceList","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}`))
+	})
+
+	srv := startTestTLSServer(t, srvCert, mux)
+
+	rc := &rest.Config{
+		Host:        srv.URL,
+		BearerToken: "test-bearer-token",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: caPEM,
+		},
+	}
+
+	cli, err := dynamic.NewClient(rc)
+	if err != nil {
+		t.Fatalf("dynamic.NewClient: %v", err)
+	}
+
+	// Drive a list call. Either it succeeds (test server returns empty
+	// NamespaceList) or it fails with a non-TLS error.
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	_, listErr := cli.List(context.Background(), dynamic.Options{GVR: gvr})
+	if listErr != nil {
+		errStr := strings.ToLower(listErr.Error())
+		if strings.Contains(errStr, "x509") || strings.Contains(errStr, "tls: failed to verify") {
+			t.Fatalf("v6 Path B BROKEN: dynamic.Client.List failed TLS handshake: %v", listErr)
+		}
+		// Anything that's not a TLS error proves the handshake
+		// completed and CA was loaded correctly.
+		// API errors (e.g. 404, 500) are fine; we only catch TLS.
+		var statusErr *apierrors.StatusError
+		if errors.As(listErr, &statusErr) {
+			t.Logf("v6 Path B handshake OK; got expected non-TLS apiserver-style error: code=%d message=%s", statusErr.ErrStatus.Code, statusErr.ErrStatus.Message)
+			return
+		}
+		t.Logf("v6 Path B handshake OK; got non-TLS error (acceptable): %v", listErr)
+		return
+	}
+	t.Logf("v6 Path B succeeded end-to-end: dynamic.Client.List returned without TLS error")
+}
+
+// TestPathBSADispatch_NoCAFails asserts the negative path: removing
+// CAData causes the TLS handshake to fail. This guards against an
+// accidental `Insecure: true` regression masking missing CA wiring.
+func TestPathBSADispatch_NoCAFails(t *testing.T) {
+	_, _, _, srvCert := generateTLSFixture(t)
+
+	srv := startTestTLSServer(t, srvCert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rc := &rest.Config{
+		Host:        srv.URL,
+		BearerToken: "tok",
+		// No CAData → must fail (and must NOT be Insecure).
+		TLSClientConfig: rest.TLSClientConfig{},
+	}
+
+	cli, err := rest.HTTPClientFor(rc)
+	if err != nil {
+		// Some Go versions reject this rest.Config at construction;
+		// either way the contract is "no implicit insecure".
+		return
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
+	resp, err := cli.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("BUG: missing CAData should not allow successful HTTPS handshake against self-signed cert (security regression)")
+	}
+	t.Logf("no-CA negative case OK: %v", err)
+}
+
+// _ ensures metav1 is referenced (avoids unused import in scenarios
+// where the dynamic-client list shape changes). metav1 is the package
+// dynamic.Client.List uses to decode list options.
+var _ = metav1.ListOptions{}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/krateoplatformops/plumbing/ptr"
 	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	httpcall "github.com/krateoplatformops/snowplow/internal/httpcall"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
 	"go.opentelemetry.io/otel/attribute"
@@ -116,7 +117,31 @@ type ResolveOptions struct {
 	// with a runtime error log (the migration sequence is: ship snowplow
 	// image with this wired BEFORE migrating any RESTAction YAML to use
 	// userAccessFilter).
+	//
+	// Q-RBAC-DECOUPLE C(d) v6 — Path B (audit 2026-05-04): the SA dispatch
+	// path now goes through SnowplowK8sClient (client-go dynamic client)
+	// instead of httpcall.Do(SnowplowEndpoint). This field is retained for
+	// (a) backward compatibility with existing test fixtures that wire
+	// SnowplowEndpoint directly, and (b) defense-in-depth fallback if
+	// SnowplowK8sClient is nil at the call site (the resolver logs a
+	// rejection and skips the api entry — mirrors v5's runtime guard).
 	SnowplowEndpoint func() (*endpoints.Endpoint, error)
+
+	// SnowplowK8sClient, if non-nil, is the in-cluster dynamic K8s client
+	// used by the SA-elevated dispatch path (Q-RBAC-DECOUPLE C(d) v6 —
+	// Path B). Replaces httpcall.Do for SA dispatch, structurally avoiding
+	// plumbing's tlsConfigFor bug that silently drops
+	// CertificateAuthorityData on token-auth endpoints (the v5 D1 defect).
+	//
+	// Threaded through ResolveOptions parallel to SnowplowEndpoint by all
+	// 5 dispatch layers: main.go middleware install, dispatcher
+	// constructors, l1cache.Input, prewarm.go, l1_refresh.go. nil-fallback
+	// to cache.SnowplowK8sFromContext(ctx) is provided by the SA branch.
+	//
+	// Production wiring constructs once at startup via
+	// dynamic.NewClient(rc) where rc is rest.InClusterConfig() — the same
+	// rc that builds the SA endpoint, so the trust boundary is identical.
+	SnowplowK8sClient dynamic.Client
 }
 
 func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
@@ -264,6 +289,37 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 		if !useSystemEndpoint && apiCall.EndpointRef == nil && cache.IsSystemIdentity(ctx) {
 			useSystemEndpoint = true
 		}
+
+		// Q-RBAC-DECOUPLE C(d) v6 — Path B (audit 2026-05-04). Resolve the
+		// snowplow-SA dynamic K8s client used for SA-elevated dispatch.
+		// opts.SnowplowK8sClient (set explicitly by the dispatcher
+		// constructors) wins; otherwise fall back to the context-stored
+		// client that main.go installs once via WithSnowplowK8s. The
+		// fallback path keeps the widget→apiref→l1cache→restactions chain
+		// working without per-dispatcher threading.
+		//
+		// snowplowK8sClient is the structural fix for the v5 D1 TLS
+		// handshake failure: the SA dispatch path bypasses plumbing's
+		// tlsConfigFor (which silently drops CertificateAuthorityData on
+		// token-auth endpoints) and uses client-go's correct
+		// rest.TLSConfigFor. The runOne fallback below uses this client
+		// when useSystemEndpoint && snowplowK8sClient != nil.
+		var snowplowK8sClient dynamic.Client
+		if useSystemEndpoint {
+			snowplowK8sClient = opts.SnowplowK8sClient
+			if snowplowK8sClient == nil {
+				if v := cache.SnowplowK8sFromContext(ctx); v != nil {
+					if c, ok := v.(dynamic.Client); ok {
+						snowplowK8sClient = c
+					} else {
+						log.Warn("snowplow K8s client context value has unexpected type",
+							slog.String("name", id),
+							slog.String("type", fmt.Sprintf("%T", v)))
+					}
+				}
+			}
+		}
+
 		if useSystemEndpoint {
 			// Resolve the snowplow-SA endpoint provider. opts.SnowplowEndpoint
 			// (set explicitly by the dispatcher constructors per Q-RBACC-IMPL-7)
@@ -271,6 +327,14 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 			// main.go installs once via the withSnowplowEndpoint middleware.
 			// The fallback path keeps the widget→apiref→l1cache→restactions
 			// chain working without per-dispatcher threading.
+			//
+			// Q-RBAC-DECOUPLE C(d) v6 — Path B carries forward the v5
+			// SnowplowEndpoint resolution as a defense-in-depth fallback
+			// for the rare case where snowplowK8sClient is nil (e.g.
+			// out-of-cluster unit tests not running envtest). The
+			// resolved ep is also still consumed by the per-RESTAction
+			// debug-log site (line ~315) and by the http_fallback path
+			// when Path B is unavailable.
 			snowplowEndpointFn := opts.SnowplowEndpoint
 			if snowplowEndpointFn == nil {
 				if anyFn := cache.SnowplowEndpointFromContext(ctx); anyFn != nil {
@@ -287,18 +351,30 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 					}
 				}
 			}
-			if snowplowEndpointFn == nil {
-				log.Error("userAccessFilter set but no snowplow endpoint configured",
+			if snowplowEndpointFn == nil && snowplowK8sClient == nil {
+				log.Error("userAccessFilter set but no snowplow endpoint or K8s client configured",
 					slog.String("name", id))
 				return false
 			}
-			snEp, snErr := snowplowEndpointFn()
-			if snErr != nil || snEp == nil {
-				log.Error("failed to obtain snowplow endpoint",
-					slog.String("name", id), slog.Any("err", snErr))
-				return false
+			if snowplowEndpointFn != nil {
+				snEp, snErr := snowplowEndpointFn()
+				if snErr != nil || snEp == nil {
+					if snowplowK8sClient == nil {
+						log.Error("failed to obtain snowplow endpoint and no K8s client fallback",
+							slog.String("name", id), slog.Any("err", snErr))
+						return false
+					}
+					// Path B is available — endpoint failure is non-fatal,
+					// but log so operators see the legacy path is broken.
+					log.Warn("snowplow endpoint unavailable; falling back to client-go SA dispatch",
+						slog.String("name", id), slog.Any("err", snErr))
+				} else {
+					ep = *snEp
+				}
 			}
-			ep = *snEp
+			// If only Path B is configured (no SnowplowEndpoint), ep stays
+			// zero — the http_fallback branch below is dead code on this
+			// path (snowplowK8sClient != nil short-circuits to Path B).
 		} else {
 			var err error
 			ep, err = mapper.resolveOne(ctx, apiCall.EndpointRef)
@@ -750,6 +826,76 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 						})
 					return nil
 				}
+			}
+
+			// Q-RBAC-DECOUPLE C(d) v6 — Path B SA dispatch
+			// (audit 2026-05-04). When the api entry uses SA dispatch AND
+			// a snowplow K8s client is available, dispatch via client-go's
+			// dynamic client instead of httpcall.Do. This structurally
+			// avoids plumbing's tlsConfigFor bug that silently drops
+			// CertificateAuthorityData on token-auth endpoints (the v5 D1
+			// defect). See sa_dispatch.go for the helper + error mapping.
+			//
+			// The success path runs the same call.ResponseHandler set up
+			// above, so jsonHandlerCompute / mergeIntoDict are reused
+			// unchanged (gojq-purity-required: raw bytes from
+			// json.Marshal(*unstructured.UnstructuredList) are a fresh
+			// tree, identical wire shape to apiserver-over-HTTP).
+			//
+			// The failure path emits the same err_write audit + dict
+			// entry as httpcall, mapped via clientGoErrorToStatus so
+			// downstream log shape (response.Status fields) is stable
+			// across the v5→v6 transition.
+			if useSystemEndpoint && snowplowK8sClient != nil {
+				log.Debug("dispatching SA call via client-go (Path B)",
+					slog.String("name", id), slog.String("path", call.Path))
+				saRes := dispatchSAViaClientGo(ctx, snowplowK8sClient, call.Path)
+				if saRes.err != nil {
+					log.Error("SA dispatch via client-go failed",
+						slog.String("name", id),
+						slog.String("path", call.Path),
+						slog.String("error", saRes.err.Error()))
+					auditUserAccessFilterSkipped(ctx, apiCall, "api_error", saRes.err.Error())
+					errMap, merr := response.AsMap(saRes.status)
+					instrumentedDictWrite(ctx, mu, dict, "err_write", "error",
+						fallbackBaseExtra(),
+						func() {
+							if merr == nil && len(errMap) > 0 {
+								dict[call.ErrorKey] = errMap
+							} else if saRes.status != nil {
+								dict[call.ErrorKey] = saRes.status.Message
+							} else {
+								dict[call.ErrorKey] = saRes.err.Error()
+							}
+						})
+					return call.ContinueOnError
+				}
+				// Success: feed raw bytes through the same response
+				// handler the http_fallback path uses. ResponseHandler is
+				// the closure set up above which reads a stream; wrap
+				// raw in a NopCloser to keep the contract.
+				if call.ResponseHandler != nil {
+					if herr := call.ResponseHandler(io.NopCloser(bytes.NewReader(saRes.raw))); herr != nil {
+						log.Error("response handler failed on Path B bytes",
+							slog.String("name", id), slog.Any("err", herr))
+						auditUserAccessFilterSkipped(ctx, apiCall, "api_error", herr.Error())
+						errStatus := response.New(http.StatusInternalServerError, herr)
+						errMap, merr := response.AsMap(errStatus)
+						instrumentedDictWrite(ctx, mu, dict, "err_write", "error",
+							fallbackBaseExtra(),
+							func() {
+								if merr == nil && len(errMap) > 0 {
+									dict[call.ErrorKey] = errMap
+								} else {
+									dict[call.ErrorKey] = herr.Error()
+								}
+							})
+						return call.ContinueOnError
+					}
+				}
+				log.Debug("api successfully resolved via Path B",
+					slog.String("name", id), slog.String("path", call.Path))
+				return true
 			}
 
 			log.Debug("calling api", slog.String("name", id),

--- a/internal/resolvers/restactions/api/sa_dispatch.go
+++ b/internal/resolvers/restactions/api/sa_dispatch.go
@@ -1,0 +1,163 @@
+// Q-RBAC-DECOUPLE C(d) v6 — Path B SA dispatch via client-go (audit 2026-05-04).
+//
+// This file replaces the SA-elevated dispatch branch's reliance on
+// httpcall.Do (which goes through plumbing's tlsConfigFor and silently
+// drops CertificateAuthorityData on token-auth endpoints — the v5 D1
+// defect). Instead, we use the existing internal/dynamic.Client which is
+// built on top of k8s.io/client-go's well-tested rest.TLSConfigFor — no
+// HasCertAuth() early-return bug — so SA dispatches succeed structurally
+// without any reflection-based plumbing patch.
+//
+// The SA branch only ever targets the in-cluster K8s apiserver (proven
+// statically: CEL admission at apis/templates/v1/core.go binds UAF to the
+// SA path AND forbids non-GET, and SnowplowEndpointFromConfig pins
+// ServerURL to https://kubernetes.default.svc). So replacing the HTTP
+// transport with a typed K8s client is a pure structural simplification:
+// no functionality is lost, and the bug class around plumbing TLS handling
+// for token-auth+CA endpoints is eliminated entirely on this path.
+//
+// The byte-equivalence test in sa_dispatch_test.go drives the same K8s
+// resource through (a) httpcall.Do via SnowplowEndpointFromConfig and
+// (b) this Path B helper, asserting json.Marshal of both is byte-identical
+// modulo deterministic key ordering — guarantees the JQ filters in the 6
+// portal-cache YAMLs keep behaving identically.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// saDispatchResult is the local shape used to bridge a client-go call
+// back to the existing httpcall response-handler path. raw is the JSON
+// bytes that would have been the apiserver's HTTP response body; err is
+// non-nil iff the dispatch failed (in which case raw is nil and the
+// caller emits the err_write audit). status is the *response.Status that
+// callers need to feed response.AsMap on the failure path.
+type saDispatchResult struct {
+	raw    []byte
+	err    error
+	status *response.Status
+}
+
+// dispatchSAViaClientGo runs an SA-elevated dispatch through client-go's
+// dynamic client. Returns the JSON bytes that match what the apiserver
+// would have returned over HTTP (so the caller's existing
+// jsonHandlerCompute / mergeIntoDict path applies unchanged).
+//
+// path MUST be a K8s API path of one of the shapes:
+//   - /api/v1/<resource>                        (cluster-wide list)
+//   - /api/v1/namespaces/<ns>/<resource>        (namespaced list)
+//   - /api/v1/namespaces/<ns>/<resource>/<name> (namespaced get)
+//   - /apis/<group>/<version>/<resource>
+//   - /apis/<group>/<version>/namespaces/<ns>/<resource>
+//   - /apis/<group>/<version>/namespaces/<ns>/<resource>/<name>
+//
+// Non-K8s paths (/call?..., external-endpoint URLs) are out-of-scope:
+// the SA branch is statically guaranteed to target only K8s API paths
+// (see file-header comment) and the caller short-circuits to httpcall.Do
+// if SnowplowK8sClient is nil.
+func dispatchSAViaClientGo(ctx context.Context, client dynamic.Client, path string) saDispatchResult {
+	if client == nil {
+		return saDispatchResult{
+			err:    fmt.Errorf("nil snowplow K8s client"),
+			status: response.New(http.StatusInternalServerError, fmt.Errorf("snowplow k8s client unavailable")),
+		}
+	}
+
+	gvr, ns, name := cache.ParseK8sAPIPath(path)
+	if gvr.Resource == "" {
+		return saDispatchResult{
+			err:    fmt.Errorf("unparseable K8s API path: %q", path),
+			status: response.New(http.StatusBadRequest, fmt.Errorf("unparseable K8s API path: %q", path)),
+		}
+	}
+
+	opts := dynamic.Options{GVR: gvr, Namespace: ns}
+
+	if name == "" {
+		list, err := client.List(ctx, opts)
+		if err != nil {
+			return saDispatchResult{
+				err:    err,
+				status: clientGoErrorToStatus(err),
+			}
+		}
+		raw, merr := json.Marshal(list)
+		if merr != nil {
+			return saDispatchResult{
+				err:    fmt.Errorf("marshal UnstructuredList: %w", merr),
+				status: response.New(http.StatusInternalServerError, merr),
+			}
+		}
+		return saDispatchResult{raw: raw}
+	}
+
+	obj, err := client.Get(ctx, name, opts)
+	if err != nil {
+		return saDispatchResult{
+			err:    err,
+			status: clientGoErrorToStatus(err),
+		}
+	}
+	raw, merr := json.Marshal(obj)
+	if merr != nil {
+		return saDispatchResult{
+			err:    fmt.Errorf("marshal Unstructured: %w", merr),
+			status: response.New(http.StatusInternalServerError, merr),
+		}
+	}
+	return saDispatchResult{raw: raw}
+}
+
+// clientGoErrorToStatus maps a client-go API error to the
+// *response.Status shape expected by the err_write audit path.
+//
+// Mapping rules (by precedence):
+//  1. apierrors.StatusError carries the canonical apiserver Status — pass
+//     its embedded Code through. This handles all RBAC denials (403),
+//     not-founds (404), conflicts (409), unauthorized (401), etc.
+//  2. Network / context-cancellation / generic errors map to 500 with
+//     the err.Error() text — same shape that plumbing's RetryClient.Do
+//     would produce on a transport failure (see do.go:252).
+//
+// The audit downstream (auditUserAccessFilterSkipped + dict[call.ErrorKey])
+// receives the same response.Status keys (Code/Message/Reason) regardless
+// of which dispatch path produced the error, so log shape stability is
+// preserved across the v5→v6 transition.
+func clientGoErrorToStatus(err error) *response.Status {
+	if err == nil {
+		return response.New(http.StatusOK, nil)
+	}
+	// apierrors.StatusError exposes the apiserver-canonical reason/code.
+	// Use its Code() helper which returns the int32 HTTP-equivalent code.
+	if statusErr, ok := err.(*apierrors.StatusError); ok {
+		code := int(statusErr.ErrStatus.Code)
+		if code == 0 {
+			code = http.StatusInternalServerError
+		}
+		return response.New(code, fmt.Errorf("%s", statusErr.ErrStatus.Message))
+	}
+	// Common typed predicates — same outcome but cleaner than chained
+	// type-switches: client-go wraps several error categories in
+	// non-StatusError types (e.g., timeout, network).
+	switch {
+	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err):
+		return response.New(http.StatusGatewayTimeout, err)
+	case apierrors.IsUnauthorized(err):
+		return response.New(http.StatusUnauthorized, err)
+	case apierrors.IsForbidden(err):
+		return response.New(http.StatusForbidden, err)
+	case apierrors.IsNotFound(err):
+		return response.New(http.StatusNotFound, err)
+	}
+	return response.New(http.StatusInternalServerError, err)
+}

--- a/internal/resolvers/restactions/api/sa_dispatch_envtest_test.go
+++ b/internal/resolvers/restactions/api/sa_dispatch_envtest_test.go
@@ -1,0 +1,387 @@
+//go:build envtest
+// +build envtest
+
+// Q-RBAC-DECOUPLE C(d) v6 — Path B byte-equivalence envtest
+// (audit 2026-05-04).
+//
+// This test asserts that the v6 Path B SA dispatch (client-go dynamic
+// client → json.Marshal) produces JSON bytes that decode to the SAME
+// data structure as v5 Path A's httpcall.Do dispatch against the same
+// real K8s apiserver. The contract is "wire-shape compatible": the JQ
+// filters in the 6 portal-cache YAMLs MUST keep working unchanged
+// because they parse `{apiVersion, kind, items: [...]}` shape — and
+// both dispatch paths produce bytes with that shape.
+//
+// Why this is the load-bearing v6 regression test:
+// the v5 D1 fix (host-pin to kubernetes.default.svc) silently degraded
+// to 200-with-`[]` via D3a graceful-degradation when TLS handshake
+// failed — operators saw "no missing namespaces", but the apiserver
+// was actually never queried. v6 closes that hole structurally; this
+// test catches any future drift between Path A and Path B (e.g. a
+// future kube-client release changes UnstructuredList wire shape, or
+// a snowplow change to ParseK8sAPIPath GVR mapping).
+//
+// Build/run:
+//   export KUBEBUILDER_ASSETS=$(setup-envtest use --bin-dir ~/.envtest -p path)
+//   go test -tags envtest -timeout 5m -run TestSADispatch ./internal/resolvers/restactions/api/
+
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	plumbingendpoints "github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
+	httpcall "github.com/krateoplatformops/snowplow/internal/httpcall"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TestSADispatch_ByteEquivalence_PathA_vs_PathB asserts:
+//
+//   1. Both Path A (httpcall.Do via SnowplowEndpointFromConfig) and
+//      Path B (dispatchSAViaClientGo via dynamic.NewClient) succeed
+//      against the same envtest apiserver.
+//   2. The decoded data structures are equivalent: same `kind`, same
+//      `apiVersion`, same `items[].metadata.name` set.
+//
+// The byte-level comparison uses a normalized form (json.Unmarshal →
+// reflect.DeepEqual) because:
+//   - apiserver wire output uses `kind: NamespaceList` `apiVersion: v1`;
+//     client-go's `*unstructured.UnstructuredList` is marshaled the same
+//     way (UnstructuredList.MarshalJSON delegates to the underlying
+//     map[string]any).
+//   - field ordering between encoders may differ; what matters for the
+//     downstream JQ filters is the parsed-tree equality.
+//
+// The test deliberately picks a list verb (Namespaces) and a get verb
+// (a specific Namespace) so both code paths in dispatchSAViaClientGo
+// are exercised.
+//
+// Path A here goes through plumbing's `HasCertAuth() == true` branch
+// because envtest's rest.Config carries a client cert+key. So Path A
+// in this test is a positive baseline (working), NOT a reproduction of
+// the v5 token-auth bug. The TLS-handshake regression catcher lives in
+// internal/httpcall/do_tls_test.go which uses a token-auth+CA endpoint
+// (the production-pod shape).
+func TestSADispatch_ByteEquivalence_PathA_vs_PathB(t *testing.T) {
+	// Test mode flag is required so SnowplowEndpointFromConfig copies
+	// rc.Host (the envtest URL with random port) instead of pinning to
+	// https://kubernetes.default.svc — the latter wouldn't resolve
+	// outside an in-cluster pod.
+	env.SetTestMode(true)
+	t.Cleanup(func() { env.SetTestMode(false) })
+
+	cfg, teardown := startEnvtest(t)
+	defer teardown()
+
+	// Seed: 5 namespaces. We don't need the full RBAC scenario for byte
+	// equivalence — both Path A and Path B run as the envtest's
+	// default admin-equivalent user, so RBAC denials don't enter the
+	// equation. RBAC behaviour is tested in the existing user-access
+	// filter envtest; this test is about wire-shape parity.
+	cli, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("kubernetes.NewForConfig: %v", err)
+	}
+	seedCtx, cancelSeed := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelSeed()
+	wantNS := []string{"v6-test-a", "v6-test-b", "v6-test-c"}
+	for _, ns := range wantNS {
+		_, cerr := cli.CoreV1().Namespaces().Create(seedCtx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}, metav1.CreateOptions{})
+		if cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			t.Fatalf("create namespace %q: %v", ns, cerr)
+		}
+	}
+
+	dispatchCtx, cancelDispatch := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelDispatch()
+
+	// ── Path A: httpcall.Do via manually-built endpoint ─────────────
+	// envtest's rest.Config carries client cert+key+CA but no bearer
+	// token, so SnowplowEndpointFromConfig (which requires a token)
+	// would error. Build the endpoint directly from the rest.Config
+	// fields to drive the same plumbing TLS code path that production
+	// would use, with whatever auth shape envtest provides. This still
+	// validates the wire-shape parity assertion: Path A returns
+	// apiserver bytes, Path B returns dynamic-client bytes, both
+	// decode to equivalent trees.
+	// Plumbing's tlsConfigFor expects base64-encoded PEM (a layer of
+	// base64 ON TOP of the PEM that K8s Secrets carry). Match that
+	// encoding so the existing plumbing code path is exercised
+	// faithfully — same as production reads from a clientconfig
+	// Secret. The CertData/KeyData/CAData fields on rest.Config are
+	// already raw PEM, so we b64-encode them once here.
+	ep := &plumbingendpoints.Endpoint{
+		ServerURL:                cfg.Host,
+		CertificateAuthorityData: base64.StdEncoding.EncodeToString(cfg.TLSClientConfig.CAData),
+		ClientCertificateData:    base64.StdEncoding.EncodeToString(cfg.TLSClientConfig.CertData),
+		ClientKeyData:            base64.StdEncoding.EncodeToString(cfg.TLSClientConfig.KeyData),
+		Insecure:                 cfg.TLSClientConfig.Insecure,
+	}
+
+	pathAList, errA := dispatchPathA(dispatchCtx, ep, "/api/v1/namespaces")
+	if errA != nil {
+		t.Fatalf("Path A list dispatch failed: %v", errA)
+	}
+
+	// ── Path B: dynamic.NewClient + dispatchSAViaClientGo ─────────────
+	dynCli, derr := dynamic.NewClient(cfg)
+	if derr != nil {
+		t.Fatalf("dynamic.NewClient: %v", derr)
+	}
+	pathBList := dispatchSAViaClientGo(dispatchCtx, dynCli, "/api/v1/namespaces")
+	if pathBList.err != nil {
+		t.Fatalf("Path B dispatch failed: %v", pathBList.err)
+	}
+
+	// ── Byte-tree equivalence ────────────────────────────────────────
+	if drift := compareJSONTrees(pathAList, pathBList.raw); drift != "" {
+		t.Fatalf("Path A vs Path B drift on /api/v1/namespaces (BUG):\n%s", drift)
+	}
+	t.Logf("byte-tree equivalence OK on /api/v1/namespaces (Path A %d bytes, Path B %d bytes)",
+		len(pathAList), len(pathBList.raw))
+
+	// Sanity: assert both paths returned the seeded namespaces.
+	pathANames := extractItemNames(t, pathAList)
+	pathBNames := extractItemNames(t, pathBList.raw)
+	if !containsAll(pathANames, wantNS) {
+		t.Fatalf("Path A list missing seeded namespaces: got %v want subset %v", pathANames, wantNS)
+	}
+	if !containsAll(pathBNames, wantNS) {
+		t.Fatalf("Path B list missing seeded namespaces: got %v want subset %v", pathBNames, wantNS)
+	}
+
+	// ── Single-item GET (the .Get() branch of dispatchSAViaClientGo) ─
+	const probeNS = "v6-test-a"
+	pathAGet, errAG := dispatchPathA(dispatchCtx, ep, "/api/v1/namespaces/"+probeNS)
+	if errAG != nil {
+		t.Fatalf("Path A GET dispatch failed: %v", errAG)
+	}
+	pathBGet := dispatchSAViaClientGo(dispatchCtx, dynCli, "/api/v1/namespaces/"+probeNS)
+	if pathBGet.err != nil {
+		t.Fatalf("Path B GET dispatch failed: %v", pathBGet.err)
+	}
+	if drift := compareJSONTrees(pathAGet, pathBGet.raw); drift != "" {
+		t.Fatalf("Path A vs Path B drift on /api/v1/namespaces/%s (BUG):\n%s",
+			probeNS, drift)
+	}
+	t.Logf("byte-tree equivalence OK on /api/v1/namespaces/%s (Path A %d bytes, Path B %d bytes)",
+		probeNS, len(pathAGet), len(pathBGet.raw))
+}
+
+// TestSADispatch_PathB_NotFound_Mapping verifies the error-shape adapter
+// in clientGoErrorToStatus produces a *response.Status whose Code field
+// matches what httpcall.Do would emit on the same condition (apiserver
+// 404).
+func TestSADispatch_PathB_NotFound_Mapping(t *testing.T) {
+	env.SetTestMode(true)
+	t.Cleanup(func() { env.SetTestMode(false) })
+
+	cfg, teardown := startEnvtest(t)
+	defer teardown()
+
+	dynCli, derr := dynamic.NewClient(cfg)
+	if derr != nil {
+		t.Fatalf("dynamic.NewClient: %v", derr)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res := dispatchSAViaClientGo(ctx, dynCli, "/api/v1/namespaces/does-not-exist-v6")
+	if res.err == nil {
+		t.Fatalf("expected NotFound error from Path B dispatch")
+	}
+	if res.status == nil {
+		t.Fatalf("clientGoErrorToStatus returned nil status; expected populated *response.Status")
+	}
+	if res.status.Code != http.StatusNotFound {
+		t.Fatalf("Path B NotFound mapping: status.Code=%d want %d (StatusNotFound)",
+			res.status.Code, http.StatusNotFound)
+	}
+	if res.status.Status != response.StatusFailure {
+		t.Fatalf("Path B NotFound mapping: status.Status=%q want %q",
+			res.status.Status, response.StatusFailure)
+	}
+	t.Logf("NotFound error mapped to apiserver-style status: code=%d reason=%q message=%q",
+		res.status.Code, res.status.Reason, res.status.Message)
+}
+
+// dispatchPathA drives a GET via httpcall.Do (the v5 production code
+// path) against the envtest apiserver. Returns the raw response body
+// bytes — the same bytes that the v5 production resolver feeds to
+// jsonHandlerCompute.
+func dispatchPathA(ctx context.Context, ep *plumbingendpoints.Endpoint, path string) ([]byte, error) {
+	if ep == nil {
+		return nil, fmt.Errorf("nil endpoint")
+	}
+	verb := http.MethodGet
+	var raw []byte
+	res := httpcall.Do(ctx, httpcall.RequestOptions{
+		Endpoint: ep,
+		RequestInfo: httpcall.RequestInfo{
+			Path: path,
+			Verb: ptr.To(verb),
+		},
+		ResponseHandler: func(r io.ReadCloser) error {
+			b, rerr := io.ReadAll(r)
+			if rerr != nil {
+				return rerr
+			}
+			raw = b
+			return nil
+		},
+	})
+	if res.Status == response.StatusFailure {
+		return nil, fmt.Errorf("Path A httpcall.Do failed: code=%d message=%q", res.Code, res.Message)
+	}
+	return raw, nil
+}
+
+// compareJSONTrees decodes both blobs to map[string]any and compares
+// using reflect.DeepEqual. Returns "" if equivalent, otherwise a short
+// diagnostic string. Pure-tree comparison ignores field ordering and
+// whitespace — what matters for downstream JQ filters is parsed-tree
+// equality, not textual byte equality.
+func compareJSONTrees(a, b []byte) string {
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return "Path A bytes do not decode as JSON: " + err.Error()
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return "Path B bytes do not decode as JSON: " + err.Error()
+	}
+	// Strip volatile fields that may differ across calls but don't
+	// affect downstream JQ filter behaviour: resourceVersion,
+	// managedFields, creationTimestamp, uid. Apiserver may bump these
+	// between Path A and Path B requests because they're separate
+	// calls; what we care about is kind/items/metadata.name shape.
+	stripVolatile(av)
+	stripVolatile(bv)
+	if reflect.DeepEqual(av, bv) {
+		return ""
+	}
+	return formatDriftSummary(av, bv)
+}
+
+// stripVolatile recursively removes fields whose values may differ
+// across calls. Walks both maps and slices.
+//
+// We strip ONLY at non-top levels so the load-bearing kind/apiVersion
+// at the root of the response (consumed by JQ filters in the 6
+// portal-cache YAMLs) are still asserted. Inside items, kind/apiVersion
+// may or may not be present depending on the apiserver build —
+// stripping makes the comparison robust to that detail.
+func stripVolatile(v any) {
+	stripVolatileWalk(v, true /* topLevel */)
+}
+
+func stripVolatileWalk(v any, topLevel bool) {
+	switch t := v.(type) {
+	case map[string]any:
+		delete(t, "resourceVersion")
+		delete(t, "managedFields")
+		delete(t, "creationTimestamp")
+		delete(t, "uid")
+		delete(t, "selfLink")
+		delete(t, "generation")
+		if !topLevel {
+			delete(t, "kind")
+			delete(t, "apiVersion")
+		}
+		for _, sv := range t {
+			stripVolatileWalk(sv, false)
+		}
+	case []any:
+		for _, item := range t {
+			stripVolatileWalk(item, false)
+		}
+	}
+}
+
+func formatDriftSummary(a, b any) string {
+	am, _ := a.(map[string]any)
+	bm, _ := b.(map[string]any)
+	akeys := mapKeys(am)
+	bkeys := mapKeys(bm)
+	sort.Strings(akeys)
+	sort.Strings(bkeys)
+	out := ""
+	out += "  pathA top-level keys: " + strings.Join(akeys, ",") + "\n"
+	out += "  pathB top-level keys: " + strings.Join(bkeys, ",") + "\n"
+	if ai, ok := am["items"].([]any); ok {
+		out += "  pathA items count: " + strconv.Itoa(len(ai)) + "\n"
+	}
+	if bi, ok := bm["items"].([]any); ok {
+		out += "  pathB items count: " + strconv.Itoa(len(bi)) + "\n"
+	}
+	if ak, ok := am["kind"].(string); ok {
+		out += "  pathA kind: " + ak + "\n"
+	}
+	if bk, ok := bm["kind"].(string); ok {
+		out += "  pathB kind: " + bk + "\n"
+	}
+	return out
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func extractItemNames(t *testing.T, raw []byte) []string {
+	t.Helper()
+	var v map[string]any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("extractItemNames: %v", err)
+	}
+	items, ok := v["items"].([]any)
+	if !ok {
+		// single-item shape (Get) — no "items" array.
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		md, _ := m["metadata"].(map[string]any)
+		name, _ := md["name"].(string)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]bool, len(haystack))
+	for _, h := range haystack {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/resolvers/restactions/l1cache/l1cache.go
+++ b/internal/resolvers/restactions/l1cache/l1cache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/krateoplatformops/snowplow/apis"
 	v1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
 	"go.opentelemetry.io/otel"
@@ -92,6 +93,10 @@ type Input struct {
 	// restactions.ResolveOptions and ultimately api.ResolveOptions. nil
 	// is permitted; UserAccessFilter calls will be rejected at runtime.
 	SnowplowEndpoint func() (*endpoints.Endpoint, error)
+
+	// SnowplowK8sClient is the in-cluster dynamic K8s client for SA
+	// dispatch (Q-RBAC-DECOUPLE C(d) v6 — Path B). nil-safe.
+	SnowplowK8sClient dynamic.Client
 }
 
 // Result is what both HTTP and widget callers need from one resolution.
@@ -170,13 +175,14 @@ func resolveAndCacheInner(ctx context.Context, in Input) (*Result, error) {
 	}
 
 	_, dict, err := restactions.Resolve(tctx, restactions.ResolveOptions{
-		In:               &cr,
-		SArc:             sArc,
-		AuthnNS:          in.AuthnNS,
-		PerPage:          in.PerPage,
-		Page:             in.Page,
-		Extras:           in.Extras,
-		SnowplowEndpoint: in.SnowplowEndpoint,
+		In:                &cr,
+		SArc:              sArc,
+		AuthnNS:           in.AuthnNS,
+		PerPage:           in.PerPage,
+		Page:              in.Page,
+		Extras:            in.Extras,
+		SnowplowEndpoint:  in.SnowplowEndpoint,
+		SnowplowK8sClient: in.SnowplowK8sClient,
 	})
 	if err != nil {
 		log.Error("unable to resolve rest action",

--- a/internal/resolvers/restactions/restactions.go
+++ b/internal/resolvers/restactions/restactions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/krateoplatformops/plumbing/ptr"
 	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
 	jqsupport "github.com/krateoplatformops/snowplow/internal/support/jq"
 
@@ -43,6 +44,13 @@ type ResolveOptions struct {
 	// through l1cache.Input from the dispatcher constructors.
 	// See api.ResolveOptions.SnowplowEndpoint for the contract.
 	SnowplowEndpoint func() (*endpoints.Endpoint, error)
+
+	// SnowplowK8sClient is the in-cluster dynamic K8s client used by the
+	// SA-elevated dispatch path (Q-RBAC-DECOUPLE C(d) v6 — Path B).
+	// Replaces httpcall.Do for SA dispatch, structurally avoiding
+	// plumbing's tlsConfigFor bug. nil-safe: api.Resolve falls back to
+	// cache.SnowplowK8sFromContext(ctx) before erroring.
+	SnowplowK8sClient dynamic.Client
 }
 
 // Resolve runs the per-api fan-out (api.Resolve) and the outer JQ filter,
@@ -69,14 +77,15 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*templates.RESTAction, m
 
 	_, apiSpan := restactionResolveTracer.Start(ctx, "restaction.api_resolve")
 	dict := api.Resolve(ctx, api.ResolveOptions{
-		RC:               opts.SArc,
-		AuthnNS:          opts.AuthnNS,
-		Verbose:          isVerbose(opts.In),
-		Items:            opts.In.Spec.API,
-		PerPage:          opts.PerPage,
-		Page:             opts.Page,
-		Extras:           opts.Extras,
-		SnowplowEndpoint: opts.SnowplowEndpoint,
+		RC:                opts.SArc,
+		AuthnNS:           opts.AuthnNS,
+		Verbose:           isVerbose(opts.In),
+		Items:             opts.In.Spec.API,
+		PerPage:           opts.PerPage,
+		Page:              opts.Page,
+		Extras:            opts.Extras,
+		SnowplowEndpoint:  opts.SnowplowEndpoint,
+		SnowplowK8sClient: opts.SnowplowK8sClient,
 	})
 	if dict == nil {
 		dict = map[string]any{}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
 	"github.com/krateoplatformops/snowplow/internal/handlers"
 	"github.com/krateoplatformops/snowplow/internal/observability"
 	"github.com/krateoplatformops/snowplow/internal/handlers/dispatchers"
@@ -221,6 +222,33 @@ func main() {
 		log.Warn("no in-cluster config; userAccessFilter calls will be rejected at runtime")
 	}
 
+	// Q-RBAC-DECOUPLE C(d) v6 — Path B (audit 2026-05-04). Build the
+	// in-cluster dynamic K8s client once at startup. The SA dispatch path
+	// in api.Resolve uses this client (via cache.SnowplowK8sFromContext)
+	// instead of httpcall.Do, structurally bypassing plumbing's
+	// tlsConfigFor bug that silently dropped CertificateAuthorityData on
+	// token-auth endpoints (the v5 D1 defect that left every SA dispatch
+	// failing x509: certificate signed by unknown authority).
+	//
+	// Construction-failure is non-fatal here: the v5 SnowplowEndpoint
+	// path stays available as a defense-in-depth fallback (it's broken
+	// for SA dispatch, but UAF api[] entries with EndpointRef set still
+	// flow through it). Production wiring expects sarc != nil and
+	// dynamic.NewClient to succeed; failure here is a strong indicator
+	// of a misconfigured pod that warrants explicit operator attention.
+	var snowplowK8sClient dynamic.Client
+	if sarc != nil {
+		var k8sErr error
+		snowplowK8sClient, k8sErr = dynamic.NewClient(sarc)
+		if k8sErr != nil {
+			log.Warn("failed to build snowplow K8s dynamic client; SA dispatch will fall back to httpcall (v5 plumbing TLS bug active)",
+				slog.Any("err", k8sErr))
+			snowplowK8sClient = nil
+		} else {
+			log.Info("snowplow K8s dynamic client built (Q-RBAC-DECOUPLE C(d) v6 — Path B SA dispatch active)")
+		}
+	}
+
 	// No Redis ping or disk store needed — MemCache is always available.
 
 	// Initialize OpenTelemetry SDK (no-op when OTEL_ENABLED != "true").
@@ -270,6 +298,10 @@ func main() {
 					return snowplowEndpointFn()
 				})
 			}
+			// Q-RBAC-DECOUPLE C(d) v6 — Path B SA dispatch client.
+			if snowplowK8sClient != nil {
+				ctx = cache.WithSnowplowK8s(ctx, snowplowK8sClient)
+			}
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)
 		})
@@ -313,7 +345,7 @@ func main() {
 	mux.Handle("GET /call", chain.Append(
 		userCfg,
 		withCache,
-		handlers.Dispatcher(dispatchers.All(snowplowEndpointFn))).
+		handlers.Dispatcher(dispatchers.All(snowplowEndpointFn, snowplowK8sClient))).
 		Then(handlers.Call()))
 	mux.Handle("POST /call", chain.Append(userCfg, withCache).Then(handlers.Call()))
 	mux.Handle("PUT /call", chain.Append(userCfg, withCache).Then(handlers.Call()))
@@ -359,7 +391,7 @@ func main() {
 	// Previously this ran before ListenAndServe, causing startup probe failures
 	// when informer sync + L2/RBAC warmup exceeded the probe timeout.
 	if appCache != nil {
-		go startBackgroundServices(ctx, log, appCache, *authnNS, *warmupConfigPath, *signKey, globalRBACWatcher, snowplowEndpointFn)
+		go startBackgroundServices(ctx, log, appCache, *authnNS, *warmupConfigPath, *signKey, globalRBACWatcher, snowplowEndpointFn, snowplowK8sClient)
 	}
 	<-ctx.Done()
 
@@ -399,7 +431,7 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 // Warmup and informer sync use a separate background context so that a SIGTERM
 // received during startup (e.g. from a failing liveness probe) does not abort
 // the warmup — the server will start with a fully warm cache regardless.
-func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cache, authnNS, warmupConfigPath, signKey string, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error)) {
+func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cache, authnNS, warmupConfigPath, signKey string, rbacWatcher *cache.RBACWatcher, snowplowEndpointFn func() (*endpoints.Endpoint, error), snowplowK8sClient dynamic.Client) {
 	rc, err := rest.InClusterConfig()
 	if err != nil {
 		log.Warn("not running in-cluster; background cache services disabled", slog.Any("err", err))
@@ -423,7 +455,7 @@ func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cach
 	}
 	globalInformerReader = resourceWatcher // InformerReader interface — reads from informer store
 	globalResourceWatcher = resourceWatcher // exposes HOT/WARM/COLD queue depths to /metrics/runtime
-	resourceWatcher.SetL1Refresher(dispatchers.MakeL1Refresher(c, rc, authnNS, signKey, rbacWatcher, snowplowEndpointFn))
+	resourceWatcher.SetL1Refresher(dispatchers.MakeL1Refresher(c, rc, authnNS, signKey, rbacWatcher, snowplowEndpointFn, snowplowK8sClient))
 
 	// Load warmup config early to get autoDiscoverGroups for CRD informer filtering.
 	warmupCfg, err := cache.LoadWarmupConfig(warmupConfigPath)
@@ -510,6 +542,9 @@ func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cach
 			return snowplowEndpointFn()
 		})
 	}
+	if snowplowK8sClient != nil {
+		warmupCtx = cache.WithSnowplowK8s(warmupCtx, snowplowK8sClient)
+	}
 
 	// Phase 5: Pre-warm L1 (resolved widget + RESTAction output) for every
 	// known user. Uses its own context because warmupCtx is cancelled when
@@ -531,6 +566,9 @@ func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cach
 				return snowplowEndpointFn()
 			})
 		}
+		if snowplowK8sClient != nil {
+			l1Ctx = cache.WithSnowplowK8s(l1Ctx, snowplowK8sClient)
+		}
 
 		feCfg, feErr := cache.LoadFrontendConfig(frontendConfigPath)
 		if feErr != nil {
@@ -546,6 +584,6 @@ func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cach
 		log.Info("L1 warmup: using frontend entry points",
 			slog.Int("entryPoints", len(eps)),
 			slog.String("configPath", frontendConfigPath))
-		dispatchers.WarmL1FromEntryPoints(l1Ctx, c, rc, authnNS, signKey, eps, rbacWatcher, snowplowEndpointFn)
+		dispatchers.WarmL1FromEntryPoints(l1Ctx, c, rc, authnNS, signKey, eps, rbacWatcher, snowplowEndpointFn, snowplowK8sClient)
 	}()
 }


### PR DESCRIPTION
## Summary

Q-RBAC-DECOUPLE C(d) v6 — replaces the SA-elevated dispatch's reliance on `httpcall.Do` (which silently drops `CertificateAuthorityData` on token-auth endpoints via plumbing's `tlsConfigFor` early-return — the v5 D1 defect that left every SA dispatch failing `tls: failed to verify certificate: x509: certificate signed by unknown authority` on `0.25.298`) with the existing `internal/dynamic.Client` wrapper around `k8s.io/client-go`'s dynamic client.

The SA branch only ever targets the in-cluster K8s apiserver (statically proven: CEL admission binds UAF to the SA path AND forbids non-GET; `SnowplowEndpointFromConfig` pins `ServerURL` to `https://kubernetes.default.svc`), so swapping the HTTP transport for a typed K8s client is a structural simplification — no functionality is lost, the bug class is structurally eliminated.

**Path B was picked over Path A** (reflection-based plumbing RT-chain unwrap) per Diego's strategic call: upstream plumbing patch cadence is outside our control, reflection-based unwrap creates ongoing fragility, and the existing `internal/dynamic.Client` (185 LOC, in production for L3 informers + RBAC watching) eliminates the SA-K8s-via-plumbing bug class structurally.

## Architecture

- New file `internal/resolvers/restactions/api/sa_dispatch.go`:
  - `dispatchSAViaClientGo(ctx, client, path)` — parses path via the existing `cache.ParseK8sAPIPath`, dispatches via `dynamic.Client.Get/List`, `json.Marshal`s the resulting `*unstructured.Unstructured(List)` to bytes that are wire-shape-equivalent to apiserver-over-HTTP.
  - `clientGoErrorToStatus(err)` — maps client-go errors to `*response.Status` so the `err_write` audit shape stays stable across the v5→v6 transition.
- Resolver `runOne` (`resolve.go`) — Path B branch right before `httpcall.Do(call)`: when `useSystemEndpoint && snowplowK8sClient != nil`, dispatch via `dynamic.Client` and feed bytes through the same `call.ResponseHandler` the `http_fallback` path uses (`jsonHandlerCompute` + `mergeIntoDict`).
- Threading: new `SnowplowK8sClient dynamic.Client` field threaded through 5 layers (`api.ResolveOptions`, `restactions.ResolveOptions`, `l1cache.Input`, `dispatchers.RESTAction`, `dispatchers.MakeL1Refresher`, `WarmL1FromEntryPoints`, `ResolveRESTActionBackground`, `dispatchers.All`) parallel to the existing `SnowplowEndpoint` plumbing.
- New `cache.WithSnowplowK8s` / `SnowplowK8sFromContext` middleware — sibling to `WithSnowplowEndpoint`, same install sites in `main.go` (HTTP middleware, warmup, L1 background) and dispatchers (`l1_refresh`, `prewarm`). Type-erased to `any` to avoid a `cache → internal/dynamic` import cycle.
- `main.go` constructs the dynamic client once at startup via `dynamic.NewClient(sarc)`; construction failure logs a warning and falls back to v5 `SnowplowEndpoint` (broken on the SA path but documented as defense-in-depth degradation).

The v5 `SnowplowEndpoint` plumbing is **retained** as a defense-in-depth fallback for unit tests that haven't migrated and any non-K8s endpoints that might surface on the UAF path in the future. The runOne SA branch tries Path B first; the `http_fallback` code is reachable only when Path B is unavailable.

## Test design

### `internal/httpcall/do_tls_test.go` (NEW, 5 cases, package `httpcall_test`)

- **`TestHttpcallDo_TokenAuthWithCA_FailsOnV5Baseline`** — drives `httpcall.Do(token-auth+CA)` against a self-signed server and asserts `StatusFailure` with x509 message. **This is the catcher**: reproduces the `0.25.298` production failure verbatim. Test MUST FAIL only when plumbing's `tlsConfigFor` ships a future fix; until then, this proves Path B is structurally necessary.
- **`TestHttpcallDo_TokenAuthWithCA_PoolPreserves`** — verifies bug reproduces across 3 sequential calls.
- **`TestPathBSADispatch_TokenAuthWithCA_HandshakeOK`** — drives `rest.HTTPClientFor(rc)` (the layer `dynamic.NewClient` builds on) against the same server, asserts TLS handshake succeeds.
- **`TestPathBSADispatch_DynamicClientHandshakeOK`** — drives the actual production v6 path: `dynamic.NewClient(rc).List(GVR{namespaces})` against a server that mocks K8s discovery + `/api/v1/namespaces`. Asserts no TLS error.
- **`TestPathBSADispatch_NoCAFails`** — negative case: no `CAData` → x509 failure; guards against accidental `Insecure` regression.

Captured failure output on v5 baseline (proves test catches the bug):
```
TestHttpcallDo_TokenAuthWithCA_FailsOnV5Baseline:
  Message: Get "https://127.0.0.1:NNN/": tls: failed to verify certificate:
  x509: certificate signed by unknown authority
```

### `internal/resolvers/restactions/api/sa_dispatch_envtest_test.go` (NEW, build tag `envtest`, 2 cases)

- **`TestSADispatch_ByteEquivalence_PathA_vs_PathB`** — drives both Path A (`httpcall.Do`) and Path B (`dispatchSAViaClientGo`) against the same envtest apiserver on list (`/api/v1/namespaces`) and get (`/api/v1/namespaces/<name>`) shapes; asserts decoded `map[string]any` trees are `reflect.DeepEqual` after stripping volatile fields (`resourceVersion`, `managedFields`, `creationTimestamp`, `uid`, `selfLink`, `generation`, plus `kind`/`apiVersion` at non-top levels). **Drift observed: 0**. This is the byte-shape parity assertion: JQ filters in the 6 portal-cache YAMLs keep working unchanged because both dispatch paths produce wire-shape-equivalent bytes.
- **`TestSADispatch_PathB_NotFound_Mapping`** — drives Path B against a non-existent namespace, asserts `clientGoErrorToStatus` returns `response.Status{Code: 404, Status: "Failure"}` for log-shape stability.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 -timeout=300s ./...` — all touched packages pass
- [x] `go test -race -tags=unit,integration -p 1 -count=1 -timeout=600s ./...` — all packages pass except the pre-existing `TestIteratorOrderDistribution_Today` failure (Q-CON-1 WIP, on main as well)
- [x] `KUBEBUILDER_ASSETS=… go test -tags=envtest -race -run 'TestSADispatch' …/api/` — 2/2 pass
- [x] TLS handshake test FAILS the appropriate way on v5 baseline (`StatusFailure` with `tls`/`x509`/`certificate` in message — captured)
- [x] TLS handshake test PASSES on v6 (Path B handshake succeeds)
- [x] Byte-equivalence envtest passes (Path A → Path B drift = 0)

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean (only pre-existing unkeyed-fields warnings on `internal/dynamic/dynamic.go` carry over from main) |
| `go test -race ./internal/httpcall/...` | PASS (5/5 new TLS cases + existing pool tests) |
| `go test -race ./internal/cache/...` | PASS |
| `go test -race ./internal/dynamic/...` | PASS |
| `go test -race ./internal/handlers/...` | PASS |
| `go test -race ./internal/resolvers/restactions/api/` (no tags) | PASS |
| `go test -tags=envtest -run TestSADispatch ./internal/resolvers/restactions/api/` | PASS (byte-equivalence + NotFound mapping) |

## Out of scope (per spec §0 carry-forward + Diego's instructions)

- No commit/tag/push to `krateoplatformops/*` (rule #2)
- No Helm chart change, no env var, no secret rotation
- v5 D2/D3a/D3b plumbing **kept** (graceful-degradation, audit emits, chart hardening) per "KEEP, defense-in-depth even after structural fix lands"
- v5 `SnowplowEndpoint` plumbing **kept** as defense-in-depth fallback (not actively removed; would create test-removal churn for unclear benefit since the SA runOne branch tries Path B first)
- TLS 1.3 floor not raised (v6-scope expansion deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)