### PR TITLE
fix(cache): restore rest.InClusterConfig fallback for nil rc in plurals helpers (0.30.229) — HARD REVERTED, fix INCOMPLETE

### DIFF
--- a/internal/cache/plurals_resolver.go
+++ b/internal/cache/plurals_resolver.go
@@ -300,7 +300,16 @@ func discoverPluralInfo(ctx context.Context, gvk schema.GroupVersionKind, rc *re
 	RecordApiserverFallthrough(ctx, ReasonPluralsDiscoveryHop, gvk.String())
 
 	if rc == nil {
-		return plurals.Info{}, fmt.Errorf("plurals discovery: nil *rest.Config for %s", gvk)
+		// Defensive in-helper fallback — restores the pre-Ship-2 contract.
+		// Several call sites (widgets.go, phase1_pip_seed.go, phase1_walk*.go)
+		// invoke GVRFor / PluralFor with nil rc on race-window cold-paths
+		// where the resolver's wireRESTConfig has not yet been threaded.
+		// See docs/nil-rc-audit-design-2026-06-01.md (Option A).
+		var err error
+		rc, err = rest.InClusterConfig()
+		if err != nil {
+			return plurals.Info{}, fmt.Errorf("plurals discovery: nil *rest.Config and in-cluster fallback failed for %s: %w", gvk, err)
+		}
 	}
 	dc, err := discoveryClientBuilder(rc)
 	if err != nil {
@@ -342,7 +351,13 @@ func discoverKindForGVR(ctx context.Context, gvr schema.GroupVersionResource, rc
 	RecordApiserverFallthrough(ctx, ReasonPluralsDiscoveryHop, gvr.String())
 
 	if rc == nil {
-		return "", plurals.Info{}, fmt.Errorf("plurals discovery: nil *rest.Config for %s", gvr)
+		// Defensive in-helper fallback — symmetric with discoverPluralInfo.
+		// See docs/nil-rc-audit-design-2026-06-01.md (Option A).
+		var err error
+		rc, err = rest.InClusterConfig()
+		if err != nil {
+			return "", plurals.Info{}, fmt.Errorf("kind discovery: nil *rest.Config and in-cluster fallback failed for %s: %w", gvr, err)
+		}
 	}
 	dc, err := discoveryClientBuilder(rc)
 	if err != nil {

--- a/internal/cache/plurals_resolver_test.go
+++ b/internal/cache/plurals_resolver_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -383,6 +384,64 @@ func TestPluralFor_DiscoveryCounter(t *testing.T) {
 	got := FallthroughCount("plurals-test", gvk.String(), ReasonPluralsDiscoveryHop)
 	if got != 1 {
 		t.Errorf("ReasonPluralsDiscoveryHop count: got %d want 1", got)
+	}
+}
+
+// --- TestDiscoverPluralInfo_NilRC_FallsBackInCluster ---------------------
+//
+// 0.30.229 nil-rc in-helper fallback (docs/nil-rc-audit-design-2026-06-01.md
+// Option A). When called with a nil *rest.Config, discoverPluralInfo MUST
+// attempt rest.InClusterConfig() before erroring. In a test process with
+// no KUBERNETES_SERVICE_HOST env var set, that attempt fails — the
+// returned error MUST be the wrapped fallback-failed sentinel, NOT the
+// pre-0.30.229 raw "nil *rest.Config" message. This proves the nil-rc
+// branch is reached AND the fallback is exercised AND error wrapping is
+// correct. The opposite branch (real in-cluster) is exercised end-to-end
+// by Phase 6 against the GKE cluster.
+func TestDiscoverPluralInfo_NilRC_FallsBackInCluster(t *testing.T) {
+	resetPluralsForTest(t)
+	t.Setenv("CACHE_ENABLED", "true")
+	// Ensure InClusterConfig() fails: clear the env vars it reads.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	gvk := schema.GroupVersionKind{Group: "templates.krateo.io", Version: "v1", Kind: "RESTAction"}
+	ctx := fakeCtxWithScope()
+	_, err := discoverPluralInfo(ctx, gvk, nil)
+	if err == nil {
+		t.Fatalf("discoverPluralInfo(nil rc) returned no error; expected fallback-failed wrapped err")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "nil *rest.Config") {
+		t.Errorf("error missing nil-rc sentinel: %q", msg)
+	}
+	if !strings.Contains(msg, "in-cluster fallback failed") {
+		t.Errorf("error missing fallback sentinel: %q", msg)
+	}
+}
+
+// --- TestDiscoverKindForGVR_NilRC_FallsBackInCluster ---------------------
+//
+// Sister test for the reverse direction. See
+// TestDiscoverPluralInfo_NilRC_FallsBackInCluster for rationale.
+func TestDiscoverKindForGVR_NilRC_FallsBackInCluster(t *testing.T) {
+	resetPluralsForTest(t)
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	gvr := schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+	ctx := fakeCtxWithScope()
+	_, _, err := discoverKindForGVR(ctx, gvr, nil)
+	if err == nil {
+		t.Fatalf("discoverKindForGVR(nil rc) returned no error; expected fallback-failed wrapped err")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "nil *rest.Config") {
+		t.Errorf("error missing nil-rc sentinel: %q", msg)
+	}
+	if !strings.Contains(msg, "in-cluster fallback failed") {
+		t.Errorf("error missing fallback sentinel: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- 0.30.229 fix restored `rest.InClusterConfig()` fallback inside `discoverPluralInfo` + `discoverKindForGVR` per architect design v2 Option A — intended structural fix for the 0.30.228 production-aim-cleanup nil-rc HARD REVERT.
- Unit tests for both helpers PASS; build PASS; architect ACK + PM ACK granted.
- **HARD REVERTED on first GKE deploy**: pod CrashLoopBackOff with restartCount=5 in <2 minutes. Panic stack revealed a SECOND nil-rc consumer that the audit missed: `dynamic.NewClient(nil, ...)` invoked from `internal/resolvers/crds/schema/schema.go:82` inside `ValidateObjectStatus`, called from `widgets.Resolve` (resolve.go:151) on the phase1Walker seed path where `opts.RC` is zero-value (phase1_walk.go:1048 constructs `widgets.ResolveOptions` with no RC field set).
- Helm rolled back to rev 397 (0.30.227 Ship I baseline). Cluster restored. Snowplow + chart tag 0.30.229 preserved on braghettos for follow-up audit.

## Failure mode (architect: please audit)

Panic stack (full in regression journal entry 2026-06-01 "Ship 0.30.229 HARD REVERT"):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
k8s.io/client-go/rest.CopyConfig(0x0)
k8s.io/client-go/dynamic.NewForConfig(0x0)
internal/dynamic.NewClient(0x0, [WithSkipMapper])
internal/resolvers/crds/schema.ValidateObjectStatus(ctx, 0x0, obj)
internal/resolvers/widgets.Resolve(resolve.go:151)
internal/handlers/dispatchers.(*phase1Walker).walk(phase1_walk.go:1048)
```

The 0.30.229 audit enumerated plurals-discovery consumers but did NOT enumerate `dynamic.NewClient` as a peer consumer. Both architect + PM ACKs missed this. Per `feedback_audit_enumerate_mechanisms`: audits enumerate every read MECHANISM, not one symbol.

## Test plan (for next-ship)

- [ ] Architect: enumerate EVERY `dynamic.NewClient(` / `dynamic.NewForConfig(` / `cache.GVRFor(` / `discovery.NewDiscoveryClientForConfig(` consumer reachable from `phase1Walker.walk` seed path
- [ ] Decide between: (A) thread `RC: w.rc` into `widgets.ResolveOptions` at phase1_walk.go:1048 (architectural fix), OR (B) defensive nil-rc fallback inside `dynamic.NewClient` itself (mirrors 0.30.229 plurals approach)
- [ ] Add HARD pre-ship gate: GKE pod-boot readiness smoke (not just unit-test green) for any CrashLoopBackOff defect fix
- [ ] Resubmit as 0.30.230 with corrected scope

## Status

This PR is left OPEN as documentation of the failed ship for the next attempt. Do NOT merge as-is — the fix is incomplete.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>