### PR TITLE
fix(bench): deep-clean widget CRs before force-finalize (prevents orphan pollution)

### DIFF
--- a/e2e/bench/snowplow_test.py
+++ b/e2e/bench/snowplow_test.py
@@ -175,6 +175,39 @@ FINALIZER_RESOURCES = [
 ]
 FINALIZER_PATCH = '{"metadata":{"finalizers":null}}'
 
+# Widget + RESTAction CRDs that may live inside a bench-ns-XX namespace.
+# These MUST be explicitly deleted before the namespace is force-finalized
+# via the /finalize subresource — otherwise force-finalize bypasses the
+# normal cascade-delete and the CRs survive as ghosts inside the
+# (re-created) namespace, polluting later bench runs. Discovered 2026-05-05
+# when fresh bench-ns-17 contained 908 Panel CRs from a 3-day-old run.
+WIDGET_KINDS = [
+    "panels.widgets.templates.krateo.io",
+    "buttons.widgets.templates.krateo.io",
+    "tables.widgets.templates.krateo.io",
+    "flowcharts.widgets.templates.krateo.io",
+    "navmenuitems.widgets.templates.krateo.io",
+    "eventlists.widgets.templates.krateo.io",
+    "markdowns.widgets.templates.krateo.io",
+    "yamlviewers.widgets.templates.krateo.io",
+    "tablists.widgets.templates.krateo.io",
+    "forms.widgets.templates.krateo.io",
+    "filters.widgets.templates.krateo.io",
+    "datagrids.widgets.templates.krateo.io",
+    "buttongroups.widgets.templates.krateo.io",
+    "rows.widgets.templates.krateo.io",
+    "columns.widgets.templates.krateo.io",
+    "pages.widgets.templates.krateo.io",
+    "barcharts.widgets.templates.krateo.io",
+    "linecharts.widgets.templates.krateo.io",
+    "piecharts.widgets.templates.krateo.io",
+    "paragraphs.widgets.templates.krateo.io",
+    "navmenus.widgets.templates.krateo.io",
+    "routes.widgets.templates.krateo.io",
+    "routesloaders.widgets.templates.krateo.io",
+    "restactions.templates.krateo.io",
+]
+
 # ═════════════════════════════════════════════════════════════════════════════
 # FORMATTING
 # ═════════════════════════════════════════════════════════════════════════════
@@ -986,6 +1019,60 @@ def _drain_argo_apps(timeout=300):
     log("Argo applications cleaned (forced)")
 
 
+def deep_clean_bench_namespace(ns):
+    """Delete every widget + RESTAction CR in `ns` BEFORE the namespace is
+    force-finalized.
+
+    Why this exists
+    ---------------
+    `delete_bench_namespaces` calls /api/v1/namespaces/<ns>/finalize to clear
+    spec.finalizers and delete the namespace immediately. That bypasses the
+    normal cascade-delete path: any CR still inside the namespace survives as
+    a ghost, and re-appears as soon as the namespace is recreated under the
+    same name in a later bench run. On 2026-05-05 a 2-hour-old bench-ns-17
+    contained 908 Panel CRs creationTimestamp=2026-05-03 (3 days stale) —
+    each pointed at a non-existent helm release and triggered a 404 storm
+    on the next /compositions-page resolve.
+
+    Strategy
+    --------
+    1. Bulk delete the kind with --wait=false + --force --grace-period=0.
+    2. Re-list; for any survivor, patch metadata.finalizers=null and
+       delete again.
+
+    Returns total CR count seen (pre-delete) for reporting.
+    """
+    total_seen = 0
+    for kind in WIDGET_KINDS:
+        rc, out, _ = kubectl("get", kind, "-n", ns, "--no-headers",
+                             "--ignore-not-found", "-o", "name")
+        if rc != 0 or not out.strip():
+            continue
+        names = [n.strip() for n in out.split("\n") if n.strip()]
+        if not names:
+            continue
+        total_seen += len(names)
+        # Bulk delete (don't wait — finalizer-patch fallback handles stuck CRs)
+        kubectl("delete", kind, "--all", "-n", ns, "--ignore-not-found",
+                "--wait=false", "--grace-period=0", "--force")
+        time.sleep(1)
+        # Patch any remaining stuck on finalizers
+        rc2, out2, _ = kubectl("get", kind, "-n", ns, "--no-headers",
+                               "--ignore-not-found", "-o", "name")
+        if rc2 == 0 and out2.strip():
+            stuck = [s.strip() for s in out2.split("\n") if s.strip()]
+
+            def _patch(target):
+                kubectl("patch", target, "-n", ns, "--type=merge",
+                        f"-p={FINALIZER_PATCH}")
+            with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+                list(ex.map(_patch, stuck))
+            # One last delete pass for the patched survivors
+            kubectl("delete", kind, "--all", "-n", ns, "--ignore-not-found",
+                    "--wait=false", "--grace-period=0", "--force")
+    return total_seen
+
+
 def delete_bench_namespaces():
     """Delete bench namespaces. Must be called AFTER compositions and CompositionDefinitions are deleted."""
     log("Deleting bench namespaces ...")
@@ -1007,6 +1094,22 @@ def delete_bench_namespaces():
                             "--type=merge", f"-p={FINALIZER_PATCH}")
                 with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
                     list(ex.map(patch, items))
+    # Deep-clean widget + RESTAction CRs in EVERY bench-ns BEFORE we trigger
+    # namespace deletion. force_finalize_namespace() (called below) bypasses
+    # cascade-delete; without this step CRs survive as ghosts and pollute
+    # subsequent bench runs that recreate the same namespaces.
+    log(f"Deep-cleaning widget CRs in {len(bench_ns)} bench namespaces ...")
+
+    def _deep_clean(n):
+        return n, deep_clean_bench_namespace(n)
+    total_purged = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+        for n, count in ex.map(_deep_clean, bench_ns):
+            if count > 0:
+                log(f"  deep-clean: {n} purged {count} widget CRs")
+                total_purged += count
+    log(f"Deep-clean total: purged {total_purged} widget CRs across "
+        f"{len(bench_ns)} bench namespaces")
     # Batch delete all bench namespaces in one kubectl call
     kubectl("delete", "ns", *bench_ns, "--ignore-not-found", "--wait=false",
             "--force", "--grace-period=0")


### PR DESCRIPTION
## Problem

The bench cleanup path force-finalizes every \`bench-ns-XX\` namespace via
\`/api/v1/namespaces/<ns>/finalize\`. That call clears \`spec.finalizers\`
(including \`kubernetes\`) at the etcd level and removes the namespace
immediately, **bypassing the normal cascade-delete pipeline**.

Side-effect: any widget CR (Panel, Button, Table, FlowChart, ...) or
RESTAction CR still inside the namespace at finalize time survives as a
ghost. When a later bench run recreates the namespace under the same
name, the ghosts re-attach and pollute the cluster.

## Evidence (2026-05-05)

A 2-hour-old \`bench-ns-17\` contained **908 Panel CRs** with
\`creationTimestamp: 2026-05-03\` (3 days stale). Each pointed at a
non-existent helm release \`bench-app-17-194-x6wcz94z\`. Cluster-wide
inventory at the time of triage:

| Bench namespace | Orphan Panel count |
|---|---|
| bench-ns-29 | 1520 |
| bench-ns-30 | 1508 |
| bench-ns-31 | 1500 |
| bench-ns-32 | 1496 |
| bench-ns-28 | 1344 |
| bench-ns-11..27 (most) | ~900 |
| **Total panels in bench-ns-* (cluster-wide)** | **23,810** |

bench-ns-17 alone, 9 widget kinds: panels=908, buttons=908, tables=227,
flowcharts=227, eventlists=227, markdowns=227, yamlviewers=227,
tablists=227, forms=227. Each helm-labelled bench-app-17-194-x6wcz94z
ghost causes the snowplow resolver to issue a child lookup against a
helm release that no longer exists, generating ~210 errors per
\`/compositions-page\` resolve.

## Fix

Add \`deep_clean_bench_namespace(ns)\` that bulk-deletes every widget +
RESTAction kind in the namespace with \`--grace-period=0 --force
--wait=false\`, then patches \`metadata.finalizers=null\` on any survivor
and re-deletes. Wire it into \`delete_bench_namespaces()\` so every
bench-ns gets purged **before** the batch namespace delete triggers
force-finalize.

Run in parallel across all bench namespaces with
\`ThreadPoolExecutor(max_workers=8)\` to keep cleanup fast.

24 CRDs covered (the full widgets.templates.krateo.io API group +
restactions.templates.krateo.io):
panels, buttons, tables, flowcharts, navmenuitems, eventlists,
markdowns, yamlviewers, tablists, forms, filters, datagrids,
buttongroups, rows, columns, pages, barcharts, linecharts, piecharts,
paragraphs, navmenus, routes, routesloaders, restactions.

## Empirical validation against the live polluted cluster

\`\`\`
BEFORE:  bench-ns-17 panels=908 buttons=908 tables=227 flowcharts=227
         eventlists=227 markdowns=227 yamlviewers=227 tablists=227
         forms=227  (3,405 widget CRs total)
ACTION:  ran the same kubectl commands the new function emits, against
         bench-ns-17 only
AFTER:   bench-ns-17 panels=0 buttons=0 ... all kinds=0
         other 19 bench-ns still polluted (untouched, as expected)
\`\`\`

## Authority

Diego authorized as **Option C** (autonomous-mode delegation): PR
creation on \`braghettos/snowplow\` allowed; merge requires architect+PM
review. No upstream \`krateoplatformops/*\` push.

## Scope

- Pure cleanup hygiene; **no** changes to bench scoring or measurement
  logic, no L2/R2 code, no chart, no helm install/upgrade.
- 103 insertions, 0 deletions in \`e2e/bench/snowplow_test.py\`.

## Test plan

- [ ] On a polluted cluster, run \`clean_environment()\` (or just
      \`delete_bench_namespaces()\`) and confirm the
      "Deep-cleaning widget CRs in N bench namespaces" log line appears.
- [ ] After cleanup, \`kubectl get panels.widgets.templates.krateo.io
      -A | grep bench-ns | wc -l\` returns 0.
- [ ] Re-run bench from clean: ghost CR pollution does not recur on
      the recreated bench-ns-XX namespaces.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>