### PR TITLE
docs(howto): widgets.md — resourcesRefsTemplate extras example + correct widgetDataTemplate jq syntax

### DIFF
--- a/howto/widgets.md
+++ b/howto/widgets.md
@@ -50,11 +50,15 @@ spec:
     title: ""
   widgetDataTemplate:
     - forPath: title
-      expression: .getDeployment.metadata.name   # jq over ds
+      expression: ${ .getDeployment.metadata.name }   # jq over ds — MUST be wrapped in ${ }
 ```
 
-Each entry's `expression` is evaluated against `ds`; the result is set into the
-static `widgetData` at `forPath` (`resolve.go:226-258`). A *read* error on
+Each entry's `expression` is evaluated against `ds` **only when wrapped in
+`${ … }`**: `jqutil.MaybeQuery` looks for the `${` marker and, finding none,
+returns the string unchanged (`widgetdatatemplate/resolve.go:50`, plumbing
+`jqutil.MaybeQuery`) — an unwrapped value is then stored **verbatim as a literal**,
+not evaluated. The (wrapped) result is set into the static `widgetData` at
+`forPath` (`resolve.go:226-258`). A *read* error on
 `widgetDataTemplate` **fails soft** to the static-only `widgetData`
 (`resolve.go:220-224`) — a load-bearing invariant kept symmetric with the cache
 routing predicate so a read error can never land a ServiceAccount-maximal
@@ -74,6 +78,29 @@ turned into a result with:
   (`resourcesrefs/resolve.go:108-112`).
 
 The frontend renders only `allowed == true` actions.
+
+**Example — `resourcesRefsTemplate` reading `extras`.** Only the *templated*
+variant is jq-expanded against `ds`, so only it can reference `extras`; static
+`resourcesRefs.items` are read verbatim and `extras`/jq never apply to them. Here
+the `iterator` fans out over an `extras` array, and each element parametrises one
+ref (jq via `${…}`):
+
+```yaml
+spec:
+  resourcesRefsTemplate:
+    - iterator: ${ .names }          # extras.names, e.g. ["kube-system","default"]
+      template:
+        id: ${ "ns-" + . }
+        apiVersion: v1
+        resource: namespaces
+        namespace: ${ . }            # each array element becomes one ref's namespace
+        verb: GET
+```
+
+Called as `/call?resource=widgets&…&extras={"names":["kube-system","default"]}`
+(URL-encoded), this yields one `status.resourcesRefs.items` entry per name. Use
+`resourcesRefsTemplate` whenever a ref must depend on `extras`; a static
+`resourcesRefs` ref cannot.
 
 ---
 


### PR DESCRIPTION
Two code-verified corrections to `howto/widgets.md`. The doc set itself already landed in #28; this is the widgets.md follow-up #28 didn't include.

1. **Added the missing `resourcesRefsTemplate` + `extras` example.** The section had prose but no worked example. Uses the tested pattern from `testdata/widgets/button.extras.static.yaml` (iterator over an `extras` array), and notes that static `resourcesRefs.items` are read verbatim — jq/`extras` apply only to the `*Template` variant.

2. **Corrected the `widgetDataTemplate` jq syntax.** The example used bare jq (`expression: .getDeployment.metadata.name`). Traced to code: `jqutil.MaybeQuery` (plumbing `v0.9.3`, `jqutil/jqutil.go`) requires the `${` marker and otherwise returns the string unchanged, so `widgetdatatemplate/resolve.go:50` would store the value as a **literal** rather than evaluate it. Wrapped it `${ ... }` and documented the rule with citations. The same `MaybeQuery` gate governs `resourcesrefstemplate/resolve.go` (`:44`, `:87`) and `restactions/api/setup.go:80`, so `${ ... }` is required uniformly across widget templates and RESTAction `path`/`payload`.

Docs-only, single file. Supersedes #29 (which redundantly re-applied the whole doc set already merged in #28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
