### PR TITLE
feat(widgets): extend extras to widgets (full parity, input-only)

### DIFF
--- a/internal/handlers/dispatchers/extras_cache_key_test.go
+++ b/internal/handlers/dispatchers/extras_cache_key_test.go
@@ -1,0 +1,168 @@
+// extras_cache_key_test.go — load-bearing cache falsifier for the
+// extras→widgets parity feature.
+//
+// The feature makes a widget's resolved output depend on the per-request
+// `extras`. That output is cached in the widget L1 layers. If the cache key
+// did NOT already fold `extras`, two requests for the same widget with
+// DIFFERENT extras would collide on one cell and the second requester would
+// be served the first requester's body — a cross-request correctness defect.
+//
+// The plan's verify-don't-assume gate asserts both widget L1 keys already
+// include extras (dispatchWidgetContentKey → ComputeKey, and
+// dispatchCacheLookupKey → ComputeKey). These tests PROVE it through the
+// widget dispatcher's own key-builder (not just the raw ResolvedKeyInputs)
+// and guard against regression. We target the IDENTITY-FREE widgetContent key
+// because that is the SHARED cell where the cross-request collision risk
+// actually lives (the per-cohort key additionally folds BindingUID; the
+// content key omits identity entirely, so extras is the ONLY per-request
+// discriminant beyond the gvr/ns/name/pagination tuple).
+package dispatchers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// enableWidgetContentL1 turns the whole resolved-output + widgetContent L1
+// stack on for one test and resets the singleton around it. Mirrors the
+// setup in widget_content_empty_shell_falsifier_test.go.
+func enableWidgetContentL1(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	t.Cleanup(cache.ResetResolvedCacheForTest)
+}
+
+// parseExtras mirrors internal/handlers/util.ParseExtras — the production
+// extras map is json.Unmarshal'd from the ?extras= query param, so values are
+// JSON-native types. Building fixtures this way keeps the key inputs
+// byte-identical to the real dispatch path.
+func parseExtras(t *testing.T, jsonExtras string) map[string]any {
+	t.Helper()
+	out := map[string]any{}
+	if jsonExtras == "" {
+		return out
+	}
+	if err := json.Unmarshal([]byte(jsonExtras), &out); err != nil {
+		t.Fatalf("parseExtras: %v", err)
+	}
+	return out
+}
+
+// TestExtras_WidgetContentKey_DiffersByExtras is THE falsifier: the same
+// widget tuple (gvr/ns/name/pagination) with DIFFERENT extras MUST produce
+// DIFFERENT identity-free content keys — otherwise the two requests collide
+// on one shared cell and leak each other's body cross-request.
+func TestExtras_WidgetContentKey_DiffersByExtras(t *testing.T) {
+	enableWidgetContentL1(t)
+
+	ctx := context.Background()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-1"
+		perPage, page     = 10, 1
+	)
+
+	keyA, handleA, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"tenant":"acme"}`))
+	keyB, handleB, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"tenant":"globex"}`))
+
+	if handleA == nil || handleB == nil {
+		t.Fatalf("widgetContent L1 must be enabled (got handles A=%v B=%v)", handleA, handleB)
+	}
+	if keyA == "" || keyB == "" {
+		t.Fatalf("expected non-empty content keys, got A=%q B=%q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("FALSIFIER FAILED: same widget + DIFFERENT extras produced the SAME content key %q — "+
+			"two requests would collide on one identity-free cell and serve each other's body", keyA)
+	}
+}
+
+// TestExtras_WidgetContentKey_StableForSameExtras — caching requires the key
+// to be DETERMINISTIC for identical inputs (incl. extras), and INSENSITIVE to
+// extras-map iteration/JSON key order (ComputeKey canonicalises via
+// sorted-key JSON). Same extras (order-shuffled) ⇒ same key ⇒ a real hit.
+func TestExtras_WidgetContentKey_StableForSameExtras(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := context.Background()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-1"
+		perPage, page     = 10, 1
+	)
+
+	key1, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"tenant":"acme","region":"eu"}`))
+	// Same content, different JSON key order — must canonicalise identically.
+	key2, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"region":"eu","tenant":"acme"}`))
+
+	if key1 != key2 {
+		t.Fatalf("same extras (key order shuffled) must produce the SAME content key, got %q vs %q", key1, key2)
+	}
+}
+
+// TestExtras_WidgetContentKey_EmptyEqualsNil — backward-compat: a request with
+// no extras param (nil) and one with the non-nil empty map ParseExtras returns
+// for absent ?extras must key IDENTICALLY, and identically to today's
+// no-extras key. ComputeKey folds extras only when len>0, so the empty/nil
+// fold writes nothing — proving the no-extras path is byte-identical to
+// pre-feature.
+func TestExtras_WidgetContentKey_EmptyEqualsNil(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := context.Background()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-1"
+		perPage, page     = 10, 1
+	)
+
+	keyNil, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, nil)
+	keyEmpty, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, map[string]any{})
+
+	if keyNil != keyEmpty {
+		t.Fatalf("nil extras and empty-map extras must key identically (backward-compat), got %q vs %q", keyNil, keyEmpty)
+	}
+}
+
+// TestExtras_WidgetContentCell_NoCrossCollision is the end-to-end serve proof:
+// store a body under extras-A's key, then look up extras-B's key — it MUST
+// miss (so request B never serves A's cached body), and a second lookup of
+// extras-A's key MUST hit (so caching still works). This exercises the real
+// cache handle Put/Get, not just key equality.
+func TestExtras_WidgetContentCell_NoCrossCollision(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := context.Background()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-1"
+		perPage, page     = 10, 1
+	)
+
+	keyA, handle, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"tenant":"acme"}`))
+	keyB, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page,
+		parseExtras(t, `{"tenant":"globex"}`))
+	if handle == nil {
+		t.Fatal("expected a live widgetContent cache handle")
+	}
+
+	bodyA := []byte(`{"status":{"widgetData":{"tenant":"acme"}}}`)
+	handle.Put(keyA, &cache.ResolvedEntry{RawJSON: bodyA})
+
+	// Request B (different extras) must NOT hit A's cell.
+	if _, hit := handle.Get(keyB); hit {
+		t.Fatalf("FALSIFIER FAILED: extras-B lookup hit a cell stored under extras-A — cross-request L1 collision")
+	}
+	// Request A (same extras) must hit, and serve exactly A's body.
+	got, hit := handle.Get(keyA)
+	if !hit {
+		t.Fatal("extras-A lookup must hit the cell it stored")
+	}
+	if string(got.RawJSON) != string(bodyA) {
+		t.Fatalf("extras-A cell served the wrong body: got %q want %q", got.RawJSON, bodyA)
+	}
+}

--- a/internal/resolvers/widgets/extras_integration_test.go
+++ b/internal/resolvers/widgets/extras_integration_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+// +build integration
+
+package widgets
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/e2e"
+	"github.com/krateoplatformops/snowplow/apis"
+	v1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// TestResolveWidgets_Extras is the END-TO-END (kind) proof of the
+// extras→widgets parity feature. It drives the REAL widgets.Resolve with an
+// Extras map and asserts the resolved status reflects the extras-supplied
+// values across all three paths the feature covers:
+//
+//   - apiRef-fetch parity (step 1): a widget whose apiRef RESTAction `path`
+//     references an extras key resolves the right object (button-extras-apiref).
+//   - widgetDataTemplate access (step 2): a widgetDataTemplate referencing an
+//     extras key yields the expected status.widgetData (button-extras-static).
+//   - resourcesRefsTemplate access (step 2, Diego's case): a
+//     resourcesRefsTemplate referencing an extras key yields the expected
+//     status.resourcesRefs (button-extras-static).
+//
+// It reuses the package TestMain (widgets_test.go) cluster/CRD/RBAC setup —
+// the buttons + restactions CRDs and rbac.namespaces.yaml (devs → cluster-wide
+// namespaces get/list) are already installed there.
+func TestResolveWidgets_Extras(t *testing.T) {
+	const jwtSignKey = "abbracadabbra"
+
+	f := features.New("ExtrasParity").
+		Setup(e2e.Logger("test")).
+		Setup(e2e.SignUp(e2e.SignUpOptions{
+			Username:   "cyberjoker",
+			Groups:     []string{"devs"},
+			Namespace:  namespace,
+			JWTSignKey: jwtSignKey,
+		})).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			apis.AddToScheme(r.GetScheme())
+			r.WithNamespace(namespace)
+
+			// Decode the extras fixtures (widget CRs + the apiRef RESTAction).
+			if err := decoder.DecodeEachFile(
+				ctx, os.DirFS(filepath.Join(testdataPath, "widgets")), "button.extras.*.yaml",
+				decoder.CreateIgnoreAlreadyExists(r),
+				decoder.MutateNamespace(namespace),
+			); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		// Step 2 over BOTH template paths (apiRef-less static widget).
+		Assess("static widget: extras in widgetDataTemplate AND resourcesRefsTemplate",
+			assertStaticExtras).
+		// Step 1: apiRef RESTAction path references an extras key.
+		Assess("apiRef widget: extras parametrises the RESTAction fetch path",
+			assertApiRefExtras).
+		Feature()
+
+	testenv.Test(t, f)
+}
+
+// assertStaticExtras resolves button-extras-static with
+// extras={tenant, region, names:[...]} and asserts the extras-derived values
+// landed in status.widgetData (label/icon) and status.resourcesRefs (one ref
+// per extras `names` element, each namespaced by the element).
+func assertStaticExtras(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	extras := map[string]any{
+		"tenant": "acme-corp",
+		"region": "fa-eu",
+		"names":  []any{"alpha", "beta"},
+	}
+	obj := resolveExtrasWidget(ctx, t, c, "button-extras-static", extras)
+
+	// status.widgetData.label == extras.tenant ; .icon == extras.region.
+	wd := nestedMap(t, obj, "status", "widgetData")
+	if got := wd["label"]; got != "acme-corp" {
+		t.Fatalf("status.widgetData.label: extras.tenant must flow into widgetDataTemplate; got %v want acme-corp", got)
+	}
+	if got := wd["icon"]; got != "fa-eu" {
+		t.Fatalf("status.widgetData.icon: extras.region must flow into widgetDataTemplate; got %v want fa-eu", got)
+	}
+
+	// status.resourcesRefs.items — one ref per extras names element, each
+	// namespaced by the element (Diego's resourcesRefsTemplate case). The
+	// resolver rewrites each ref into a snowplow /call loopback path of the
+	// shape `/call?apiVersion=v1&namespace=<el>&resource=namespaces`, and sets
+	// id to the template's `"ns-"+<el>`. We assert BOTH the per-element id
+	// (template-set, stable) AND that the resolved path carries the element's
+	// namespace (proving the extras element drove the ref's namespace).
+	items := nestedSlice(t, obj, "status", "resourcesRefs", "items")
+	if len(items) != 2 {
+		t.Fatalf("resourcesRefsTemplate must fan out one ref per extras names element; got %d items want 2 (items=%v)", len(items), items)
+	}
+	for _, el := range []string{"alpha", "beta"} {
+		if !hasRefWithID(items, "ns-"+el) {
+			t.Fatalf("expected a resourcesRefs item with id ns-%s (from extras.names element %q); items=%v", el, el, items)
+		}
+		if !hasRefPathContainingNamespace(items, el) {
+			t.Fatalf("expected a resourcesRefs item whose resolved /call path targets namespace=%s (from extras.names); items=%v", el, items)
+		}
+	}
+	return ctx
+}
+
+// assertApiRefExtras resolves button-extras-apiref with extras={nsName:"kube-system"};
+// the apiRef RESTAction's `path` is ${ "/api/v1/namespaces/" + .nsName }, so a
+// correct resolve GETs the kube-system namespace and surfaces its name into
+// status.widgetData.label. If extras had NOT reached the path, the GET would
+// target a name-less namespaces path and .ns.nsName would be absent.
+func assertApiRefExtras(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	extras := map[string]any{"nsName": "kube-system"}
+	obj := resolveExtrasWidget(ctx, t, c, "button-extras-apiref", extras)
+
+	wd := nestedMap(t, obj, "status", "widgetData")
+	if got := wd["label"]; got != "kube-system" {
+		t.Fatalf("apiRef path must be parametrised by extras.nsName: status.widgetData.label got %v want kube-system "+
+			"(if nil/empty, extras did not reach the RESTAction fetch path)", got)
+	}
+	return ctx
+}
+
+// (Backward-compat / no-op-when-extras-absent is covered at the unit + cache-
+// key layers: TestMergeExtras_NilOrEmptyIsNoOp, TestExtras_NoExtras_Template-
+// Unchanged, and TestExtras_WidgetContentKey_EmptyEqualsNil. It is deliberately
+// NOT re-asserted here: a static fixture whose widgetDataTemplate writes an
+// extras-derived value into a REQUIRED string field (Button.spec label) would,
+// with extras absent, write jq null and trip the Button CRD's string-type
+// status validation — exercising CRD validation, not the feature's no-op
+// property.)
+
+// resolveExtrasWidget fetches the named Button and resolves it through the REAL
+// widgets.Resolve with the given extras (AuthnNS set so the apiRef per-user
+// endpoint resolves — see resolveWidget in widgets_test.go for the rationale).
+func resolveExtrasWidget(ctx context.Context, t *testing.T, c *envconf.Config, name string, extras map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	r, err := resources.New(c.Client().RESTConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.WithNamespace(namespace)
+	apis.AddToScheme(r.GetScheme())
+
+	res := objects.Get(ctx, v1.ObjectReference{
+		Reference: v1.Reference{Name: name, Namespace: namespace},
+		Resource:  "buttons", APIVersion: "widgets.templates.krateo.io/v1beta1",
+	})
+	if res.Err != nil {
+		log := xcontext.Logger(ctx)
+		log.Error("unable to get widget", slog.Any("err", res.Err))
+		t.Fatalf("get widget %q: %v", name, res.Err)
+	}
+
+	obj, err := Resolve(ctx, ResolveOptions{
+		RC:      c.Client().RESTConfig(),
+		AuthnNS: namespace,
+		In:      res.Unstructured,
+		Extras:  extras,
+	})
+	if err != nil {
+		log := xcontext.Logger(ctx)
+		log.Error("unable to resolve widget", slog.Any("err", err))
+		t.Fatalf("resolve widget %q with extras=%v: %v", name, extras, err)
+	}
+	return obj
+}
+
+// --- small unstructured accessors (test-local) ---
+
+func nestedMap(t *testing.T, obj *unstructured.Unstructured, fields ...string) map[string]any {
+	t.Helper()
+	m, ok, err := unstructured.NestedMap(obj.Object, fields...)
+	if err != nil {
+		t.Fatalf("NestedMap %v: %v", fields, err)
+	}
+	if !ok {
+		return nil
+	}
+	return m
+}
+
+func nestedSlice(t *testing.T, obj *unstructured.Unstructured, fields ...string) []any {
+	t.Helper()
+	s, ok, err := unstructured.NestedSlice(obj.Object, fields...)
+	if err != nil {
+		t.Fatalf("NestedSlice %v: %v", fields, err)
+	}
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+func hasRefWithID(items []any, wantID string) bool {
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, _ := m["id"].(string); id == wantID {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRefPathContainingNamespace reports whether some resolved ref's /call
+// loopback path carries `namespace=<ns>` (the resolver rewrites a
+// resourcesRefsTemplate ref into /call?apiVersion=…&namespace=<ns>&resource=…).
+func hasRefPathContainingNamespace(items []any, ns string) bool {
+	want := "namespace=" + ns
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if p, _ := m["path"].(string); strings.Contains(p, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolvers/widgets/extras_merge_test.go
+++ b/internal/resolvers/widgets/extras_merge_test.go
@@ -1,0 +1,311 @@
+package widgets
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets/resourcesrefstemplate"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets/widgetdatatemplate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+// parseExtras mirrors internal/handlers/util.ParseExtras: in production the
+// extras map is ALWAYS the result of json.Unmarshal of the ?extras= query
+// param, so its values are JSON-native Go types (float64 for every number,
+// string, bool, []any, map[string]any, nil) — never a Go int/int64. Tests
+// MUST build extras this way so the fixture matches the real wire shape that
+// flows through mergeExtras → ds → the gojq evaluator (gojq's encoder
+// handles int/float64 but panics on a raw int64 — exactly the type a literal
+// int64 fixture or maps.DeepCopyJSON(int) would produce, and a shape
+// production never emits).
+func parseExtras(t *testing.T, jsonExtras string) map[string]any {
+	t.Helper()
+	out := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(jsonExtras), &out))
+	return out
+}
+
+// These are the step-2 (mergeExtras) unit tests for the extras→widgets
+// parity feature. mergeExtras is the resolver's data-source merge that runs
+// after injectSlice and before resolveWidgetData / resolveResourceRefs (both
+// of which evaluate their jq against the SAME `ds`). They are plain unit
+// tests (no integration build tag, no cluster) — exactly the shape of the
+// sibling resolve_slice_injection_test.go, which unit-tests injectSlice + the
+// widgetdatatemplate.Resolve jq path against an in-memory ds.
+
+// TestMergeExtras_AddsKeysNonOverwriting is the core precedence falsifier:
+// extras is the BASE; any key already in ds (an apiRef-RA result key or the
+// injectSlice triple) WINS on collision. Mirrors the RESTAction precedence
+// at restactions/api/resolve.go:228-230 (dict starts as the extras copy, API
+// results overwrite).
+func TestMergeExtras_AddsKeysNonOverwriting(t *testing.T) {
+	ds := map[string]any{
+		// pre-existing apiRef-RA result key — MUST win on collision.
+		"shared": "from-apiRef",
+		"list":   []any{map[string]any{"x": 1}},
+	}
+	// JSON-native extras (the production wire shape — numbers are float64).
+	extras := parseExtras(t, `{"shared":"from-extras","tenant":"acme","limit":7}`)
+
+	mergeExtras(ds, extras)
+
+	assert.Equal(t, "from-apiRef", ds["shared"],
+		"collision: the pre-existing apiRef-result key MUST win over extras (mirrors RESTAction precedence)")
+	assert.Equal(t, "acme", ds["tenant"], "new extras key must be added to ds")
+	assert.EqualValues(t, 7, ds["limit"], "new extras key must be added to ds")
+	assert.Equal(t, []any{map[string]any{"x": 1}}, ds["list"], "unrelated ds key must be untouched")
+}
+
+// TestMergeExtras_DoesNotClobberInjectedSlice — the injectSlice triple is
+// written into ds BEFORE mergeExtras runs (resolve.go), so an extras key
+// named "slice" must NOT overwrite the resolver-owned pagination triple.
+// Pagination is authoritative; a caller cannot override it via extras at the
+// widget-template layer.
+func TestMergeExtras_DoesNotClobberInjectedSlice(t *testing.T) {
+	ds := map[string]any{"list": []any{}}
+	injectSlice(ds, 50, 2) // ds["slice"] = {page:2, perPage:50, offset:50}
+
+	extras := map[string]any{
+		"slice": map[string]any{"page": 999, "perPage": 999, "offset": 999},
+	}
+	mergeExtras(ds, extras)
+
+	got, ok := ds["slice"].(map[string]any)
+	require.True(t, ok, "slice must remain a map[string]any")
+	assert.Equal(t, 2, got["page"], "resolver-injected slice.page must survive the extras merge")
+	assert.Equal(t, 50, got["perPage"], "resolver-injected slice.perPage must survive the extras merge")
+	assert.Equal(t, 50, got["offset"], "resolver-injected slice.offset must survive the extras merge")
+}
+
+// TestMergeExtras_NilOrEmptyIsNoOp — the backward-compat guard. A widget
+// resolved with no extras param (nil OR the non-nil empty map ParseExtras
+// returns when ?extras is absent) must leave ds byte-identical.
+func TestMergeExtras_NilOrEmptyIsNoOp(t *testing.T) {
+	build := func() map[string]any {
+		return map[string]any{
+			"list": []any{map[string]any{"a": 1}},
+			"meta": map[string]any{"k": "v"},
+		}
+	}
+
+	// nil extras
+	dsNil := build()
+	mergeExtras(dsNil, nil)
+	assert.Equal(t, build(), dsNil, "nil extras must be a no-op")
+
+	// non-nil empty extras (what util.ParseExtras returns for absent ?extras)
+	dsEmpty := build()
+	mergeExtras(dsEmpty, map[string]any{})
+	assert.Equal(t, build(), dsEmpty, "empty extras must be a no-op")
+}
+
+// TestMergeExtras_NilDsIsNoOp — defensive, symmetric with injectSlice.
+func TestMergeExtras_NilDsIsNoOp(t *testing.T) {
+	assert.NotPanics(t, func() {
+		mergeExtras(nil, map[string]any{"k": "v"})
+	})
+}
+
+// TestMergeExtras_DeepCopiesValues — ds must NOT alias the caller's extras
+// map; mutating the merged value through the original extras map (or vice
+// versa) must not bleed across. Proves the DeepCopyJSON isolation that keeps
+// the per-call ds self-contained.
+func TestMergeExtras_DeepCopiesValues(t *testing.T) {
+	nested := map[string]any{"inner": "orig"}
+	extras := map[string]any{"obj": nested}
+
+	ds := map[string]any{}
+	mergeExtras(ds, extras)
+
+	// mutate the ORIGINAL extras' nested map after the merge.
+	nested["inner"] = "mutated-after-merge"
+
+	got, ok := ds["obj"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "orig", got["inner"],
+		"ds must hold a DEEP COPY — a post-merge mutation of the source extras must not bleed into ds")
+}
+
+// --- step-2 through the TEMPLATE resolvers (the real consumers of ds) ---
+
+// TestExtrasReferenceable_InWidgetDataTemplate — a widgetDataTemplate whose
+// jq references an extras key resolves to the extras-supplied value.
+// resolveWidgetData feeds the post-mergeExtras ds straight into
+// widgetdatatemplate.Resolve, so this is the exact production eval path for
+// step 2 over the widgetData path.
+func TestExtrasReferenceable_InWidgetDataTemplate(t *testing.T) {
+	// Simulate the resolver: an apiRef-less widget ⇒ ds starts empty, then
+	// extras is merged in. JSON-native extras (count is float64 on the wire).
+	ds := map[string]any{}
+	mergeExtras(ds, parseExtras(t, `{"tenant":"acme","count":3}`))
+
+	items := []templatesv1.WidgetDataTemplate{
+		{ForPath: "data.tenant", Expression: "${ .tenant }"},
+		{ForPath: "data.count", Expression: "${ .count }"},
+	}
+	evals, err := widgetdatatemplate.Resolve(context.Background(), widgetdatatemplate.ResolveOptions{
+		Items:      items,
+		DataSource: ds,
+	})
+	require.NoError(t, err)
+	require.Len(t, evals, 2)
+
+	byPath := map[string]any{}
+	for _, e := range evals {
+		byPath[e.Path] = e.Value
+	}
+	assert.Equal(t, "acme", byPath["data.tenant"],
+		"widgetDataTemplate jq referencing an extras key must yield the extras value")
+	// jqutil.InferType narrows a JSON integer; accept any integer width.
+	assert.EqualValues(t, 3, toInt(t, byPath["data.count"]),
+		"widgetDataTemplate jq referencing a numeric extras key must yield the numeric value")
+}
+
+// TestExtrasReferenceable_InResourcesRefsTemplate is Diego's EXPLICIT case:
+// a resourcesRefsTemplate whose jq references an extras key resolves
+// correctly. resolveResourceRefs feeds the post-mergeExtras ds into
+// resourcesrefstemplate.Resolve, so this is the exact production eval path
+// for step 2 over the resourcesRefs path.
+func TestExtrasReferenceable_InResourcesRefsTemplate(t *testing.T) {
+	ds := map[string]any{}
+	mergeExtras(ds, parseExtras(t, `{"targetNs":"team-a","targetName":"my-secret"}`))
+
+	// Non-iterator template: each ${...} field is evaluated directly against
+	// ds. The Name/Namespace reference extras keys.
+	items := []templatesv1.ResourceRefTemplate{
+		{
+			Template: templatesv1.ResourceRef{
+				ID:         "${ \"ref-\" + .targetName }",
+				APIVersion: "v1",
+				Resource:   "secrets",
+				Name:       "${ .targetName }",
+				Namespace:  "${ .targetNs }",
+				Verb:       "get",
+			},
+		},
+	}
+	refs, err := resourcesrefstemplate.Resolve(context.Background(), items, ds)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, "my-secret", refs[0].Name,
+		"resourcesRefsTemplate Name jq referencing an extras key must yield the extras value")
+	assert.Equal(t, "team-a", refs[0].Namespace,
+		"resourcesRefsTemplate Namespace jq referencing an extras key must yield the extras value")
+	assert.Equal(t, "ref-my-secret", refs[0].ID,
+		"resourcesRefsTemplate ID jq composing an extras key must resolve")
+}
+
+// TestExtrasReferenceable_InResourcesRefsTemplate_Iterator — extras drives an
+// ITERATOR jq too (the fan-out shape), proving extras keys are visible to the
+// iterator expression, not just the per-field templates.
+func TestExtrasReferenceable_InResourcesRefsTemplate_Iterator(t *testing.T) {
+	ds := map[string]any{}
+	mergeExtras(ds, parseExtras(t, `{"names":["alpha","beta","gamma"],"ns":"team-b"}`))
+
+	items := []templatesv1.ResourceRefTemplate{
+		{
+			Iterator: ptr.To("${ .names }"),
+			Template: templatesv1.ResourceRef{
+				// Inside the iterator, "." is each name string.
+				Name:       "${ . }",
+				Namespace:  "team-b", // literal — exercises the static path too
+				Resource:   "configmaps",
+				APIVersion: "v1",
+				Verb:       "get",
+			},
+		},
+	}
+	refs, err := resourcesrefstemplate.Resolve(context.Background(), items, ds)
+	require.NoError(t, err)
+	require.Len(t, refs, 3, "iterator over an extras array must fan out one ref per element")
+	gotNames := []string{refs[0].Name, refs[1].Name, refs[2].Name}
+	assert.ElementsMatch(t, []string{"alpha", "beta", "gamma"}, gotNames,
+		"each fanned-out ref Name must equal the corresponding extras array element")
+}
+
+// TestExtras_ApiRefResultWins_OverExtras_InTemplate — end-to-end precedence
+// through the widgetDataTemplate path: when ds already carries an apiRef key,
+// the template sees the apiRef value, NOT the colliding extras value.
+func TestExtras_ApiRefResultWins_OverExtras_InTemplate(t *testing.T) {
+	// ds simulates the apiRef-RA result already holding "tenant".
+	ds := map[string]any{"tenant": "from-apiRef"}
+	mergeExtras(ds, parseExtras(t, `{"tenant":"from-extras","extra":"only-in-extras"}`))
+
+	items := []templatesv1.WidgetDataTemplate{
+		{ForPath: "data.tenant", Expression: "${ .tenant }"},
+		{ForPath: "data.extra", Expression: "${ .extra }"},
+	}
+	evals, err := widgetdatatemplate.Resolve(context.Background(), widgetdatatemplate.ResolveOptions{
+		Items:      items,
+		DataSource: ds,
+	})
+	require.NoError(t, err)
+	byPath := map[string]any{}
+	for _, e := range evals {
+		byPath[e.Path] = e.Value
+	}
+	assert.Equal(t, "from-apiRef", byPath["data.tenant"],
+		"the apiRef-result key MUST win over the colliding extras key at template eval")
+	assert.Equal(t, "only-in-extras", byPath["data.extra"],
+		"a non-colliding extras key is still referenceable")
+}
+
+// TestExtras_NoExtras_TemplateUnchanged — backward-compat at the template
+// layer: with no extras merged, a template referencing a key that only extras
+// would have supplied evaluates to jq null (the pre-feature behaviour), and a
+// template that does NOT reference extras is unaffected.
+func TestExtras_NoExtras_TemplateUnchanged(t *testing.T) {
+	dsBase := map[string]any{"list": []any{map[string]any{"a": 1}, map[string]any{"a": 2}}}
+
+	// (a) no extras merged — a .tenant reference yields null (key absent).
+	dsA := map[string]any{"list": dsBase["list"]}
+	mergeExtras(dsA, nil)
+	// (b) empty extras merged — must be identical to (a).
+	dsB := map[string]any{"list": dsBase["list"]}
+	mergeExtras(dsB, map[string]any{})
+
+	items := []templatesv1.WidgetDataTemplate{
+		{ForPath: "data.count", Expression: "${ .list | length }"},
+		{ForPath: "data.tenant", Expression: "${ .tenant }"},
+	}
+	evalsA, err := widgetdatatemplate.Resolve(context.Background(), widgetdatatemplate.ResolveOptions{Items: items, DataSource: dsA})
+	require.NoError(t, err)
+	evalsB, err := widgetdatatemplate.Resolve(context.Background(), widgetdatatemplate.ResolveOptions{Items: items, DataSource: dsB})
+	require.NoError(t, err)
+
+	require.Equal(t, len(evalsA), len(evalsB))
+	for i := range evalsA {
+		assert.Equal(t, evalsA[i].Path, evalsB[i].Path)
+		assert.Equal(t, evalsA[i].Value, evalsB[i].Value,
+			"nil-extras and empty-extras must produce byte-identical template output")
+	}
+	// The non-extras template (count) is unaffected by the absence of extras.
+	for _, e := range evalsA {
+		if e.Path == "data.count" {
+			assert.EqualValues(t, 2, toInt(t, e.Value), "a template that ignores extras is unchanged when extras is absent")
+		}
+	}
+}
+
+// toInt narrows jqutil.InferType's integer result (int/int32/int64/float64)
+// to int for width-agnostic numeric assertions.
+func toInt(t *testing.T, v any) int {
+	t.Helper()
+	switch x := v.(type) {
+	case int:
+		return x
+	case int32:
+		return int(x)
+	case int64:
+		return int(x)
+	case float64:
+		return int(x)
+	default:
+		t.Fatalf("expected a numeric value, got %T (%v)", v, v)
+		return 0
+	}
+}

--- a/internal/resolvers/widgets/resolve.go
+++ b/internal/resolvers/widgets/resolve.go
@@ -87,6 +87,14 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	// materialising the unbounded list at the resolver layer.
 	injectSlice(ds, opts.PerPage, opts.Page)
 
+	// extras-widgets parity (step 2): merge the per-request extras into
+	// `ds` so the widget's widgetDataTemplate AND resourcesRefsTemplate jq
+	// can reference extras keys, and so apiRef-less (static) widgets get
+	// them too. Non-overwriting (any apiRef-result key or the injectSlice
+	// triple above WINS on collision). See mergeExtras for the full
+	// rationale + precedence.
+	mergeExtras(ds, opts.Extras)
+
 	widgetDataStart := time.Now()
 	widgetData, err := resolveWidgetData(ctx, opts.In, ds)
 	phaseWidgetDataMs = time.Since(widgetDataStart).Milliseconds()
@@ -176,6 +184,20 @@ func resolveApiRef(ctx context.Context, opts ResolveOptions) (map[string]any, er
 		AuthnNS: opts.AuthnNS,
 		PerPage: opts.PerPage,
 		Page:    opts.Page,
+		// extras-widgets parity (step 1): thread the per-request extras
+		// into the apiRef fetch — the thread that was previously dropped
+		// here, so any extras a widget received was silently discarded.
+		// extras now flows widget → apiref → restactions.Resolve →
+		// api.Resolve, where api.Resolve seeds the resolve dict via
+		// maps.DeepCopyJSON(opts.Extras) (restactions/api/resolve.go:228-230).
+		// Effect: the apiRef RESTAction's OWN jq (its `path` / `payload`)
+		// can reference extras keys (parametrise the fetch), and those
+		// extras keys land top-level in the resolved data source `ds` the
+		// widget templates evaluate against. nil/empty extras (the
+		// prewarm/seed/refresher callers, which never set it) is a no-op:
+		// api.Resolve's `if opts.Extras != nil` gate skips the seed for
+		// nil, and an empty map deep-copies to an empty dict.
+		Extras: opts.Extras,
 	})
 }
 
@@ -293,5 +315,44 @@ func injectSlice(ds map[string]any, perPage, page int) {
 		"page":    page,
 		"perPage": perPage,
 		"offset":  (page - 1) * perPage,
+	}
+}
+
+// mergeExtras folds the per-request extras into the resolved data source
+// `ds`, NON-OVERWRITING: extras is the base; any key already present in
+// `ds` (an apiRef-RA result key, or the injectSlice pagination triple)
+// WINS on collision. This is the widget-side analogue of the RESTAction
+// precedence at internal/resolvers/restactions/api/resolve.go:228-230,
+// where the resolve dict STARTS as maps.DeepCopyJSON(opts.Extras) and the
+// API results then overwrite it — same net ordering (API/apiRef result >
+// extras), reached from the opposite direction because here `ds` already
+// holds the apiRef result.
+//
+// WHY it lives here (not only in step 1's apiref thread): widgetDataTemplate
+// (resolveWidgetData) AND resourcesRefsTemplate (resolveResourceRefs) both
+// evaluate their jq against this SAME `ds`, so one merge makes extras
+// referenceable in BOTH template paths. It is ALSO the only thing that puts
+// extras into `ds` for a widget with NO apiRef (step 1 never runs there, so
+// `ds` comes back as the empty apiref result) — covering apiRef-less / static
+// widgets.
+//
+// Each value is deep-copied via plumbing/maps.DeepCopyJSON (the same util the
+// RESTAction path uses) so `ds` — a per-call map — never aliases the
+// per-request extras map. nil/empty extras is a no-op (the len-guard skips
+// the copy + range), so a widget resolved without an extras param is
+// byte-identical to pre-change behaviour. nil `ds` is a no-op (defensive,
+// symmetric with injectSlice).
+//
+// Mechanism-uniform per feedback_no_special_cases: no widget-name table, no
+// key allowlist — every extras key is merged the same way for every widget.
+func mergeExtras(ds map[string]any, extras map[string]any) {
+	if ds == nil || len(extras) == 0 {
+		return
+	}
+	extrasCopy := maps.DeepCopyJSON(extras)
+	for k, v := range extrasCopy {
+		if _, present := ds[k]; !present {
+			ds[k] = v
+		}
 	}
 }

--- a/testdata/widgets/button.extras.apiref.yaml
+++ b/testdata/widgets/button.extras.apiref.yaml
@@ -1,0 +1,57 @@
+# Extras→widgets parity (step 1) END-TO-END fixture: the apiRef RESTAction's
+# OWN `path` jq references an extras key. This proves the previously-dropped
+# thread (resolve.go:173 → apiref → restactions → api.Resolve, which seeds the
+# resolve dict with the extras deep-copy). The RESTAction GETs a single
+# namespace BY NAME supplied via extras.nsName; createRequestOptions
+# (restactions/api/setup.go:61) evaluates `path` jq against the extras-seeded
+# dict. The integration test resolves the widget with extras={nsName:"kube-system"}
+# and asserts status.widgetData.label == "kube-system" — only reachable if
+# extras parametrised the fetch path.
+#
+# cyberjoker (group devs) is granted cluster-wide namespaces get/list by
+# testdata/rbac.namespaces.yaml, so the per-user-token fetch of
+# /api/v1/namespaces/kube-system succeeds.
+apiVersion: templates.krateo.io/v1
+kind: RESTAction
+metadata:
+  annotations:
+    "krateo.io/verbose": "false"
+  name: extras-namespace-by-name
+  namespace: demo-system
+spec:
+  api:
+    - name: ns
+      # PATH references the extras key — the load-bearing step-1 assertion.
+      # The resolved path becomes /api/v1/namespaces/<extras.nsName>.
+      path: ${ "/api/v1/namespaces/" + .nsName }
+      # No filter: the stage stores the RAW fetched namespace object under
+      # the stage key `ns` (api/handler.go jsonHandlerCore: out[key]=tmp). The
+      # widget template below reads .ns.metadata.name — the name of the object
+      # the extras-parametrised path fetched. (Deliberately filter-free to keep
+      # the assertion independent of the per-stage filter `pig` keying.)
+      continueOnError: true
+      errorKey: nsError
+---
+apiVersion: widgets.templates.krateo.io/v1beta1
+kind: Button
+metadata:
+  namespace: demo-system
+  name: button-extras-apiref
+spec:
+  widgetData:
+    actions: {}
+    clickActionId: nop
+    label: base-label
+    icon: fa-clock
+    type: text
+  apiRef:
+    name: extras-namespace-by-name
+    namespace: demo-system
+  # The fetched namespace's own name is surfaced into widgetData.label. It can
+  # only equal "kube-system" if extras.nsName parametrised the RESTAction path
+  # and the GET fetched that exact namespace object. If extras had NOT reached
+  # the path, the GET would target a name-less namespaces path and
+  # .ns.metadata.name would be absent.
+  widgetDataTemplate:
+    - forPath: label
+      expression: ${ .ns.metadata.name }

--- a/testdata/widgets/button.extras.static.yaml
+++ b/testdata/widgets/button.extras.static.yaml
@@ -1,0 +1,38 @@
+# Extras→widgets parity (step 2) END-TO-END fixture: an apiRef-LESS (static)
+# widget. With no apiRef, the resolver's `ds` starts as the empty apiref
+# result, so the ONLY way extras keys reach the widgetDataTemplate AND the
+# resourcesRefsTemplate jq is mergeExtras (resolve.go step 2). Both templates
+# below reference extras keys; the integration test resolves this widget with
+# extras={tenant, region, names:[...]} and asserts status.widgetData +
+# status.resourcesRefs carry the extras-derived values. Fully deterministic in
+# kind — no apiserver fetch, no RBAC dependency.
+apiVersion: widgets.templates.krateo.io/v1beta1
+kind: Button
+metadata:
+  namespace: demo-system
+  name: button-extras-static
+spec:
+  widgetData:
+    actions: {}
+    clickActionId: nop
+    label: base-label
+    icon: fa-clock
+    type: text
+  # widgetDataTemplate references extras keys → proves step 2 over the
+  # widgetData path end-to-end.
+  widgetDataTemplate:
+    - forPath: label
+      expression: ${ .tenant }
+    - forPath: icon
+      expression: ${ .region }
+  # resourcesRefsTemplate references an extras key (Diego's explicit case) →
+  # proves step 2 over the resourcesRefs path end-to-end. The iterator fans
+  # over the extras `names` array; each ref's namespace is the extras element.
+  resourcesRefsTemplate:
+    - iterator: ${ .names }
+      template:
+        id: ${ "ns-" + . }
+        apiVersion: v1
+        resource: namespaces
+        namespace: ${ . }
+        verb: GET


### PR DESCRIPTION
## What

`extras` is per-request JSON context (`?extras={...}`). It was fully wired for **RESTActions** but **silently dropped for widgets** — the `apiref.Resolve` call in `internal/resolvers/widgets/resolve.go` omitted `Extras`. This PR restores **full parity** (input-only) via **two additive changes** in `resolve.go`. **No CRD/type changes.**

1. **Step 1 — thread the dropped extras into the apiRef fetch.** Add `Extras: opts.Extras` to the `apiref.Resolve(ResolveOptions{…})` call. extras flows `widget → apiref → restactions.Resolve → api.Resolve`, which seeds the resolve dict with `maps.DeepCopyJSON(opts.Extras)` (`restactions/api/resolve.go:228-230`). The apiRef RESTAction's own jq (`path`/`payload`) can reference extras; extras keys land top-level in `ds`.
2. **Step 2 — merge extras into `ds`** (new `mergeExtras` helper, mirrors the existing `injectSlice` pattern) after `injectSlice`, before the template evals, **non-overwriting** (any apiRef-result key + the injected `slice` triple win on collision — mirrors RESTAction precedence). Because `widgetDataTemplate` AND `resourcesRefsTemplate` both evaluate against this same `ds`, one merge makes extras referenceable in **both** template paths, and for **apiRef-less (static)** widgets. Reuses `plumbing/maps.DeepCopyJSON`.

**Input-only** — extras is resolve-time context, never echoed into `status`. **Backward-compatible** — nil/empty extras is a no-op (byte-identical to pre-change; the prewarm/seed/refresher callers never set Extras → no behaviour change).

## Verify-don't-assume gates (both confirmed from code — no change needed)

- **Cache keys already fold extras.** `cache.ComputeKey` (`internal/cache/resolved.go:679-689`) hashes `canonicaliseExtras(Extras)` for BOTH widget L1 keys (`dispatchWidgetContentKey` `helpers.go:165`, `dispatchCacheLookupKey` `helpers.go:240`). Empty/nil writes nothing → byte-identical to no-extras. No cross-request collision; the new dispatcher falsifier guards it.
- **RBAC routing intact.** `isRBACSensitiveApiRefWidget` (`widget_content.go:348-359`) is shape-based (apiRef + template presence); extras is a runtime param in the content key and does not change classification → no new cross-user surface.

## Tests (test-side only)

- `internal/resolvers/widgets/extras_merge_test.go` (unit): `mergeExtras` precedence (apiRef wins) / slice-not-clobbered / nil-empty no-op / deep-copy isolation; extras in `widgetDataTemplate` and `resourcesRefsTemplate` (incl. iterator fan-out) through the real template resolvers.
- `internal/resolvers/widgets/extras_integration_test.go` (kind, `integration` tag): `TestResolveWidgets_Extras` — step-2 static widget (both template paths) + step-1 apiRef widget (RESTAction `path` parametrised by extras).
- `internal/handlers/dispatchers/extras_cache_key_test.go` (dispatcher): **load-bearing cache falsifier** — different extras → different widget content key → no L1 collision; Put/Get round-trip proving request B never serves request A's cell.
- Fixtures: `testdata/widgets/button.extras.static.yaml`, `button.extras.apiref.yaml`.

## Validation (local kind, exact CI flags `go test -race -tags=unit,integration -p 1`, KUBECONFIG unset)

- Widgets package: **PASS** (incl. existing `TestResolveWidgets` + injectSlice/dashboard/nav regression — no regression).
- Dispatcher cache falsifier: **PASS** under `-race` (4/4).
- Whole-module `go build ./...`: OK. `gofmt -l`: clean. CI pre-gate `scripts/check_resolveoptions_rc.sh`: PASS.

**Step-1 runtime falsifier** (from the integration log): `base dict for api resolver, dict:{"nsName":"kube-system"}` then `api successfully resolved … path:/api/v1/namespaces/kube-system` — extras reached the RESTAction dict AND parametrised the fetch path; the widget then surfaced the fetched object's name.

## Review note

Held **UNMERGED** for the architect (design soundness) + PM (acceptance + falsifier) pre-merge review, per the repo's agent-authored-PR pattern (#24/#25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)