### PR TITLE
fix(cache): evict L1 deps on CRD auto-register (Q-PREWARM-R5 convergence regression)

### DIFF
--- a/internal/cache/crd_register_evict_test.go
+++ b/internal/cache/crd_register_evict_test.go
@@ -1,0 +1,302 @@
+// Q-PREWARM-R5 convergence fix — unit tests for the per-group L1
+// reverse index and EvictL1KeysForGroup. The bug being fixed:
+//
+//   1. R5 prewarm fires when admin's secret ADD event arrives.
+//   2. If a customer CRD doesn't yet exist, the iterator-based RESTAction
+//      returns 0 namespaces, registers ZERO cluster-deps, and writes an
+//      L1 entry keyed on a (now-incorrect) empty result.
+//   3. When the CRD later appears via autoRegisterCRDInformer, watch
+//      events for new CRs find an empty L1ResourceDepKey set and never
+//      refresh the L1 entry — it stays stale until ResolvedCacheTTL
+//      expires (1 hour).
+//
+// The fix: register every L1 resolved key in a per-group SET keyed on
+// L1ResourceDepGroupKey(group). When autoRegisterCRDInformer runs, it
+// evicts every L1 key in the new CRD's group via EvictL1KeysForGroup.
+// Subsequent HTTP requests re-resolve at the correct cluster state and
+// re-register cluster-deps; watch events then converge normally.
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestL1ResourceDepGroupKey_NormalizesEmptyGroup verifies that the empty
+// API group ("") is encoded as "core" — matching the GVRToKey convention.
+func TestL1ResourceDepGroupKey_NormalizesEmptyGroup(t *testing.T) {
+	if got := L1ResourceDepGroupKey(""); got != "snowplow:l1dep-group:core" {
+		t.Errorf("empty group: got %q, want snowplow:l1dep-group:core", got)
+	}
+	if got := L1ResourceDepGroupKey("templates.krateo.io"); got != "snowplow:l1dep-group:templates.krateo.io" {
+		t.Errorf("namespaced group: got %q, want snowplow:l1dep-group:templates.krateo.io", got)
+	}
+}
+
+// TestEvictL1KeysForGroup_NilCache covers the defensive nil branch.
+func TestEvictL1KeysForGroup_NilCache(t *testing.T) {
+	if n := EvictL1KeysForGroup(context.Background(), nil, "templates.krateo.io"); n != 0 {
+		t.Errorf("nil cache eviction should return 0, got %d", n)
+	}
+}
+
+// TestEvictL1KeysForGroup_EmptySet verifies that an absent / empty SET
+// for the group is a no-op. This is the no-op branch the architect
+// asked for under "Empty group SET → no-op".
+func TestEvictL1KeysForGroup_EmptySet(t *testing.T) {
+	c := NewMem(0)
+	ctx := context.Background()
+	if n := EvictL1KeysForGroup(ctx, c, "templates.krateo.io"); n != 0 {
+		t.Errorf("empty group set: got %d, want 0", n)
+	}
+}
+
+// TestEvictL1KeysForGroup_EvictsAllRegisteredKeys covers the primary
+// happy path. Register N L1 keys via RegisterL1Dependencies for the same
+// group, then evict — all N must be gone, the per-group SET must be
+// gone, and unrelated-group keys must be preserved.
+func TestEvictL1KeysForGroup_EvictsAllRegisteredKeys(t *testing.T) {
+	c := NewMem(0)
+	ctx := context.Background()
+
+	templatesGVR := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+	widgetsGVR := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "widgets"}
+	coreGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+
+	// Register 3 L1 keys touching templates.krateo.io GVRs.
+	templateKeys := []string{
+		ResolvedKey("admin", templatesGVR, "ns-01", "compositions-list", 0, 0),
+		ResolvedKey("admin", templatesGVR, "ns-01", "piechart", 0, 0),
+		// A widget L1 entry that depends on a templates.krateo.io GVR
+		// via an apiref — same group, different resource.
+		ResolvedKey("user-1", widgetsGVR, "ns-02", "my-widget", 0, 0),
+	}
+	for i, k := range templateKeys {
+		if err := c.SetResolvedRaw(ctx, k, []byte(`{"items":[]}`)); err != nil {
+			t.Fatalf("seed[%d]: %v", i, err)
+		}
+		tr := NewDependencyTracker()
+		if i < 2 {
+			tr.AddGVR(templatesGVR)
+			tr.AddResource(templatesGVR, "ns-01", "")
+		} else {
+			tr.AddGVR(widgetsGVR)
+			tr.AddResource(widgetsGVR, "ns-02", "my-widget")
+		}
+		RegisterL1Dependencies(ctx, c, tr, k)
+	}
+
+	// Register one L1 key in the core group — must NOT be evicted.
+	coreKey := ResolvedKey("admin", coreGVR, "krateo-system", "admin-clientconfig", 0, 0)
+	if err := c.SetResolvedRaw(ctx, coreKey, []byte(`{}`)); err != nil {
+		t.Fatalf("seed core: %v", err)
+	}
+	tr := NewDependencyTracker()
+	tr.AddGVR(coreGVR)
+	tr.AddResource(coreGVR, "krateo-system", "admin-clientconfig")
+	RegisterL1Dependencies(ctx, c, tr, coreKey)
+
+	// Sanity: per-group SET is populated for templates.krateo.io.
+	members, err := c.SMembers(ctx, L1ResourceDepGroupKey("templates.krateo.io"))
+	if err != nil {
+		t.Fatalf("smembers templates: %v", err)
+	}
+	if len(members) != len(templateKeys) {
+		t.Errorf("expected %d members in templates set, got %d (members=%v)", len(templateKeys), len(members), members)
+	}
+
+	// Evict.
+	evicted := EvictL1KeysForGroup(ctx, c, "templates.krateo.io")
+	if evicted != len(templateKeys) {
+		t.Errorf("eviction count: got %d, want %d", evicted, len(templateKeys))
+	}
+
+	// All template L1 keys must be gone.
+	for _, k := range templateKeys {
+		if _, hit, _ := c.GetRaw(ctx, k); hit {
+			t.Errorf("template L1 key %q should be evicted, still present", k)
+		}
+	}
+	// Core L1 key must be preserved.
+	if _, hit, _ := c.GetRaw(ctx, coreKey); !hit {
+		t.Errorf("core L1 key %q must NOT be evicted (different group)", coreKey)
+	}
+	// Per-group SET itself must be gone.
+	postMembers, _ := c.SMembers(ctx, L1ResourceDepGroupKey("templates.krateo.io"))
+	if len(postMembers) != 0 {
+		t.Errorf("post-eviction templates group set must be empty, got %v", postMembers)
+	}
+	// Core per-group SET must still hold its member.
+	coreMembers, _ := c.SMembers(ctx, L1ResourceDepGroupKey(""))
+	if len(coreMembers) != 1 || coreMembers[0] != coreKey {
+		t.Errorf("core group set: got %v, want [%s]", coreMembers, coreKey)
+	}
+}
+
+// TestEvictL1KeysForGroup_PaginatedBaseKeyAlsoEvicted verifies that the
+// unpaginated base key (registered alongside the paginated variant) is
+// also evicted. This is the same pattern the per-resource and cluster
+// deps already follow.
+func TestEvictL1KeysForGroup_PaginatedBaseKeyAlsoEvicted(t *testing.T) {
+	c := NewMem(0)
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+
+	pagedKey := ResolvedKey("admin", gvr, "ns-01", "compositions-list", 1, 10)
+	baseKey := ResolvedKeyBase("admin", gvr, "ns-01", "compositions-list")
+
+	if err := c.SetResolvedRaw(ctx, pagedKey, []byte(`{"items":[],"page":1}`)); err != nil {
+		t.Fatalf("seed paged: %v", err)
+	}
+	if err := c.SetResolvedRaw(ctx, baseKey, []byte(`{"items":[]}`)); err != nil {
+		t.Fatalf("seed base: %v", err)
+	}
+
+	tr := NewDependencyTracker()
+	tr.AddGVR(gvr)
+	tr.AddResource(gvr, "ns-01", "")
+	RegisterL1Dependencies(ctx, c, tr, pagedKey)
+
+	evicted := EvictL1KeysForGroup(ctx, c, "templates.krateo.io")
+	if evicted != 2 {
+		t.Errorf("expected 2 keys evicted (paged + base), got %d", evicted)
+	}
+	if _, hit, _ := c.GetRaw(ctx, pagedKey); hit {
+		t.Errorf("paginated key %q must be evicted", pagedKey)
+	}
+	if _, hit, _ := c.GetRaw(ctx, baseKey); hit {
+		t.Errorf("base key %q must be evicted (paginated variant registered it)", baseKey)
+	}
+}
+
+// TestEvictL1KeysForGroup_DedupAcrossGVRsInGroup verifies that an L1
+// key touching MULTIPLE GVRs in the same group is registered ONCE in
+// the per-group SET (not once per ref/GVR). EvictL1KeysForGroup must
+// still report a single eviction for that L1 key.
+func TestEvictL1KeysForGroup_DedupAcrossGVRsInGroup(t *testing.T) {
+	c := NewMem(0)
+	ctx := context.Background()
+	raGVR := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+	wGVR := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "widgets"}
+
+	l1 := ResolvedKey("admin", wGVR, "ns-01", "my-widget", 0, 0)
+	if err := c.SetResolvedRaw(ctx, l1, []byte("{}")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tr := NewDependencyTracker()
+	tr.AddGVR(raGVR)
+	tr.AddGVR(wGVR)
+	tr.AddResource(raGVR, "ns-01", "compositions-list")
+	tr.AddResource(wGVR, "ns-01", "my-widget")
+	RegisterL1Dependencies(ctx, c, tr, l1)
+
+	members, _ := c.SMembers(ctx, L1ResourceDepGroupKey("templates.krateo.io"))
+	if len(members) != 1 {
+		t.Errorf("expected 1 member after dedup, got %d (members=%v)", len(members), members)
+	}
+
+	evicted := EvictL1KeysForGroup(ctx, c, "templates.krateo.io")
+	if evicted != 1 {
+		t.Errorf("expected 1 eviction after dedup, got %d", evicted)
+	}
+}
+
+// TestRegisterL1Dependencies_Race covers the architect's "Race: register
+// L1 dep + autoRegisterCRDInformer in parallel → eventual consistency"
+// requirement. Two goroutines hammer the per-group SET: one registers
+// new L1 keys for the group while the other repeatedly evicts. The
+// invariant we check is liveness — no panic, no deadlock, and the
+// FINAL eviction empties whatever was last written. There is an
+// inherent TOCTOU window between SMembers and Delete that may cause
+// some keys registered AFTER the SMembers snapshot to survive the
+// eviction; that is acceptable per EvictL1KeysForGroup's documented
+// semantics: such keys were resolved AFTER the CRD became visible
+// to the writer.
+func TestEvictL1KeysForGroup_ConcurrentRegisterAndEvict(t *testing.T) {
+	c := NewMem(0)
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+
+	const N = 200
+	keys := make([]string, N)
+	for i := 0; i < N; i++ {
+		k := ResolvedKey("u", gvr, "ns", "ra-"+itoa(i), 0, 0)
+		keys[i] = k
+		_ = c.SetResolvedRaw(ctx, k, []byte("{}"))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Writer goroutine: register L1 deps for all N keys.
+	go func() {
+		defer wg.Done()
+		for _, k := range keys {
+			tr := NewDependencyTracker()
+			tr.AddGVR(gvr)
+			tr.AddResource(gvr, "ns", "")
+			RegisterL1Dependencies(ctx, c, tr, k)
+		}
+	}()
+	// Evictor goroutine: spin evictions in parallel.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = EvictL1KeysForGroup(ctx, c, "templates.krateo.io")
+		}
+	}()
+	wg.Wait()
+
+	// Drain to a quiescent state — eventual consistency.
+	_ = EvictL1KeysForGroup(ctx, c, "templates.krateo.io")
+	final, _ := c.SMembers(ctx, L1ResourceDepGroupKey("templates.krateo.io"))
+	if len(final) != 0 {
+		t.Errorf("after final drain, group set must be empty, got %d members", len(final))
+	}
+}
+
+// TestGvrKeyGroup_Forms verifies the gvr-key parser used by
+// RegisterL1Dependencies to populate the per-group SET.
+func TestGvrKeyGroup_Forms(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"core/v1/secrets", "core"},
+		{"templates.krateo.io/v1/restactions", "templates.krateo.io"},
+		{"", ""},
+		{"malformed", ""},
+		{"/v1/foo", ""}, // empty group, idx==0 → ""
+	}
+	for _, c := range cases {
+		if got := gvrKeyGroup(c.in); got != c.want {
+			t.Errorf("gvrKeyGroup(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// itoa is a tiny strconv-free helper to avoid importing strconv solely
+// for tests; keeps the test file dependency-free.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/cache/keys.go
+++ b/internal/cache/keys.go
@@ -295,15 +295,110 @@ func L1ResourceDepKey(gvrKey, ns, name string) string {
 	return "snowplow:l1dep:" + gvrKey + ":" + ns + ":" + name
 }
 
+// L1ResourceDepGroupKey returns the SET key that maps a Kubernetes API group
+// to ALL L1 resolved keys whose resolution touched ANY GVR in that group.
+//
+// This is the convergence reverse index used by autoRegisterCRDInformer to
+// evict L1 entries that were resolved against a stale cluster state (e.g.,
+// before the CRD existed). The empty group is normalised to "core" so that
+// both `core/v1/configmaps` and `templates.krateo.io/v1/restactions` share
+// the same lookup pattern as GVRToKey.
+//
+// Q-PREWARM-R5 convergence regression (architect's H1, 2026-05-06): when R5
+// prewarm runs before a customer CRD exists, the iterator-based RESTAction
+// returns 0 namespaces, registers ZERO cluster-deps, and writes an L1 entry
+// keyed on a (now-incorrect) empty result. When the CRD later appears via
+// autoRegisterCRDInformer, watch events for its CRs find an empty
+// L1ResourceDepKey set and never refresh that L1 entry. The per-group SET
+// lets us evict those L1 entries as soon as the CRD is registered, so the
+// next HTTP request re-resolves against the true cluster state and the
+// cluster-dep gets registered properly.
+func L1ResourceDepGroupKey(group string) string {
+	if group == "" {
+		group = "core"
+	}
+	return "snowplow:l1dep-group:" + group
+}
+
+// gvrKeyGroup extracts the API group component from a GVRToKey-formatted
+// string ("group/version/resource"). Returns "core" for the empty/core
+// group, matching GVRToKey's encoding. Returns "" if the key is malformed.
+func gvrKeyGroup(gvrKey string) string {
+	idx := strings.Index(gvrKey, "/")
+	if idx <= 0 {
+		return ""
+	}
+	return gvrKey[:idx]
+}
+
+// EvictL1KeysForGroup deletes every L1 resolved key registered as depending
+// on any GVR in the given API group, then clears the per-group SET itself.
+// Returns the count of L1 keys evicted.
+//
+// Used by ResourceWatcher.autoRegisterCRDInformer to fix the Q-PREWARM-R5
+// convergence regression: when a previously-unknown CRD appears, any L1
+// entry that was resolved against the (then-stale) cluster state is now
+// authoritatively wrong, and watch events for the new CRs cannot refresh
+// it (the dependency was never recorded). DELETE-only invalidation matches
+// the existing semantics — see feedback_l1_invalidation_delete_only.md.
+//
+// The set is cleared (via SRemMembers) at the end so a subsequent CRD
+// registration for the same group does not re-evict already-resolved
+// keys (which by then will have been re-registered with deps that
+// legitimately reference the now-existing CRD).
+//
+// Thread-safety: SMembers + Delete + SRemMembers are not atomic on Cache
+// implementations without a transaction primitive; concurrent writers
+// (RegisterL1Dependencies) during eviction may register an L1 key that
+// is missed by this pass. That is acceptable because the missed key was
+// resolved AFTER the CRD became visible to the writer, so it is by
+// definition resolved against the correct cluster state and does not
+// need eviction.
+func EvictL1KeysForGroup(ctx context.Context, c Cache, group string) int {
+	if c == nil {
+		return 0
+	}
+	setKey := L1ResourceDepGroupKey(group)
+	members, err := c.SMembers(ctx, setKey)
+	if err != nil || len(members) == 0 {
+		return 0
+	}
+	// Deduplicate: an L1 key may appear once per (ns,name) ref but evict
+	// only counts unique L1 keys.
+	uniq := make(map[string]struct{}, len(members))
+	for _, k := range members {
+		uniq[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(uniq))
+	for k := range uniq {
+		keys = append(keys, k)
+	}
+	if len(keys) > 0 {
+		_ = c.Delete(ctx, keys...)
+		// Clear the per-group set so the same keys are not re-evicted on
+		// the next CRD registration. SRemMembers is the only Cache-level
+		// way to drain a set in-place; callers concurrently registering
+		// new keys after this point write to a fresh empty set.
+		_ = c.SRemMembers(ctx, setKey, members...)
+	}
+	return len(keys)
+}
+
 
 // RegisterL1Dependencies registers the L1 resolved key in reverse indexes
 // based on dependencies captured by the tracker. Writes:
 // - Per-resource deps: L1ResourceDepKey(gvr, ns, name) for each specific resource
 // - Cluster-wide deps: L1ResourceDepKey(gvr, "", "") for each GVR accessed
+// - Per-group convergence deps: L1ResourceDepGroupKey(group) for each API group
 //
 // The cluster-wide dep ensures that when ANY resource of a GVR changes in
 // ANY namespace, the L1 key is found by triggerL1RefreshBatch. This is critical
 // for RESTActions like compositions-list that iterate all namespaces.
+//
+// The per-group dep (Q-PREWARM-R5 convergence fix) lets autoRegisterCRDInformer
+// evict L1 entries whose resolution touched any GVR in a newly-registered
+// CRD's group, so an L1 entry resolved before the CRD existed self-heals on
+// the next HTTP request. See L1ResourceDepGroupKey for rationale.
 func RegisterL1Dependencies(ctx context.Context, c Cache, tracker *DependencyTracker, l1Key string) {
 	if c == nil || tracker == nil {
 		return
@@ -324,6 +419,32 @@ func RegisterL1Dependencies(ctx context.Context, c Cache, tracker *DependencyTra
 	var baseKey string
 	if isPaginated && (info.Page > 0 || info.PerPage > 0) {
 		baseKey = ResolvedKeyBase(info.Username, info.GVR, info.NS, info.Name)
+	}
+
+	// ── Per-group convergence index (Q-PREWARM-R5 fix) ─────────────────
+	// Register the L1 key (and its unpaginated base) under the SET for
+	// each distinct API group accessed. We collect groups from BOTH
+	// gvrKeys (LIST-only deps) and refs (GET deps) so the eviction
+	// reach matches the full dependency surface. See L1ResourceDepGroupKey
+	// and EvictL1KeysForGroup for the convergence rationale.
+	groupSeen := make(map[string]bool)
+	registerGroupDep := func(gvrKey string) {
+		group := gvrKeyGroup(gvrKey)
+		if group == "" || groupSeen[group] {
+			return
+		}
+		groupSeen[group] = true
+		setKey := L1ResourceDepGroupKey(group)
+		_ = c.SAddWithTTL(ctx, setKey, l1Key, ReverseIndexTTL)
+		if baseKey != "" {
+			_ = c.SAddWithTTL(ctx, setKey, baseKey, ReverseIndexTTL)
+		}
+	}
+	for _, gk := range gvrKeys {
+		registerGroupDep(gk)
+	}
+	for _, ref := range refs {
+		registerGroupDep(ref.GVRKey)
 	}
 
 	// Per-resource deps (ns + name specific).

--- a/internal/cache/metrics.go
+++ b/internal/cache/metrics.go
@@ -58,6 +58,13 @@ type Metrics struct {
 	WatchEventsDelete          atomic.Int64
 	WatchEventsDeleteTombstone atomic.Int64
 
+	// ── CRD auto-register convergence (Q-PREWARM-R5 fix) ─────────────────
+	// CRDRegisterL1Evictions counts L1 resolved keys evicted because a CRD
+	// for their dependency group was just auto-registered (the convergence
+	// path that R5 prewarm shortened). Non-zero values mean the cache
+	// self-healed L1 entries that were resolved before the CRD existed.
+	CRDRegisterL1Evictions atomic.Int64
+
 	// ── L2 post-refilter cache (Q-RBACC-L2-1) ────────────────────────────
 	// Counters surface at /metrics/runtime under l2_* keys. Hit-rate is
 	// computed by the snapshot consumer.
@@ -118,6 +125,11 @@ type MetricsSnapshot struct {
 	WatchEventsDelete          int64 `json:"watch_events_delete"`
 	WatchEventsDeleteTombstone int64 `json:"watch_events_delete_tombstone"`
 
+	// CRD auto-register convergence (Q-PREWARM-R5 fix). Counts L1
+	// resolved keys evicted because a CRD for their dependency group
+	// was just auto-registered. See keys.go L1ResourceDepGroupKey.
+	CRDRegisterL1Evictions int64 `json:"crd_register_l1_evictions"`
+
 	// L2 post-refilter cache (Q-RBACC-L2-1). HitRate is computed in the
 	// snapshot for parity with L1. ResidentBytes/Count are sampled once
 	// per snapshot from the live counters.
@@ -173,6 +185,8 @@ func (m *Metrics) snapshotFromAtomics() MetricsSnapshot {
 		WatchEventsUpdate:          m.WatchEventsUpdate.Load(),
 		WatchEventsDelete:          m.WatchEventsDelete.Load(),
 		WatchEventsDeleteTombstone: m.WatchEventsDeleteTombstone.Load(),
+
+		CRDRegisterL1Evictions: m.CRDRegisterL1Evictions.Load(),
 
 		L2Hits:              m.L2Hits.Load(),
 		L2Misses:            m.L2Misses.Load(),

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -1318,6 +1318,31 @@ func (rw *ResourceWatcher) autoRegisterCRDInformer(uns *unstructured.Unstructure
 	rw.dynamicGVRsMu.Lock()
 	rw.dynamicGVRs[GVRToKey(newGVR)] = newGVR
 	rw.dynamicGVRsMu.Unlock()
+
+	// ── Q-PREWARM-R5 convergence fix ───────────────────────────────────
+	// Evict any L1 resolved keys that depend on the CRD's group. Such
+	// entries were resolved BEFORE this CRD existed, so their cluster-dep
+	// reverse index was never populated for the new GVR — meaning watch
+	// events for new CRs would find an empty SMembers result and never
+	// refresh the L1 entry. By DELETING the L1 keys, the next HTTP request
+	// triggers a fresh resolve at the now-correct cluster state, which
+	// re-registers the cluster-dep, and subsequent watch events converge
+	// normally. DELETE-only invalidation matches the existing
+	// stale-while-revalidate semantics (see feedback_l1_invalidation_delete_only).
+	//
+	// Generic per-group: no hardcoded GVRs, group names, or RESTAction
+	// names per feedback_no_special_cases.md.
+	if rw.cache != nil {
+		evicted := EvictL1KeysForGroup(context.Background(), rw.cache, group)
+		if evicted > 0 {
+			GlobalMetrics.CRDRegisterL1Evictions.Add(int64(evicted))
+			slog.Info("resource-watcher: evicted L1 keys on CRD auto-register (R5 convergence fix)",
+				slog.String("crd", uns.GetName()),
+				slog.String("group", group),
+				slog.String("gvr", newGVR.String()),
+				slog.Int("evicted", evicted))
+		}
+	}
 }
 
 // matchesAutoDiscoverGroup checks if a CRD group matches any configured


### PR DESCRIPTION
## Summary

Fixes the R5 event-driven prewarm **convergence regression** flagged P0 by the architect (H1 verdict, `.claude/analysis/architect-convergence-bug-2026-05-06.md`). When R5 prewarm fires before a customer CRD is present in the cluster, the resulting L1 entry is keyed on a stale-empty result and watch events for newly-created CRs cannot refresh it — the cache stays at 0 items until `ResolvedCacheTTL` (1h) expires.

The fix is **generic per-group reverse-index eviction**, ~30 LOC of behaviour code plus tests:

- `keys.go` — adds `L1ResourceDepGroupKey(group)` and `EvictL1KeysForGroup`. `RegisterL1Dependencies` now also writes the L1 key (and its unpaginated base when paginated) into a per-group SET keyed by Kubernetes API group, with the same `ReverseIndexTTL` used for the existing per-resource and cluster-wide dep sets.
- `watcher.go` — `autoRegisterCRDInformer` calls `EvictL1KeysForGroup` with the new CRD's group, immediately after `startInformer`. DELETE-only invalidation per `feedback_l1_invalidation_delete_only.md`.
- `metrics.go` — exposes `crd_register_l1_evictions` counter on `/metrics/runtime` for observability.

No hardcoded GVRs / group names / RESTAction names — generic to any CRD discovery, per `feedback_no_special_cases.md`.

## Architect's confirmed root cause (H1)

R5 prewarm fires when admin's `-clientconfig` secret ADD event arrives. If a customer CRD doesn't exist yet at that moment (e.g., post-snowplow-restart-during-bench-clean-and-rebuild), the iterator-based RESTAction returns 0 namespaces, runs 0 upstream LISTs, and the cluster-dep registration at `internal/resolvers/restactions/api/resolve.go:638-651` is unreachable. When the CRD later appears + watch events fire for new CRs, the `SMembers` lookup at `internal/cache/watcher.go:739-749` returns empty (no deps registered), so no workqueue entry is created. L1 stays empty until 1h TTL.

Empirical evidence: cluster=12,826 compositions, snowplow API for `compositions-list` returned 0 to admin, `watch_events.add=50,947`, workqueue cold=100, pod 0 restarts.

Pre-R5 the race existed but was masked because `WarmL1FromEntryPoints` ran late in startup (after customer CRDs typically existed). R5 commit `65ffd9c` removed that fallback by short-circuiting on the secret event.

## Why this fix converges

- **DELETE on auto-register** — next HTTP request triggers a fresh `resolve` at the now-correct cluster state.
- **Fresh resolve re-registers cluster-dep** at `resolve.go:638-651` because `pathGVR` now resolves to non-empty namespaces.
- **Subsequent watch events** for CRs of that GVR find non-empty `SMembers` → workqueue → L1 refresh.
- **Cache self-heals** — same stale-while-revalidate semantics as every other invalidation path.

## 5-step verification scenario (manual, post-merge)

1. Pod start with composition CRD **missing** from the cluster.
2. R5 prewarm fires for admin → 0 compositions in L1 (expected, no CRD).
3. CRD applied to the cluster.
4. `autoRegisterCRDInformer` fires → evicts the 0-items L1 entry. Counter `crd_register_l1_evictions` increments.
5. Bench creates compositions → watch events → SMembers finds the L1 key (next HTTP request re-registered it) → L1 refreshes.
6. Admin queries `compositions-list` → sees compositions.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/cache/ -race -count=1` — all green (new tests + existing).
- [x] `go test ./... -race -count=1` — all packages green.
- [x] Unit tests in `crd_register_evict_test.go`:
  - empty group SET → no-op
  - registered N keys → all N evicted, dedup across GVRs in same group
  - paginated L1 key → both paginated and base-key registered + evicted
  - unrelated-group L1 keys preserved
  - concurrent register + evict goroutines → no deadlock, eventual consistency
  - `gvrKeyGroup` parser for core/non-core/malformed
- [ ] **Post-merge**: replay the 5-step convergence scenario on the GKE bench cluster.

## Hard rules followed

- PR creation only — merge requires architect+PM review per autonomous-mode `feedback_no_commit_without_approval.md`.
- `braghettos/snowplow` only — `feedback_never_push_upstream.md`.
- Generic per-group SET, no RA-name carve-outs — `feedback_no_special_cases.md`.
- DELETE-only invalidation — `feedback_l1_invalidation_delete_only.md`.
- No `PREWARM_MODE=legacy` workaround. No L2-cache-logic touch. No R5 worker pool changes. No deploy. No chart PR.

## Reviewers

Draft pending architect + PM review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)