### PR TITLE
ci: canonical agnostic multi-platform release-tag.yaml

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,22 +1,34 @@
+# Canonical Krateo COMPONENT (code-repo) release workflow — THE single way every krateo-*
+# code repo builds & pushes its image and (if it owns CRDs) publishes them. Identical
+# byte-for-byte across ALL component repos (no per-repo config); everything is derived from
+# the repo itself.
+#
+#   • build  — ONE multi-platform image (linux/amd64 + linux/arm64) via docker/build-push-action@v7
+#              (QEMU + buildx), tagged from the pushed git tag. Image = ghcr.io/<this repo>.
+#   • crds   — only acts for CRD-owning repos: runs `make generate` (the single agnostic entry
+#              point each CRD repo exposes; repos without it skip cleanly), then opens a PR into
+#              the component's chart repo (braghettos/<repo>-chart) refreshing crds-subchart/,
+#              injecting helm.sh/resource-policy: keep, and patch-bumping the crds-subchart.
 name: release-tag
 
 on:
   push:
-    tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
+    tags: ["[0-9]+.[0-9]+.[0-9]+"]
 
 env:
   GHCR_REPO: ghcr.io/${{ github.repository }}
 
 jobs:
   build:
-    name: Build and Push (linux/amd64)
+    name: Build & push image (multi-platform)
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
-
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
@@ -30,31 +42,31 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
-        id: build
+      # ONE job, multi-platform manifest list built with buildx (arm64 via QEMU emulation).
+      - name: Build and push (linux/amd64, linux/arm64)
         uses: docker/build-push-action@v7
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}
 
   crds:
     name: Generate & publish crds-subchart
     runs-on: ubuntu-latest
-    needs:
-      - build
+    needs: [build]
     permissions:
       contents: write
       pull-requests: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -66,68 +78,62 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Generate crds
-        run: bash scripts/gen.sh
+      # Agnostic CRD generation: each CRD-owning repo exposes a single `make generate` target
+      # that regenerates ./crds. A repo with no such target is not a CRD owner — skip cleanly.
+      - name: Generate CRDs (skip if not a CRD owner)
+        id: gen
+        run: |
+          set -euo pipefail
+          if [ -f Makefile ] && make -n generate >/dev/null 2>&1; then
+            make generate
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No 'make generate' target — this component owns no CRDs; skipping CRD publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: List generated CRDs
-        run: ls -la ./crds
-
-      - name: Upload generated CRDs
-        uses: actions/upload-artifact@v4
-        with:
-          name: snowplow-crds-yaml-files
-          path: ${{ github.workspace }}/crds/*.yaml
-
-      - name: Push CRDs to braghettos/krateo-snowplow-chart (crds-subchart) via PR
+      - name: Publish crds-subchart to the chart repo via PR
+        if: steps.gen.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
           set -eo pipefail
           cd "$GITHUB_WORKSPACE"
 
-          TARGET_REPO="braghettos/krateo-snowplow-chart"
+          # Convention: the component's chart repo is <this repo>-chart; the CRD short name
+          # and branch are derived from the repo name. No per-repo configuration.
+          NAME="${GITHUB_REPOSITORY##*/}"
+          TARGET_REPO="${GITHUB_REPOSITORY}-chart"
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "main")
-          BRANCH="snowplow-crds-${LATEST_TAG}"
+          BRANCH="${NAME}-crds-${LATEST_TAG}"
           echo "Target repo: $TARGET_REPO | tag: $LATEST_TAG | branch: $BRANCH"
 
-          # The generated CRDs must exist locally before we touch the chart repo.
           shopt -s nullglob
           LOCAL_CRDS=("$GITHUB_WORKSPACE"/crds/*.yaml)
           if [ "${#LOCAL_CRDS[@]}" -eq 0 ]; then
-            echo "ERROR: no generated CRDs found in crds/" >&2
-            exit 1
+            echo "make generate produced no CRDs in ./crds — nothing to publish."
+            exit 0
           fi
           echo "Generated ${#LOCAL_CRDS[@]} CRD file(s)."
 
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Clone the chart repo and authenticate the push remote.
           gh repo clone "$TARGET_REPO" /tmp/chart
           cd /tmp/chart
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git"
-          git fetch origin
-          git checkout main
-          git pull origin main
+          git fetch origin && git checkout main && git pull origin main
 
-          # One-time migration: rename the legacy crd-chart/ -> crds-subchart/.
-          # git mv preserves Chart.yaml/values.* so the Helm chart name (krateo-snowplow-crd,
-          # pinned by the installer) is unchanged — only the directory moves.
-          if [ -d crd-chart ] && [ ! -d crds-subchart ]; then
-            echo "Migrating crd-chart/ -> crds-subchart/"
-            git mv crd-chart crds-subchart
-          fi
+          # One-time migration of any legacy crd-chart/ -> crds-subchart/ (Helm chart name unchanged).
+          if [ -d crd-chart ] && [ ! -d crds-subchart ]; then git mv crd-chart crds-subchart; fi
           mkdir -p crds-subchart/templates
 
-          # Refresh the CRD templates: drop the previous set, copy the freshly generated ones.
           rm -f crds-subchart/templates/*.yaml
           cp "$GITHUB_WORKSPACE"/crds/*.yaml crds-subchart/templates/
 
-          # Deletion-safety: every published CRD must carry helm.sh/resource-policy: keep so
-          # Helm never garbage-collects it on upgrade/uninstall/prune (this installer
-          # heavy-reconciles and has pruned templated resources mid-cascade). controller-gen
-          # cannot emit a Helm annotation, so the publishing CI injects it — uniformly, and
-          # idempotently, so the regen can never strip it again.
+          # Deletion-safety: every published CRD carries helm.sh/resource-policy: keep so Helm
+          # never garbage-collects it on upgrade/uninstall/prune. controller-gen cannot emit a
+          # Helm annotation, so the publishing CI injects it — uniformly and idempotently.
           for f in crds-subchart/templates/*.yaml; do
             yq -i '.metadata.annotations."helm.sh/resource-policy" = "keep"' "$f"
           done
@@ -145,20 +151,20 @@ jobs:
           echo "crds-subchart version: ${CUR} -> ${NEXT}"
 
           if git diff --quiet && git diff --cached --quiet; then
-            echo "✅ crds-subchart already matches the generated CRDs — nothing to push."
+            echo "crds-subchart already matches the generated CRDs — nothing to push."
             exit 0
           fi
 
-          git checkout -b "$BRANCH" 2>/dev/null || { git branch -D "$BRANCH" 2>/dev/null; git push origin --delete "$BRANCH" 2>/dev/null || true; git checkout -b "$BRANCH"; }
+          git checkout -b "$BRANCH" 2>/dev/null || { git push origin --delete "$BRANCH" 2>/dev/null || true; git checkout -b "$BRANCH"; }
           git add -A
-          git commit -m "Update snowplow CRDs (crds-subchart) from tag ${LATEST_TAG}
+          git commit -m "Update ${NAME} CRDs (crds-subchart) from tag ${LATEST_TAG}
 
-          Regenerated by the krateo-snowplow code-repo CI (controller-gen, pinned).
-          Bumps crds-subchart ${CUR} -> ${NEXT}."
+          Regenerated by the ${NAME} code-repo CI (make generate). Refreshes
+          crds-subchart/templates/, injects helm.sh/resource-policy: keep, bumps ${CUR} -> ${NEXT}."
           git push origin "$BRANCH"
 
-          PR_TITLE="Update snowplow CRDs (crds-subchart) — ${LATEST_TAG}"
-          PR_BODY="Automated update of the RESTAction CRD in \`crds-subchart/templates/\` from \`braghettos/krateo-snowplow\` @ \`${LATEST_TAG}\` (controller-gen, pinned). Bumps crds-subchart \`${CUR}\` -> \`${NEXT}\`."
+          PR_TITLE="Update ${NAME} CRDs (crds-subchart) — ${LATEST_TAG}"
+          PR_BODY="Automated update of ${NAME} CRDs in \`crds-subchart/templates/\` from \`${GITHUB_REPOSITORY}\` @ \`${LATEST_TAG}\` (make generate). Injects \`helm.sh/resource-policy: keep\`; bumps crds-subchart \`${CUR}\` -> \`${NEXT}\`."
           PR_STATE=$(gh pr view "$BRANCH" --repo "$TARGET_REPO" --json state -q .state 2>/dev/null || echo "NONE")
           if [ "$PR_STATE" = "OPEN" ]; then
             echo "PR already open for $BRANCH."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# Krateo component codegen entry point. `make generate` is the single, uniform way every
+# CRD-owning repo regenerates ./crds — go mod tidy + go generate ./... driving the
+# build-tagged apis/generate.go controller-gen directive (pinned to go.mod controller-tools).
+.PHONY: tidy generate
+
+tidy: ## Ensure all Go imports are satisfied.
+	go mod tidy
+
+generate: tidy ## Regenerate CRDs into ./crds.
+	go generate ./...


### PR DESCRIPTION
Adopts **the single canonical agnostic `release-tag.yaml`** — identical across all krateo-* component code repos.

- **build**: ONE multi-platform image (`linux/amd64,linux/arm64`) via `docker/build-push-action@v7` (QEMU+buildx). No matrix, no buildjet, no manifest-merge.
- **crds**: runs the single `make generate` entry point (skips cleanly if the repo owns no CRDs), then publishes to `<repo>-chart` with `helm.sh/resource-policy: keep` injected — all derived from the repo name.

CRD-owning repos that lacked it get a minimal `make generate` Makefile (the uniform codegen entry point: `go mod tidy && go generate ./...` driving the existing `apis/generate.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)