### PR TITLE
test: fix pre-existing integration-test build/isolation bugs

### DIFF
--- a/internal/dynamic/kind_test.go
+++ b/internal/dynamic/kind_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/support/kind"
 
+	"github.com/krateoplatformops/snowplow/internal/cache"
 	xenv "github.com/krateoplatformops/plumbing/env"
 )
 
@@ -49,11 +50,11 @@ func TestKindFor(t *testing.T) {
 
 	f := features.New("Setup").
 		Assess("KindFor", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			want := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
-
-			got, err := KindFor(c.Client().RESTConfig(), schema.GroupVersionResource{Version: "v1", Resource: "configmaps"})
+			// KindFor was refactored out of internal/dynamic; cache.KindForGVR is its
+			// replacement (returns the Kind string for a GVR).
+			got, err := cache.KindForGVR(ctx, schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}, c.Client().RESTConfig())
 			assert.Nil(t, err)
-			assert.Equal(t, want, got)
+			assert.Equal(t, "ConfigMap", got)
 
 			return ctx
 		}).

--- a/internal/handlers/call_test.go
+++ b/internal/handlers/call_test.go
@@ -110,7 +110,7 @@ func TestCallHandler(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "restactions")), "*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {

--- a/internal/objects/get_test.go
+++ b/internal/objects/get_test.go
@@ -103,7 +103,7 @@ func TestGet(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "restactions")), "*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {

--- a/internal/rbac/rbac_test.go
+++ b/internal/rbac/rbac_test.go
@@ -213,7 +213,7 @@ func TestUserCan(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "restactions")), "*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {

--- a/internal/resolvers/restactions/api/phase1_itercap_falsifier_test.go
+++ b/internal/resolvers/restactions/api/phase1_itercap_falsifier_test.go
@@ -101,13 +101,5 @@ func TestFAL127_PostFix_IteratorExpandsFullyReachingNavmenuitemNamespace(t *test
 	}
 }
 
-// contains is a tiny substring helper (the test avoids strings.Contains
-// only to keep the import set minimal).
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}
+// contains() is shared with jsoncopy_test.go in this package (same substring helper);
+// the duplicate definition here was removed to fix a redeclaration compile error.

--- a/internal/resolvers/restactions/api/resolve_test.go
+++ b/internal/resolvers/restactions/api/resolve_test.go
@@ -101,7 +101,7 @@ func TestResolveAPI(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "restactions")), "*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {

--- a/internal/resolvers/restactions/restactions_test.go
+++ b/internal/resolvers/restactions/restactions_test.go
@@ -104,7 +104,7 @@ func TestRESTAction(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "restactions")), "*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {

--- a/internal/resolvers/widgets/widgets_test.go
+++ b/internal/resolvers/widgets/widgets_test.go
@@ -117,7 +117,7 @@ func TestResolveWidgets(t *testing.T) {
 
 			err = decoder.DecodeEachFile(
 				ctx, os.DirFS(filepath.Join(testdataPath, "widgets")), "button.*.yaml",
-				decoder.CreateHandler(r),
+				decoder.CreateIgnoreAlreadyExists(r),
 				decoder.MutateNamespace(namespace),
 			)
 			if err != nil {


### PR DESCRIPTION
Fixes the three pre-existing failures that broke `go test -race -tags=unit,integration ./...` (independent of the CI standardization):

1. **`internal/dynamic/kind_test.go` — compile error.** Called the removed package-level `KindFor`; switched to its replacement `cache.KindForGVR` (returns the Kind string).
2. **`secrets "httpbin-endpoint" already exists` — fixture isolation.** The per-feature fixture apply used `decoder.CreateHandler` (fails if a prior feature already created the object). Switched to `decoder.CreateIgnoreAlreadyExists` (idempotent) across all 6 test packages that re-apply `restactions/*.yaml` into the shared namespace.
3. **Duplicate `func contains` in `restactions/api`** (jsoncopy_test.go + phase1_itercap_falsifier_test.go) → redeclaration compile error; removed the duplicate.

Verified locally: `go vet -tags=unit,integration ./...` is clean. (Full integration run self-provisions KinD via e2e-framework in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)