### PR TITLE
feat(probes): R2 - decouple Ready from prewarm + isolate probe port (Q-PREWARM-R2R5 PR-A)

### DIFF
--- a/internal/cache/informer_ready.go
+++ b/internal/cache/informer_ready.go
@@ -1,0 +1,43 @@
+// Q-PREWARM-R2 — informer-ready signal
+//
+// Decouples the kubernetes /ready probe from L1 prewarm completion. Pod
+// becomes Ready as soon as informers complete their initial LIST/WATCH
+// sync (Phase 3 in startBackgroundServices). Prewarm continues to fill
+// L1 in the background; cache misses fall through to the foreground
+// singleflight resolve path, so the pod can serve cold-L1 requests
+// without blocking on the multi-minute prewarm loop.
+//
+// See /tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-postPR2PR3-2026-05-05/
+// Q-PREWARM-R2R5-SPEC.md §1 (R2.1).
+package cache
+
+import "sync/atomic"
+
+// informersReady flips to true after ResourceWatcher.WaitForSync succeeds
+// in main.go's startBackgroundServices. Read by the /ready handler via
+// IsInformerReady. Process-global because there is exactly one
+// ResourceWatcher per snowplow process.
+var informersReady atomic.Bool
+
+// MarkInformersReady is called once by main after WaitForSync succeeds.
+// Safe to call multiple times; only the first call is observable.
+func MarkInformersReady() {
+	informersReady.Store(true)
+}
+
+// IsInformerReady returns true once the resource informers have completed
+// their initial sync. Used by the /ready probe handler — pod becomes
+// Ready as soon as informers are populated, regardless of L1 prewarm
+// state.
+func IsInformerReady() bool {
+	return informersReady.Load()
+}
+
+// ResetInformersReadyForTest restores the informer-ready flag to its
+// initial false state. Test-only — production code MUST NOT call this.
+// Public so tests in sibling packages (e.g. internal/handlers) can
+// reset state between subtests; the alternative is per-package
+// shadow flags that drift from the production singleton.
+func ResetInformersReadyForTest() {
+	informersReady.Store(false)
+}

--- a/internal/cache/informer_ready_test.go
+++ b/internal/cache/informer_ready_test.go
@@ -1,0 +1,71 @@
+// Q-PREWARM-R2 — informer-ready signal tests.
+package cache
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInformerReady_DefaultFalse(t *testing.T) {
+	ResetInformersReadyForTest()
+	if IsInformerReady() {
+		t.Fatalf("expected IsInformerReady() == false at startup")
+	}
+}
+
+func TestInformerReady_MarkFlipsToTrue(t *testing.T) {
+	ResetInformersReadyForTest()
+	if IsInformerReady() {
+		t.Fatalf("precondition: expected false")
+	}
+	MarkInformersReady()
+	if !IsInformerReady() {
+		t.Fatalf("expected IsInformerReady() == true after MarkInformersReady()")
+	}
+	ResetInformersReadyForTest()
+}
+
+func TestInformerReady_Idempotent(t *testing.T) {
+	ResetInformersReadyForTest()
+	MarkInformersReady()
+	MarkInformersReady()
+	MarkInformersReady()
+	if !IsInformerReady() {
+		t.Fatalf("expected idempotent MarkInformersReady to leave flag true")
+	}
+	ResetInformersReadyForTest()
+}
+
+// TestInformerReady_ConcurrentSafe verifies the atomic semantics under
+// the same kind of concurrent access the production /ready handler
+// experiences (kubelet probes interleaving with the single
+// MarkInformersReady call from main).
+func TestInformerReady_ConcurrentSafe(t *testing.T) {
+	ResetInformersReadyForTest()
+
+	const N = 256
+	var wg sync.WaitGroup
+	wg.Add(N + 1)
+
+	// Many concurrent readers (probe handlers).
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = IsInformerReady()
+			}
+		}()
+	}
+
+	// One concurrent writer (the post-WaitForSync hook).
+	go func() {
+		defer wg.Done()
+		MarkInformersReady()
+	}()
+
+	wg.Wait()
+	if !IsInformerReady() {
+		t.Fatalf("expected true after MarkInformersReady completed")
+	}
+	ResetInformersReadyForTest()
+}

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -4,33 +4,64 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/krateoplatformops/plumbing/env"
-	"github.com/krateoplatformops/plumbing/http/response"
 	"github.com/krateoplatformops/plumbing/kubeutil"
 	"github.com/krateoplatformops/snowplow/internal/cache"
-	"github.com/krateoplatformops/snowplow/internal/handlers/dispatchers"
-	"k8s.io/client-go/rest"
 )
 
-// @Summary Liveness Endpoint
-// @Description Health HealthCheck
-// @ID health
-// @Produce  json
-// @Success 200 {object} serviceInfo
-// @Router /health [get]
+// Q-PREWARM-R2 — probe handler surgery (spec §1, R2.1+R2.2).
+//
+// Three changes vs the pre-R2 implementation:
+//
+//   - /health is a pure in-process liveness check. No more
+//     rest.InClusterConfig() per probe. Under prewarm CPU saturation
+//     even a 10ms cgroup file stat could miss the 1s probe timeout
+//     when all P's were busy in JQ; the result was an unbreakable
+//     restart loop. /health now writes 200 + "ok" with zero
+//     filesystem or kube-API touches.
+//
+//   - /ready decouples from dispatchers.IsPreWarmComplete().
+//     Gates only on cache.IsInformerReady() — set after the Phase 3
+//     informer WaitForSync completes (~10-30s at 50K). L1 misses
+//     fall through to the foreground singleflight resolve, so cold-
+//     L1 requests are slow-but-correct rather than rejected with
+//     503. Prewarm continues in the background regardless.
+//
+//   - Service metadata (name/build/namespace) moves to /info.
+//     Operators that scraped /health for build info now scrape
+//     /info. The kube probes do not depend on /info.
+//
+// These handlers are intended to be registered on a SECOND
+// http.Server bound to PROBE_PORT (default 8082) with no
+// middleware chain — see main.go probeServer wiring (R2.3).
+
+// HealthCheck returns a pure in-process liveness handler.
+//
+// The handler does NOT touch the kube API server, the filesystem,
+// or any user code. It exists solely to confirm the binary is
+// running and able to schedule a goroutine to write a 5-byte
+// response. Anything richer belongs on /info.
+//
+// Signature is preserved (serviceName, build, nsgetter) for
+// backwards compatibility with the existing main.go wiring; the
+// extra arguments are ignored. Callers that want the rich JSON
+// payload should register InfoHandler at /info instead.
 func HealthCheck(serviceName, build string, nsgetter func() (string, error)) http.HandlerFunc {
 	return func(wri http.ResponseWriter, req *http.Request) {
-		if !env.TestMode() {
-			if _, err := rest.InClusterConfig(); err != nil {
-				response.ServiceUnavailable(wri, err)
-				return
-			}
-		}
+		wri.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		wri.WriteHeader(http.StatusOK)
+		_, _ = wri.Write([]byte("ok"))
+	}
+}
 
-		if nsgetter == nil {
-			nsgetter = kubeutil.ServiceAccountNamespace
-		}
-
+// InfoHandler returns the rich service-info JSON that pre-R2
+// /health used to return. Mounted on /info on the main mux so
+// operators and dashboards can still scrape build/namespace
+// without competing with the kube probes.
+func InfoHandler(serviceName, build string, nsgetter func() (string, error)) http.HandlerFunc {
+	if nsgetter == nil {
+		nsgetter = kubeutil.ServiceAccountNamespace
+	}
+	return func(wri http.ResponseWriter, req *http.Request) {
 		ns, _ := nsgetter()
 
 		data := serviceInfo{
@@ -41,22 +72,33 @@ func HealthCheck(serviceName, build string, nsgetter func() (string, error)) htt
 
 		wri.Header().Set("Content-Type", "application/json")
 		wri.WriteHeader(http.StatusOK)
-		json.NewEncoder(wri).Encode(data)
+		_ = json.NewEncoder(wri).Encode(data)
 	}
 }
 
-// ReadinessCheck returns 200 only after the initial L1 pre-warm is complete.
-// Used as the Kubernetes readiness probe so traffic isn't routed to a pod
-// with a cold cache.
+// ReadinessCheck returns 200 once the resource informers have
+// completed their initial LIST/WATCH sync (Phase 3 in
+// startBackgroundServices). Pre-R2 this gated on
+// dispatchers.IsPreWarmComplete(), which under production load
+// (50K + 1004 users) never flipped — the pod was permanently
+// NotReady and entered a restart loop. Post-R2 the pod becomes
+// Ready as soon as informers are populated; L1 prewarm keeps
+// running in the background and L1 misses fall through to the
+// foreground resolve singleflight.
+//
+// When CACHE_ENABLED=false the cache subsystem is bypassed
+// entirely; informers are not started, so there is nothing to
+// wait for and the pod is Ready as soon as the handler is
+// reachable.
 func ReadinessCheck() http.HandlerFunc {
 	return func(wri http.ResponseWriter, req *http.Request) {
-		if !cache.Disabled() && !dispatchers.IsPreWarmComplete() {
+		if !cache.Disabled() && !cache.IsInformerReady() {
 			http.Error(wri, `{"status":"warming up"}`, http.StatusServiceUnavailable)
 			return
 		}
 		wri.Header().Set("Content-Type", "application/json")
 		wri.WriteHeader(http.StatusOK)
-		wri.Write([]byte(`{"status":"ready"}`))
+		_, _ = wri.Write([]byte(`{"status":"ready"}`))
 	}
 }
 

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -4,59 +4,154 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
-	"github.com/krateoplatformops/plumbing/env"
-	"k8s.io/client-go/rest"
+	"github.com/krateoplatformops/snowplow/internal/cache"
 )
-
-// Mock di `rest.InClusterConfig`
-var mockInClusterConfig func() (*rest.Config, error)
 
 func mockNSGetter() (string, error) {
 	return "test-namespace", nil
 }
 
-func TestHealthCheck(t *testing.T) {
-	env.SetTestMode(true)
-
-	tests := []struct {
-		name               string
-		expectedStatusCode int
-		expectedResponse   serviceInfo
-	}{
-		{
-			name:               "Success - valid cluster config & namespace",
-			expectedStatusCode: http.StatusOK,
-			expectedResponse:   serviceInfo{Name: "test-service", Build: "v1.0.0", Namespace: "test-namespace"},
-		},
+// TestHealthCheck_PureInProcess verifies Q-PREWARM-R2.2: /health
+// must NOT touch the kube API server, NOT call rest.InClusterConfig,
+// and must respond synchronously regardless of test mode flags.
+//
+// The post-R2 handler is a 5-byte write — anything else is a
+// regression that re-introduces the death-spiral risk.
+func TestHealthCheck_PureInProcess(t *testing.T) {
+	// Sanity — even outside test-mode the handler must work, because
+	// production probes never set TestMode and must still get 200.
+	if err := os.Unsetenv("KUBERNETES_SERVICE_HOST"); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
 
-			req := httptest.NewRequest(http.MethodGet, "/health", nil)
-			rec := httptest.NewRecorder()
+	handler := HealthCheck("test-service", "v1.0.0", mockNSGetter)
+	handler.ServeHTTP(rec, req)
 
-			handler := HealthCheck("test-service", "v1.0.0", mockNSGetter)
-			handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "ok" {
+		t.Fatalf("expected body 'ok', got %q", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain content-type, got %q", ct)
+	}
+}
 
-			// Verifica codice HTTP
-			if rec.Code != tc.expectedStatusCode {
-				t.Errorf("expected status %d, got %d", tc.expectedStatusCode, rec.Code)
-			}
+// TestInfoHandler_RichJSON verifies the rich service-info payload
+// (formerly served at /health) is now served at /info.
+func TestInfoHandler_RichJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/info", nil)
+	rec := httptest.NewRecorder()
 
-			// Se è un 200 OK, verifichiamo il JSON restituito
-			if tc.expectedStatusCode == http.StatusOK {
-				var resp serviceInfo
-				err := json.Unmarshal(rec.Body.Bytes(), &resp)
-				if err != nil {
-					t.Errorf("failed to parse response JSON: %v", err)
-				}
-				if resp != tc.expectedResponse {
-					t.Errorf("expected response %+v, got %+v", tc.expectedResponse, resp)
-				}
-			}
-		})
+	handler := InfoHandler("test-service", "v1.0.0", mockNSGetter)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp serviceInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response JSON: %v", err)
+	}
+	want := serviceInfo{Name: "test-service", Build: "v1.0.0", Namespace: "test-namespace"}
+	if resp != want {
+		t.Errorf("expected %+v, got %+v", want, resp)
+	}
+}
+
+// TestReadinessCheck_GatesOnInformerReady verifies Q-PREWARM-R2.1:
+// /ready returns 503 until cache.MarkInformersReady() is called,
+// 200 thereafter — independent of the legacy
+// dispatchers.IsPreWarmComplete() flag (which used to be the gate).
+func TestReadinessCheck_GatesOnInformerReady(t *testing.T) {
+	// Make sure we're testing the cache-enabled path.
+	if err := os.Unsetenv("CACHE_ENABLED"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Reset the package-level atomic so the test is order-
+	// independent. The test helper lives in the cache package.
+	cache.ResetInformersReadyForTest()
+
+	handler := ReadinessCheck()
+
+	// Before MarkInformersReady — 503.
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 before informer-ready, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "warming up") {
+		t.Errorf("expected 'warming up' in body, got %q", rec.Body.String())
+	}
+
+	// After MarkInformersReady — 200.
+	cache.MarkInformersReady()
+	req2 := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 after informer-ready, got %d", rec2.Code)
+	}
+	if !strings.Contains(rec2.Body.String(), "ready") {
+		t.Errorf("expected 'ready' in body, got %q", rec2.Body.String())
+	}
+
+	// Cleanup so subsequent tests start from a known state.
+	cache.ResetInformersReadyForTest()
+}
+
+// TestReadinessCheck_CacheDisabledShortcircuits verifies that with
+// CACHE_ENABLED=false the /ready handler returns 200 immediately —
+// the informer subsystem is bypassed entirely so there is no
+// readiness gate to wait on.
+func TestReadinessCheck_CacheDisabledShortcircuits(t *testing.T) {
+	cache.ResetInformersReadyForTest()
+	t.Setenv("CACHE_ENABLED", "false")
+
+	handler := ReadinessCheck()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with cache disabled, got %d", rec.Code)
+	}
+}
+
+// TestReadinessCheck_NoPrewarmDependency is the core regression
+// guard for the death-spiral fix. /ready MUST flip to 200 once
+// MarkInformersReady is called even if no prewarm has ever run.
+//
+// Pre-R2 this test would fail because the gate also checked
+// dispatchers.IsPreWarmComplete(); post-R2 it must pass.
+func TestReadinessCheck_NoPrewarmDependency(t *testing.T) {
+	cache.ResetInformersReadyForTest()
+	if err := os.Unsetenv("CACHE_ENABLED"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Simulate: informers have synced, prewarm has NOT.
+	cache.MarkInformersReady()
+	defer cache.ResetInformersReadyForTest()
+
+	handler := ReadinessCheck()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (informers ready, prewarm not run): got %d body=%q",
+			rec.Code, rec.Body.String())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -101,6 +101,14 @@ func main() {
 	blizzardOn := flag.Bool("blizzard", env.Bool("BLIZZARD", false), "dump verbose output")
 	prettyLog := flag.Bool("pretty-log", env.Bool("PRETTY_LOG", true), "print a nice JSON formatted log")
 	port := flag.Int("port", env.ServicePort("PORT", 8081), "port to listen on")
+	// Q-PREWARM-R2.3 — separate HTTP server for kubernetes probes.
+	// Probes get their own goroutine, accept loop, and small mux with
+	// no middleware. Isolates /health and /ready from request-side
+	// goroutine pressure (slow /call requests cannot starve probes).
+	// 0 = disabled (single-server pre-R2 behaviour); helm chart sets
+	// 8082 to enable the split.
+	probePort := flag.Int("probe-port", env.ServicePort("PROBE_PORT", 0),
+		"if > 0, expose /health, /ready and /info on this port with no middleware")
 	authnNS := flag.String("authn-namespace", env.String("AUTHN_NAMESPACE", ""),
 		"krateo authn service clientconfig secrets namespace")
 	signKey := flag.String("jwt-sign-key", env.String("JWT_SIGN_KEY", ""), "secret key used to sign JWT tokens")
@@ -334,8 +342,21 @@ func main() {
 
 	mux.Handle("GET /swagger/", httpSwagger.WrapHandler)
 
+	// Q-PREWARM-R2.3 — probe handlers.
+	//
+	// Always register /health and /ready on the main mux too, for two
+	// reasons:
+	//   1. Backwards compatibility — older charts / operators that hit
+	//      :8081/health continue to work during the rollout window.
+	//   2. PROBE_PORT defaults to 0 (disabled). When unset the main
+	//      port is the only port serving probes, identical to pre-R2
+	//      behaviour.
+	// When PROBE_PORT > 0, the SAME handlers are also registered on a
+	// second http.Server bound to that port with NO middleware — that
+	// is the address the kubelet should target via the helm chart.
 	mux.Handle("GET /health", handlers.HealthCheck(serviceName, build, kubeutil.ServiceAccountNamespace))
 	mux.Handle("GET /ready", handlers.ReadinessCheck())
+	mux.Handle("GET /info", handlers.InfoHandler(serviceName, build, kubeutil.ServiceAccountNamespace))
 	mux.Handle("GET /metrics/cache", chain.Then(handlers.CacheMetrics()))
 	mux.Handle("GET /metrics/runtime", handlers.RuntimeMetricsHandler(appCache, workQueueLensAdapter{}))
 	mux.Handle("GET /api-info/names", chain.Then(handlers.Plurals()))
@@ -394,6 +415,48 @@ func main() {
 
 	log.Info("server is ready to handle requests", slog.String("addr", server.Addr))
 
+	// Q-PREWARM-R2.3 — probe-isolated http.Server.
+	//
+	// Bound to PROBE_PORT (default 0 = disabled). Uses its OWN mux,
+	// its OWN ReadTimeout/WriteTimeout, and NO middleware chain
+	// (no otelhttp wrapper, no CORS, no recovery, no gzip). This
+	// keeps probe response time bounded by the kernel accept queue
+	// + a single write syscall, regardless of pressure on the main
+	// :8081 server's request goroutine pool.
+	//
+	// Helm chart points livenessProbe and readinessProbe at this
+	// port once R2 ships. Until then, the kubelet still hits the
+	// main port — which now also serves the new R2 handlers, so
+	// the rollout is a strict superset of pre-R2 behaviour.
+	var probeServer *http.Server
+	if *probePort > 0 {
+		probeMux := http.NewServeMux()
+		probeMux.Handle("GET /health", handlers.HealthCheck(serviceName, build, kubeutil.ServiceAccountNamespace))
+		probeMux.Handle("GET /ready", handlers.ReadinessCheck())
+		probeMux.Handle("GET /info", handlers.InfoHandler(serviceName, build, kubeutil.ServiceAccountNamespace))
+
+		probeServer = &http.Server{
+			Addr:    fmt.Sprintf(":%d", *probePort),
+			Handler: probeMux,
+			// Short timeouts: probe traffic is sub-millisecond by
+			// design. A probe that takes >1s is a pod we want
+			// kubelet to consider unhealthy.
+			ReadTimeout:  1 * time.Second,
+			WriteTimeout: 1 * time.Second,
+			IdleTimeout:  5 * time.Second,
+		}
+
+		go func() {
+			if err := probeServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Error("probe server cannot run",
+					slog.String("addr", probeServer.Addr),
+					slog.Any("err", err))
+			}
+		}()
+
+		log.Info("probe server is ready", slog.String("addr", probeServer.Addr))
+	}
+
 	// Run cache warmup in background so /health responds immediately.
 	// Previously this ran before ListenAndServe, causing startup probe failures
 	// when informer sync + L2/RBAC warmup exceeded the probe timeout.
@@ -411,6 +474,13 @@ func main() {
 	server.SetKeepAlivesEnabled(false)
 	if err := server.Shutdown(shutCtx); err != nil {
 		log.Error("server forced to shutdown", slog.Any("err", err))
+	}
+
+	if probeServer != nil {
+		probeServer.SetKeepAlivesEnabled(false)
+		if err := probeServer.Shutdown(shutCtx); err != nil {
+			log.Error("probe server forced to shutdown", slog.Any("err", err))
+		}
 	}
 
 	log.Info("server gracefully stopped")
@@ -515,8 +585,19 @@ func startBackgroundServices(ctx context.Context, log *slog.Logger, c cache.Cach
 	defer syncCancel()
 	if resourceWatcher.WaitForSync(syncCtx) {
 		log.Info("informer caches synced")
+		// Q-PREWARM-R2.1 — flip the /ready gate. Pod becomes Ready
+		// from this point on, regardless of whether the L1 prewarm
+		// loop (Phase 5, runs in its own goroutine) has completed.
+		// L1 misses fall through to the foreground singleflight
+		// resolve so cold-L1 requests are slow-but-correct.
+		cache.MarkInformersReady()
 	} else {
 		log.Warn("informer caches did not sync within timeout; proceeding with warmup anyway")
+		// Even on timeout, mark ready so the pod can serve traffic.
+		// The alternative is permanent NotReady, which triggers the
+		// pre-R2 death-spiral. Operators should investigate via
+		// /metrics/runtime if WaitForSync ever returns false.
+		cache.MarkInformersReady()
 	}
 
 	// Phase 4: Run L2 warmup using the background context.


### PR DESCRIPTION
## Summary

Three independent fixes for the production death-spiral where a snowplow pod running 50K compositions + 1004 users could never reach Ready:

1. **`/ready` decouples from `dispatchers.IsPreWarmComplete()`.** Pre-R2 the gate required the multi-minute L1 prewarm loop to finish before the pod could serve traffic; under load the loop ran for >30 min and the kubelet liveness probe killed the pod first. Post-R2 the gate is `cache.IsInformerReady()`, set after Phase 3 `WaitForSync` (~10-30s at 50K). L1 misses fall through to the foreground singleflight resolve.
2. **`/health` is now a pure 5-byte write** with zero kube-API touches. Pre-R2 `HealthCheck` called `rest.InClusterConfig()` per probe, which under prewarm CPU saturation could miss the 1s timeout when all `GOMAXPROCS=4` P's were busy in JQ. The rich service-info JSON moves to `/info`.
3. **Probe-only `http.Server` on `PROBE_PORT`** (default 0 = disabled, helm chart sets 8082). Dedicated mux, dedicated goroutine, 1s read/write timeouts, NO middleware. Probes are isolated from request-side pressure on the main accept loop.

Both old and new probe paths are registered on the main `:8081` mux for backwards compatibility; the helm chart controls the cutover by pointing the kubelet at the new port.

## Coordinated PR pair

This PR ships the binary side. **Cross-linked chart-side PR**: braghettos/snowplow-chart#q-prewarm-r2-chart (filed alongside this one). Both must merge together for the deploy to behave correctly: an older chart against this binary works (it just hits :8081 probes, same as today + the extra `/info` endpoint), but this chart against an older binary leaves :8082 closed and produces connection-refused on every probe.

## Acceptance gates targeted (PR-A scope)

| Gate | Today | Target |
|---|---|---|
| G_ready: pod /ready=200 after start | NEVER | <= 30s |
| G_probe: probe response p99 during prewarm | > 1s | <= 100ms |
| G_no_restart: pod restart count during first prewarm | 3/146min | 0 |

Out of scope (PR-B / R5 covers): `G_prewarm_complete`, `G_uxImpact`.

## Files changed

- `internal/cache/informer_ready.go` (new) — atomic flag + `MarkInformersReady()` / `IsInformerReady()` getters
- `internal/cache/informer_ready_test.go` (new) — unit tests including concurrent-access race coverage
- `internal/handlers/health.go` — strip kube-API call from `/health`; new `InfoHandler`; `/ready` gates on `cache.IsInformerReady()`
- `internal/handlers/health_test.go` — regression guards: pure-in-process /health, /ready informer-gate, no prewarm dependency
- `main.go` — `--probe-port` flag, second `http.Server` registration, `cache.MarkInformersReady()` after WaitForSync, graceful shutdown for probe server

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -tags=unit ./internal/handlers/... ./internal/cache/...` -> all green (handlers 26.7s, cache 1.99s, dispatchers 1.99s)
- [x] Helm template render of cross-linked chart shows correct probe wiring (port `probe`/8082, `PROBE_PORT` ConfigMap entry)
- [ ] Deploy to test cluster, verify `/ready` flips within 30s on dirty cluster
- [ ] Cache-tester probe-p99 measurement post-deploy

## Spec

`/tmp/snowplow-runs/q-cold-1-cd-v6-phase6-50k-postPR2PR3-2026-05-05/Q-PREWARM-R2R5-SPEC.md` s1

## Authority

Diego direct-authorize (Path A: R2 ships first, R5 follows after cache-tester K-sweep). Per autonomous-mode delegation: PR creation allowed; merge requires architect+PM review.