### PR TITLE
Q-RBACC-L2-1: post-refilter L2 cache + UAF yield discipline (DRAFT)

### DIFF
--- a/internal/cache/l2_audit.go
+++ b/internal/cache/l2_audit.go
@@ -1,0 +1,62 @@
+// Q-RBACC-L2-1 — sampled L2 hit audit.
+//
+// L2 hits SKIP applyUserAccessFilter (the function that emits
+// audit=user_access_filter). The decision the L2 hit reflects was made
+// the FIRST time the L2 entry was filled (and audited then). For
+// operational visibility, we still want a low-volume signal that an L2
+// hit occurred for a (user, identity, restaction) triple — defaulting
+// to 1% sample (CACHE_L2_REFILTER_HIT_AUDIT_SAMPLE).
+//
+// SecOps may want a 100% rate post-canary; that's why the sample is env-
+// configurable (default 0.01). The "user_access_filter_l2_hit" string is
+// intentionally distinct from "user_access_filter" so log-aggregation
+// pipelines can grep them separately without aliasing.
+//
+// Counter `cache.GlobalMetrics.L2Hits` records every hit (100%); the
+// audit-emit is the post-hoc-grep complement of that counter.
+
+package cache
+
+import (
+	"context"
+	"hash/fnv"
+	"log/slog"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+)
+
+// EmitL2HitAudit logs a sampled audit=user_access_filter_l2_hit line.
+// Caller passes the (l1Key, identity, restAction, username) tuple. The
+// sampling decision is keyed on a fast hash of (l1Key + identity) so
+// the same (l1Key, identity) consistently emits or doesn't — this
+// preserves "rare is rare; common is common" without random-walk noise.
+//
+// SAFETY: never mutates input; cheap (one fnv64 + one float compare).
+// Returns nothing — safe to call from any hot path under enabled L2.
+func EmitL2HitAudit(ctx context.Context, l1Key, identity, restAction, username string) {
+	rate := l2HitAuditSample()
+	if rate <= 0 {
+		return
+	}
+	if rate < 1.0 {
+		h := fnv.New64a()
+		h.Write([]byte(l1Key))
+		h.Write([]byte{0})
+		h.Write([]byte(identity))
+		// Map the 64-bit hash into [0, 1) via a uint conversion. This is
+		// a deterministic sampler — consistent across calls for the same
+		// pair, so a single (key, identity) is either always-sampled or
+		// never-sampled at a given rate.
+		bucket := float64(h.Sum64()&0x7FFFFFFFFFFFFFFF) / float64(1<<63)
+		if bucket >= rate {
+			return
+		}
+	}
+	xcontext.Logger(ctx).Info("cache.user_access_filter_l2_hit",
+		slog.String("audit", "user_access_filter_l2_hit"),
+		slog.String("user", username),
+		slog.String("identity", identity),
+		slog.String("restaction", restAction),
+		slog.String("l1_key", l1Key),
+	)
+}

--- a/internal/cache/l2_refilter.go
+++ b/internal/cache/l2_refilter.go
@@ -78,10 +78,16 @@ const L2EntryV1Tag = "l2-v1"
 // Status map mirrors what apiref consumers read (`json.Unmarshal(refiltered)["status"]`)
 // — pre-decoded so the read path stays O(1).
 //
-// CONTRACT (load-bearing): downstream readers MUST treat Status as
-// READ-ONLY. The value is shared across goroutines via pointer; mutating
-// it would corrupt cached state. The widget pipeline already passes the
-// status map to gojq read-only; the contract matches existing code.
+// CONTRACT (load-bearing — Q-RBACC-L2-1 architect-review CONCERN-1,
+// 2026-05-05): EVERY field of L2Entry is IMMUTABLE once the entry has
+// been published via SetL2Refilter. Readers obtain the entry via
+// sync.Map.Load and MUST NOT mutate any field — including the Status
+// map and the Refiltered bytes. Writers MUST populate Status at write
+// time (no lazy fill); a nil Status on a hit signals "soft miss, fall
+// through to refilter". The original lazy-fill design opened a data
+// race: two readers observing Status==nil could both Unmarshal and
+// both assign, with no synchronisation on the shared *L2Entry pointer.
+// Fix: Status is computed by the writer and never mutated thereafter.
 type L2Entry struct {
 	Refiltered []byte         // exact bytes the dispatcher writes to wri.Write
 	Status     map[string]any // pre-decoded "status" object for apiref consumers

--- a/internal/cache/l2_refilter.go
+++ b/internal/cache/l2_refilter.go
@@ -1,0 +1,669 @@
+// Package cache — Q-RBACC-L2-1: post-refilter L2 cache.
+//
+// OVERVIEW
+//
+// L1 stores the v3 wrapper `cachedRESTAction{ CR, ProtectedDict, "v3" }`
+// keyed per binding identity. On every HTTP /call the dispatcher walks
+// that wrapper through `RefilterRESTAction` (per-item gojq for nsFrom +
+// per-item RBAC eval + outer JQ), turning a 1.9 KB wire output into a
+// 1.0–1.4 s wall on the cyberjoker hot path. For the 40 MB
+// `compositions-panels` page the refilter cost saturated CPU long enough
+// to miss 30 consecutive 1 s liveness probes (v6 phase-6 SIGKILL).
+//
+// L2 is a SECOND, post-refilter cache. Key tuple (l1Key, binding identity,
+// groups hash) — collapsing per-user keying down to per-binding-identity ×
+// groups (so 1000 users → ~10 entries in the hot path). Value is the
+// wire-bytes the dispatcher writes to `wri.Write` plus a pre-decoded
+// status map for the apiref consumer. Hits skip refilter entirely.
+//
+// INVARIANTS PRESERVED
+//
+//  - feedback_l1_invalidation_delete_only.md  — L2 evicts ONLY on K8s
+//    DELETE, CRB transition, or RESTAction-CR change. UPDATE/PATCH stays
+//    SWR (matches L1).
+//  - feedback_no_special_cases.md             — `MIN_REDUCTION_RATIO` is
+//    a generic property of post-refilter / L1 ratio. No per-user / per-RA
+//    branches anywhere.
+//  - feedback_cache_must_not_constrain_jq.md  — bytes are byte-identical
+//    to a fresh refilter; widget canonicalisation is unconstrained.
+//  - project_redis_removal.md                 — `CACHE_ENABLED=false`
+//    short-circuits L2 (cache stays removable).
+//
+// ROLLBACK
+//
+// Behind env flag `CACHE_L2_REFILTER_ENABLED` (default false). Flipping
+// to false makes every Get/Set return zero-value/no-op without disturbing
+// the L1 hit path (the dispatcher falls through to RefilterRESTActionDeduped).
+
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ── Tunables (env-overridable) ────────────────────────────────────────────────
+
+const (
+	envL2Enabled        = "CACHE_L2_REFILTER_ENABLED"
+	envL2MaxBytes       = "CACHE_L2_REFILTER_MAX_BYTES"
+	envL2MaxEntryBytes  = "CACHE_L2_REFILTER_MAX_ENTRY_BYTES"
+	envL2MaxEntries     = "CACHE_L2_REFILTER_MAX_ENTRIES"
+	envL2MinReduction   = "CACHE_L2_REFILTER_MIN_REDUCTION_RATIO"
+	envL2HitAuditSample = "CACHE_L2_REFILTER_HIT_AUDIT_SAMPLE"
+
+	defaultL2MaxBytes        int64   = 512 << 20 // 512 MB
+	defaultL2MaxEntryBytes   int64   = 50 << 20  // 50 MB
+	defaultL2MaxEntries      int     = 100_000
+	defaultL2MinReduction    float64 = 0.20
+	defaultL2HitAuditSample  float64 = 0.01 // 1% of L2 hits emit audit
+)
+
+// L2EntryV1Tag identifies the wire shape of an L2 entry written by this
+// version of the binary. Bumping this string forces all readers to treat
+// older entries as a miss + opportunistic evict (defends against schema
+// migrations on the L1 wrapper that happen out-of-band).
+const L2EntryV1Tag = "l2-v1"
+
+// L2Entry is the value stored in the L2 cache. The Refiltered byte slice
+// is the EXACT wire payload the dispatcher writes to `wri.Write`; the
+// Status map mirrors what apiref consumers read (`json.Unmarshal(refiltered)["status"]`)
+// — pre-decoded so the read path stays O(1).
+//
+// CONTRACT (load-bearing): downstream readers MUST treat Status as
+// READ-ONLY. The value is shared across goroutines via pointer; mutating
+// it would corrupt cached state. The widget pipeline already passes the
+// status map to gojq read-only; the contract matches existing code.
+type L2Entry struct {
+	Refiltered []byte         // exact bytes the dispatcher writes to wri.Write
+	Status     map[string]any // pre-decoded "status" object for apiref consumers
+	HasUAF     bool           // cached unstructuredHasUAF result (apiref needs it)
+	SizeBytes  int            // == len(Refiltered) — fast budget accounting
+	StoredAt   int64          // unix nano — LRU eviction timestamp
+	SchemaVer  string         // wrapper schema_version snapshot — defends L1 schema bump
+	tag        string         // L2EntryV1Tag — refuse on mismatch
+	// Reverse-index components, used by EvictL2For* helpers without
+	// re-parsing the cache key on every eviction. Filled at SetL2 time.
+	l1Key       string
+	identity    string
+	gvrName     string // ParseResolvedKey-derived "{group}/{version}/{resource}/{name}"; "" when unparseable
+}
+
+// l2Index is the in-process L2 cache. sync.Map for the hash table; an
+// inline LRU list maintained under a fine-grained mutex for eviction
+// ordering. Reverse indexes (by l1Key, by identity, by gvrName) are kept
+// as sync.Map<string, *sync.Map[hashKey]struct{}> so that targeted
+// eviction is O(N) over the affected subset, not O(N) over the entire
+// cache.
+type l2Index struct {
+	enabled        atomic.Bool
+	store          sync.Map // hashKey (string) -> *L2Entry
+	residentBytes  atomic.Int64
+	residentCount  atomic.Int64
+
+	// Reverse indexes for targeted eviction.
+	byL1Key    sync.Map // l1Key -> *sync.Map[hashKey]struct{}
+	byIdentity sync.Map // bindingIdentity -> *sync.Map[hashKey]struct{}
+	byGVRName  sync.Map // "{gvrKey}/{name}" -> *sync.Map[hashKey]struct{}
+
+	// LRU access list. Every Set/Get under enabled appends a tick; the
+	// sweeper runs on the same 30s ticker as MemCache.StartEviction and
+	// trims entries when residentBytes or residentCount exceeds the cap.
+	// We do NOT maintain a doubly-linked list (sync.Map cannot be ordered
+	// without a separate slice); instead we rely on StoredAt timestamps
+	// and a periodic sweep. For the 50-100 identity scale, a single
+	// 100K-entry sweep at 30s cadence is cheap (~1 ms wall).
+	mu        sync.Mutex
+	gen       int64 // monotonic generation tag for last sweep
+}
+
+// globalL2 is the package-level L2 cache. Allocated on first call to
+// initL2 (lazy). Tests may use NewL2IndexForTest to avoid touching the
+// global.
+var globalL2 = &l2Index{}
+var globalL2Once sync.Once
+
+// initL2 reads env defaults once and caches the enabled flag. Subsequent
+// SetL2 / GetL2 calls are zero-allocation if disabled.
+func initL2() {
+	globalL2Once.Do(func() {
+		if os.Getenv(envL2Enabled) == "true" {
+			globalL2.enabled.Store(true)
+		}
+	})
+}
+
+// L2Enabled returns true iff the env flag is on AND the master CACHE_ENABLED
+// flag is not set to false. Cheap; safe in hot paths.
+func L2Enabled() bool {
+	if Disabled() {
+		return false
+	}
+	initL2()
+	return globalL2.enabled.Load()
+}
+
+// SetL2EnabledForTest forces the L2 enabled state without consulting env.
+// TEST-ONLY: production code MUST go through the env path.
+func SetL2EnabledForTest(v bool) {
+	initL2()
+	globalL2.enabled.Store(v)
+}
+
+// l2MaxBytes / l2MaxEntryBytes / l2MaxEntries / l2MinReduction read
+// env vars on each call (cheap; called at write time only). We don't
+// cache them because operators may set them via downward-API at pod
+// start; once set they don't change. The repeated env lookup costs
+// ~50 ns per write — orders below the cost we save by caching the bytes.
+func l2MaxBytes() int64        { return envInt64(envL2MaxBytes, defaultL2MaxBytes) }
+func l2MaxEntryBytes() int64   { return envInt64(envL2MaxEntryBytes, defaultL2MaxEntryBytes) }
+func l2MaxEntries() int        { return int(envInt64(envL2MaxEntries, int64(defaultL2MaxEntries))) }
+func l2MinReduction() float64  { return envFloat(envL2MinReduction, defaultL2MinReduction) }
+func l2HitAuditSample() float64 {
+	return envFloat(envL2HitAuditSample, defaultL2HitAuditSample)
+}
+
+func envInt64(name string, def int64) int64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
+func envFloat(name string, def float64) float64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f < 0 || f > 1 {
+		return def
+	}
+	return f
+}
+
+// ── Key helpers ───────────────────────────────────────────────────────────────
+
+// L2Key derives the L2 cache key. To avoid `|`-injection collisions
+// between components, we prefix each component with its 8-byte big-endian
+// length before hashing. Adversarial inputs that put `|` characters
+// inside a component cannot collide with a different distribution of
+// the same total bytes across components.
+//
+// Empty inputs yield an empty key; callers MUST treat "" as "skip L2".
+func L2Key(l1Key, bindingIdentity, groupsHash string) string {
+	if l1Key == "" || bindingIdentity == "" || groupsHash == "" {
+		return ""
+	}
+	h := sha256.New()
+	h.Write([]byte("L2"))
+	writeLP(h, l1Key)
+	writeLP(h, bindingIdentity)
+	writeLP(h, groupsHash)
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// writeLP writes an 8-byte big-endian length prefix followed by the
+// component bytes. Domain-separates each component so the hash is
+// unambiguous regardless of the bytes inside any component.
+func writeLP(h interface{ Write([]byte) (int, error) }, s string) {
+	var lp [8]byte
+	n := uint64(len(s))
+	lp[0] = byte(n >> 56)
+	lp[1] = byte(n >> 48)
+	lp[2] = byte(n >> 40)
+	lp[3] = byte(n >> 32)
+	lp[4] = byte(n >> 24)
+	lp[5] = byte(n >> 16)
+	lp[6] = byte(n >> 8)
+	lp[7] = byte(n)
+	_, _ = h.Write(lp[:])
+	_, _ = h.Write([]byte(s))
+}
+
+// HashGroups returns a stable hex-encoded sha256 of the sorted, joined
+// group list. Mirrors `refilterFlightKey`'s hash so the L2 key reuses
+// the same cohort fingerprint as the singleflight key. Exported so
+// dispatcher and apiref callers stay in lockstep on the hash function.
+//
+// Empty groups → "no_groups". This matches the singleflight contract
+// exactly so callers don't have to remember the convention.
+func HashGroups(groups []string) string {
+	if len(groups) == 0 {
+		return "no_groups"
+	}
+	cp := make([]string, len(groups))
+	copy(cp, groups)
+	sort.Strings(cp)
+	h := sha256.Sum256([]byte(strings.Join(cp, "\x00")))
+	return hex.EncodeToString(h[:])
+}
+
+// gvrNameFromL1Key extracts the "{gvrKey}/{name}" tag used by
+// EvictL2ForRESTAction. Returns "" on parse failure (caller skips the
+// reverse-index registration; eviction by RA is a no-op for that entry,
+// matching pre-L2 behaviour where unaffected entries decay via L1 TTL).
+func gvrNameFromL1Key(l1Key string) string {
+	info, ok := ParseResolvedKey(l1Key)
+	if !ok {
+		return ""
+	}
+	return GVRToKey(info.GVR) + "/" + info.Name
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+// GetL2Refilter returns the cached entry for `key`. (nil, false) on miss
+// or when L2 is disabled. Schema mismatch is treated as a miss and the
+// stale entry is evicted opportunistically.
+func GetL2Refilter(key string) (*L2Entry, bool) {
+	if !L2Enabled() || key == "" {
+		return nil, false
+	}
+	v, ok := globalL2.store.Load(key)
+	if !ok {
+		GlobalMetrics.L2Misses.Add(1)
+		return nil, false
+	}
+	e, ok := v.(*L2Entry)
+	if !ok || e == nil {
+		GlobalMetrics.L2Misses.Add(1)
+		return nil, false
+	}
+	if e.tag != L2EntryV1Tag {
+		// Wire-shape mismatch — opportunistic evict + miss.
+		globalL2.evictKey(key, e)
+		GlobalMetrics.L2Misses.Add(1)
+		return nil, false
+	}
+	GlobalMetrics.L2Hits.Add(1)
+	return e, true
+}
+
+// SetL2Refilter writes an entry IFF (a) L2 is enabled, (b) the entry
+// passes the size cap, and (c) the entry passes the reduction-ratio
+// gate (post-refilter ≤ (1 - MIN_REDUCTION) × L1 raw size). The reduction
+// gate is the §1.3 generic policy that prevents admin × compositions-panels
+// (post-refilter ≈ L1) from consuming the L2 budget.
+//
+// Returns the resident-bytes delta (0 if the entry was rejected). The
+// `rawL1Size` parameter is the size of the L1 wrapper bytes the refilter
+// was computed from; pass 0 to bypass the reduction gate (e.g. for
+// prewarm where the L1 size is not handy — accept the entry on size cap
+// only).
+func SetL2Refilter(key string, e *L2Entry, rawL1Size int) {
+	if !L2Enabled() || key == "" || e == nil || len(e.Refiltered) == 0 {
+		return
+	}
+	maxEntry := l2MaxEntryBytes()
+	if int64(len(e.Refiltered)) > maxEntry {
+		GlobalMetrics.L2SkippedSizeCap.Add(1)
+		return
+	}
+	if rawL1Size > 0 {
+		ratio := float64(len(e.Refiltered)) / float64(rawL1Size)
+		if ratio > (1.0 - l2MinReduction()) {
+			GlobalMetrics.L2SkippedHighRatio.Add(1)
+			return
+		}
+	}
+
+	// Stamp internal fields so eviction does not need to re-parse.
+	e.tag = L2EntryV1Tag
+	e.SizeBytes = len(e.Refiltered)
+	e.StoredAt = time.Now().UnixNano()
+	if e.gvrName == "" {
+		e.gvrName = gvrNameFromL1Key(e.l1Key)
+	}
+
+	prev, loaded := globalL2.store.LoadOrStore(key, e)
+	if loaded {
+		// Slot existed — replace and adjust counters. We use Store, not
+		// CompareAndSwap, because LoadOrStore's loser path is the rare
+		// case (singleflight already deduplicates concurrent writers).
+		if pe, ok := prev.(*L2Entry); ok && pe != nil {
+			globalL2.residentBytes.Add(-int64(pe.SizeBytes))
+			globalL2.residentCount.Add(-1)
+			// Reverse-index removal handled by registerReverseIndex below;
+			// since we're about to re-add, just skip the explicit detach.
+		}
+		globalL2.store.Store(key, e)
+	}
+	globalL2.residentBytes.Add(int64(e.SizeBytes))
+	globalL2.residentCount.Add(1)
+	globalL2.registerReverseIndex(key, e)
+	GlobalMetrics.L2Writes.Add(1)
+
+	// Cheap, opportunistic budget enforcement: if we're over the cap
+	// after this write, kick a sweep (best-effort; no goroutine fan-out).
+	if globalL2.residentBytes.Load() > l2MaxBytes() ||
+		int(globalL2.residentCount.Load()) > l2MaxEntries() {
+		globalL2.sweepLocked(time.Now().UnixNano())
+	}
+}
+
+// EvictL2ForL1Keys removes every L2 entry whose l1Key is in the input
+// set. Called from the watcher's DELETE-event path immediately after
+// L1 deletion. Cluster-restart-DELETE storms (10K+ events) are
+// debounced upstream by triggerL1RefreshBatch; this function does NOT
+// add additional batching — the upstream batch shape is the right
+// granularity.
+//
+// O(K) where K is the number of L2 entries pinned to those L1 keys
+// (typically ≤ 50 per L1 key — one per active binding identity ×
+// groups cohort).
+func EvictL2ForL1Keys(_ context.Context, l1Keys []string) int {
+	if !L2Enabled() || len(l1Keys) == 0 {
+		return 0
+	}
+	total := 0
+	for _, k := range l1Keys {
+		v, ok := globalL2.byL1Key.Load(k)
+		if !ok {
+			continue
+		}
+		bucket, ok := v.(*sync.Map)
+		if !ok {
+			continue
+		}
+		bucket.Range(func(hashKey, _ any) bool {
+			hk, _ := hashKey.(string)
+			if e, hit := globalL2.store.Load(hk); hit {
+				if pe, ok := e.(*L2Entry); ok {
+					globalL2.evictKey(hk, pe)
+					total++
+				}
+			}
+			bucket.Delete(hashKey)
+			return true
+		})
+		globalL2.byL1Key.Delete(k)
+	}
+	if total > 0 {
+		GlobalMetrics.L2EvictionsL1Delete.Add(int64(total))
+	}
+	return total
+}
+
+// EvictL2ForIdentity removes every L2 entry whose binding identity
+// matches `identity`. Called from purgeUserCacheData on CRB transitions
+// so the FIRST request post-transition computes refilter against the
+// NEW binding (G10). identity == "" is a no-op.
+func EvictL2ForIdentity(_ context.Context, identity string) int {
+	if !L2Enabled() || identity == "" {
+		return 0
+	}
+	v, ok := globalL2.byIdentity.Load(identity)
+	if !ok {
+		return 0
+	}
+	bucket, ok := v.(*sync.Map)
+	if !ok {
+		return 0
+	}
+	total := 0
+	bucket.Range(func(hashKey, _ any) bool {
+		hk, _ := hashKey.(string)
+		if e, hit := globalL2.store.Load(hk); hit {
+			if pe, ok := e.(*L2Entry); ok {
+				globalL2.evictKey(hk, pe)
+				total++
+			}
+		}
+		bucket.Delete(hashKey)
+		return true
+	})
+	globalL2.byIdentity.Delete(identity)
+	if total > 0 {
+		GlobalMetrics.L2EvictionsIdentity.Add(int64(total))
+	}
+	return total
+}
+
+// EvictL2ForRESTAction removes every L2 entry whose l1Key references
+// the given (gvrKey, name) tuple — one (gvrKey, name) maps to many L1
+// keys (one per binding identity × namespace × pagination). Called from
+// the RESTAction-CR-change path (filter or api[] mutation) since those
+// changes invalidate every cohort's refilter output for that resource.
+//
+// Uses the byGVRName reverse index so eviction is O(K) where K is the
+// number of L2 entries for that resource — typically ≤ 200 (10
+// identities × 1 ns × 1 name × ~20 paginated variants).
+func EvictL2ForRESTAction(_ context.Context, gvrKey, name string) int {
+	if !L2Enabled() || gvrKey == "" || name == "" {
+		return 0
+	}
+	tag := gvrKey + "/" + name
+	v, ok := globalL2.byGVRName.Load(tag)
+	if !ok {
+		return 0
+	}
+	bucket, ok := v.(*sync.Map)
+	if !ok {
+		return 0
+	}
+	total := 0
+	bucket.Range(func(hashKey, _ any) bool {
+		hk, _ := hashKey.(string)
+		if e, hit := globalL2.store.Load(hk); hit {
+			if pe, ok := e.(*L2Entry); ok {
+				globalL2.evictKey(hk, pe)
+				total++
+			}
+		}
+		bucket.Delete(hashKey)
+		return true
+	})
+	globalL2.byGVRName.Delete(tag)
+	if total > 0 {
+		GlobalMetrics.L2EvictionsRA.Add(int64(total))
+	}
+	return total
+}
+
+// L2ResidentBytes returns the current resident byte count (best-effort,
+// atomic). Exposed for /metrics/runtime.
+func L2ResidentBytes() int64 { return globalL2.residentBytes.Load() }
+
+// L2ResidentCount returns the current entry count.
+func L2ResidentCount() int64 { return globalL2.residentCount.Load() }
+
+// FlushL2ForTest clears the L2 cache. TEST-ONLY.
+func FlushL2ForTest() {
+	globalL2.store.Range(func(k, _ any) bool {
+		globalL2.store.Delete(k)
+		return true
+	})
+	globalL2.byL1Key.Range(func(k, _ any) bool {
+		globalL2.byL1Key.Delete(k)
+		return true
+	})
+	globalL2.byIdentity.Range(func(k, _ any) bool {
+		globalL2.byIdentity.Delete(k)
+		return true
+	})
+	globalL2.byGVRName.Range(func(k, _ any) bool {
+		globalL2.byGVRName.Delete(k)
+		return true
+	})
+	globalL2.residentBytes.Store(0)
+	globalL2.residentCount.Store(0)
+}
+
+// ── Internal: reverse-index + sweep ───────────────────────────────────────────
+
+// registerReverseIndex populates byL1Key, byIdentity, byGVRName so the
+// EvictL2For* helpers can reach every entry in O(K). Each bucket is
+// itself a sync.Map keyed by the L2 hash key — concurrent writers safe.
+func (idx *l2Index) registerReverseIndex(key string, e *L2Entry) {
+	if e.l1Key != "" {
+		bucket, _ := idx.byL1Key.LoadOrStore(e.l1Key, &sync.Map{})
+		bucket.(*sync.Map).Store(key, struct{}{})
+	}
+	if e.identity != "" {
+		bucket, _ := idx.byIdentity.LoadOrStore(e.identity, &sync.Map{})
+		bucket.(*sync.Map).Store(key, struct{}{})
+	}
+	if e.gvrName != "" {
+		bucket, _ := idx.byGVRName.LoadOrStore(e.gvrName, &sync.Map{})
+		bucket.(*sync.Map).Store(key, struct{}{})
+	}
+}
+
+// evictKey removes a single entry from the store and adjusts counters.
+// The reverse-index entries are NOT removed eagerly here — the caller
+// (which iterates the reverse index) is responsible. Background sweep
+// uses store.Delete which leaves dangling reverse-index pointers; those
+// resolve to a store-miss on the next eviction-by-reverse-index call
+// and are removed there. Net effect: bounded staleness, zero
+// correctness risk.
+func (idx *l2Index) evictKey(key string, e *L2Entry) {
+	if e == nil {
+		return
+	}
+	idx.store.Delete(key)
+	idx.residentBytes.Add(-int64(e.SizeBytes))
+	idx.residentCount.Add(-1)
+	GlobalMetrics.L2EvictionsTotal.Add(1)
+}
+
+// sweepLocked is the LRU sweep. Called inline when SetL2Refilter pushes
+// the cache over its caps; also called periodically from
+// StartL2EvictionLoop (set up by main.go alongside MemCache.StartEviction).
+//
+// Strategy: collect all entries' StoredAt + key, sort ascending, evict
+// from the head until residentBytes ≤ 0.9 × cap (10% slack so we don't
+// thrash on repeated writes). For 100K entries this is ~5 ms — well
+// under the 30s tick we run on.
+func (idx *l2Index) sweepLocked(_ int64) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	maxBytes := l2MaxBytes()
+	maxEntries := l2MaxEntries()
+	curBytes := idx.residentBytes.Load()
+	curCount := int(idx.residentCount.Load())
+
+	// Fast path: under both caps — nothing to do.
+	if curBytes <= maxBytes && curCount <= maxEntries {
+		return
+	}
+
+	type item struct {
+		key string
+		ts  int64
+		sz  int
+	}
+	items := make([]item, 0, curCount)
+	idx.store.Range(func(k, v any) bool {
+		ks, _ := k.(string)
+		e, ok := v.(*L2Entry)
+		if !ok || e == nil {
+			return true
+		}
+		items = append(items, item{key: ks, ts: e.StoredAt, sz: e.SizeBytes})
+		return true
+	})
+	sort.Slice(items, func(i, j int) bool { return items[i].ts < items[j].ts })
+
+	targetBytes := int64(float64(maxBytes) * 0.9)
+	targetCount := int(float64(maxEntries) * 0.9)
+
+	for _, it := range items {
+		if idx.residentBytes.Load() <= targetBytes && int(idx.residentCount.Load()) <= targetCount {
+			break
+		}
+		v, ok := idx.store.Load(it.key)
+		if !ok {
+			continue
+		}
+		e, _ := v.(*L2Entry)
+		if e == nil {
+			continue
+		}
+		idx.evictKey(it.key, e)
+		// Reverse-index entries become dangling; cleaned lazily on next
+		// targeted eviction (see comment in evictKey).
+	}
+}
+
+// StartL2EvictionLoop launches a background goroutine that runs the LRU
+// sweep every 30s (matches MemCache.StartEviction cadence). Cancellable
+// via ctx. Called once at startup from main.go after the L2 enabled
+// flag is honoured.
+func StartL2EvictionLoop(ctx context.Context) {
+	if !L2Enabled() {
+		return
+	}
+	go func() {
+		t := time.NewTicker(30 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				globalL2.sweepLocked(time.Now().UnixNano())
+			}
+		}
+	}()
+}
+
+// ── Convenience setter: build entry from refilter output + reverse-index
+//    fields, then write. Used by dispatcher + apiref so call sites stay
+//    one-liners.
+
+// L2Put builds an L2Entry from the refilter output and stores it. Returns
+// the entry (so the apiref consumer's caller can synchronously read the
+// status without a follow-up Get on writes that survived the gate).
+//
+// `refiltered` is the wire payload; `status` is the pre-decoded status
+// map (apiref pre-decode). Pass nil for status if the dispatcher path
+// computed only the bytes — apiref will lazily decode on its first L2
+// hit and re-Set with status populated (next-write upgrades the entry
+// in place).
+//
+// `rawL1Size` is the size of the L1 wrapper bytes (used by the reduction
+// gate). Pass 0 to bypass the gate (e.g. on prewarm).
+func L2Put(l1Key, identity, groupsHash string, refiltered []byte, status map[string]any, hasUAF bool, schemaVer string, rawL1Size int) {
+	if !L2Enabled() {
+		return
+	}
+	hk := L2Key(l1Key, identity, groupsHash)
+	if hk == "" || len(refiltered) == 0 {
+		return
+	}
+	e := &L2Entry{
+		Refiltered: append([]byte(nil), refiltered...), // defensive copy
+		Status:     status,
+		HasUAF:     hasUAF,
+		SchemaVer:  schemaVer,
+		l1Key:      l1Key,
+		identity:   identity,
+	}
+	SetL2Refilter(hk, e, rawL1Size)
+}
+
+// L2Get is the convenience reader. Mirrors GetL2Refilter but accepts
+// the (l1Key, identity, groupsHash) tuple so call sites avoid threading
+// the hash key through their own machinery.
+func L2Get(l1Key, identity, groupsHash string) (*L2Entry, bool) {
+	hk := L2Key(l1Key, identity, groupsHash)
+	if hk == "" {
+		return nil, false
+	}
+	return GetL2Refilter(hk)
+}

--- a/internal/cache/l2_refilter_test.go
+++ b/internal/cache/l2_refilter_test.go
@@ -1,0 +1,451 @@
+// Q-RBACC-L2-1 — unit tests for the post-refilter L2 cache.
+//
+// Coverage matrix:
+//
+//   - L2Key determinism (same inputs → same hash; ordering of any
+//     component flips the hash; empty inputs → empty key).
+//   - HashGroups stability (sort-invariant; empty → "no_groups").
+//   - SetL2 / GetL2 happy path with reduction-ratio gate.
+//   - Reduction-ratio gate skips high-ratio entries (admin × panels
+//     pattern; counter L2SkippedHighRatio increments).
+//   - Size-cap gate skips entries > MAX_ENTRY_BYTES (counter).
+//   - Schema-mismatch on read evicts opportunistically + miss.
+//   - LRU sweep evicts oldest entries when over cap.
+//   - EvictL2ForL1Keys evicts only the targeted entries.
+//   - EvictL2ForIdentity evicts only entries pinned to the identity.
+//   - EvictL2ForRESTAction evicts entries by gvr+name across cohorts.
+//   - Disabled flag short-circuits Get/Set without state change.
+//   - 1000-randomized-pair byte-equivalence harness (G9): the L2 entry
+//     returned by Get is BYTE-IDENTICAL to the value passed at Set time.
+//
+// All tests reset the package-global L2 between cases via
+// SetL2EnabledForTest + FlushL2ForTest. They DO NOT touch metrics
+// across cases (each case asserts a metric delta, not absolute value).
+
+package cache
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestL2Key_Determinism(t *testing.T) {
+	a := L2Key("snowplow:resolved:bid1:templates.krateo.io/v1/restactions:ns:name", "bid1", "ghash1")
+	b := L2Key("snowplow:resolved:bid1:templates.krateo.io/v1/restactions:ns:name", "bid1", "ghash1")
+	if a != b {
+		t.Fatalf("L2Key not deterministic: %q vs %q", a, b)
+	}
+	if len(a) != 32 {
+		t.Fatalf("L2Key length = %d; want 32 (hex-truncated SHA-256)", len(a))
+	}
+	c := L2Key("snowplow:resolved:bid1:templates.krateo.io/v1/restactions:ns:name", "bid2", "ghash1")
+	if a == c {
+		t.Fatalf("identity must enter the hash; got identical keys")
+	}
+	d := L2Key("snowplow:resolved:bid1:templates.krateo.io/v1/restactions:ns:name", "bid1", "ghash2")
+	if a == d {
+		t.Fatalf("groups hash must enter the hash; got identical keys")
+	}
+	e := L2Key("snowplow:resolved:bid2:templates.krateo.io/v1/restactions:ns:name", "bid1", "ghash1")
+	if a == e {
+		t.Fatalf("l1Key must enter the hash; got identical keys")
+	}
+}
+
+func TestL2Key_EmptyInputs(t *testing.T) {
+	if L2Key("", "id", "g") != "" {
+		t.Fatalf("empty l1Key must yield empty key")
+	}
+	if L2Key("k", "", "g") != "" {
+		t.Fatalf("empty identity must yield empty key")
+	}
+	if L2Key("k", "id", "") != "" {
+		t.Fatalf("empty groupsHash must yield empty key")
+	}
+}
+
+func TestHashGroups_SortInvariant(t *testing.T) {
+	a := HashGroups([]string{"alpha", "beta", "gamma"})
+	b := HashGroups([]string{"gamma", "alpha", "beta"})
+	if a != b {
+		t.Fatalf("HashGroups must be sort-invariant: %q vs %q", a, b)
+	}
+	if HashGroups(nil) != "no_groups" {
+		t.Fatalf("nil groups should produce no_groups sentinel")
+	}
+	if HashGroups([]string{}) != "no_groups" {
+		t.Fatalf("empty groups should produce no_groups sentinel")
+	}
+}
+
+func TestL2_SetGet_HappyPath(t *testing.T) {
+	enableL2(t)
+	k := L2Key("snowplow:resolved:bid:g/v/r:ns:name", "bid", "ghash")
+	want := []byte(`{"refiltered":true,"items":[1,2,3]}`)
+	e := &L2Entry{Refiltered: bytes.Clone(want), l1Key: "snowplow:resolved:bid:g/v/r:ns:name", identity: "bid", SchemaVer: "v3"}
+	SetL2Refilter(k, e, 1000) // L1 raw 1000B, refiltered 36B → ratio 0.036 → cached
+	got, ok := GetL2Refilter(k)
+	if !ok {
+		t.Fatalf("expected hit after Set")
+	}
+	if !bytes.Equal(got.Refiltered, want) {
+		t.Fatalf("byte-equivalence violation: got %q want %q", got.Refiltered, want)
+	}
+	if got.tag != L2EntryV1Tag {
+		t.Fatalf("tag not stamped on Set: %q", got.tag)
+	}
+}
+
+func TestL2_ReductionRatioGate_SkipsHighRatio(t *testing.T) {
+	enableL2(t)
+	k := L2Key("k1", "id1", "g1")
+	skipped0 := GlobalMetrics.L2SkippedHighRatio.Load()
+	// refiltered = 95% of L1 raw → ratio 0.95 → above 0.80 threshold → SKIP.
+	bigRefilter := bytes.Repeat([]byte("X"), 950)
+	SetL2Refilter(k, &L2Entry{Refiltered: bigRefilter, l1Key: "k1", identity: "id1"}, 1000)
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("high-ratio entry must be skipped (ratio 0.95 > 0.80)")
+	}
+	if got := GlobalMetrics.L2SkippedHighRatio.Load(); got <= skipped0 {
+		t.Fatalf("L2SkippedHighRatio counter did not advance (was %d, now %d)", skipped0, got)
+	}
+}
+
+func TestL2_ReductionRatioGate_AcceptsLowRatio(t *testing.T) {
+	enableL2(t)
+	k := L2Key("k2", "id2", "g2")
+	// refiltered = 10% of L1 raw → ratio 0.10 → cached.
+	smallRefilter := bytes.Repeat([]byte("Y"), 100)
+	SetL2Refilter(k, &L2Entry{Refiltered: smallRefilter, l1Key: "k2", identity: "id2"}, 1000)
+	if _, ok := GetL2Refilter(k); !ok {
+		t.Fatalf("low-ratio entry must be cached (ratio 0.10 < 0.80)")
+	}
+}
+
+func TestL2_SizeCap_SkipsHugeEntry(t *testing.T) {
+	enableL2(t)
+	t.Setenv(envL2MaxEntryBytes, "1024") // 1 KB cap for this test
+	k := L2Key("k3", "id3", "g3")
+	skipped0 := GlobalMetrics.L2SkippedSizeCap.Load()
+	huge := bytes.Repeat([]byte("Z"), 4096) // 4 KB > 1 KB cap
+	SetL2Refilter(k, &L2Entry{Refiltered: huge, l1Key: "k3", identity: "id3"}, 1<<20 /* huge raw */)
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("oversize entry must be skipped")
+	}
+	if got := GlobalMetrics.L2SkippedSizeCap.Load(); got <= skipped0 {
+		t.Fatalf("L2SkippedSizeCap counter did not advance")
+	}
+}
+
+func TestL2_BypassReductionGate_RawZero(t *testing.T) {
+	enableL2(t)
+	k := L2Key("k4", "id4", "g4")
+	// rawL1Size=0 → bypass reduction gate (used by prewarm).
+	bigRefilter := bytes.Repeat([]byte("X"), 5000)
+	SetL2Refilter(k, &L2Entry{Refiltered: bigRefilter, l1Key: "k4", identity: "id4"}, 0)
+	if _, ok := GetL2Refilter(k); !ok {
+		t.Fatalf("rawL1Size=0 must bypass the reduction gate")
+	}
+}
+
+func TestL2_SchemaTag_Mismatch_OpportunisticEvict(t *testing.T) {
+	enableL2(t)
+	k := L2Key("k5", "id5", "g5")
+	// Inject an entry with the wrong tag directly (bypassing SetL2Refilter
+	// which always stamps the correct tag).
+	bad := &L2Entry{Refiltered: []byte("stale"), tag: "l2-vBOGUS", l1Key: "k5", identity: "id5"}
+	globalL2.store.Store(k, bad)
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("entry with wrong tag must be treated as miss")
+	}
+	// And evicted on the read.
+	if _, ok := globalL2.store.Load(k); ok {
+		t.Fatalf("schema-mismatch entry must be opportunistically evicted")
+	}
+}
+
+func TestL2_DisabledShortCircuits(t *testing.T) {
+	defer FlushL2ForTest()
+	SetL2EnabledForTest(false)
+	defer SetL2EnabledForTest(true) // restore for downstream tests
+	k := L2Key("k6", "id6", "g6")
+	SetL2Refilter(k, &L2Entry{Refiltered: []byte("x"), l1Key: "k6", identity: "id6"}, 100)
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("disabled L2 must not store or return entries")
+	}
+}
+
+func TestL2_EvictL2ForL1Keys(t *testing.T) {
+	enableL2(t)
+	l1A := "snowplow:resolved:idA:g/v/r:ns:nameA"
+	l1B := "snowplow:resolved:idB:g/v/r:ns:nameB"
+	keyA := L2Key(l1A, "idA", "g1")
+	keyB := L2Key(l1B, "idB", "g1")
+	SetL2Refilter(keyA, &L2Entry{Refiltered: []byte("A"), l1Key: l1A, identity: "idA"}, 100)
+	SetL2Refilter(keyB, &L2Entry{Refiltered: []byte("B"), l1Key: l1B, identity: "idB"}, 100)
+
+	n := EvictL2ForL1Keys(context.Background(), []string{l1A})
+	if n != 1 {
+		t.Fatalf("EvictL2ForL1Keys: got %d evictions, want 1", n)
+	}
+	if _, ok := GetL2Refilter(keyA); ok {
+		t.Fatalf("keyA must be evicted")
+	}
+	if _, ok := GetL2Refilter(keyB); !ok {
+		t.Fatalf("keyB must remain")
+	}
+}
+
+func TestL2_EvictL2ForIdentity(t *testing.T) {
+	enableL2(t)
+	// Two cohorts, same RA, different identities.
+	l1A := "snowplow:resolved:idA:g/v/r:ns:name"
+	l1B := "snowplow:resolved:idB:g/v/r:ns:name"
+	keyA := L2Key(l1A, "idA", "g1")
+	keyB := L2Key(l1B, "idB", "g1")
+	SetL2Refilter(keyA, &L2Entry{Refiltered: []byte("A"), l1Key: l1A, identity: "idA"}, 100)
+	SetL2Refilter(keyB, &L2Entry{Refiltered: []byte("B"), l1Key: l1B, identity: "idB"}, 100)
+	n := EvictL2ForIdentity(context.Background(), "idA")
+	if n != 1 {
+		t.Fatalf("EvictL2ForIdentity: got %d, want 1", n)
+	}
+	if _, ok := GetL2Refilter(keyA); ok {
+		t.Fatalf("idA entries must be evicted")
+	}
+	if _, ok := GetL2Refilter(keyB); !ok {
+		t.Fatalf("idB entries must remain")
+	}
+}
+
+func TestL2_EvictL2ForRESTAction(t *testing.T) {
+	enableL2(t)
+	// Multiple cohorts share the same RESTAction (gvr/name); RA mutation
+	// must evict ALL of them.
+	gvrKey := "g/v/r"
+	name := "compositions-list"
+	l1A := "snowplow:resolved:idA:" + gvrKey + ":ns:" + name
+	l1B := "snowplow:resolved:idB:" + gvrKey + ":ns:" + name
+	keyA := L2Key(l1A, "idA", "g1")
+	keyB := L2Key(l1B, "idB", "g1")
+	SetL2Refilter(keyA, &L2Entry{Refiltered: []byte("A"), l1Key: l1A, identity: "idA"}, 100)
+	SetL2Refilter(keyB, &L2Entry{Refiltered: []byte("B"), l1Key: l1B, identity: "idB"}, 100)
+	n := EvictL2ForRESTAction(context.Background(), gvrKey, name)
+	if n != 2 {
+		t.Fatalf("EvictL2ForRESTAction: got %d, want 2 (cohorts share the same RA)", n)
+	}
+	if _, ok := GetL2Refilter(keyA); ok {
+		t.Fatalf("keyA must be evicted on RA mutation")
+	}
+	if _, ok := GetL2Refilter(keyB); ok {
+		t.Fatalf("keyB must be evicted on RA mutation")
+	}
+}
+
+// G9 — byte-equivalence harness over 1000 random (user, l1Key) pairs.
+//
+// The contract: for any (user, l1Key), L2 returns BYTE-IDENTICAL bytes
+// to what was passed at Set time. This is the load-bearing test against
+// `feedback_cache_must_not_constrain_jq.md` — if L2 ever truncates,
+// canonicalises, or otherwise mutates the bytes, this test catches it.
+func TestL2_G9_ByteEquivalence_1000Pairs(t *testing.T) {
+	enableL2(t)
+
+	type pair struct {
+		l1Key      string
+		identity   string
+		groupsHash string
+		want       []byte
+	}
+	pairs := make([]pair, 1000)
+	for i := range pairs {
+		// 8-byte random suffix per pair guarantees uniqueness without
+		// relying on any deterministic counter (which would mask
+		// hash-collision bugs).
+		buf := make([]byte, 8)
+		_, _ = rand.Read(buf)
+		// payload size varies 1–8 KB to exercise small-and-large
+		size := 1024 + (int(buf[0])*32)%(7*1024)
+		payload := make([]byte, size)
+		_, _ = rand.Read(payload)
+
+		pairs[i] = pair{
+			l1Key:      fmt.Sprintf("snowplow:resolved:bid%d:g/v/r:ns:name%d", i, i),
+			identity:   fmt.Sprintf("bid%d", i),
+			groupsHash: fmt.Sprintf("ghash%x", buf),
+			want:       payload,
+		}
+		k := L2Key(pairs[i].l1Key, pairs[i].identity, pairs[i].groupsHash)
+		SetL2Refilter(k, &L2Entry{
+			Refiltered: bytes.Clone(payload),
+			l1Key:      pairs[i].l1Key,
+			identity:   pairs[i].identity,
+		}, 0 /* bypass ratio gate so every payload is cached */)
+	}
+
+	// Now read every pair back and assert byte-equivalence.
+	for i, p := range pairs {
+		k := L2Key(p.l1Key, p.identity, p.groupsHash)
+		e, ok := GetL2Refilter(k)
+		if !ok {
+			t.Fatalf("pair %d: L2 miss after Set", i)
+		}
+		if !bytes.Equal(e.Refiltered, p.want) {
+			t.Fatalf("pair %d: byte-equivalence violation (len got=%d want=%d)",
+				i, len(e.Refiltered), len(p.want))
+		}
+	}
+}
+
+// TestL2_G11_HitRatePattern simulates the burst pattern (1 cold + 9
+// hits) and asserts hit-rate ≥ 90%. This is the unit-form of G11.
+func TestL2_G11_HitRatePattern(t *testing.T) {
+	enableL2(t)
+	// Reset L2 metric counters for a clean measurement.
+	GlobalMetrics.L2Hits.Store(0)
+	GlobalMetrics.L2Misses.Store(0)
+
+	l1Key := "snowplow:resolved:bidH:g/v/r:ns:nameH"
+	identity := "bidH"
+	groupsHash := "ghash-burst"
+	k := L2Key(l1Key, identity, groupsHash)
+
+	// Rep 1: cold (miss).
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("rep1 should miss")
+	}
+	// Pretend the dispatcher computed and stored.
+	SetL2Refilter(k, &L2Entry{Refiltered: []byte("burstpayload"), l1Key: l1Key, identity: identity}, 1000)
+
+	// Reps 2..10: hits.
+	for i := 2; i <= 10; i++ {
+		if _, ok := GetL2Refilter(k); !ok {
+			t.Fatalf("rep%d should hit", i)
+		}
+	}
+	hits := GlobalMetrics.L2Hits.Load()
+	misses := GlobalMetrics.L2Misses.Load()
+	rate := float64(hits) / float64(hits+misses)
+	if rate < 0.90 {
+		t.Fatalf("G11 hit-rate < 0.90: hits=%d misses=%d rate=%.3f", hits, misses, rate)
+	}
+}
+
+// TestL2_G12_SkipsAdminPanelsPattern simulates the admin × compositions-
+// panels pattern (post-refilter ≈ L1) and asserts the entry is recorded
+// as L2SkippedHighRatio (validates the conditional caching policy).
+func TestL2_G12_SkipsAdminPanelsPattern(t *testing.T) {
+	enableL2(t)
+	skipped0 := GlobalMetrics.L2SkippedHighRatio.Load()
+	k := L2Key("snowplow:resolved:admin:g/v/r:ns:compositions-panels", "admin", "ghash-admin")
+
+	// Admin sees all 50 NS; refilter is a near-pass-through.
+	rawSize := 40 << 20
+	refiltered := bytes.Repeat([]byte("X"), int(float64(rawSize)*0.95)) // 95% of L1
+	SetL2Refilter(k, &L2Entry{Refiltered: refiltered, l1Key: "x", identity: "admin"}, rawSize)
+
+	if got := GlobalMetrics.L2SkippedHighRatio.Load(); got <= skipped0 {
+		t.Fatalf("G12 admin-panels pattern should record L2SkippedHighRatio")
+	}
+	if _, ok := GetL2Refilter(k); ok {
+		t.Fatalf("admin × panels must not be cached when ratio > 0.80")
+	}
+}
+
+func TestL2_LRUSweep_BoundsResident(t *testing.T) {
+	enableL2(t)
+	// Tighten the byte cap so the sweep fires.
+	t.Setenv(envL2MaxBytes, "10240") // 10 KB cap
+	t.Setenv(envL2MaxEntries, "1000")
+
+	for i := 0; i < 50; i++ {
+		k := L2Key(fmt.Sprintf("k-lru-%d", i), fmt.Sprintf("id-%d", i), "g-lru")
+		// Each entry ~512 B → 50 × 512 = 25 KB > 10 KB cap → sweep evicts.
+		SetL2Refilter(k, &L2Entry{
+			Refiltered: bytes.Repeat([]byte("a"), 512),
+			l1Key:      fmt.Sprintf("k-lru-%d", i),
+			identity:   fmt.Sprintf("id-%d", i),
+		}, 0)
+	}
+	// After all writes the resident bytes must be at-or-below cap.
+	// (The sweep targets 90% of cap on each overshoot, so the final
+	// state oscillates between 90% and 100% as new writes accumulate
+	// up to the next sweep trigger. 100% is a valid steady state.)
+	if got := L2ResidentBytes(); got > 10240 {
+		t.Fatalf("LRU sweep failed to bound resident bytes: %d > 10240 (cap)", got)
+	}
+}
+
+// TestL2_ConcurrentSetGet — race-discovery harness for the Get/Set
+// surfaces. Run with `go test -race`.
+func TestL2_ConcurrentSetGet(t *testing.T) {
+	enableL2(t)
+	const writers = 32
+	const writes = 500
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	var totalSet atomic.Int64
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < writes; i++ {
+				k := L2Key(
+					fmt.Sprintf("snowplow:resolved:bid-conc-%d:g/v/r:ns:name", w),
+					fmt.Sprintf("bid-conc-%d", w),
+					"g-conc",
+				)
+				SetL2Refilter(k, &L2Entry{
+					Refiltered: []byte(fmt.Sprintf("payload-%d-%d", w, i)),
+					l1Key:      fmt.Sprintf("snowplow:resolved:bid-conc-%d:g/v/r:ns:name", w),
+					identity:   fmt.Sprintf("bid-conc-%d", w),
+				}, 1000)
+				_, _ = GetL2Refilter(k)
+				totalSet.Add(1)
+			}
+		}(w)
+	}
+	wg.Wait()
+	// We don't assert exact counters under concurrency — sufficient that
+	// the test ran without a -race violation.
+	if totalSet.Load() != writers*writes {
+		t.Fatalf("counter mismatch: %d", totalSet.Load())
+	}
+}
+
+// TestL2Hash_NoCollisionAcrossComponents — adversarial test that the
+// '|' separator and SHA-256 hash don't suffer from a trivial collision
+// (e.g., l1Key="a|b", identity="" would NOT collide with l1Key="a",
+// identity="b" because empty inputs short-circuit to "").
+func TestL2Hash_NoCollisionAcrossComponents(t *testing.T) {
+	a := L2Key("a", "b|c", "d")
+	b := L2Key("a|b", "c", "d")
+	if a == b {
+		t.Fatalf("hash collision across separator: %q", a)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// enableL2 turns the L2 cache on for the duration of the calling test
+// and flushes state. Tests that need a fresh L2 should call this first.
+// Restores prior state on test cleanup.
+func enableL2(t *testing.T) {
+	t.Helper()
+	prev := globalL2.enabled.Load()
+	SetL2EnabledForTest(true)
+	FlushL2ForTest()
+	t.Cleanup(func() {
+		FlushL2ForTest()
+		globalL2.enabled.Store(prev)
+	})
+}
+
+// _ keeps sort imported — used by HashGroups via the production code,
+// referenced here so go imports doesn't strip if the file is reorganized.
+var _ = sort.Strings

--- a/internal/cache/l2_refilter_test.go
+++ b/internal/cache/l2_refilter_test.go
@@ -381,6 +381,97 @@ func TestL2_LRUSweep_BoundsResident(t *testing.T) {
 	}
 }
 
+// TestL2_StatusImmutableAfterSet — Q-RBACC-L2-1 architect-review
+// CONCERN-1 (2026-05-05). After SetL2Refilter publishes an L2Entry,
+// the Status field MUST NOT be mutated by any read path. The
+// previous lazy-fill design wrote `l2e.Status = decoded` from
+// concurrent readers — a data race on the *L2Entry pointer shared
+// via sync.Map.
+//
+// This test:
+//
+//  1. Writes an entry with Status pre-populated (current contract).
+//  2. Forks 32 readers concurrently issuing GetL2Refilter.
+//  3. Each reader reads Status[key] and asserts it matches expected.
+//
+// Run with `go test -race` to catch any concurrent write to the
+// Status map (or to the L2Entry struct fields). The previous
+// lazy-fill design would fail the race detector on this exact shape.
+func TestL2_StatusImmutableAfterSet(t *testing.T) {
+	enableL2(t)
+
+	k := L2Key("snowplow:resolved:bid:g/v/r:ns:name", "bid", "ghash")
+	status := map[string]any{"answer": 42, "list": []any{"a", "b"}}
+
+	SetL2Refilter(k, &L2Entry{
+		Refiltered: []byte(`{"status":{"answer":42}}`),
+		Status:     status,
+		l1Key:      "snowplow:resolved:bid:g/v/r:ns:name",
+		identity:   "bid",
+	}, 1000)
+
+	const readers = 32
+	const iters = 500
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				e, ok := GetL2Refilter(k)
+				if !ok {
+					t.Errorf("unexpected miss")
+					return
+				}
+				if e.Status == nil {
+					t.Errorf("nil Status (writer should populate at write time)")
+					return
+				}
+				if v, _ := e.Status["answer"].(int); v != 42 {
+					t.Errorf("status[answer] mismatch: got %v", e.Status["answer"])
+					return
+				}
+				// Length stable: no concurrent writer is mutating Status.
+				if len(e.Status) != 2 {
+					t.Errorf("Status length changed under reader: %d", len(e.Status))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestL2_NilStatusIsSoftMiss — when an L2 entry was published with
+// Status==nil (defensive shape against future codec migration), the
+// apiref read site treats it as a soft miss and falls through to a
+// fresh refilter. The cache layer simply returns the entry as-is;
+// the apiref caller decides what nil Status means. This test asserts
+// the cache layer does NOT lazy-fill (no mutation post-publish).
+func TestL2_NilStatusIsSoftMiss(t *testing.T) {
+	enableL2(t)
+
+	k := L2Key("nil-status-key", "id-ns", "g-ns")
+	SetL2Refilter(k, &L2Entry{
+		Refiltered: []byte(`{}`),
+		Status:     nil, // explicit nil
+		l1Key:      "nil-status-key",
+		identity:   "id-ns",
+	}, 1000)
+
+	// Two consecutive reads must observe Status==nil; the cache layer
+	// MUST NOT mutate the entry to populate Status.
+	for i := 0; i < 2; i++ {
+		e, ok := GetL2Refilter(k)
+		if !ok {
+			t.Fatalf("expected hit on iteration %d", i)
+		}
+		if e.Status != nil {
+			t.Fatalf("CONCERN-1: cache layer lazy-filled Status (was nil at write); iter %d", i)
+		}
+	}
+}
+
 // TestL2_ConcurrentSetGet — race-discovery harness for the Get/Set
 // surfaces. Run with `go test -race`.
 func TestL2_ConcurrentSetGet(t *testing.T) {

--- a/internal/cache/metrics.go
+++ b/internal/cache/metrics.go
@@ -57,6 +57,19 @@ type Metrics struct {
 	WatchEventsUpdate          atomic.Int64
 	WatchEventsDelete          atomic.Int64
 	WatchEventsDeleteTombstone atomic.Int64
+
+	// ── L2 post-refilter cache (Q-RBACC-L2-1) ────────────────────────────
+	// Counters surface at /metrics/runtime under l2_* keys. Hit-rate is
+	// computed by the snapshot consumer.
+	L2Hits               atomic.Int64
+	L2Misses             atomic.Int64
+	L2Writes             atomic.Int64
+	L2SkippedHighRatio   atomic.Int64
+	L2SkippedSizeCap     atomic.Int64
+	L2EvictionsL1Delete  atomic.Int64
+	L2EvictionsIdentity  atomic.Int64
+	L2EvictionsRA        atomic.Int64
+	L2EvictionsTotal     atomic.Int64
 }
 
 // Inc atomically increments the given counter and updates the OTel metric.
@@ -104,6 +117,22 @@ type MetricsSnapshot struct {
 	WatchEventsUpdate          int64 `json:"watch_events_update"`
 	WatchEventsDelete          int64 `json:"watch_events_delete"`
 	WatchEventsDeleteTombstone int64 `json:"watch_events_delete_tombstone"`
+
+	// L2 post-refilter cache (Q-RBACC-L2-1). HitRate is computed in the
+	// snapshot for parity with L1. ResidentBytes/Count are sampled once
+	// per snapshot from the live counters.
+	L2Hits              int64   `json:"l2_hits"`
+	L2Misses            int64   `json:"l2_misses"`
+	L2Writes            int64   `json:"l2_writes"`
+	L2SkippedHighRatio  int64   `json:"l2_skipped_high_ratio"`
+	L2SkippedSizeCap    int64   `json:"l2_skipped_size_cap"`
+	L2EvictionsL1Delete int64   `json:"l2_evictions_l1_delete"`
+	L2EvictionsIdentity int64   `json:"l2_evictions_identity"`
+	L2EvictionsRA       int64   `json:"l2_evictions_ra"`
+	L2EvictionsTotal    int64   `json:"l2_evictions_total"`
+	L2HitRate           float64 `json:"l2_hit_rate"`
+	L2ResidentBytes     int64   `json:"l2_resident_bytes"`
+	L2ResidentCount     int64   `json:"l2_resident_count"`
 }
 
 var GlobalMetrics = &Metrics{}
@@ -144,11 +173,24 @@ func (m *Metrics) snapshotFromAtomics() MetricsSnapshot {
 		WatchEventsUpdate:          m.WatchEventsUpdate.Load(),
 		WatchEventsDelete:          m.WatchEventsDelete.Load(),
 		WatchEventsDeleteTombstone: m.WatchEventsDeleteTombstone.Load(),
+
+		L2Hits:              m.L2Hits.Load(),
+		L2Misses:            m.L2Misses.Load(),
+		L2Writes:            m.L2Writes.Load(),
+		L2SkippedHighRatio:  m.L2SkippedHighRatio.Load(),
+		L2SkippedSizeCap:    m.L2SkippedSizeCap.Load(),
+		L2EvictionsL1Delete: m.L2EvictionsL1Delete.Load(),
+		L2EvictionsIdentity: m.L2EvictionsIdentity.Load(),
+		L2EvictionsRA:       m.L2EvictionsRA.Load(),
+		L2EvictionsTotal:    m.L2EvictionsTotal.Load(),
+		L2ResidentBytes:     L2ResidentBytes(),
+		L2ResidentCount:     L2ResidentCount(),
 	}
 	s.GetHitRate = hitRate(s.GetHits, s.GetMisses)
 	s.ListHitRate = hitRate(s.ListHits, s.ListMisses)
 	s.RBACHitRate = hitRate(s.RBACHits, s.RBACMisses)
 	s.L1HitRate = hitRate(s.L1Hits, s.L1Misses)
+	s.L2HitRate = hitRate(s.L2Hits, s.L2Misses)
 	if sampled := m.ClusterDepSampledKeys.Load(); sampled > 0 {
 		s.ClusterDepSetSizeAvg = float64(m.ClusterDepSetSizeSumLast.Load()) / float64(sampled)
 	}

--- a/internal/cache/rbac_watcher.go
+++ b/internal/cache/rbac_watcher.go
@@ -248,7 +248,8 @@ func (rw *RBACWatcher) purgeUserCacheData(ctx context.Context, username string) 
 	// the new identity. We purge it because the RBAC decisions cached
 	// under the new identity may have been stale (computed before the
 	// binding change propagated).
-	if newBid := rw.ComputeBindingIdentity(username, nil); newBid != "" && newBid != username && newBid != oldBid {
+	newBid := rw.ComputeBindingIdentity(username, nil)
+	if newBid != "" && newBid != username && newBid != oldBid {
 		_ = rw.cache.DeleteUserRBAC(ctx, newBid)
 		total++
 		bidIdx := UserResolvedIndexKey(newBid)
@@ -261,6 +262,27 @@ func (rw *RBACWatcher) purgeUserCacheData(ctx context.Context, username string) 
 			total += len(bidKeys)
 		}
 	}
+
+	// Q-RBACC-L2-1 — evict the L2 post-refilter cache entries pinned to
+	// the affected binding identities. The OLD binding identity is the
+	// one the user's L2 entries were keyed under BEFORE this CRB change
+	// fired; the NEW identity (if it differs) is the one upcoming
+	// requests will use. Both must be cleared so the FIRST
+	// post-transition request returns refilter-against-NEW-binding bytes
+	// (G10), and the OLD identity's tombstoned entries are not served to
+	// any other user that happens to land on the same identity.
+	//
+	// The username-as-fallback case (CacheIdentity returns username when
+	// no bid is in ctx) is also handled: pass `username` so the L2
+	// reverse-index by identity catches it too. evictL2ForIdentity is
+	// no-op for unknown identities (returns 0).
+	if oldBid != "" {
+		_ = EvictL2ForIdentity(ctx, oldBid)
+	}
+	if newBid != "" {
+		_ = EvictL2ForIdentity(ctx, newBid)
+	}
+	_ = EvictL2ForIdentity(ctx, username)
 
 	return total
 }

--- a/internal/cache/rbac_watcher.go
+++ b/internal/cache/rbac_watcher.go
@@ -202,16 +202,57 @@ func (rw *RBACWatcher) invalidateFromBinding(ctx context.Context, obj any) {
 //     also purges the binding-identity-keyed RBAC hash and L1 resolved index
 //
 // Returns the total number of keys deleted.
+//
+// Q-RBACC-L2-1 architect-review CONCERN-2 (2026-05-05) — ORDERING is
+// load-bearing. apiref reads L2 BEFORE L1 (apiref/resolve.go: L2Get
+// runs before c.GetRaw). If we evicted L1 first, a microsecond
+// window would open where:
+//
+//   1. L1 evicted.
+//   2. Concurrent apiref read finds STALE L2, serves stale bytes
+//      against the OLD binding (G10 violation — cyberjoker post-CRB
+//      sees old-binding refiltered output).
+//   3. L2 evicted (window closes).
+//
+// Fix: evict L2 FIRST, then L1. Concurrent reads see L2 miss → fall
+// through to L1 → if L1 still present, refilter against (still-cached)
+// old wrapper but with the new identity in ctx — which produces the
+// CORRECT new-binding refilter, because RefilterRESTAction recomputes
+// per-user against the cached unfiltered ProtectedDict. Then L1
+// evicts; subsequent reads MISS at L1 too and re-resolve. Either path
+// returns new-binding bytes; no stale-L2 window.
 func (rw *RBACWatcher) purgeUserCacheData(ctx context.Context, username string) int {
 	total := 0
 
-	// Load old identity from cache BEFORE clearing it, so we can purge
-	// stale entries keyed under the previous binding identity.
+	// Phase 1: snapshot identities (no cache mutation yet).
+	//
+	// Load old identity BEFORE clearing the in-memory cache so we can
+	// purge stale entries keyed under the previous binding identity.
+	// Compute new identity ahead of any cache mutation so the L2 evict
+	// step (Phase 2) has the full identity set without ordering hazards.
 	var oldBid string
 	if v, ok := rw.identityCache.Load(username); ok {
 		oldBid = v.(string)
 	}
 	rw.identityCache.Delete(username)
+	newBid := rw.ComputeBindingIdentity(username, nil)
+
+	// Phase 2: evict L2 FIRST (architect CONCERN-2). Order matters
+	// because apiref reads L2 before L1 — flushing L1 first would
+	// expose a stale-L2 read window.
+	//
+	// EvictL2ForIdentity is no-op for unknown identities (the byIdentity
+	// reverse-index lookup misses, returning 0). Safe to call with
+	// empty / unknown values; cheap.
+	if oldBid != "" {
+		_ = EvictL2ForIdentity(ctx, oldBid)
+	}
+	if newBid != "" {
+		_ = EvictL2ForIdentity(ctx, newBid)
+	}
+	_ = EvictL2ForIdentity(ctx, username)
+
+	// Phase 3: evict L1 + RBAC hash entries.
 
 	// Purge username-keyed entries (backward compat / migration).
 	_ = rw.cache.DeleteUserRBAC(ctx, username)
@@ -248,7 +289,6 @@ func (rw *RBACWatcher) purgeUserCacheData(ctx context.Context, username string) 
 	// the new identity. We purge it because the RBAC decisions cached
 	// under the new identity may have been stale (computed before the
 	// binding change propagated).
-	newBid := rw.ComputeBindingIdentity(username, nil)
 	if newBid != "" && newBid != username && newBid != oldBid {
 		_ = rw.cache.DeleteUserRBAC(ctx, newBid)
 		total++
@@ -262,27 +302,6 @@ func (rw *RBACWatcher) purgeUserCacheData(ctx context.Context, username string) 
 			total += len(bidKeys)
 		}
 	}
-
-	// Q-RBACC-L2-1 — evict the L2 post-refilter cache entries pinned to
-	// the affected binding identities. The OLD binding identity is the
-	// one the user's L2 entries were keyed under BEFORE this CRB change
-	// fired; the NEW identity (if it differs) is the one upcoming
-	// requests will use. Both must be cleared so the FIRST
-	// post-transition request returns refilter-against-NEW-binding bytes
-	// (G10), and the OLD identity's tombstoned entries are not served to
-	// any other user that happens to land on the same identity.
-	//
-	// The username-as-fallback case (CacheIdentity returns username when
-	// no bid is in ctx) is also handled: pass `username` so the L2
-	// reverse-index by identity catches it too. evictL2ForIdentity is
-	// no-op for unknown identities (returns 0).
-	if oldBid != "" {
-		_ = EvictL2ForIdentity(ctx, oldBid)
-	}
-	if newBid != "" {
-		_ = EvictL2ForIdentity(ctx, newBid)
-	}
-	_ = EvictL2ForIdentity(ctx, username)
 
 	return total
 }

--- a/internal/cache/rbac_watcher_l2_ordering_test.go
+++ b/internal/cache/rbac_watcher_l2_ordering_test.go
@@ -1,0 +1,165 @@
+// Q-RBACC-L2-1 architect-review CONCERN-2 (2026-05-05) — purge ordering.
+//
+// purgeUserCacheData MUST evict L2 before any L1 cache.Delete fires.
+// apiref reads L2 before L1, so L1-then-L2 ordering exposes a stale-L2
+// window where the user observes refiltered bytes against the OLD
+// binding even though L1 was already cleared.
+//
+// This test wraps a MemCache with an orderingCache decorator that
+// records (operation, time-of-call). For each cache.Delete invocation,
+// the decorator records a snapshot of L2ResidentBytes for the test
+// identity. The invariant: at every Delete event, the L2 entries for
+// the test identity are already evicted.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// orderingCache wraps a MemCache and records the L2 resident-count
+// snapshot at every Delete invocation. Used to assert the ordering
+// invariant: L2 evict precedes L1 delete in purgeUserCacheData.
+type orderingCache struct {
+	*MemCache
+	deletes []deleteSnapshot
+}
+
+type deleteSnapshot struct {
+	t              time.Time
+	keys           []string
+	l2ResidentByID int64 // L2 byIdentity bucket size for the test identity
+}
+
+func (oc *orderingCache) Delete(ctx context.Context, keys ...string) error {
+	cnt := byIdentitySize(testIdentityForOrdering)
+	oc.deletes = append(oc.deletes, deleteSnapshot{
+		t:              time.Now(),
+		keys:           append([]string(nil), keys...),
+		l2ResidentByID: cnt,
+	})
+	return oc.MemCache.Delete(ctx, keys...)
+}
+
+func (oc *orderingCache) DeleteUserRBAC(ctx context.Context, username string) error {
+	cnt := byIdentitySize(testIdentityForOrdering)
+	oc.deletes = append(oc.deletes, deleteSnapshot{
+		t:              time.Now(),
+		keys:           []string{"<DeleteUserRBAC:" + username + ">"},
+		l2ResidentByID: cnt,
+	})
+	return oc.MemCache.DeleteUserRBAC(ctx, username)
+}
+
+const testIdentityForOrdering = "test-bid-ordering"
+
+// byIdentitySize returns the count of L2 entries pinned to identity.
+// Reads the byIdentity reverse-index; returns 0 for unknown identities.
+func byIdentitySize(identity string) int64 {
+	v, ok := globalL2.byIdentity.Load(identity)
+	if !ok {
+		return 0
+	}
+	bucket, ok := v.(*sync.Map)
+	if !ok {
+		return 0
+	}
+	var n int64
+	bucket.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// TestPurgeUserCacheData_L2EvictsBeforeL1 — Q-RBACC-L2-1 architect-
+// review CONCERN-2 (2026-05-05). Asserts that purgeUserCacheData
+// evicts L2 entries pinned to the user's binding identity BEFORE
+// issuing any L1 cache.Delete (or DeleteUserRBAC).
+//
+// We exercise the ordering invariant directly by:
+//
+//  1. Pre-seeding an L2 entry for the test identity.
+//  2. Pre-seeding an L1 resolved-index member so purgeUserCacheData
+//     attempts to delete a L1 key.
+//  3. Calling purgeUserCacheData under an orderingCache wrapper.
+//  4. Asserting: at the time of the FIRST Delete or DeleteUserRBAC
+//     event, the L2 byIdentity bucket for the test identity is empty.
+//
+// This is a direct race-free assertion of the architect's CONCERN-2
+// fix (no goroutine synchronisation; the ordering is sequential
+// inside purgeUserCacheData).
+func TestPurgeUserCacheData_L2EvictsBeforeL1(t *testing.T) {
+	enableL2(t)
+	mc := NewMem(time.Hour)
+	oc := &orderingCache{MemCache: mc}
+
+	// Pre-seed: one L2 entry pinned to the test identity (so the L2
+	// reverse-index has at least one entry to evict).
+	identity := testIdentityForOrdering
+	l1Key := "snowplow:resolved:" + identity + ":g/v/r:ns:testra"
+	hk := L2Key(l1Key, identity, "ghash-x")
+	SetL2Refilter(hk, &L2Entry{
+		Refiltered: []byte("payload"),
+		Status:     map[string]any{"k": "v"},
+		l1Key:      l1Key,
+		identity:   identity,
+	}, 1000)
+
+	// Sanity: pre-call, the byIdentity bucket has 1 entry.
+	if got := byIdentitySize(identity); got != 1 {
+		t.Fatalf("pre-seed: byIdentity=%d, want 1", got)
+	}
+
+	// Construct an RBACWatcher with the wrapped cache. Informers are
+	// not started — ComputeBindingIdentity will return "" (synced=false),
+	// which is acceptable here: we exercise the (oldBid, newBid="")
+	// ordering. The L2 evict still runs for oldBid via the
+	// identityCache pre-seed below.
+	rw := &RBACWatcher{cache: oc}
+	// Pre-seed the identityCache so purgeUserCacheData sees oldBid =
+	// testIdentityForOrdering.
+	username := "test-user"
+	rw.identityCache.Store(username, identity)
+
+	// Run the purge. With the architect CONCERN-2 fix, L2 evict
+	// happens FIRST (Phase 2), then L1 + DeleteUserRBAC (Phase 3).
+	rw.purgeUserCacheData(context.Background(), username)
+
+	if len(oc.deletes) == 0 {
+		t.Fatalf("expected at least one cache.Delete or DeleteUserRBAC during purge")
+	}
+
+	// THE LOAD-BEARING ASSERTION: at the FIRST L1-touching call, the
+	// L2 byIdentity bucket for `identity` MUST already be empty.
+	first := oc.deletes[0]
+	if first.l2ResidentByID != 0 {
+		t.Fatalf(
+			"CONCERN-2: at first L1 op, L2 byIdentity[%s] = %d (must be 0). "+
+				"Order detected: %v",
+			identity, first.l2ResidentByID, sumarizeDeletes(oc.deletes),
+		)
+	}
+
+	// Defense in depth: every subsequent L1 op should also see the L2
+	// byIdentity bucket already drained (we never re-populate during a
+	// single purge call).
+	for i, d := range oc.deletes {
+		if d.l2ResidentByID != 0 {
+			t.Fatalf("delete[%d] observed L2 byIdentity=%d (expected 0)", i, d.l2ResidentByID)
+		}
+	}
+}
+
+func sumarizeDeletes(ds []deleteSnapshot) []string {
+	out := make([]string, len(ds))
+	for i, d := range ds {
+		out[i] = fmt.Sprintf("[t+%dus l2=%d keys=%v]",
+			d.t.UnixNano()/1000%1_000_000_000, d.l2ResidentByID, d.keys)
+	}
+	return out
+}

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -854,6 +854,53 @@ func (rw *ResourceWatcher) triggerL1RefreshBatch(ctx context.Context, events []l
 	if (hasDelete || hasAdd) && len(apiResultKeys) > 0 {
 		_ = rw.cache.Delete(ctx, apiResultKeys...)
 	}
+
+	// Q-RBACC-L2-1 — DELETE-driven L2 eviction. Per
+	// feedback_l1_invalidation_delete_only.md, L2 evicts ONLY on K8s
+	// DELETE events (the same rule that gates L1 outer-key deletion);
+	// UPDATE/PATCH stays SWR. We collect the L1-resolved keys touched
+	// by THIS batch and pass them to EvictL2ForL1Keys. Reverse-index
+	// keeps the eviction O(K) where K is the # of L2 entries pinned to
+	// these L1 keys (typically ≤ 50).
+	//
+	// NOTE: this fires on hasDelete only (not hasAdd); ADD events do
+	// NOT evict L2 — the L1 entry is refreshed in place and the prior
+	// L2 entry remains valid until L1 raw bytes change (next time the
+	// dispatcher computes a refilter, the new L1 wrapper produces a
+	// distinct entry that overwrites the L2 slot). This matches the
+	// stale-while-revalidate invariant.
+	if hasDelete && L2Enabled() {
+		l1Keys := make([]string, 0, len(allKeys))
+		for k := range allKeys {
+			if !IsAPIResultKey(k) {
+				l1Keys = append(l1Keys, k)
+			}
+		}
+		if len(l1Keys) > 0 {
+			_ = EvictL2ForL1Keys(ctx, l1Keys)
+		}
+	}
+
+	// Q-RBACC-L2-1 — RESTAction-CR-change L2 eviction. The L2 entry is
+	// the function of (L1 wrapper, identity, groups). When the RESTAction
+	// CR itself mutates (filter expression or api[] block change), the
+	// cached refilter bytes are invalid even though the l1Key has not
+	// changed. Per spec §2.2 row 4, evict L2 entries by (gvr, name) on
+	// ANY event affecting a RESTAction CR. The byGVRName reverse index
+	// holds only RESTAction-output entries (gvrNameFromL1Key derives from
+	// L1 keys, which today come exclusively from the RESTAction
+	// dispatcher and the apiref widget consumer); other GVRs result in a
+	// no-op lookup. NO hardcoded GVR strings — feedback_no_special_cases.md
+	// honored.
+	if L2Enabled() {
+		for _, evt := range events {
+			if evt.eventType == "delete" || evt.name == "" {
+				continue
+			}
+			_ = EvictL2ForRESTAction(ctx, evt.gvrKey, evt.name)
+		}
+	}
+
 	hotKeys = filterResolved(hotKeys)
 	warmKeys = filterResolved(warmKeys)
 	coldKeys = filterResolved(coldKeys)

--- a/internal/handlers/dispatchers/prewarm.go
+++ b/internal/handlers/dispatchers/prewarm.go
@@ -161,6 +161,28 @@ func preWarmChildWidgets(parentCtx context.Context, c cache.Cache, resolved *uns
 
 // recursivePreWarm resolves refs into L1 cache, then extracts their children
 // and recurses until maxDepth or no more children are found.
+//
+// Q-RBACC-L2-1 — L2 prewarm coverage (PR review N3, 2026-05-05).
+// This function transitively populates the L2 post-refilter cache via
+// the call chain:
+//
+//   recursivePreWarm → resolveL1RefsCollect → widgets.Resolve
+//     → resolveApiRef → apiref.Resolve → resolveViaL1Cache
+//     → l1cache.ResolveAndCache → cache.L2Put
+//
+// The architect-deviation #2 design point (single L2 writer at
+// l1cache.ResolveAndCache) is what makes this "free": ANY caller that
+// passes through l1cache.ResolveAndCache populates L2 alongside L1.
+// Coverage is empirically verified by
+// internal/resolvers/restactions/l1cache/prewarm_l2_coverage_test.go,
+// which asserts that ResolveAndCache (called with the prewarm-shaped
+// Input) advances cache.GlobalMetrics.L2Writes.
+//
+// Consequence: when CACHE_L2_REFILTER_ENABLED=true at startup and
+// active users / warmable RAs are present, L2 entries are populated
+// before pod becomes Ready (per OQ-5 spec). The +30 s pod-startup
+// budget is amortised over both L1 and L2 fill — no separate L2
+// prewarm pass is required.
 func recursivePreWarm(ctx context.Context, user jwtutil.UserInfo, ep endpoints.Endpoint, accessToken string, c cache.Cache, dynClient k8sdynamic.Interface, refs []l1Ref, authnNS string, visited map[string]bool, depth int) {
 	if len(refs) == 0 {
 		return
@@ -559,6 +581,13 @@ type l1Ref struct {
 
 // warmL1RestActionsForUser resolves the explicitly-configured RESTActions for
 // a single user and stores them in L1 cache. Returns the number warmed.
+//
+// Q-RBACC-L2-1 — L2 prewarm coverage (PR review N3, 2026-05-05).
+// This function calls l1cache.ResolveAndCache directly (line below),
+// which is the single L2 writer per architect-deviation #2. So every
+// RESTAction warmed here also lands in L2 (subject to the reduction
+// ratio gate / size cap). Empirical verification in
+// internal/resolvers/restactions/l1cache/prewarm_l2_coverage_test.go.
 func warmL1RestActionsForUser(ctx context.Context, c cache.Cache, dynClient k8sdynamic.Interface, user jwtutil.UserInfo, ep endpoints.Endpoint, accessToken string, ras []cache.WarmupRestAction, authnNS string) int64 {
 	log := slog.Default()
 	raGVR := schema.GroupVersionResource{

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -102,6 +102,54 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 				}
 				lookupSpan.End()
 				if hit {
+					// Q-RBACC-L2-1 — POST-REFILTER L2 LOOKUP.
+					// Before the per-user refilter (which is expensive
+					// for the cyberjoker hot path: 1.0–1.4 s on a 1.9 KB
+					// output), check the L2 cache. The L2 key folds in
+					// the binding identity + groups hash, so cohorts
+					// sharing identical RBAC bindings share one entry.
+					// On hit: skip refilter entirely, serve bytes.
+					// On miss: fall through to the existing refilter
+					// path; the leader writes L2 below.
+					groupsHash := cache.HashGroups(user.Groups)
+					if l2e, l2hit := cache.L2Get(resolvedKey, identity, groupsHash); l2hit {
+						_, l2Span := restactionTracer.Start(req.Context(), "restaction.l2_refilter_lookup",
+							trace.WithAttributes(
+								attribute.String("cache.key", resolvedKey),
+								attribute.Bool("l2.hit", true),
+								attribute.Int("l2.size_bytes", l2e.SizeBytes),
+								attribute.String("l2.l1_key", resolvedKey),
+								attribute.String("user", user.Username),
+							))
+						l2Span.End()
+						if httpSpan := trace.SpanFromContext(req.Context()); httpSpan.IsRecording() {
+							httpSpan.AddEvent("cache.hit", trace.WithAttributes(
+								attribute.String("cache.key", resolvedKey),
+								attribute.String("cache.layer", "l2"),
+							))
+						}
+						cache.GlobalMetrics.Inc(&cache.GlobalMetrics.RawHits, "raw_hits")
+						cache.GlobalMetrics.Inc(&cache.GlobalMetrics.L1Hits, "l1_hits")
+						cache.TouchKey(cache.ResolvedKeyBase(identity, gvr, nsn.Namespace, nsn.Name))
+						cache.EmitL2HitAudit(req.Context(), resolvedKey, identity, nsn.Name, user.Username)
+						log.Info("RESTAction resolved from L2",
+							slog.String("key", resolvedKey),
+							slog.String("user", user.Username),
+							slog.String("source", "L2-cache"),
+							slog.String("duration", util.ETA(start)))
+						wri.Header().Set("Content-Type", "application/json")
+						wri.WriteHeader(http.StatusOK)
+						_, writeSpan := restactionTracer.Start(req.Context(), "http.write",
+							trace.WithAttributes(
+								attribute.Bool("cache.hit", true),
+								attribute.String("cache.layer", "l2"),
+								attribute.Int("http.response.body.size", l2e.SizeBytes),
+							))
+						_, _ = wri.Write(l2e.Refiltered)
+						writeSpan.End()
+						return
+					}
+
 					// Q-RBAC-DECOUPLE C(d) v3 — refilter the cached
 					// (binding-identity-shared) entry per the requesting
 					// user. The trust-boundary contract is non-negotiable:
@@ -154,6 +202,14 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 						cache.GlobalMetrics.Inc(&cache.GlobalMetrics.RawHits, "raw_hits")
 						cache.GlobalMetrics.Inc(&cache.GlobalMetrics.L1Hits, "l1_hits")
 						cache.TouchKey(cache.ResolvedKeyBase(identity, gvr, nsn.Namespace, nsn.Name))
+						// Q-RBACC-L2-1 — write the freshly-computed refilter
+						// output to L2 for the next request from this
+						// (l1Key, identity, groupsHash) cohort. SetL2 enforces
+						// the size cap and reduction-ratio gate (admin ×
+						// compositions-panels ratio ~0.95 → skipped here, by
+						// design — see spec §1.3). rawL1Size lets the gate
+						// run; passing 0 would bypass the gate.
+						cache.L2Put(resolvedKey, identity, groupsHash, refiltered, nil, false, "v3", len(raw))
 						log.Info("RESTAction resolved from cache",
 							slog.String("key", resolvedKey),
 							slog.String("user", user.Username),
@@ -258,6 +314,11 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 			cache.TouchKey(cache.ResolvedKeyBase(rki.Username, rki.GVR, rki.NS, rki.Name))
 		}
 	}
+
+	// Q-RBACC-L2-1 — L1-MISS-path L2 write happens inside
+	// l1cache.ResolveAndCache (single writer; benefits prewarm + apiref
+	// MISS uniformly). The dispatcher only needs the L1-HIT-then-fresh-
+	// refilter L2 write above.
 
 	pathAttr := "inline"
 	if resolvedKey != "" {

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -2,6 +2,7 @@ package dispatchers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -209,7 +210,22 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 						// compositions-panels ratio ~0.95 → skipped here, by
 						// design — see spec §1.3). rawL1Size lets the gate
 						// run; passing 0 would bypass the gate.
-						cache.L2Put(resolvedKey, identity, groupsHash, refiltered, nil, false, "v3", len(raw))
+						//
+						// Q-RBACC-L2-1 architect-review CONCERN-1 (2026-05-05):
+						// pre-decode the status map AT WRITE TIME so apiref
+						// readers never observe Status==nil after an L2 hit.
+						// The previous shape (write nil + lazy-fill on the
+						// apiref read path) opened a data race on the entry
+						// pointer shared via sync.Map. By moving the decode
+						// inside the dispatcher (the leader of the
+						// singleflight refilter), the L2 entry's Status is
+						// immutable from Set time onward and apiref hits are
+						// race-free read-only. Decode cost: one
+						// json.Unmarshal per L1-HIT-then-fresh-refilter (i.e.
+						// once per cold L2 cohort) — amortised across the
+						// thundering-herd burst by the singleflight upstream.
+						l2Status := decodeStatusForL2(refiltered)
+						cache.L2Put(resolvedKey, identity, groupsHash, refiltered, l2Status, false, "v3", len(raw))
 						log.Info("RESTAction resolved from cache",
 							slog.String("key", resolvedKey),
 							slog.String("user", user.Username),
@@ -338,6 +354,29 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		))
 	_, _ = wri.Write(body)
 	writeSpan.End()
+}
+
+// decodeStatusForL2 extracts the "status" subtree from a v3 refiltered
+// CR JSON blob, returning nil on any decode failure. Used by the L1-HIT
+// L2 write path to populate L2Entry.Status at write time so apiref
+// readers never need to lazy-fill (which would race on the shared
+// sync.Map entry pointer — Q-RBACC-L2-1 architect-review CONCERN-1).
+//
+// Failure-mode: nil status. apiref readers treat nil Status as a soft
+// miss and fall through to refilter; the next refilter completes and
+// L2Put overwrites the entry with a Status-populated copy. Net effect
+// of a transient decode failure is one extra refilter, never an
+// incorrect response.
+func decodeStatusForL2(refiltered []byte) map[string]any {
+	if len(refiltered) == 0 {
+		return nil
+	}
+	var cr map[string]any
+	if err := json.Unmarshal(refiltered, &cr); err != nil {
+		return nil
+	}
+	st, _ := cr["status"].(map[string]any)
+	return st
 }
 
 // errEmptyResolveResult indicates the shared l1cache helper returned

--- a/internal/resolvers/restactions/api/user_access_filter.go
+++ b/internal/resolvers/restactions/api/user_access_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"time"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
@@ -13,6 +14,20 @@ import (
 	jqsupport "github.com/krateoplatformops/snowplow/internal/support/jq"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// uafYieldEvery controls the cadence at which applyUserAccessFilter
+// releases its P back to the runtime (Q-RBACC-L2-1, OQ-6). The 50K-item
+// cyberjoker × compositions-panels refilter walks one tight loop with
+// per-item gojq Eval + per-item EvaluateRBAC; without yield, that loop
+// can hold a P through 30+ liveness probe windows on a freshly-restarted
+// pod and trip the SIGKILL pattern that killed v6 phase-6.
+//
+// 1024 chosen as a power-of-2 tradeoff: at 50K items the loop yields ~50
+// times (~2 µs per yield → ~100 µs total overhead, < 0.1% of refilter
+// wall). Generic yield discipline; not a refilter-specific behaviour
+// optimization. feedback_no_special_cases.md honoured: applies uniformly
+// to every applyUserAccessFilter caller, no per-RA / per-user branches.
+const uafYieldEvery = 1024
 
 // applyUserAccessFilter drops items from `computed` for which the requesting
 // user lacks the RBAC permission declared in apiCall.UserAccessFilter.
@@ -109,7 +124,15 @@ func applyUserAccessFilter(ctx context.Context, apiCall *templates.API, computed
 	nsFrom := ptr.Deref(f.NamespaceFrom, "")
 
 	out := make([]any, 0, len(items))
-	for _, item := range items {
+	for i, item := range items {
+		// Q-RBACC-L2-1, OQ-6 — yield discipline. Release the P every
+		// uafYieldEvery items so the liveness probe goroutine can run
+		// during a long refilter pass over a 50K-item input. Without
+		// this, the v6-phase-6 panels SIGKILL recurs on prewarm-time
+		// admin × compositions-panels refilter (40 MB body, ~10 s wall).
+		if i > 0 && i%uafYieldEvery == 0 {
+			runtime.Gosched()
+		}
 		ns := ""
 		if nsFrom != "" {
 			// gojq-purity-required: item came from JQ filter output via

--- a/internal/resolvers/restactions/l1cache/l1cache.go
+++ b/internal/resolvers/restactions/l1cache/l1cache.go
@@ -274,6 +274,25 @@ func resolveAndCacheInner(ctx context.Context, in Input) (*Result, error) {
 		}
 	}
 
+	// Q-RBACC-L2-1 — populate the post-refilter L2 cache. Identity is
+	// the L1 key prefix (so prewarm, dispatcher MISS, apiref MISS all
+	// benefit identically). Groups hash is derived from the ctx
+	// UserInfo if present; otherwise we write under "no_groups" which
+	// matches the singleflight key convention used by
+	// RefilterRESTActionDeduped (so the dispatcher's L2-read uses the
+	// same hash). If UserInfo is missing entirely (unit-test path), we
+	// skip L2 — the L1-HIT branch will compute and cache on the next
+	// real request.
+	if in.Cache != nil && in.ResolvedKey != "" && len(refiltered) > 0 {
+		if rki, ok := cache.ParseResolvedKey(in.ResolvedKey); ok {
+			groupsHash := "no_groups"
+			if user, uerr := xcontext.UserInfo(ctx); uerr == nil {
+				groupsHash = cache.HashGroups(user.Groups)
+			}
+			cache.L2Put(in.ResolvedKey, rki.Username, groupsHash, refiltered, status, false, "v3", len(raw))
+		}
+	}
+
 	// Diagnostic for S7: log item count for list-type RESTActions (e.g.
 	// compositions-list). The JQ filter produces {"list": [...items...]},
 	// so status["list"] is the array. This lets us see whether a delete

--- a/internal/resolvers/restactions/l1cache/prewarm_l2_coverage_test.go
+++ b/internal/resolvers/restactions/l1cache/prewarm_l2_coverage_test.go
@@ -1,0 +1,173 @@
+// Q-RBACC-L2-1 PR review N3 (PM strategic, 2026-05-05) — prewarm-L2
+// coverage proof.
+//
+// CLAIM (architect deviation #2): the L2 cache is the single L2 writer
+// and lives inside l1cache.ResolveAndCache. Therefore prewarm — which
+// goes through:
+//
+//   WarmL1FromEntryPoints → recursivePreWarm → resolveL1RefsCollect
+//     → widgets.Resolve → resolveApiRef → apiref.Resolve
+//     → resolveViaL1Cache → l1cache.ResolveAndCache → cache.L2Put
+//
+//   WarmL1ForAllUsers → ... → warmL1RestActionsForUser
+//     → l1cache.ResolveAndCache → cache.L2Put
+//
+// — populates L2 entries "for free" alongside L1.
+//
+// The PM concern: this is plausible-but-unverified. This test EMPIRICALLY
+// verifies the load-bearing leg: l1cache.ResolveAndCache writes to L2
+// when (Cache != nil, ResolvedKey != "", L2Enabled=true).
+//
+// Test shape:
+//   1. Snapshot L2Writes counter.
+//   2. Build a minimal RESTAction CR (no api[] entries, no filter) so
+//      restactions.Resolve completes without needing a kube apiserver.
+//   3. Call l1cache.ResolveAndCache with a populated ResolvedKey + a
+//      MemCache + UserInfo on ctx.
+//   4. Assert L2Writes counter incremented by 1 (or, if the reduction
+//      gate skipped the entry, L2SkippedHighRatio incremented by 1).
+//   5. Assert the L2 store has the entry under the expected key.
+//
+// Both branches (Writes incremented OR SkippedHighRatio incremented)
+// PROVE that the L2 write site executed for the prewarm-shaped caller.
+// A test that observes NEITHER counter advancing would prove the L2
+// write site was bypassed entirely (the bug PM N3 was guarding against).
+
+package l1cache
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestL1Cache_ResolveAndCache_WritesL2_PrewarmShape — Q-RBACC-L2-1 PM
+// review N3. Empirical proof that the prewarm-shaped caller exercises
+// the L2 write path inside resolveAndCacheInner.
+func TestL1Cache_ResolveAndCache_WritesL2_PrewarmShape(t *testing.T) {
+	prevEnabled := envEnabledForTest()
+	cache.SetL2EnabledForTest(true)
+	defer func() { cache.SetL2EnabledForTest(prevEnabled) }()
+	cache.FlushL2ForTest()
+
+	mc := cache.NewMem(time.Hour)
+
+	// Minimal RESTAction CR: no api[] entries, no filter. restactions.
+	// Resolve handles empty Spec.API (returns empty dict) and empty
+	// Spec.Filter (marshals the empty dict directly), so the resolve
+	// chain completes without needing a kube apiserver or rest.Config.
+	cr := &templates.RESTAction{}
+	cr.SetName("ra-prewarm-test")
+	cr.SetNamespace("ns-prewarm-test")
+
+	// Convert to unstructured via the standard converter (matches what
+	// the prewarm path passes — `cached.Object`).
+	uns, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+
+	// Build a context shaped like the prewarm context: cache, logger,
+	// UserInfo (so RefilterRESTAction inside ResolveAndCache doesn't
+	// fail-closed), and binding identity (so CacheIdentity returns the
+	// shared identity instead of the username).
+	identity := "bid-prewarm-test"
+	username := "test-prewarm-user"
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithLogger(slog.Default()),
+		xcontext.WithUserInfo(jwtutil.UserInfo{
+			Username: username,
+			Groups:   []string{"devs"},
+		}),
+	)
+	ctx = cache.WithCache(ctx, mc)
+	ctx = cache.WithBindingIdentity(ctx, identity)
+
+	// L1 key shape mirrors prewarm.go:614 / 757.
+	gvr := schema.GroupVersionResource{
+		Group: "templates.krateo.io", Version: "v1", Resource: "restactions",
+	}
+	l1Key := cache.ResolvedKey(identity, gvr, "ns-prewarm-test", "ra-prewarm-test", -1, -1)
+
+	// Snapshot counters BEFORE the call so we measure the delta caused
+	// by THIS invocation only.
+	writesBefore := cache.GlobalMetrics.L2Writes.Load()
+	skippedHighBefore := cache.GlobalMetrics.L2SkippedHighRatio.Load()
+	skippedSizeBefore := cache.GlobalMetrics.L2SkippedSizeCap.Load()
+
+	result, err := ResolveAndCache(ctx, Input{
+		Cache:       mc,
+		Obj:         uns,
+		ResolvedKey: l1Key,
+		AuthnNS:     "krateo-system",
+		PerPage:     -1,
+		Page:        -1,
+	})
+	if err != nil {
+		t.Fatalf("ResolveAndCache: %v", err)
+	}
+	if result == nil {
+		t.Fatalf("ResolveAndCache returned nil result")
+	}
+
+	writesDelta := cache.GlobalMetrics.L2Writes.Load() - writesBefore
+	skippedHighDelta := cache.GlobalMetrics.L2SkippedHighRatio.Load() - skippedHighBefore
+	skippedSizeDelta := cache.GlobalMetrics.L2SkippedSizeCap.Load() - skippedSizeBefore
+
+	// THE LOAD-BEARING ASSERTION: the L2 write site executed at least
+	// once. Either Writes (entry stored) or SkippedHighRatio /
+	// SkippedSizeCap (gates fired) is acceptable evidence — both prove
+	// the call reached cache.L2Put. The bug PM N3 was guarding against
+	// would manifest as ALL THREE counters at zero (write site
+	// bypassed entirely).
+	if writesDelta == 0 && skippedHighDelta == 0 && skippedSizeDelta == 0 {
+		t.Fatalf(
+			"PM N3 regression: l1cache.ResolveAndCache did NOT call cache.L2Put. "+
+				"L2Writes Δ=%d, L2SkippedHighRatio Δ=%d, L2SkippedSizeCap Δ=%d. "+
+				"Prewarm path would NOT populate L2.",
+			writesDelta, skippedHighDelta, skippedSizeDelta,
+		)
+	}
+
+	// On the happy path (small payload, no skip), assert the write
+	// landed and the L2 entry is retrievable. The empty-dict CR
+	// produces a tiny refilter output (~80 bytes for `{"status":{}}` +
+	// CR metadata), well under any size cap; no L1 raw bytes to compare
+	// for the reduction gate.
+	if writesDelta > 0 {
+		// Verify the entry is materialised under the expected L2 key
+		// (using the same key derivation as the writer).
+		groupsHash := cache.HashGroups([]string{"devs"})
+		// In l1cache.ResolveAndCache, identity comes from
+		// ParseResolvedKey(in.ResolvedKey).Username — which is `identity`
+		// here because `cache.ResolvedKey(identity, ...)` puts `identity`
+		// in that slot.
+		if e, ok := cache.L2Get(l1Key, identity, groupsHash); !ok {
+			t.Fatalf("L2 entry not retrievable at expected key (l1Key=%q identity=%q)",
+				l1Key, identity)
+		} else if len(e.Refiltered) == 0 {
+			t.Fatalf("L2 entry has zero-length Refiltered bytes")
+		}
+	}
+
+	t.Logf("PM N3 verified: L2 write site reached. Δwrites=%d Δskipped_high=%d Δskipped_size=%d",
+		writesDelta, skippedHighDelta, skippedSizeDelta)
+}
+
+// envEnabledForTest reads the current L2 enabled state via a Get-after-
+// SetL2EnabledForTest cycle so the deferred restore doesn't accidentally
+// disable L2 for downstream tests in the same package.
+func envEnabledForTest() bool {
+	// Force-init by querying L2Enabled; if it returns false but a Set
+	// would set it true, that's the right baseline. This is best-effort:
+	// the test is the only L2-toucher in this package.
+	return cache.L2Enabled()
+}

--- a/internal/resolvers/widgets/apiref/resolve.go
+++ b/internal/resolvers/widgets/apiref/resolve.go
@@ -269,6 +269,42 @@ func resolveInline(ctx context.Context, opts ResolveOptions) (map[string]any, er
 // raw cached status; the cached wrapper holds the unfiltered ProtectedDict
 // shape and would leak items to a user lacking the corresponding RBAC.
 func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[string]any, bool, bool) {
+	// Q-RBACC-L2-1 — L2 fast path. The L2 entry, when present, holds the
+	// pre-decoded status map and the hasUAF flag, so the apiref path
+	// avoids both the per-user refilter AND the json.Unmarshal that
+	// follows it. The L2 key folds (l1Key, binding identity, groups
+	// hash); cohorts sharing identical RBAC bindings share one entry.
+	user, uerr := xcontext.UserInfo(ctx)
+	var identity, groupsHash string
+	if uerr == nil {
+		identity = cache.CacheIdentity(ctx, user.Username)
+		groupsHash = cache.HashGroups(user.Groups)
+		if l2e, l2hit := cache.L2Get(l1Key, identity, groupsHash); l2hit {
+			// Lazy-fill: if the dispatcher wrote the L2 entry without
+			// pre-decoding the status map, decode it once here and
+			// upgrade the entry in place — subsequent L2 hits hit the
+			// cached map directly. Mutating the entry's Status field is
+			// safe because the apiref reader already treats the status
+			// as read-only and the singleflight upstream prevents
+			// concurrent fills with diverging bytes.
+			if l2e.Status == nil && len(l2e.Refiltered) > 0 {
+				var cached map[string]any
+				if json.Unmarshal(l2e.Refiltered, &cached) == nil {
+					if status, ok := cached["status"].(map[string]any); ok {
+						l2e.Status = status
+					}
+				}
+			}
+			if l2e.Status != nil {
+				cache.EmitL2HitAudit(ctx, l1Key, identity, l1Key, user.Username)
+				return l2e.Status, l2e.HasUAF, true
+			}
+			// Status missing on the entry — fall through to refilter
+			// below. Treat as a miss so we re-decode and re-Set with a
+			// usable Status.
+		}
+	}
+
 	raw, hit, err := c.GetRaw(ctx, l1Key)
 	if err != nil || !hit || len(raw) == 0 {
 		return nil, false, false
@@ -306,6 +342,18 @@ func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[s
 	// per-user-projected shape via the outer JQ). The wrapper holds
 	// `cr.spec.api[*].userAccessFilter` verbatim.
 	hasUAF := wrapperHasUAF(raw)
+
+	// Q-RBACC-L2-1 — populate L2 with the freshly-computed refilter
+	// output, including the pre-decoded status and the hasUAF flag
+	// (which the dispatcher MISS-path L2 write inside l1cache cannot
+	// derive without re-decoding the wrapper). The L2 write inside
+	// l1cache.ResolveAndCache uses hasUAF=false; here we upgrade it
+	// with the correct flag so the next L2 hit on this entry returns
+	// hasUAF correctly to the widget caller.
+	if identity != "" {
+		cache.L2Put(l1Key, identity, groupsHash, refiltered, status, hasUAF, "v3", len(raw))
+	}
+
 	return status, hasUAF, true
 }
 

--- a/internal/resolvers/widgets/apiref/resolve.go
+++ b/internal/resolvers/widgets/apiref/resolve.go
@@ -274,34 +274,26 @@ func lookupL1Refiltered(ctx context.Context, c cache.Cache, l1Key string) (map[s
 	// avoids both the per-user refilter AND the json.Unmarshal that
 	// follows it. The L2 key folds (l1Key, binding identity, groups
 	// hash); cohorts sharing identical RBAC bindings share one entry.
+	//
+	// Q-RBACC-L2-1 architect-review CONCERN-1 (2026-05-05):
+	// L2Entry.Status is populated AT WRITE TIME by every writer
+	// (dispatcher L1-HIT-then-fresh, l1cache MISS path, apiref MISS
+	// path) — so on a hit the field is immutable and the read here is
+	// race-free. NEVER mutate l2e.Status from this read site; doing so
+	// would re-introduce the data race the post-hit lazy-fill design
+	// caused. If Status is nil on a hit, that signals a writer encoded
+	// a malformed wrapper (defensive against future codec migration);
+	// fall through to a fresh refilter and treat the L2 entry as a
+	// soft miss — the subsequent L2Put below overwrites it with a
+	// well-formed entry.
 	user, uerr := xcontext.UserInfo(ctx)
 	var identity, groupsHash string
 	if uerr == nil {
 		identity = cache.CacheIdentity(ctx, user.Username)
 		groupsHash = cache.HashGroups(user.Groups)
-		if l2e, l2hit := cache.L2Get(l1Key, identity, groupsHash); l2hit {
-			// Lazy-fill: if the dispatcher wrote the L2 entry without
-			// pre-decoding the status map, decode it once here and
-			// upgrade the entry in place — subsequent L2 hits hit the
-			// cached map directly. Mutating the entry's Status field is
-			// safe because the apiref reader already treats the status
-			// as read-only and the singleflight upstream prevents
-			// concurrent fills with diverging bytes.
-			if l2e.Status == nil && len(l2e.Refiltered) > 0 {
-				var cached map[string]any
-				if json.Unmarshal(l2e.Refiltered, &cached) == nil {
-					if status, ok := cached["status"].(map[string]any); ok {
-						l2e.Status = status
-					}
-				}
-			}
-			if l2e.Status != nil {
-				cache.EmitL2HitAudit(ctx, l1Key, identity, l1Key, user.Username)
-				return l2e.Status, l2e.HasUAF, true
-			}
-			// Status missing on the entry — fall through to refilter
-			// below. Treat as a miss so we re-decode and re-Set with a
-			// usable Status.
+		if l2e, l2hit := cache.L2Get(l1Key, identity, groupsHash); l2hit && l2e.Status != nil {
+			cache.EmitL2HitAudit(ctx, l1Key, identity, l1Key, user.Username)
+			return l2e.Status, l2e.HasUAF, true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -162,6 +162,13 @@ func main() {
 		appCache = mc
 		log.Info("in-process cache enabled")
 
+		// Q-RBACC-L2-1 — start the L2 post-refilter cache LRU sweep on
+		// the same 30s cadence as the L1 eviction loop. No-op when
+		// CACHE_L2_REFILTER_ENABLED is unset/false; safe to call
+		// unconditionally. Cancellation flows from the parent ctx via
+		// the eviction loop's own ticker.
+		cache.StartL2EvictionLoop(context.Background())
+
 		// Q-RBAC-DECOUPLE C(d) v3 — flush any stale snowplow:resolved:*
 		// entries written under an incompatible schema (e.g. v2-shape
 		// CachedRESTAction wrappers from a previous image roll). On the


### PR DESCRIPTION
## Follow-up commits (review feedback, 2026-05-05)

Three fixes merged into this PR after architect + PM review (Diego authorized all three):

| Concern | Fix | Commit |
|---|---|---|
| **Architect CONCERN-1** — `l2e.Status = decoded` race in apiref lazy-fill | Pre-decode `Status` AT WRITE TIME inside dispatcher's L1-HIT-then-fresh-refilter site. Lazy-fill removed; nil Status on a hit is now a soft miss. L2Entry fields documented as immutable post-publish. New tests `TestL2_StatusImmutableAfterSet` (32 readers × 500 iters under -race) + `TestL2_NilStatusIsSoftMiss`. | `05151e0` |
| **Architect CONCERN-2** — `purgeUserCacheData` evicts L1 before L2 (apiref reads L2 first → stale-L2 window) | Restructured into Phase 1 (snapshot identities) → Phase 2 (evict L2) → Phase 3 (delete L1). `EvictL2ForIdentity` now fires BEFORE any `cache.Delete` / `DeleteUserRBAC`. New test `TestPurgeUserCacheData_L2EvictsBeforeL1` uses an `orderingCache` decorator that records L2 byIdentity bucket size at every L1 op; asserts L2 is empty BEFORE the first L1 op. Verified by inversion: temporary buggy ordering → test FAILS with explicit message. | `f452ca2` |
| **PM N3** — claim "prewarm covers L2 for free" was unverified | Audited the call graph: both prewarm paths (`recursivePreWarm` and `warmL1RestActionsForUser`) route through `l1cache.ResolveAndCache` (the single L2 writer per architect-deviation #2). New empirical test `TestL1Cache_ResolveAndCache_WritesL2_PrewarmShape` builds a minimal RESTAction CR, calls `ResolveAndCache` with the prewarm-shaped Input, asserts `L2Writes` advanced. Result: **`Δwrites=1 Δskipped_high=0 Δskipped_size=0`** — concrete proof. Documentation comments added in `prewarm.go` linking both prewarm functions to the coverage test. | `9cf7603` |

### Architect post-merge defer (NOT addressed in this PR, per Diego)

- **CONCERN-3** — inline `sweepLocked` on hot Set path. Informational; monitor at scale via `l2_resident_bytes` + heap snapshots.
- **CONCERN-4** — eliminated naturally by Fix 1 (no more decode-twice path).

### Verification

```
$ go test -race -tags=unit -count=1 -timeout=120s -skip TestIteratorOrderDistribution \
    ./internal/cache/... ./internal/handlers/dispatchers/... ./internal/resolvers/...
ok    github.com/krateoplatformops/snowplow/internal/cache              1.581s
ok    github.com/krateoplatformops/snowplow/internal/handlers/dispatchers  1.864s
ok    github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api  2.418s
ok    github.com/krateoplatformops/snowplow/internal/resolvers/restactions/l1cache  2.646s
ok    github.com/krateoplatformops/snowplow/internal/resolvers/widgets/resourcesrefs  2.462s
ok    github.com/krateoplatformops/snowplow/internal/resolvers/widgets/widgetdatatemplate  2.110s
```

Integration-tag failures (`-tags=unit,integration`) are pre-existing kind-cluster setup issues (project_open_topics.md / Q-CI-1) — unrelated to these fixes.

---

## Summary

Adds a second cache layer (L2) keyed on `(l1Key, binding_identity, groups_hash)` storing the post-refilter wire bytes the dispatcher writes to `wri.Write`. On L2 hit, the cyberjoker hot path skips `RefilterRESTAction` entirely:

- predicted p99 1.4 s → ~5 ms on small RAs
- predicted p99 ~30 ms on the previously pod-killing `compositions-panels` page

Plus the OQ-6 yield discipline (`runtime.Gosched()` every 1024 items in `applyUserAccessFilter`) — generic, no special cases. Without yield, prewarm-time admin × 40 MB compositions-panels refilter could recur the v6 phase-6 SIGKILL on cold pods.

**Source documents (not committed; on Diego's filesystem):**
- Implementation-ready spec: `/tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-2026-05-05/Q-RBACC-L2-1-SPEC.md` (439 LOC, architect, Rev 1)
- otel-expert investigation: `/tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-2026-05-05/dictmu-investigation.md`
- architect-review: `/tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-2026-05-05/architect-review.md`
- Phase-6 finding: `/tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-2026-05-05/FINDING.md`

## Resolved OQs (from Diego, dispatch authorization)

- **OQ-5 prewarm L2** — IN SCOPE. L2 fill happens inside `l1cache.ResolveAndCache` so `WarmL1FromEntryPoints` warms L2 alongside L1 for free; no separate prewarm pass needed.
- **OQ-6 `runtime.Gosched()` every 1024 items** — IN SCOPE. 5-LOC generic change in `applyUserAccessFilter`.
- **OQ-1 max-bytes default = 512 MB** — adopted via `CACHE_L2_REFILTER_MAX_BYTES`.
- **OQ-2 sample-1% audit** — adopted via `CACHE_L2_REFILTER_HIT_AUDIT_SAMPLE` (default 0.01); deterministic per-(l1Key, identity) sampler so same pair consistently emits or doesn't.
- **OQ-7 MIN_REDUCTION_RATIO = 0.20** — adopted via `CACHE_L2_REFILTER_MIN_REDUCTION_RATIO`. Generic gate; admin × panels skipped naturally.

## Architecture

- **L2 key**: SHA-256 over length-prefixed `("L2", l1Key, identity, groupsHash)`. Length-prefixing prevents `|`-injection collisions (caught by `TestL2Hash_NoCollisionAcrossComponents`). Truncated to 32 hex chars.
- **L2 entry**: `Refiltered` (exact wire bytes), pre-decoded `Status` map, `HasUAF` flag, `SchemaVer` snapshot, internal reverse-index components.
- **Reverse indexes**: `byL1Key`, `byIdentity`, `byGVRName` — each is a `sync.Map<string, *sync.Map[hashKey]struct{}>`. Targeted eviction is O(K).
- **LRU sweep**: 30s ticker. Inline trigger when over cap. Targets 90% of cap on each pass.
- **Schema-tag (`l2-v1`)**: bump to force opportunistic eviction on L1 schema migration.

## Invalidation matrix

| Event | L1 effect | L2 effect | Wiring |
|---|---|---|---|
| K8s DELETE | L1 keys deleted | `EvictL2ForL1Keys(l1Keys)` | `internal/cache/watcher.go` after `triggerL1RefreshBatch` allKeys collected |
| K8s ADD/UPDATE | L1 refreshed in place | **Stale-while-revalidate** (no evict) | per `feedback_l1_invalidation_delete_only.md` |
| RESTAction CR change (UPDATE) | L1 overwritten on next resolve | `EvictL2ForRESTAction(gvrKey, name)` | `internal/cache/watcher.go` per-event UPDATE branch (generic; no-op for non-RA GVRs) |
| CRB transition | `purgeUserCacheData` deletes per-user L1 keys | `EvictL2ForIdentity(oldBid, newBid, username)` | `internal/cache/rbac_watcher.go:purgeUserCacheData` |
| `CACHE_ENABLED=false` | L1 disabled | L2 disabled (master switch) | `cache.L2Enabled()` returns false |
| `CACHE_L2_REFILTER_ENABLED=false` | unaffected | L2 disabled (per-feature toggle) | env flag, default false |

## Concurrency

- `sync.Map` for store + reverse indexes. `LoadOrStore` for write-write race; `Store` for replace.
- `atomic.Int64` for resident bytes/count + every metric counter.
- LRU sweep guarded by single `sync.Mutex` (only contended at sweep time, ≤30s cadence).
- All race-clean (`go test -race -count=1 ./internal/cache/ ./internal/handlers/dispatchers/ ./internal/resolvers/...`).

## Test plan

Acceptance gates per spec §5 — implemented as unit tests where feasible, deferred to phase-6 driver where infra-bound.

- [x] **G9 byte-equivalence** — `TestL2_G9_ByteEquivalence_1000Pairs`: 1000 random (user, l1Key) pairs; `bytes.Equal` post-roundtrip.
- [x] **G11 hit-rate ≥ 90%** — `TestL2_G11_HitRatePattern`: 1 cold + 9 hits → assert hit-rate ≥ 0.90.
- [x] **G12 conditional caching** — `TestL2_G12_SkipsAdminPanelsPattern`: ratio 0.95 → counter `L2SkippedHighRatio` advances + entry not cached.
- [x] **Eviction triggers** — `TestL2_EvictL2ForL1Keys` / `TestL2_EvictL2ForIdentity` / `TestL2_EvictL2ForRESTAction`.
- [x] **Schema mismatch evict + miss** — `TestL2_SchemaTag_Mismatch_OpportunisticEvict`.
- [x] **Hash collision guard** — `TestL2Hash_NoCollisionAcrossComponents` (length-prefix domain separation).
- [x] **Race-clean** — `TestL2_ConcurrentSetGet` (32 writers × 500 ops).
- [x] **LRU bounds resident** — `TestL2_LRUSweep_BoundsResident`.
- [x] **Disabled flag short-circuits** — `TestL2_DisabledShortCircuits`.
- [x] **`go build ./...`** — clean.
- [x] **`go test -race -count=1 ./internal/cache/`** — all green.
- [ ] **G1 cyberjoker × ALL 6 RAs cold p99 ≤ 1 s @ 50K REPS=10** — phase-6 driver, post-canary deploy.
- [ ] **G2 NONE excluded (compositions-panels included)** — phase-6 driver.
- [ ] **G3 warm p99 ≤ 500 ms** — phase-6 driver.
- [ ] **G4 L1-fresh ≤ 1 s** — phase-6 driver.
- [ ] **G5 0 pod restarts during compositions-panels REPS=30 burst** — load-bearing safety; phase-6 driver.
- [ ] **G6 v6 D1 invariants stay zero** — log-grep checks; phase-6 driver.
- [ ] **G7 admin no-regression vs 43.7 s baseline** — phase-6 driver.
- [ ] **G8 heap_alloc_mb post-warm ≤ 1.5× v0.25.299 baseline + L2 resident ≤ 512 MB** — `/metrics/runtime` snapshot.
- [ ] **G10 post-CRB-change FIRST request returns NEW-binding bytes (zero stale)** — e2e in lane-A.

## Rollout (per spec §6.2)

1. Tag image with `CACHE_L2_REFILTER_ENABLED=false` (default). Run G1/G3/G4/G7 — must match v0.25.299 baseline (proves no-regression with feature-off).
2. Flip `CACHE_L2_REFILTER_ENABLED=true`. Run all G1-G12.
3. Rollback ≤ 30 s: `helm upgrade --set env.CACHE_L2_REFILTER_ENABLED=false`.

## Hard rules compliance

- `feedback_l1_invalidation_delete_only.md` — DELETE evicts; UPDATE/PATCH stays SWR. Verified at `internal/cache/watcher.go` (DELETE branch only) and `rbac_watcher.go:purgeUserCacheData` (CRB-driven).
- `feedback_no_special_cases.md` — `MIN_REDUCTION_RATIO` is a generic property of post-refilter / L1 ratio. No per-user / per-RA branches anywhere. UAF yield is generic loop discipline.
- `feedback_cache_must_not_constrain_jq.md` — L2 stores wire bytes verbatim. G9 (byte-equivalence over 1000 pairs) enforces.
- `feedback_restaction_no_widget_logic.md` — L2 lives in the RESTAction layer; widgets canonicalise on top, unchanged.
- `project_redis_removal.md` — `CACHE_ENABLED=false` short-circuits L2 (master switch). L2 stays removable.
- `feedback_never_push_upstream.md` — PR opens against `braghettos/snowplow` fork only.
- `feedback_no_commit_without_approval.md` — DRAFT PR; awaiting Diego's review + tag authorization.

## Deviations from spec (with reasoning)

1. **Length-prefix L2 key construction** instead of `|`-separator. Spec §1.1 says `sha256("L2|" + l1Key + "|" + bid + "|" + gh)`; the `|` separator is collision-prone for adversarial inputs (`l1Key="a", bid="b|c"` collides with `l1Key="a|b", bid="c"` — caught by `TestL2Hash_NoCollisionAcrossComponents`). I switched to 8-byte big-endian length prefixes per component. Functional behavior unchanged; collision-safe.
2. **Single L2 writer site** in `l1cache.ResolveAndCache` (not three separate writers as the spec implied at §3.1 + §3.2). One writer benefits prewarm + dispatcher-MISS + apiref-MISS uniformly with zero call-site duplication. `hasUAF` upgraded by the apiref branch (which has wrapper context). The dispatcher's L1-HIT-then-fresh-refilter site keeps its own L2 write because it has no l1cache call there.
3. **`gvrName` reverse-index from L1-key parse** (not RA-specific GVR string). EvictL2ForRESTAction is a generic `(gvrKey, name)` lookup; no hardcoded `templates.krateo.io/v1/restactions` literal. The spec authorizes this (§9 — `feedback_no_special_cases.md` compliance row).
4. **`L2Key()` helper kept in `l2_refilter.go`** instead of `internal/cache/keys.go`. Keeps L2-related code colocated. Trivially relocatable later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
