### PR TITLE
fix(resolve): refilter child api before sentinel-deflect when sibling iterates (Q-RBAC-DECOUPLE v3 regression)

### DIFF
--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -98,6 +98,28 @@ const (
 	headerAcceptJSON = "Accept: application/json"
 )
 
+// hasSiblingDependsOn reports whether any api[] entry in apiMap (other than
+// the entry named id) declares dependsOn.name == id.
+//
+// Used at the /call deflection site to decide whether the v3 child-ref
+// sentinel can be safely written into dict[id] (no sibling consumer ⇒ yes;
+// some sibling iterates this slot ⇒ inline-refilter instead). See the call
+// site in runOne for the full rationale.
+//
+// Generic across any parent→child→sibling iterator topology (no
+// resource-specific carve-outs).
+func hasSiblingDependsOn(apiMap map[string]*templates.API, id string) bool {
+	for sibID, sibAPI := range apiMap {
+		if sibID == id || sibAPI == nil || sibAPI.DependsOn == nil {
+			continue
+		}
+		if sibAPI.DependsOn.Name == id {
+			return true
+		}
+	}
+	return false
+}
+
 type ResolveOptions struct {
 	RC      *rest.Config
 	AuthnNS string
@@ -720,6 +742,35 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 						attribute.String("api.namespace", callNS),
 						attribute.String("api.name", callName),
 					}
+
+					// Q-RBAC-DECOUPLE C(d) v3 regression fix — sibling iterator
+					// dependency detection.
+					//
+					// The default v3 deflection writes a childRef sentinel into
+					// dict[id]. The sentinel is opaque (no .status field) and
+					// is intended to be expanded by RefilterRESTAction at HTTP
+					// dispatch time. That works for outer-JQ consumers but
+					// BREAKS sibling api[] entries that iterate over this
+					// entry's status (dependsOn.iterator = ".<id>.status…"):
+					// createRequestOptions evaluates the iterator JQ against
+					// the in-flight dict before refilter runs, finds nothing
+					// where .status used to live, and emits zero requests.
+					//
+					// Detect the sibling-iterator topology and refilter the
+					// child's L1 bytes inline instead of writing the sentinel.
+					// The refilter result is the legacy v0/v2 wire shape (full
+					// CR with cr.Status populated), so the sibling iterator
+					// resolves correctly. The trust boundary is preserved: the
+					// parent's stored L1 still holds the childRef in
+					// ProtectedDict — only intra-resolution sees the inlined
+					// per-user-filtered child.
+					//
+					// Detection key: any sibling api[] entry (excluding self)
+					// declares dependsOn.name == id. We do NOT special-case
+					// iterator presence — a direct `.<id>.status` reference
+					// from a dependent has the same problem.
+					hasSiblingDep := hasSiblingDependsOn(apiMap, id)
+
 					// Q-RBAC-DECOUPLE C(d) v3 — child /call slot is stored
 					// as an opaque reference; the parent's L1 entry holds
 					// only the pointer. RefilterRESTAction recurses into
@@ -727,8 +778,41 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 					// per-user-refiltered output. Avoids inlining the (large)
 					// child body into every parent and avoids serving the
 					// resolving user's pre-filtered child to other users.
-					if _, l1Hit, _ := c.GetRaw(ctx, l1Key); l1Hit {
+					if l1Raw, l1Hit, _ := c.GetRaw(ctx, l1Key); l1Hit {
 						cache.GlobalMetrics.Inc(&cache.GlobalMetrics.L1Hits, "l1_hits")
+
+						if hasSiblingDep {
+							// Sibling iterator path: refilter inline so the
+							// dict[id] slot has the legacy CR shape with
+							// cr.Status populated for the iterator JQ to
+							// drill into.
+							refilteredRaw, rerr := RefilterRESTAction(ctx, c, l1Raw)
+							if rerr != nil {
+								log.Warn("call_l1 sibling-dep refilter failed; falling through",
+									slog.String("name", id),
+									slog.String("l1_key", l1Key),
+									slog.Any("err", rerr))
+							} else {
+								handlerOpts := jsonHandlerOptions{
+									key: id, out: dict, filter: apiCall.Filter,
+								}
+								computed, cerr := jsonHandlerCompute(ctx, handlerOpts, refilteredRaw, sliceSnap)
+								if cerr == nil {
+									instrumentedDictWrite(ctx, mu, dict, "call_l1_sibling_refilter", "append",
+										callExtra,
+										func() {
+											mergeIntoDict(dict, id, computed)
+										})
+									return true
+								}
+								log.Warn("call_l1 sibling-dep compute failed; falling through",
+									slog.String("name", id), slog.Any("err", cerr))
+							}
+							// Fall through to the default sentinel path on
+							// refilter or compute error so the resolver can
+							// still produce a (possibly degraded) result.
+						}
+
 						childRef := MarshalChildRESTActionRef(callGVR, callNS, callName, l1Key, apiCall.Filter)
 						instrumentedDictWrite(ctx, mu, dict, "call_l1", "append",
 							callExtra,
@@ -750,6 +834,48 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 							if obj, ok := ir.GetObject(callGVR, callNS, callName); ok {
 								raw, rerr := callResolver(ctx, obj.Object, l1Key, opts.AuthnNS)
 								if rerr == nil && len(raw) > 0 {
+									if hasSiblingDep {
+										// Sibling iterator path: refilter the
+										// freshly-written L1 bytes (callResolver
+										// has just persisted them) and inline.
+										// We re-fetch via c.GetRaw rather than
+										// reusing `raw` because callResolver's
+										// returned bytes are the legacy
+										// pre-cache shape on some paths and
+										// only the post-write L1 entry is
+										// guaranteed to be the v3 wrapper.
+										if l1Raw, l1Hit, _ := c.GetRaw(ctx, l1Key); l1Hit {
+											refilteredRaw, refErr := RefilterRESTAction(ctx, c, l1Raw)
+											if refErr == nil {
+												handlerOpts := jsonHandlerOptions{
+													key: id, out: dict, filter: apiCall.Filter,
+												}
+												computed, cerr := jsonHandlerCompute(ctx, handlerOpts, refilteredRaw, sliceSnap)
+												if cerr == nil {
+													instrumentedDictWrite(ctx, mu, dict, "call_inline_sibling_refilter", "append",
+														callExtra,
+														func() {
+															mergeIntoDict(dict, id, computed)
+														})
+													return true
+												}
+												log.Warn("call_inline sibling-dep compute failed; falling through",
+													slog.String("name", id), slog.Any("err", cerr))
+											} else {
+												log.Warn("call_inline sibling-dep refilter failed; falling through",
+													slog.String("name", id),
+													slog.String("l1_key", l1Key),
+													slog.Any("err", refErr))
+											}
+										} else {
+											log.Warn("call_inline sibling-dep: post-callResolver L1 miss; falling through",
+												slog.String("name", id), slog.String("l1_key", l1Key))
+										}
+										// Fall through to the default sentinel
+										// path on any refilter / compute / L1
+										// re-fetch error.
+									}
+
 									childRef := MarshalChildRESTActionRef(callGVR, callNS, callName, l1Key, apiCall.Filter)
 									instrumentedDictWrite(ctx, mu, dict, "call_inline", "append",
 										callExtra,

--- a/internal/resolvers/restactions/api/resolve_sibling_dep_test.go
+++ b/internal/resolvers/restactions/api/resolve_sibling_dep_test.go
@@ -1,0 +1,241 @@
+// Q-RBAC-DECOUPLE C(d) v3 regression fix — sibling-iterator detection.
+//
+// Anti-regression for the parent→child→sibling iterator topology that the
+// v3 child-ref sentinel breaks (#37b7bce). Architect-confirmed root cause:
+// the call_l1 / call_inline branches write an opaque sentinel into
+// dict[parentApiName] which has no `.status` field; a sibling api[] entry
+// that does dependsOn.iterator = ".<parent>.status…" walks into a null
+// value, throws "must return a JSON array", and emits zero requests.
+//
+// The fix detects the topology by scanning apiMap for any sibling whose
+// dependsOn.name equals the resolving entry's id, and inlines a refiltered
+// child shape (legacy CR with .status) instead of the sentinel.
+//
+// Detection lives in hasSiblingDependsOn (resolve.go). The unit tests here
+// cover the three documented cases:
+//   • sibling-with-dependsOn: detection returns true → refilter path
+//   • no sibling: detection returns false → sentinel-deflection path
+//   • multiple siblings depending on same id: detection returns true once
+package api
+
+import (
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+)
+
+// makeAPIMap is a tiny constructor that mirrors how Resolve builds apiMap.
+// It accepts a slice and returns the keyed-by-Name map runOne sees.
+func makeAPIMap(items []*templates.API) map[string]*templates.API {
+	m := make(map[string]*templates.API, len(items))
+	for _, el := range items {
+		if el == nil {
+			continue
+		}
+		m[el.Name] = el
+	}
+	return m
+}
+
+func TestHasSiblingDependsOn_NoSibling_FalseDetection(t *testing.T) {
+	// One api entry with no siblings; nothing depends on it. Default
+	// deflection path applies — sentinel is the correct write.
+	items := []*templates.API{
+		{Name: "lonely", Path: "/call?resource=foo"},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "lonely"); got {
+		t.Errorf("no sibling case: expected false, got true")
+	}
+}
+
+func TestHasSiblingDependsOn_SiblingWithoutDependsOn_FalseDetection(t *testing.T) {
+	// Sibling exists but does NOT depend on the resolving entry.
+	// Detection must remain false — sentinel still safe.
+	items := []*templates.API{
+		{Name: "parent", Path: "/call?resource=foo"},
+		{Name: "unrelated", Path: "/api/v1/configmaps"},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "parent"); got {
+		t.Errorf("sibling-without-dependsOn case: expected false, got true")
+	}
+}
+
+func TestHasSiblingDependsOn_SiblingDependsOnDifferentName_FalseDetection(t *testing.T) {
+	// Sibling depends on a different api entry — must NOT trigger detection.
+	items := []*templates.API{
+		{Name: "parent", Path: "/call?resource=foo"},
+		{Name: "other", Path: "/call?resource=bar"},
+		{
+			Name: "consumer",
+			Path: "/api/v1/x",
+			DependsOn: &templates.Dependency{
+				Name:     "other",
+				Iterator: ptr.To(".other.status[]"),
+			},
+		},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "parent"); got {
+		t.Errorf("sibling-depends-on-other case: expected false, got true")
+	}
+}
+
+func TestHasSiblingDependsOn_OneSibling_TrueDetection(t *testing.T) {
+	// The headline case: sibling iterates parent's output. Detection must
+	// fire so the call_l1 site refilters inline instead of writing a
+	// sentinel that the iterator can't consume.
+	items := []*templates.API{
+		{Name: "allNamespacesAndCrds", Path: "/call?resource=ns-and-crd"},
+		{
+			Name: "allCompositions",
+			Path: "/api/v1/compositions",
+			DependsOn: &templates.Dependency{
+				Name:     "allNamespacesAndCrds",
+				Iterator: ptr.To(".allNamespacesAndCrds.status[]"),
+			},
+		},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "allNamespacesAndCrds"); !got {
+		t.Errorf("one-sibling case: expected true, got false")
+	}
+}
+
+func TestHasSiblingDependsOn_DirectDependsOnNoIterator_TrueDetection(t *testing.T) {
+	// Per the fix's design comment: a direct `.<id>` reference from a
+	// dependent has the same null-status problem the iterator does.
+	// Detection key is just the dependsOn.name match, NOT iterator presence.
+	items := []*templates.API{
+		{Name: "parent", Path: "/call?resource=x"},
+		{
+			Name: "consumer",
+			Path: "/api/v1/y",
+			DependsOn: &templates.Dependency{
+				Name: "parent",
+				// Iterator intentionally nil — direct payload reference.
+			},
+		},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "parent"); !got {
+		t.Errorf("direct-dependsOn-no-iterator case: expected true, got false")
+	}
+}
+
+func TestHasSiblingDependsOn_MultipleSiblingsSameId_TrueDetection(t *testing.T) {
+	// Several siblings depend on the same parent. Detection must fire
+	// (single sibling is sufficient); the fix's refilter path runs once
+	// regardless of sibling count because dict[id] is set once.
+	items := []*templates.API{
+		{Name: "parent", Path: "/call?resource=p"},
+		{
+			Name: "consumerA",
+			Path: "/api/v1/a",
+			DependsOn: &templates.Dependency{
+				Name:     "parent",
+				Iterator: ptr.To(".parent.status[]"),
+			},
+		},
+		{
+			Name: "consumerB",
+			Path: "/api/v1/b",
+			DependsOn: &templates.Dependency{
+				Name:     "parent",
+				Iterator: ptr.To(".parent.status[].nested"),
+			},
+		},
+		{
+			Name: "consumerC",
+			Path: "/api/v1/c",
+			DependsOn: &templates.Dependency{
+				Name: "parent", // direct reference
+			},
+		},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "parent"); !got {
+		t.Errorf("multiple-siblings-same-id case: expected true, got false")
+	}
+}
+
+func TestHasSiblingDependsOn_SelfReferenceIgnored(t *testing.T) {
+	// Defensive: an api entry that mentions itself in dependsOn (which
+	// topologicalLevels would reject anyway, but cheap to assert here)
+	// must NOT trigger detection — self is excluded by the sibling loop.
+	items := []*templates.API{
+		{
+			Name: "parent",
+			Path: "/call?resource=p",
+			DependsOn: &templates.Dependency{
+				Name: "parent",
+			},
+		},
+	}
+	if got := hasSiblingDependsOn(makeAPIMap(items), "parent"); got {
+		t.Errorf("self-reference case: expected false (self excluded), got true")
+	}
+}
+
+func TestHasSiblingDependsOn_NilEntryInMapSkipped(t *testing.T) {
+	// Defensive: a nil entry in the map (defensive against caller bugs)
+	// must not panic and must not contribute to the result.
+	m := map[string]*templates.API{
+		"parent":      {Name: "parent", Path: "/call?resource=p"},
+		"nilSibling":  nil,
+		"realSibling": {Name: "realSibling", DependsOn: &templates.Dependency{Name: "parent"}},
+	}
+	if got := hasSiblingDependsOn(m, "parent"); !got {
+		t.Errorf("nil-entry case: expected true (real sibling matches), got false")
+	}
+	// And the inverse: a map with only nil entries returns false.
+	mEmpty := map[string]*templates.API{
+		"parent":     {Name: "parent"},
+		"nilSibling": nil,
+	}
+	if got := hasSiblingDependsOn(mEmpty, "parent"); got {
+		t.Errorf("nil-only-siblings case: expected false, got true")
+	}
+}
+
+func TestHasSiblingDependsOn_EmptyMap(t *testing.T) {
+	// Defensive: empty map must return false without panic.
+	if got := hasSiblingDependsOn(nil, "parent"); got {
+		t.Errorf("nil map: expected false, got true")
+	}
+	if got := hasSiblingDependsOn(map[string]*templates.API{}, "parent"); got {
+		t.Errorf("empty map: expected false, got true")
+	}
+}
+
+// TestRefilterOutput_HasStatusForIterator asserts the byte-shape contract
+// the sibling-iterator fix relies on: RefilterRESTAction's output, when
+// unmarshaled, has a top-level `status` field. The runOne refilter path
+// writes this output (after jsonHandlerCompute filtering) into dict[id],
+// and a sibling iterator JQ of the form `.<id>.status…` MUST be able to
+// drill into it.
+//
+// This is the contract that would silently break if a future change to
+// RefilterRESTAction renamed or restructured the status field. It ALSO
+// proves the fix's "inlined refilter shape supports iterator dependents"
+// claim at the byte level without needing envtest.
+func TestRefilterOutput_HasStatusForIterator(t *testing.T) {
+	// Same fixture shape as the v3 anti-defect test: a CR with a single
+	// api[] entry, a UAF on namespaces, an outer JQ that flips the unfiltered
+	// list into `{namespaces: <slice>}`. The refilter output must be a
+	// legacy CR whose `.status.namespaces` an iterator can walk.
+	cr := makeNSCR()
+	dict := map[string]any{"ns": []any{"ns-a", "ns-b", "ns-c"}}
+	raw := mustMarshalCachedFor(t, cr, dict)
+
+	rbac := &stubRBACEvaluator{allow: map[string]map[string]bool{
+		"user-a": {"ns-a": true, "ns-b": true},
+	}}
+	out, err := RefilterRESTAction(ctxWith(t, "user-a", rbac), nil, raw)
+	if err != nil {
+		t.Fatalf("RefilterRESTAction: %v", err)
+	}
+	got := extractStatusNS(out)
+	if len(got) == 0 {
+		t.Fatalf("expected non-empty status.namespaces in refilter output, got empty (raw=%s)", string(out))
+	}
+	// Sibling-iterator topology: a dependent api[] would do
+	// `.<id>.status.namespaces[]` against {<id>: out}. The fact that
+	// extractStatusNS returns non-empty proves the JQ path resolves.
+}


### PR DESCRIPTION
## Summary

P0 fix for the Q-RBAC-DECOUPLE C(d) v3 regression introduced in commit \`37b7bce\` (2026-05-04).

## Architect's diagnosis

The v3 child-ref sentinel (\`refilter.go:121-135\`) is opaque — it has no \`.status\` field. When an api[] entry \`A\` resolves a /call to a child RESTAction, the resolver writes the sentinel into \`dict[A]\`. That works for outer-JQ consumers (\`RefilterRESTAction\` recurses into the sentinel at HTTP-time and produces the full CR shape), but it **silently breaks** any sibling api[] entry that declares \`dependsOn.iterator = ".A.status…"\`:

1. \`createRequestOptions\` (setup.go:30-42) evaluates the iterator JQ against the in-flight \`dict\` BEFORE \`RefilterRESTAction\` runs.
2. JQ on \`.A.status…\` against the sentinel returns \`null\`.
3. \`jqutil.ForEach\` throws "must return a JSON array".
4. The dependent api \`B\` runs with empty request options → 0 items resolved.

**Customer-visible symptom (2026-05-04 dirty cluster, Diego):** admin compositions-list returned 0 items where the cluster has ~12 826.

The 5-step verification scenario:
1. Admin user fetches a parent RESTAction with \`api[]\` entries \`A\` (\`/call?…\`) + \`B\` (depends on \`.A.status[]\`).
2. First request: cold miss, full resolve, \`A\`'s output is stored as the v3 wrapper containing a childRef.
3. Second request: L1 hit on the parent. v3 deflection writes the sentinel into \`dict[A]\`.
4. \`B\`'s iterator JQ runs against \`dict.A.status[]\` → \`null\` → "must return a JSON array".
5. \`B\`'s request options are empty → resolver returns 0 items for \`B\`.

## Topology (parent→child→sibling iterator)

\`\`\`
RESTAction { api: [
  { name: A, path: /call?resource=…&apiVersion=… },     ← deflects to childRef
  { name: B, dependsOn: { name: A, iterator: ".A.status[]" } }   ← can't iterate sentinel
]}
\`\`\`

## Fix (Option A — architectural)

Detect the sibling-iterator topology at the deflection site and refilter inline instead of writing the sentinel.

\`hasSiblingDependsOn(apiMap, id)\` (resolve.go) returns true iff any sibling api[] entry's \`dependsOn.name\` equals \`id\`. When true:

- \`call_l1\` site: fetch the child's L1 wrapper, call \`RefilterRESTAction(ctx, c, l1Raw)\`, run \`jsonHandlerCompute\` with \`apiCall.Filter\`, \`mergeIntoDict(dict, id, computed)\`. Same legacy v0/v2 wire shape (full CR with \`cr.Status\` populated) the iterator can drill into.
- \`call_inline\` site: same flow on the freshly-written L1 entry after \`callResolver\` completes.

Trust boundary preserved: the parent's stored L1 still holds the childRef in \`ProtectedDict\`. Only intra-resolution sees the inlined refiltered shape.

Defense in depth: any error in the refilter / compute / re-fetch steps falls through to the original sentinel path — the resolver still produces a (possibly degraded) result instead of failing hard.

## Per feedback_no_special_cases.md

Detection key is purely "any sibling has \`dependsOn.name == id\`". No resource-specific carve-outs, no RESTAction-name carve-outs, no compositions-list-specific path.

## Diff summary

- \`internal/resolvers/restactions/api/resolve.go\`:
  - \`+22\` lines: \`hasSiblingDependsOn\` helper.
  - \`+105\` lines: gated refilter path at the call_l1 and call_inline sites.
- \`internal/resolvers/restactions/api/resolve_sibling_dep_test.go\` (new):
  - 9 unit tests for the detection helper covering all documented cases (no sibling, sibling-without-dependsOn, sibling-depends-on-different-name, one sibling, direct-dependsOn-no-iterator, multiple siblings, self-reference, nil entries, empty map).
  - 1 contract test asserting \`RefilterRESTAction\`'s output is iterator-friendly (top-level \`.status\` reachable).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test -race ./internal/resolvers/restactions/api/... -count=1\` — all green (1.7s).
- [x] \`go test -race ./... -count=1\` — full suite green; only pre-existing linker warnings (unrelated to this change).
- [ ] Behavioral verification on cluster (post-merge): deploy + observe admin's compositions-list returns the actual cluster count (~12 826) instead of 0.

## Hard rules respected

- Per \`feedback_no_commit_without_approval.md\` (autonomous-mode form): PR creation only. Merge requires architect+PM review.
- Per \`feedback_never_push_upstream.md\`: \`braghettos/snowplow\` only.
- Per \`feedback_no_special_cases.md\`: detection generic across any topology.
- Per \`feedback_l1_invalidation_delete_only.md\`: this fix doesn't touch L1 invalidation; preserves existing semantics.
- Per \`feedback_cache_must_not_constrain_jq.md\`: refilter result is byte-identical to fresh refilter (same \`RefilterRESTAction\` helper); no JQ shape constraint.
- Option A only — no \`httpcall.Do\` self-call (Option B), no \`PREWARM_MODE=legacy\` workaround, no chart change, no L2 / R5 changes, no cluster deploy.

## Refs

- v3 regression commit: \`37b7bce\` (feat(rbac): C(d) v3 — fix Q-RBACC-DEFECT-1).
- Sentinel definition: \`refilter.go:121-135\` (\`MarshalChildRESTActionRef\`).
- Iterator failure site: \`setup.go:30-42\`.
- Spec context: Q-RBAC-DECOUPLE C(d) v3 spec (/tmp/snowplow-runs/q-rbac-decouple-cd-v3-spec-2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)