### PR TITLE
test: replace TestMain time.Sleep(2s) with wait.For discovery gate (5 pkgs)

### DIFF
--- a/internal/handlers/call_test.go
+++ b/internal/handlers/call_test.go
@@ -6,6 +6,7 @@ package handlers_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,9 +22,12 @@ import (
 	"github.com/krateoplatformops/plumbing/http/response"
 	"github.com/krateoplatformops/plumbing/ptr"
 	"github.com/krateoplatformops/snowplow/apis"
+	v1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/handlers"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -68,9 +72,34 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			// TODO: add a wait.For conditional helper that can
-			// check and wait for the existence of a CRD resource
-			time.Sleep(2 * time.Second)
+			// Wait for the freshly-installed RESTAction CRD
+			// (templates.krateo.io/v1) to be discoverable before any test
+			// proceeds. SetupCRDs registers the group/version, but the
+			// controller-runtime client's RESTMapper does a full
+			// ServerPreferredResources on first use; against a just-installed
+			// CRD that discovery transiently returns
+			// "templates.krateo.io/v1: no matches ... Resource=" — the
+			// apiserver lists the group before its resource list is
+			// populated. ResourceListN lists RESTActions; ResourceListMatchN
+			// returns (false,nil) on a List error (conditions.go), so it
+			// retries until the group/version is fully established. We assert
+			// a minimum of 0 because no RESTAction CRs exist yet at TestMain
+			// time (the per-test Setup decodes them later) — a List that
+			// succeeds at all proves discovery has settled. This replaces the
+			// fixed time.Sleep race (the TODO here) that left CI flaky and is
+			// exactly the discovery gate that fixed TestResolveAPI.
+			// AddToScheme so the typed RESTActionList is mappable by r's
+			// client (the per-test Setup adds it too, but the wait runs here).
+			if err := apis.AddToScheme(r.GetScheme()); err != nil {
+				return ctx, err
+			}
+			if err := wait.For(
+				conditions.New(r).ResourceListN(&v1.RESTActionList{}, 0),
+				wait.WithTimeout(60*time.Second),
+				wait.WithInterval(time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("waiting for RESTAction CRD discovery to settle: %w", err)
+			}
 			return ctx, nil
 		},
 	).Finish(

--- a/internal/objects/get_test.go
+++ b/internal/objects/get_test.go
@@ -5,6 +5,7 @@ package objects
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -19,6 +20,8 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -61,9 +64,34 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			// TODO: add a wait.For conditional helper that can
-			// check and wait for the existence of a CRD resource
-			time.Sleep(2 * time.Second)
+			// Wait for the freshly-installed RESTAction CRD
+			// (templates.krateo.io/v1) to be discoverable before any test
+			// proceeds. SetupCRDs registers the group/version, but the
+			// controller-runtime client's RESTMapper does a full
+			// ServerPreferredResources on first use; against a just-installed
+			// CRD that discovery transiently returns
+			// "templates.krateo.io/v1: no matches ... Resource=" — the
+			// apiserver lists the group before its resource list is
+			// populated. ResourceListN lists RESTActions; ResourceListMatchN
+			// returns (false,nil) on a List error (conditions.go), so it
+			// retries until the group/version is fully established. We assert
+			// a minimum of 0 because no RESTAction CRs exist yet at TestMain
+			// time (the per-test Setup decodes them later) — a List that
+			// succeeds at all proves discovery has settled. This replaces the
+			// fixed time.Sleep race (the TODO here) that left CI flaky and is
+			// exactly the discovery gate that fixed TestResolveAPI.
+			// AddToScheme so the typed RESTActionList is mappable by r's
+			// client (the per-test Setup adds it too, but the wait runs here).
+			if err := apis.AddToScheme(r.GetScheme()); err != nil {
+				return ctx, err
+			}
+			if err := wait.For(
+				conditions.New(r).ResourceListN(&templatesv1.RESTActionList{}, 0),
+				wait.WithTimeout(60*time.Second),
+				wait.WithInterval(time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("waiting for RESTAction CRD discovery to settle: %w", err)
+			}
 			return ctx, nil
 		},
 	).Finish(

--- a/internal/rbac/rbac_test.go
+++ b/internal/rbac/rbac_test.go
@@ -31,10 +31,13 @@ import (
 	"github.com/krateoplatformops/plumbing/e2e"
 	xenv "github.com/krateoplatformops/plumbing/env"
 	"github.com/krateoplatformops/snowplow/apis"
+	v1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -171,9 +174,34 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			// TODO: add a wait.For conditional helper that can
-			// check and wait for the existence of a CRD resource
-			time.Sleep(2 * time.Second)
+			// Wait for the freshly-installed RESTAction CRD
+			// (templates.krateo.io/v1) to be discoverable before any test
+			// proceeds. SetupCRDs registers the group/version, but the
+			// controller-runtime client's RESTMapper does a full
+			// ServerPreferredResources on first use; against a just-installed
+			// CRD that discovery transiently returns
+			// "templates.krateo.io/v1: no matches ... Resource=" — the
+			// apiserver lists the group before its resource list is
+			// populated. ResourceListN lists RESTActions; ResourceListMatchN
+			// returns (false,nil) on a List error (conditions.go), so it
+			// retries until the group/version is fully established. We assert
+			// a minimum of 0 because no RESTAction CRs exist yet at TestMain
+			// time (the per-test Setup decodes them later) — a List that
+			// succeeds at all proves discovery has settled. This replaces the
+			// fixed time.Sleep race (the TODO here) that left CI flaky and is
+			// exactly the discovery gate that fixed TestResolveAPI.
+			// AddToScheme so the typed RESTActionList is mappable by r's
+			// client (the per-test Setup adds it too, but the wait runs here).
+			if err := apis.AddToScheme(r.GetScheme()); err != nil {
+				return ctx, err
+			}
+			if err := wait.For(
+				conditions.New(r).ResourceListN(&v1.RESTActionList{}, 0),
+				wait.WithTimeout(60*time.Second),
+				wait.WithInterval(time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("waiting for RESTAction CRD discovery to settle: %w", err)
+			}
 			return ctx, nil
 		},
 	).Finish(

--- a/internal/resolvers/restactions/restactions_test.go
+++ b/internal/resolvers/restactions/restactions_test.go
@@ -5,6 +5,7 @@ package restactions
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -20,6 +21,8 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -62,9 +65,34 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			// TODO: add a wait.For conditional helper that can
-			// check and wait for the existence of a CRD resource
-			time.Sleep(2 * time.Second)
+			// Wait for the freshly-installed RESTAction CRD
+			// (templates.krateo.io/v1) to be discoverable before any test
+			// proceeds. SetupCRDs registers the group/version, but the
+			// controller-runtime client's RESTMapper does a full
+			// ServerPreferredResources on first use; against a just-installed
+			// CRD that discovery transiently returns
+			// "templates.krateo.io/v1: no matches ... Resource=" — the
+			// apiserver lists the group before its resource list is
+			// populated. ResourceListN lists RESTActions; ResourceListMatchN
+			// returns (false,nil) on a List error (conditions.go), so it
+			// retries until the group/version is fully established. We assert
+			// a minimum of 0 because no RESTAction CRs exist yet at TestMain
+			// time (the per-test Setup decodes them later) — a List that
+			// succeeds at all proves discovery has settled. This replaces the
+			// fixed time.Sleep race (the TODO here) that left CI flaky and is
+			// exactly the discovery gate that fixed TestResolveAPI.
+			// AddToScheme so the typed RESTActionList is mappable by r's
+			// client (the per-test Setup adds it too, but the wait runs here).
+			if err := apis.AddToScheme(r.GetScheme()); err != nil {
+				return ctx, err
+			}
+			if err := wait.For(
+				conditions.New(r).ResourceListN(&v1.RESTActionList{}, 0),
+				wait.WithTimeout(60*time.Second),
+				wait.WithInterval(time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("waiting for RESTAction CRD discovery to settle: %w", err)
+			}
 			return ctx, nil
 		},
 	).Finish(

--- a/internal/resolvers/widgets/widgets_test.go
+++ b/internal/resolvers/widgets/widgets_test.go
@@ -5,6 +5,7 @@ package widgets
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -18,9 +19,13 @@ import (
 	v1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/objects"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -90,9 +95,46 @@ func TestMain(m *testing.M) {
 				return ctx, err
 			}
 
-			// TODO: add a wait.For conditional helper that can
-			// check and wait for the existence of a CRD resource
-			time.Sleep(2 * time.Second)
+			// Wait for the freshly-installed Button CRD
+			// (widgets.templates.krateo.io/v1beta1) to be discoverable before
+			// any test proceeds. SetupCRDs registers the group/version, but
+			// the controller-runtime client's RESTMapper does a full
+			// ServerPreferredResources on first use; against a just-installed
+			// CRD that discovery transiently returns "no matches ...
+			// Resource=" — the apiserver lists the group before its resource
+			// list is populated. ResourceListMatchN returns (false,nil) on a
+			// List error (conditions.go), so it retries until the
+			// group/version is fully established.
+			//
+			// Buttons is the package-distinguishing CRD this TestMain
+			// installs (the asserted widget is a Button that the resolver
+			// fetches via objects.Get(buttons …)); the sibling restactions
+			// CRD is installed in the same SetupCRDs step and settles in
+			// lockstep, and is exercised by the per-test apiRef resolve. There
+			// is no typed Go Button/ButtonList in apis/ (the widgets group is
+			// consumed unstructured throughout the resolver), so the
+			// package-correct ObjectList is an *unstructured.UnstructuredList
+			// stamped with the ButtonList GVK — listing it proves the widgets
+			// group/version is discoverable without registering a typed
+			// kind. We assert a minimum of 0 because no Button CRs exist yet
+			// at TestMain time (the per-test Setup decodes button.*.yaml
+			// later) — a List that succeeds at all proves discovery has
+			// settled. This replaces the fixed time.Sleep race (the TODO
+			// here) that left CI flaky and is exactly the discovery gate that
+			// fixed TestResolveAPI.
+			buttons := &unstructured.UnstructuredList{}
+			buttons.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "widgets.templates.krateo.io",
+				Version: "v1beta1",
+				Kind:    "ButtonList",
+			})
+			if err := wait.For(
+				conditions.New(r).ResourceListN(buttons, 0),
+				wait.WithTimeout(60*time.Second),
+				wait.WithInterval(time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("waiting for Button CRD discovery to settle: %w", err)
+			}
 			return ctx, nil
 		},
 	).Finish(


### PR DESCRIPTION
## What

Follow-up hardening to the merged \`resolve_test.go\` discovery-gate work (#24). The integration \`TestMain\`s in **five** packages still applied CRDs/RBAC and then did a fixed \`time.Sleep(2 * time.Second)\` (the \`// TODO: add a wait.For\` placeholder) before any test ran. That is the *exact* discovery race that broke \`TestResolveAPI\`: a freshly-installed CRD group is listed by the apiserver before its resource list is populated, so the first List/Get transiently fails with \`no matches for ... Resource=\`. A fixed sleep is both flaky (too short under load) and slow (too long otherwise).

This converts each TestMain sleep to a proper \`wait.For\` discovery gate mirroring the merged pattern:

\`\`\`go
wait.For(conditions.New(r).ResourceListN(&<List>{}, 0),
    wait.WithTimeout(60*time.Second), wait.WithInterval(time.Second))
\`\`\`

\`ResourceListMatchN\` returns \`(false, nil)\` on a List error (e2e-framework v0.6.0 \`conditions.go:85-86\`), so \`wait.For\` retries until the group/version is fully discoverable; a List that *succeeds* proves discovery has settled. The minimum count is **0** because no CRs exist yet at TestMain time — the per-test \`Setup\` decodes fixtures later (this is why the count differs from resolve_test.go's post-decode \`ResourceListN(..., 1)\`).

## Per-package ObjectList type (architect's explicit note: do NOT blindly reuse RESTActionList)

| Package | ObjectList type | Why |
|---|---|---|
| \`internal/resolvers/widgets\` | \`*unstructured.UnstructuredList\` w/ \`ButtonList\` GVK (\`widgets.templates.krateo.io/v1beta1\`) | Buttons is the package-distinguishing CRD this TestMain installs (asserted widget is a Button fetched via \`objects.Get(buttons …)\`). **There is no typed Go \`Button\`/\`ButtonList\` in \`apis/\`** — the widgets group is consumed unstructured throughout the resolver — so the package-correct ObjectList is an unstructured list stamped with the ButtonList GVK. The sibling restactions CRD is installed in the same \`SetupCRDs\` step and settles in lockstep (exercised by the per-test apiRef resolve). |
| \`internal/resolvers/restactions\` | \`v1.RESTActionList\` (typed) | restactions CRD is what it installs + Gets/Resolves. |
| \`internal/objects\` | \`templatesv1.RESTActionList\` (typed) | installs restactions CRD; \`TestGet\` Gets a RESTAction. |
| \`internal/handlers\` | \`v1.RESTActionList\` (typed) | installs restactions CRD; \`/call\` resolves restactions. |
| \`internal/rbac\` | \`v1.RESTActionList\` (typed) | installs restactions CRD; \`TestUserCan\` SAR over restactions. |

For the four typed-RESTActionList packages, \`apis.AddToScheme(r.GetScheme())\` is now called in the setup func before the wait so \`r\`'s client can map the typed list (the per-test Setup already adds it, but the wait runs in TestMain). The widgets unstructured path needs no scheme registration.

## Verification (local, real kind cluster, exact CI flags)

\`-race -tags=unit,integration -p 1\`, \`KUBECONFIG\` unset (each TestMain creates/destroys its own \`krateo\` kind cluster):

- widgets — PASS 40.9s (\`TestResolveWidgets\`)
- restactions — PASS 41.2s (\`TestRESTAction\` + all sub-assessments)
- objects — PASS 48.5s (\`TestGet\`)
- handlers — PASS 37.3s (\`TestCallHandler\`)
- rbac — PASS 38.6s (\`TestUserCan\`), run with \`RBAC_TEST_ALLOW_DESTRUCTIVE=1\` against **kind only** (KUBECONFIG unset; default kubeconfig has no current-context, so the destructive guard + env client both bind to kind — never the GKE cluster).

### Falsifier (failing-then-passing)

A throwaway negative-control test (NOT committed) ran the same gate against an undiscoverable group \`nonexistent.krateo.io/v1\`:

\`\`\`
TEETH CONFIRMED: gate timed out after 4.003580042s on undiscoverable group: context deadline exceeded
--- PASS: TestDiscoveryGateHasTeeth (4.01s)
--- PASS: TestGet (3.16s)   # same gate, real CRD → settles fast
\`\`\`

This proves the gate is **not a vacuous no-op**: it blocks/times out when discovery never settles, and passes the instant a List succeeds. (\`conditions.go:85-86\` retry-on-list-error semantics verified against the v0.6.0 source.)

## Scope / safety

- **Test-harness only — no product code touched.** None of the TestMain races masked a product issue.
- One pre-existing \`gofmt\` nit in \`rbac_test.go\` (\`productionKubeconfigSubstrings\` comment alignment, present on \`main\`) is left untouched to keep the commit surgical; CI does not gofmt-gate.

**Do NOT merge** — held for the architect (design soundness) + PM (acceptance + falsifier) gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)