### PR TITLE
ci(crds): inject helm.sh/resource-policy: keep into published CRDs

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -122,6 +122,15 @@ jobs:
           # Refresh the CRD templates: drop the previous set, copy the freshly generated ones.
           rm -f crds-subchart/templates/*.yaml
           cp "$GITHUB_WORKSPACE"/crds/*.yaml crds-subchart/templates/
+
+          # Deletion-safety: every published CRD must carry helm.sh/resource-policy: keep so
+          # Helm never garbage-collects it on upgrade/uninstall/prune (this installer
+          # heavy-reconciles and has pruned templated resources mid-cascade). controller-gen
+          # cannot emit a Helm annotation, so the publishing CI injects it — uniformly, and
+          # idempotently, so the regen can never strip it again.
+          for f in crds-subchart/templates/*.yaml; do
+            yq -i '.metadata.annotations."helm.sh/resource-policy" = "keep"' "$f"
+          done
           if [ -d crd-chart ]; then git rm -r crd-chart; fi
 
           # Patch-bump the independently-versioned crds-subchart Chart.yaml.


### PR DESCRIPTION
Adds a deletion-safety step to the `crds` publishing job: after copying the controller-gen output into `crds-subchart/templates/`, inject `helm.sh/resource-policy: keep` into every CRD via `yq`.

**Why:** CRDs live in `templates/` so Helm can *upgrade* them (fixes CRD drift), but templated CRDs are also prunable/deletable by Helm — and this installer heavy-reconciles and has pruned templated resources mid-cascade. `keep` stops Helm from garbage-collecting a CRD (which would cascade-delete every CR of that kind cluster-wide). controller-gen cannot emit a Helm annotation, and the previous hand-added annotation was silently stripped on every regen — so the publishing CI now injects it, uniformly and idempotently.

Verified locally (yq v4, as preinstalled on ubuntu runners): produces exactly the annotation the chart carried by hand, idempotent on re-run, document-aware (covers multi-CRD files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)