### PR TITLE
feat(refresh): live-refresh-coherence signal — Ship 1 (option A)

### DIFF
--- a/docs/live-refresh-coherence-design-2026-06-18.md
+++ b/docs/live-refresh-coherence-design-2026-06-18.md
@@ -1,0 +1,610 @@
+# Snowplow per-key live-refresh-coherence — file:line implementation design
+
+**Date:** 2026-06-18
+**Author:** cache architect (snowplow)
+**Status:** design / pre-PM-gate. NO code changes; design only.
+**Repo:** `~/krateo/snowplow-cache/snowplow` (branch `main`, tip `9bd24c7`; read-only checkout).
+**Embraces:** `/Users/diegobraga/.claude/plans/snowplow-live-refresh-coherence-plan.md` + `…-proposal.md`.
+**Source-map note:** This `main` checkout is the re-aligned canonical line (`project_release_branch_topology`); the plan's anchors were written against it and are accurate — verified below. kubectl current-context at trace time was `gke_integration-test-431120_europe-west1-b_krateo-bell` (NOT canonical) — irrelevant to this design (source-only), but any falsifier run MUST pass `--context gke_neon-481711_us-central1-a_cluster-1`.
+
+The MECHANISM/root-cause (independent eventrouter-SSE vs snowplow-informer pipelines + stale-while-revalidate) is taken as TRACED per the brief and not re-derived. This document is the buildable fix.
+
+---
+
+## 0. Prior-art check (`feedback_check_k8s_clientgo_prior_art`)
+
+| Need | client-go / stdlib prior art | Verdict |
+|---|---|---|
+| In-process fan-out hub | `k8s.io/apimachinery/pkg/watch.Broadcaster` (`mux.go:43`, `NewBroadcaster(queueLength, fullChannelBehavior)` :68; `FullChannelBehavior=DropIfChannelFull`) — TRACED at `…/apimachinery@v0.31.0/pkg/watch/mux.go`. | **Borrow the pattern, not the type.** `Broadcaster` fans EVERY event to EVERY watcher with NO per-key/per-subject routing (`mux.go` `loop()`/`distribute`). Using it as-is would push every refreshing l1Key to every connection → leaks the cluster-wide churn set to all 1000 users and wastes fan-out. We need **per-key-set subscription routing + per-subject validation**, which `Broadcaster` does not provide. We copy its proven primitives: per-watcher buffered channel + drop-on-full (so one slow SSE consumer never blocks the refresher). |
+| SSE over `net/http` | `http.NewResponseController(w).SetWriteDeadline(time.Time{})` (Go 1.20+; we are on go 1.25.3 per `go.mod`) defeats the server's global `WriteTimeout` per-connection. `http.Flusher`/`ResponseController.Flush()` for frame flushing. Standard stdlib pattern. | **Adopt.** No third-party SSE lib. (Confirmed: golang/go #54136, MDN ResponseController.) |
+| `EventSource` auth without headers | `EventSource` cannot set `Authorization`; the ONLY native credential channel is cookies via `withCredentials:true` (MDN `EventSource.withCredentials`). Token-in-URL is rejected by the brief (leaks in logs/referrer). | **Cookie-borne JWT.** See §4. |
+
+**No existing `/refreshes`, broadcaster, or `Subscribe`/`PublishRefresh` symbol in the tree** (grepped `internal/**`, excluding worktrees/_test) — this is net-new.
+
+---
+
+## 1. Anchor verification (TRACED vs INFERRED, your numbers vs source)
+
+### 1.1 Emit point — **your anchor is DIRECTIONALLY right but the precise seam is one layer deeper. CORRECTION below.** (TRACED)
+
+The refresher call chain, end to end:
+
+- `processNext` (`internal/cache/refresher.go:651`) dequeues a key, applies the rate-floor, then calls `processOne` at **`refresher.go:755`**.
+- `processOne` (`refresher.go:804`) looks up the registered `RefreshFunc` by class (`refresher.go:820-826`) and invokes it at **`refresher.go:827`**: `if err := fn(ctx, key, *entry.Inputs); err != nil { … }`. Success falls through to `return nil` at **`refresher.go:837`**.
+- The registered `fn` is the closure in `RegisterRefreshHandlers` (`internal/handlers/dispatchers/dispatchers.go:79-87`), which delegates to `resolveAndPopulateL1` (`dispatchers.go:86`).
+- `resolveAndPopulateL1` (`internal/handlers/dispatchers/resolve_populate.go:92`) recomputes `key := cache.ComputeKey(inputs)` (`resolve_populate.go:101`) and **commits the L1 write at `c.Put(key, entry)` — `resolve_populate.go:291`.**
+
+**Your claim that `SetRefreshHook` is the WRONG seam — CONFIRMED (TRACED).** `DepTracker.SetRefreshHook` (`internal/cache/deps.go:407`, wired from `refresher.go:400`) installs `enqueueFn`, which `onChange` (`deps.go:524`) calls at **`deps.go:539`** — at **dirty-mark time, pre-resolve**. It only enqueues into the workqueue; nothing is in L1 yet. Emitting there would announce a refresh that has not happened. Correct to reject it.
+
+**CORRECTION to "emit in `processOne` after `fn` returns".** Emitting at `refresher.go:836-837` (after `fn` returns nil) is *almost* right but **over-fires**, because `resolveAndPopulateL1` has FOUR success-returns (`return nil`, which `processOne` reads as success) that DO NOT Put:
+- `resolve_populate.go:98` — cache nil (cache-off).
+- `resolve_populate.go:217` — `encoded == nil`, handler declined.
+- `resolve_populate.go:228` — entry evicted during refresh; **deliberately not resurrected**.
+- `resolve_populate.go:259` — stage-error decline; **prior good entry intentionally kept** (`feedback_validate_content_not_just_status` lineage).
+
+Emitting in `processOne` would fire a "refreshed" signal on all four — triggering a frontend refetch when L1 did NOT change (and, in the evicted/declined cases, the refetch would read a stale or absent entry). That violates "coherent **by construction** — the signal exists only after the fresh entry is in L1" (proposal §4) and adds needless fan-out.
+
+> **EXACT EMIT LINE (the deliverable):** immediately **after** `c.Put(key, entry)` at `internal/handlers/dispatchers/resolve_populate.go:291`, on the refresher path only, insert one call:
+> ```go
+> c.Put(key, entry)
+> cache.PublishRefresh(key)   // ← new line, post-commit, only on actual-Put paths
+> ```
+> This is strictly post-commit (the Put returned), and it is reached ONLY when L1 actually changed. It is in `internal/handlers/dispatchers`, which already imports `internal/cache` (no cycle — `internal/cache` does NOT import `internal/handlers`; verified by grep). `PublishRefresh` lives in the broadcaster in `internal/cache` (§2).
+
+**One subtlety to honour, NOT a blocker:** `resolveAndPopulateL1` is ALSO the shared target of the **prewarm/F2 walker** and the **cold dispatch** paths? — **No.** Verified: `resolveAndPopulateL1` is invoked ONLY from the refresher closure (`dispatchers.go:86`); grep for `resolveAndPopulateL1(` shows the definition (`resolve_populate.go:92`) + the single call site in the closure. Cold dispatch Puts via `dispatchCacheLookupKey`→handler→`writeResolvedJSON` and a separate Put; prewarm Puts via the walker. So emitting at `resolve_populate.go:291` fires on **refresher commits only** — exactly the dep-change-driven re-resolve we want to announce, NOT cold first-resolves or boot prewarm. This is the cleanest possible seam: surgically the refresher's post-commit, reached only on a genuine refresh that changed L1. (If a future change makes `resolveAndPopulateL1` shared with prewarm, the emit would need a `from-refresher` guard; today it is not shared.)
+
+### 1.1a — WHEN does the post-commit fire? Two on-by-default gates sit IN FRONT of the re-resolve (TRACED; Phase-0 tester corroborated)
+
+The proposal/plan assumed the refresher commit is "sub-ms–ms" so the signal closes the gap to ~milliseconds. **The raw commit IS sub-ms** (the Phase-0 tester measured 56–86µs for the Put itself) — **but two gates between dequeue and the re-resolve delay the commit deterministically on EXACTLY our scenario** (a live-refetch hits a *young* dirty entry that was just dirty-marked by the same reconcile):
+
+1. **Per-key re-resolve RATE-FLOOR, default 2s** — `defaultRefresherRateFloorSeconds int64 = 2` (`refresher.go:105`; env `RESOLVED_CACHE_REFRESHER_RATE_FLOOR_SECONDS`, **unset in-tree → 2s in prod**). In `processNext` (`refresher.go:729-752`): if the dequeued entry's `time.Since(entry.CreatedAt) < floor`, the re-resolve is DEFERRED via `q.AddAfter(key, floor-elapsed)` (`refresher.go:749`) and `processOne` does NOT run this cycle. A composition reconcile dirty-marks the dependent cell; a live-refetch arriving < 2s later finds a young entry → the floor fires → the commit (and thus our emit) is deferred to ~floor-expiry. This is Task #321 / #318-R1a (within-wave CRUD-burst collapse). **FAIL-OPEN nuance (TRACED, `refresher.go:743-747`):** `CreatedAt` is stamped only by a successful `Put` (`resolved.go:771-772`); a cell that declines to cache re-resolves every dequeue. So the floor only delays cells that recently committed — i.e. exactly the live-refresh-after-reconcile case.
+2. **Customer-priority cooperative YIELD, cap 5s** — `refresherYieldMaxParked = 5 * time.Second` (`refresher.go:124`, Ship #98), applied by `yieldToCustomer` (`refresher.go:580`, called at `refresher.go:694` BEFORE the handler). Under sustained customer `/call` the refresher worker parks (25ms poll, `refresher.go:113`) up to 5s before proceeding.
+
+The docstring at **`refresher.go:97-99`** states the composed worst case verbatim: **"yield 5s + resolve ≤3s + floor 2s = 10s"** convergence SLA.
+
+**Corrected freshness claim (do NOT overstate — this is the honest framing):** the emit at `resolve_populate.go:291` fires at the **post-floor (and post-yield) commit**, so under default config the signal arrives **~2s after the change at rest, ~5s under sustained `/call`, ~10s pathological worst case** — NOT "milliseconds." **What the design buys is not a smaller number but COHERENCE:** today the refetch is *silent-stale until the frontend's blind 5s throttle re-fires* (proposal §2, probabilistic); after this change the client is *signalled at exactly the moment L1 is fresh* — it learns precisely when to refetch and the refetch is a guaranteed HIT. We close a **deterministic ~2s/5s SILENT-stale window** to a **coherent, signalled ~2s** (the floor latency is shared with today; we just make the freshness observable instead of guessed). The Phase-0 tester confirmed the emit POINT (refresher post-commit, never the pre-resolve `SetRefreshHook`) is correct; the floor/yield gates change only the latency narrative, not the seam.
+
+**This surfaces a strategic scope trade (options A/B below, §10) — do NOT pick here.** Either accept the ~2s post-floor latency (option A, respects #318-R1a burst-collapse) or lower/bypass the floor for signal-subscribed keys (option B, sub-second, but trades against the floor's reason-for-existing — CRUD-burst collapse / refresher amplification, a regression class that has bitten before: `feedback_refresher_populate_amplification`, the 0.30.185 5.9× wall-clock revert).
+
+### 1.2 Subscription key = the L1 key. (TRACED)
+`ComputeKey(ResolvedKeyInputs)` (`internal/cache/resolved.go:608`) is a SHA-256 over `version ∥ class ∥ GVR ∥ ns ∥ name ∥ BindingUID ∥ perPage ∥ page ∥ stage ∥ extras`. The identity fold is **`in.BindingUID`** at `resolved.go:653`, written for every class **except `widgetContent`** (the `if in.CacheEntryClass != CacheEntryClassWidgetContent` guard, `resolved.go:652`). So:
+- For `restactions`/`widgets`/`apistage`/`raFullList`, the key is **identity-bearing** (folds the binding that authorised the requester). TRACED.
+- For `widgetContent` the key is **identity-FREE** — shared across all users (`resolved.go:644,652`; the per-user `allowed` flag is re-derived at serve time per `widgets.go:144`). **This is the one class that is NOT per-subject at the key level** — see §5 for how isolation still holds.
+
+### 1.3 Subject = `xcontext.UserInfo`. (TRACED)
+`internal/handlers/dispatchers/helpers.go:96/205/327` all read `xcontext.UserInfo(ctx)` → `jwtutil.UserInfo{Username, Groups}`. `xcontext` = `github.com/krateoplatformops/plumbing/context` (`context.go:59`), value placed by `WithUserInfo` (`context.go:101`). TRACED.
+
+### 1.4 Mux. (TRACED)
+`main.go:777-808` registers `/swagger /health /readyz /api-info/names /list /call` (+ write-verb `/call`, `/jq`, `/debug/*`, expvar). No stream endpoint. Base chain = `use.NewChain(use.TraceId(), use.Logger(log))` (`main.go:157-160`); auth (`middleware.UserConfig(*signKey, *authnNS)`) is **appended per-route** (`main.go:793,804,…`). `/refreshes` is net-new.
+
+---
+
+## 2. Broadcaster — `internal/cache/refresh_broadcaster.go` (new file, ~120 LOC)
+
+A purpose-built per-key fan-out hub. Borrows `watch.Broadcaster`'s drop-on-slow-consumer discipline; adds per-key subscription routing.
+
+### 2.1 Types & API (the `internal/cache` surface)
+```go
+// refresh_broadcaster.go (new)
+package cache
+
+// subscriber is one SSE connection's sink. chans are buffered; a full
+// channel DROPS (coalesce-by-design — the frontend refetches on the next
+// signal, and a refetch is idempotent, so a dropped duplicate is harmless).
+type refreshSub struct {
+    id    uint64
+    keys  map[string]struct{} // l1Keys this connection is armed for
+    ch    chan string         // buffered (cap ~64); carries l1Key
+}
+
+type refreshBroadcaster struct {
+    mu   sync.RWMutex
+    subs map[uint64]*refreshSub
+    next uint64
+    // coalesce: per-key last-emit timestamp (monotonic), for the
+    // churn-collapse window (§2.3).
+    coalesceWindow time.Duration
+    lastEmit       map[string]time.Time
+    cmu            sync.Mutex
+}
+
+// package-singleton, lazily built; nil-safe so cache-off is a no-op.
+func refreshHub() *refreshBroadcaster { … }   // returns nil when Disabled()
+
+// PublishRefresh announces that l1Key was just committed to L1. Non-
+// blocking: fans out to every subscriber armed for l1Key; a full sink is
+// dropped (counter bump). No-op when cache is disabled or no hub exists.
+func PublishRefresh(l1Key string) { … }       // called from resolve_populate.go:291
+
+// SubscribeRefresh registers a connection. Returns the sink channel + an
+// unsubscribe func. armedKeys is the validated key-set (§5).
+func SubscribeRefresh(armedKeys map[string]struct{}) (<-chan string, func()) { … }
+
+// ArmKey / DisarmKey let a live connection add/remove a key without
+// reconnecting (the frontend mounts/unmounts widgets over one stream).
+func (s *refreshSub) ArmKey(l1Key string)  { … }
+func (s *refreshSub) DisarmKey(l1Key string){ … }
+```
+
+### 2.2 `PublishRefresh` fan-out (non-blocking, drop-on-full)
+```go
+func PublishRefresh(l1Key string) {
+    if Disabled() { return }          // transparent-fallback no-op
+    h := refreshHub()
+    if h == nil { return }
+    if h.coalesced(l1Key) { return }  // §2.3 churn-collapse
+    h.mu.RLock()
+    for _, s := range h.subs {
+        if _, armed := s.keys[l1Key]; !armed { continue }
+        select {
+        case s.ch <- l1Key:
+        default:
+            refreshDroppedTotal.Add(1)  // expvar; slow consumer, coalesced away
+        }
+    }
+    h.mu.RUnlock()
+}
+```
+Mirrors `watch.Broadcaster`'s per-watcher `DropIfChannelFull` (`mux.go:56-62`): a slow SSE consumer never stalls the refresher goroutine (the `default:` arm). Drop is safe — the next committed refresh for the same key re-signals, and the frontend's refetch is idempotent.
+
+**Concurrency:** `PublishRefresh` is called from the refresher worker goroutine(s) (post-Put, off the customer request path). The `sync.RWMutex` read-lock is held only for the fan-out loop (no I/O inside). Subscribe/unsubscribe take the write-lock. `-race` test required (`feedback_shared_vs_copy_is_a_concurrency_change`).
+
+### 2.3 Coalesce per key (proposal §5.5)
+`coalesced(l1Key)` consults `lastEmit[l1Key]` under `cmu`; if the last emit for this key was within `coalesceWindow` (default ~250ms, env-tunable, see §7), return `true` (skip — collapse the burst to one signal). Under heavy churn (a composition reconcile that re-resolves a LIST cell repeatedly) this caps fan-out to ≤1 signal / window / key. The frontend ALSO throttles per widget (proposal §6, `liveRefresh.ts` leading+trailing 5s) — server coalescing is the cheaper first line.
+
+### 2.4 Cache-off (`project_cache_off_is_transparent_fallback`)
+`refreshHub()` returns nil under `Disabled()`; `PublishRefresh` no-ops; `SubscribeRefresh` returns a closed/empty channel. The refresher does not run when cache is off (no `ResolvedCache()`), so `resolve_populate.go:96-99` returns before the Put, so the emit line is never reached either. `/refreshes` (§3) detects cache-off and serves a clean idle stream that emits only heartbeats. **Verified-removable.**
+
+---
+
+## 3. `/refreshes` SSE endpoint — `internal/handlers/refreshes.go` (new, ~140 LOC) + `main.go` wiring
+
+### 3.1 Mux wiring (`main.go`, alongside `:803-808`)
+```go
+mux.Handle("GET /refreshes", chain.Append(
+    middleware.RefreshAuth(*signKey),                 // §4 — cookie-or-header → UserInfo
+    cache.FallthroughScopeMiddleware(cache.ScopeCallGeneric), // optional; benign
+).Then(handlers.Refreshes(*signKey)))
+// NOTE: NOT cache.RegisterScopedRoute — /refreshes issues zero apiserver
+// reads, so it is out of the read-path-scoped invariant (AssertReadPathsScoped,
+// main.go:914). Confirm with PM whether to register a no-op scope for symmetry.
+```
+`chain` is the base `use.Chain` (TraceId+Logger). `Append` returns a new chain (`use/chain.go:84`); `Then` terminates (`use/chain.go:45`).
+
+### 3.2 Handler shape (`handlers.Refreshes`)
+```go
+func Refreshes(signingKey string) http.HandlerFunc {
+  return func(w http.ResponseWriter, r *http.Request) {
+    // 1. cache-off → clean idle stream (transparent fallback).
+    if cache.Disabled() { serveIdleSSE(w, r); return }
+
+    // 2. identity already on ctx (RefreshAuth middleware put UserInfo).
+    ui, err := xcontext.UserInfo(r.Context())
+    if err != nil { response.Unauthorized(w, err); return }   // defence in depth
+
+    // 3. validate the requested key-set against THIS subject (§5).
+    armed := validateSubscription(r, ui)   // map[string]struct{}; empty ⇒ 400
+    if len(armed) == 0 { http.Error(w, "no valid subscription keys", 400); return }
+
+    // 4. SSE headers + defeat the 300s WriteTimeout for THIS connection.
+    rc := http.NewResponseController(w)
+    _ = rc.SetWriteDeadline(time.Time{})         // ← the WriteTimeout fix (§6)
+    w.Header().Set("Content-Type", "text/event-stream")
+    w.Header().Set("Cache-Control", "no-cache")
+    w.Header().Set("Connection", "keep-alive")
+    w.Header().Set("X-Accel-Buffering", "no")    // disable proxy buffering
+    w.WriteHeader(http.StatusOK)
+    rc.Flush()
+
+    // 5. subscribe + stream until client disconnect.
+    ch, unsub := cache.SubscribeRefresh(armed)
+    defer unsub()
+    heartbeat := time.NewTicker(20 * time.Second)
+    defer heartbeat.Stop()
+    for {
+      select {
+      case <-r.Context().Done(): return          // client gone
+      case k := <-ch:
+        fmt.Fprintf(w, "event: refresh\ndata: %s\n\n", k)
+        rc.Flush()
+      case <-heartbeat.C:
+        fmt.Fprint(w, ": keepalive\n\n")          // SSE comment frame
+        rc.Flush()
+      }
+    }
+  }
+}
+```
+**Signal-only, no payload** (proposal §5.3): `data:` carries just the l1Key. The frontend refetches `/call` → reads the freshly-committed L1 as a HIT. Heartbeat (SSE comment `:`) keeps intermediaries from idling the connection and lets the client detect a dead link.
+
+### 3.3 Request chain (one round)
+```
+browser EventSource(/refreshes?keys=…, {withCredentials:true})
+  → gateway → snowplow mux GET /refreshes
+  → use.CORS (main.go:889; see §4 origin caveat)
+  → base chain (TraceId, Logger)
+  → middleware.RefreshAuth (cookie|header JWT → WithUserInfo)   ← NEW
+  → handlers.Refreshes: validate key-set vs UserInfo → SubscribeRefresh → stream
+```
+
+---
+
+## 4. AUTH — the make-or-break. **VERDICT: viable, NOT a hard blocker, but requires a new cookie-aware auth shim + a CORS-origin decision.** (TRACED)
+
+### 4.1 How `UserInfo` is populated TODAY (TRACED, the make-or-break trace)
+The `/call` (and `/list`) auth middleware is `middleware.UserConfig(signKey, authnNS)` in **`internal/handlers/middleware/userconfig.go:130`**. The flow:
+1. `req.Header.Get("Authorization")` — **header-only**; missing ⇒ 401 (`userconfig.go:134-138`).
+2. `strings.SplitN(authHeader, " ", 2)`, require `bearer` prefix (`userconfig.go:141-145`).
+3. **`userInfo, err := jwtutil.Validate(signingKey, parts[1])`** (`userconfig.go:151`).
+4. `xcontext.WithUserInfo(userInfo)` onto ctx (`userconfig.go:231`).
+
+So today `UserInfo` comes **strictly from an `Authorization: Bearer <jwt>` header.** `EventSource` cannot set that header → mounting `/refreshes` behind `middleware.UserConfig` as-is would 401 every connection at `userconfig.go:135`. **That is the blocker the brief warned about — and it is real for the unmodified middleware.**
+
+### 4.2 Why it is NOT a HARD blocker (the decisive finding)
+`jwtutil.Validate` (`…/plumbing@v0.9.3/jwtutil/validate.go:16`) is a **pure, stateless HS256 verification**: `jwt.ParseWithClaims(bearer, &KrateoClaims{}, …signingKey…)` → returns `claims.UserInfo`. The `UserInfo{Username, Groups}` is **embedded in the token** (`jwtutil/create.go:16-24` — `KrateoClaims` embeds `UserInfo`). **There is NO session store, NO server-side lookup.** The token is self-contained and signature-verified against `signKey` (the same `*signKey` flag, `main.go:82`, `JWT_SIGN_KEY` / `AUTHN_JWT_SECRET`).
+
+**Consequence:** the identical `UserInfo` is recoverable from the SAME JWT regardless of transport. If the SPA delivers that JWT in a **cookie** (which `EventSource` sends automatically with `withCredentials:true`), a `/refreshes`-specific middleware can extract it from the cookie and call the byte-identical `jwtutil.Validate(signingKey, cookieToken)` → byte-identical `UserInfo`. No new token type, no new validation path, no session infrastructure.
+
+### 4.3 Design — `middleware.RefreshAuth(signingKey)` (new, in `internal/handlers/middleware/refreshauth.go`, ~40 LOC)
+A SIBLING of `UserConfig`, NOT a replacement (do not perturb the audited `UserConfig` mirror — `feedback_claim_vs_code_identity_at_diff_review`; it is a verbatim upstream transcription with a drift-pin test). `RefreshAuth`:
+1. Token source order: **(a) `Authorization: Bearer` header** (so non-browser/polyfill clients and curl falsifiers work) → **(b) a cookie** (the `EventSource` path). Cookie name = a config constant (e.g. `krateo-session` — confirm the portal's actual cookie name with the frontend owner; that is a cross-team fact, NOT source-recoverable here → OPEN).
+2. `jwtutil.Validate(signingKey, token)` — **the identical call** as `userconfig.go:151`.
+3. `xcontext.WithUserInfo(userInfo)` (`context.go:101`) — identical to `userconfig.go:231`.
+4. **Deliberately SKIP the `<user>-clientconfig` Secret/`WithUserConfig` lookup** that `UserConfig` does (`userconfig.go:169-232`). `/refreshes` issues **zero apiserver reads** — it never resolves, so it needs no `UserConfig` endpoint. This keeps `/refreshes` off the F-3 Secret-GET path entirely (no fall-through counter, no apiserver hit). **`UserInfo` alone is sufficient for §5 validation.** TRACED: §5's `validateSubscription` needs only `ui.Username`+`ui.Groups` (it calls `rbac.EvaluateRBAC` with those).
+
+**No token-in-URL.** The query string carries only resource-coordinates + the claimed key (§5/§6), never the JWT.
+
+### 4.4 CORS — a deployment-topology decision you MUST make (TRACED finding)
+Current CORS (`main.go:889-902`, via `plumbing/server/use/cors`): `AllowedOrigins:["*"]` + `AllowCredentials:true`. Traced in `cors.go:256-271`: under the `*` config (`allowedOriginsAll`), the handler emits **literal `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true`**. The web platform **forbids** this pair for credentialed requests — a browser will reject a `withCredentials:true` EventSource against `*` (MDN; `Access-Control-Allow-Credentials`). **So cross-origin cookie-SSE does NOT work under today's CORS.**
+
+Two resolutions (strategic — surface to Diego/team lead):
+- **(I) Same-origin deployment (preferred if true).** If the portal SPA and snowplow `/refreshes` are served under the SAME origin (same gateway host), the CORS-credential restriction does not apply (no CORS preflight for same-origin), and the cookie flows. **Verify the deployed topology** — this is a `reference_portal_chart` / gateway fact, NOT snowplow-source-recoverable → OPEN. Likely the case (portal is behind the same gateway), which would make this a non-issue.
+- **(II) Cross-origin.** Change `AllowedOrigins` from `["*"]` to the explicit portal origin(s) so `use.CORS` echoes the specific origin (`cors.go:259`) alongside credentials — the legal combination. This edits `main.go:890` (snowplow code) but the origin list is config-shaped; it should flow via a flag/env, NOT a hardcoded literal (`feedback_no_special_cases`). This is a small additive change, but it is a **behaviour change to the shared CORS for ALL routes** → needs PM sign-off and a check that the `*`-using clients today (if any non-browser) are unaffected.
+
+**Auth verdict, one line:** *Cookie-borne JWT is the clean path; `jwtutil.Validate` is stateless so `UserInfo` is transport-independent; the only real work is a ~40-LOC `RefreshAuth` sibling middleware + resolving the CORS `*`-vs-credentials topology question (I) or (II). NOT a blocker.*
+
+---
+
+## 5. Per-subject isolation — re-derivation, NOT a provenance map (the load-bearing design; `feedback_l1_per_user_keyed_never_cohort`)
+
+### 5.1 The constraint, traced
+The l1Key folds `BindingUID` (`resolved.go:653`), and `BindingUID` is derived per-request from `rbac.EvaluateRBAC(Username, Groups, verb, GVR, ns, name)` at **`internal/handlers/dispatchers/helpers.go:212`** (the `dispatchCacheLookupKey` path). The key is a one-way SHA — **the server cannot recover the subject from the key alone**, and the client never computes the key (snowplow returns it, §6). Two users sharing a binding **share one key** (per-binding sharing — `resolved.go:305-330`, the equivalence-class invariant); `RepresentativeUsername` records only the FIRST writer (`helpers.go:236`, `resolved.go:319`), so **representative-equals-you is the WRONG isolation test** (it would deny a legitimate co-binding user). And `widgetContent` keys are identity-FREE (`resolved.go:652`) — shared by everyone.
+
+### 5.2 Mechanism — server re-derives the expected key under the CONNECTION's identity (RECOMMENDED)
+The client, on `/refreshes`, sends for each widget it wants to arm: the **resource coordinates it used for `/call`** (`group, version, resource, namespace, name, page, perPage, extras, class`) — NOT just the opaque key. `validateSubscription(r, ui)` then, for each requested tuple, **recomputes the expected key under the connection's authenticated `UserInfo`** using the IDENTICAL derivation the dispatcher uses:
+
+- identity-bound classes → reuse `dispatchCacheLookupKey`'s logic: `rbac.EvaluateRBAC(ui.Username, ui.Groups, "get", group, resource, ns, name)` → `BindingUID` → `cache.ComputeKey(inputs)` (`helpers.go:212-242`).
+- `widgetContent` → reuse `dispatchWidgetContentKey` (`helpers.go:147`, identity-free `ComputeKey`).
+
+If the recomputed key **equals** the key the client claims (and/or the client just sends the tuple and the server arms the recomputed key directly — see §6), arm it; else reject that key.
+
+**Why this is forgery-proof:** the server computes `BindingUID` from the **connection's** JWT-derived `UserInfo` (`ui`, from §4), never from anything the client supplies. A malicious client that sends user-B's coordinates + user-B's key gets the server to compute the key under **attacker-A's** identity → A's `BindingUID` → a DIFFERENT key → mismatch → rejected. A client can only ever arm keys that A's own identity legitimately produces. This is exactly the `dispatchCacheLookupKey` FAIL-CLOSED posture (`helpers.go:197-210`: missing/foreign identity ⇒ empty-identity key ⇒ no match). **This reuses the existing key-derivation seam verbatim — no new identity logic, no `feedback_no_special_cases` violation.**
+
+**`widgetContent` caveat (the one identity-free class):** its key is shared, so re-derivation yields the same key for every subject — a client CAN legitimately arm a widgetContent key it doesn't "own" because nobody owns it (the envelope is shared; the per-user `allowed` flag is applied at serve time, `widgets.go:144`, NOT in the cached body). **This is NOT a leak:** the signal is content-free (just "this shared envelope refreshed"), and the subsequent `/call` refetch re-applies per-user gating at serve. So arming a widgetContent key reveals only "the shared widget envelope changed," which is not subject-specific information. Document this explicitly; it is consistent with the existing identity-free-shell design.
+
+### 5.3 Alternative — provenance map (NOT recommended)
+Record `key → {authorized subjects}` at `/call` serve time; validate/filter against it at subscribe (a) or emit (b). **Rejected:** (i) unbounded growth (every served key × every subject); (ii) races a freshly-granted user (not yet in the map → false deny) or a freshly-revoked user (stale allow → leak window); (iii) duplicates state the RBAC snapshot already has. Re-derivation (§5.2) reads the live RBAC snapshot each time — correct under binding churn by construction.
+
+---
+
+## 6. Subscription-key exposure in `/call` (additive; `feedback_cache_must_not_constrain_jq`, body contract preserved)
+
+The `/call` body is written by `writeResolvedJSON` (`internal/handlers/dispatchers/helpers.go:413`) — `Content-Type: application/json` + raw resolved bytes. Hit/miss sites: `restactions.go:139,291`, `widgets.go:147,187,299`. **Do NOT mutate the JSON body** (it is the widget-prop contract; any envelope change risks the layering contract and the byte-identical baselines, `feedback_byte_identical_baselines_clean_wire_shape`).
+
+**RECOMMENDED — response HEADER, not body.** Emit the L1 key as a response header at every `/call` serve site:
+```go
+wri.Header().Set("X-Snowplow-Refresh-Key", cacheKey)   // additive; before WriteHeader
+```
+`cacheKey` is already in scope at all serve sites (it is the `dispatchCacheLookupKey`/`dispatchWidgetContentKey` return). A header is invisible to the JSON body contract and to non-subscribing clients. It MUST be added to CORS `ExposedHeaders` (`main.go:899`, currently only `["Link"]`) so the browser `fetch`/react-query layer can read it cross-origin.
+
+**The frontend then has two equivalent options (frontend decides):**
+- **(a) subscribe by the key** (`?keys=<k1>,<k2>`) AND send the coordinates for §5 validation; OR
+- **(b) subscribe by the coordinates only** (`?sub=<base64 json of {group,version,resource,ns,name,page,perPage,extras,class}>`), and let the server re-derive the key under the connection identity (§5.2) and arm THAT. **(b) is cleaner** — the client never needs to round-trip the opaque key, and there's nothing to validate-by-equality (the server simply arms what it derives). The `X-Snowplow-Refresh-Key` header is then optional/diagnostic. **Recommend (b)**; expose the header anyway for debuggability + a future "supersede the hand-declared `watch`" path (plan Phase 5).
+
+**Tradeoff to flag:** option (b) means the `?sub=` payload includes `extras`, which can be large for some widgets; cap/validate its size (reject > a few KB) to avoid a memory-amplification subscribe vector.
+
+---
+
+## 7. Flags / gating (`project_single_cache_flag_direction`, `project_caching_is_provisional`)
+
+- **No new master flag.** `/refreshes` and the broadcaster are **implicit under `CACHE_ENABLED`** (lean implicit, per `project_single_cache_flag_direction`). Cache-off ⇒ no refresher ⇒ no emit ⇒ idle stream. The endpoint is registered unconditionally on the mux (a route that no-ops under cache-off is harmless and matches `/list`/`/call` which also serve transparently cache-off).
+- **One sub-layer back-out knob** (consistent with `RESOLVED_CACHE_APISTAGE_ENABLED` et al.): `REFRESH_SSE_ENABLED` (default true-when-cache-on) so the SSE layer is independently disable-able without losing L1 — provisional/removable. The broadcaster `Publish`/`Subscribe` become no-ops when off.
+- **Coalesce window:** `REFRESH_COALESCE_WINDOW_MS` (default 250). **Connection budget / heartbeat interval:** must be sized **empirically** at 1000 users × N widgets (`feedback_capacity_caps_empirical_per_entry_cost`) — do NOT ship a guessed FD/connection cap. The Phase-0 tester baseline + a connection-scale measurement feed this.
+
+---
+
+## 8. LOC estimate & file:line targets
+
+| Component | File | LOC | Kind |
+|---|---|---|---|
+| Broadcaster (hub, Publish, Subscribe, Arm/Disarm, coalesce, expvar counters) | `internal/cache/refresh_broadcaster.go` | ~120 | NEW |
+| Emit call (1 line) | `internal/handlers/dispatchers/resolve_populate.go` @ `:291` | 1 | EDIT |
+| SSE handler | `internal/handlers/refreshes.go` | ~140 | NEW |
+| `validateSubscription` (re-derive key under conn identity; reuse `dispatchCacheLookupKey`/`dispatchWidgetContentKey` logic — may need a small exported helper from `dispatchers`) | `internal/handlers/refreshes.go` (+ ~30 in `dispatchers` to export the derivation) | ~70 | NEW |
+| `RefreshAuth` cookie-or-header middleware | `internal/handlers/middleware/refreshauth.go` | ~45 | NEW |
+| Mux wiring + `ExposedHeaders` += refresh-key | `main.go` @ `:803` region, `:899` | ~6 | EDIT |
+| `X-Snowplow-Refresh-Key` header at 5 serve sites | `restactions.go:139,291`; `widgets.go:147,187,299` | ~5 | EDIT |
+| CORS origin change (ONLY if cross-origin, §4.4-II) | `main.go:890` (config-shaped) | ~3 | EDIT (conditional) |
+| Flags (`REFRESH_SSE_ENABLED`, `REFRESH_COALESCE_WINDOW_MS`) | `internal/cache/*.go` + `main.go` | ~15 | NEW |
+| **B-delta — `keyRefs` reverse index + `HasRefreshSubscriber`** | `internal/cache/refresh_broadcaster.go` (A's file) | ~15 | NEW (B) |
+| **B-delta R-B1' — `ResolvedEntry.LastResolveMS` field + stamp (`time.Since` around `resolveOnceFn`)** | `internal/cache/resolved.go` (struct) + `internal/handlers/dispatchers/resolve_populate.go:209` | ~4 | EDIT+NEW (B) |
+| **B-delta — `effectiveFloor` + `isCheapShortFloorEligible` (positive cost gate: PRIMARY `LastResolveMS` + belt-and-braces `entryBytes`,resolved.go:902 + optional `Pinned`) + per-cheap-key bypass-rate cap + `flooredSubscribedTotal` counter** | `internal/cache/refresher.go` @ `:729` (replace `rateFloor()` read) + helpers | ~45 | EDIT+NEW (B) |
+| **B-delta — flags `REFRESH_SUBSCRIBED_FLOOR_MS` (default=coalesce window), `REFRESH_SHORT_FLOOR_MAX_MS` (R-B2.c, PRIMARY), `REFRESH_SHORT_FLOOR_MAX_BYTES` (R-B2.a), `REFRESH_MAX_SHORT_FLOOR_PER_MIN` (R-B2.b)** | `internal/cache/*.go` | ~12 | NEW (B) |
+| Unit + `-race` tests (broadcaster ordering/drop/coalesce; isolation forge-reject incl. 9.4 per-row; cache-off unreachability 9.5; 9.7 amplification harness; 9.8 dropped-terminal) | `*_test.go` | ~310 | NEW (test) |
+
+**Total production code: A ≈ 380 LOC; B-delta ≈ +63 LOC** (one EDIT at refresher.go:729 + the broadcaster reverse-index + 2 flags) across the same 3 new files + ~5 edited lines; **+~310 LOC tests.** Net-new behaviour is additive and toggle-gated; no existing path's bytes change (the `/call` body is untouched; the header is additive; the emit fires only on refresher commits; B alters ONLY the floor *value* for subscribed keys, leaving the defer/dedup/dispatch identical).
+
+---
+
+## 9. Falsifiers (the gates; `feedback_falsifier_first_before_ship`, `feedback_validate_content_not_just_status`)
+
+All runtime falsifiers MUST run against `--context gke_neon-481711_us-central1-a_cluster-1` (diagnostic-only; `kubectl` not in any latency score).
+
+1. **No apiserver LIST issued by the refetch (THE invariant).** Drive a composition reconcile; observe one SSE `event: refresh` for the dependent widget's key; the frontend (or a curl emulating it) refetches `/call`. **Assert:** `snowplow_apiserver_fallthrough_cells` (the F-1/F-3 scope counters, `/debug/vars`) for the `call-*` scope do **not** increment across the refetch, AND `resolved_cache.lookup hit=true` fires for that key (`helpers.go:269`). Artifact: expvar delta + the `resolved_cache.lookup` log line. (If a refetch ever shows a miss→passthrough, the design failed — proposal §4 risk.)
+2. **Coherence, not zero-latency (the corrected falsifier — see §1.1a).** Capture `body_sha` of the widget `/call` at: (t0) pre-reconcile, (t1) the instant the SSE signal arrives, (t2) the refetch response. **Assert:** (i) t2 `body_sha` == the post-reconcile expected; (ii) the signal at t1 arrives ONLY AFTER `resolveAndPopulateL1` logged `re-resolved + stored` (`resolve_populate.go:292`) for that key (ordering: emit is strictly post-Put); (iii) a `/call` issued at any t∈(t0, t1) still returns the OLD `body_sha` — i.e. the signal does NOT arrive before L1 is actually fresh (coherent-by-construction). **Latency expectation, NOT a fail condition:** t1−t0 ≈ the rate-floor (~2s at-rest default; ~5s under sustained `/call`) — this MATCHES the Phase-0 tester's measured ~2.0s/~5s/~10s window and is the floor's cost, shared with today. The PASS criterion is **coherence (the signal is never premature, and the post-signal refetch is always fresh)**, NOT a sub-second t1. Compare t1−t0 against the tester's baseline; if option B (§10-E) is chosen, re-assert t1−t0 drops sub-second AND re-run falsifier-for-amplification (§9.7).
+3. **Emit fires once per coalesced commit, never pre-commit.** Unit: a refresher cycle that Puts → exactly one `PublishRefresh`; a cycle that hits a no-Put return (`resolve_populate.go:217/228/259`) → **zero** `PublishRefresh` (this is the §1.1 correction's encoded test); N Puts within the coalesce window → 1 signal.
+4. **Cross-user isolation (RBAC-leak falsifier) — STRENGTHENED per PM (9.4).** Two parts:
+   - **(4a) identity-bound classes:** User A's connection subscribes with user B's resource coordinates + B's key. **Assert** the server re-derives under A's identity → different key → arm rejected (0 signals to A for B's key) even when B's key actively refreshes.
+   - **(4b) identity-FREE `widgetContent` — per-ROW RBAC CONTENT assertion (NOT status-only; `feedback_validate_content_not_just_status`).** A arms a shared `widgetContent` key (legitimately — nobody owns it, §5.2). On signal, A refetches `/call`. **Assert the refetched BODY is per-A-gated at the row level:** for a widget whose `status.resourcesRefs.items[]` A and B can see DIFFERENT subsets of, assert A's response contains A's `allowed:true` rows and `allowed:false` (or omitted) for rows only B may act on — i.e. diff A's served rows against B's served rows for the SAME key and assert they differ exactly per each subject's RBAC. The signal being shared must NOT leak B's row-level visibility into A's body. Artifact: A's vs B's `/call` body row-set + `allowed` flags for the shared key, post-signal, asserted against each subject's `rbac.EvaluateRBAC` grant. This is the gate that proves the identity-free-shell + serve-time-gate design (widgets.go:144) holds end-to-end through the live-refresh path.
+5. **`CACHE_ENABLED=false` ⇒ clean no-op — STRENGTHENED per PM (9.5): prove UNREACHABILITY + correct CONTENT.** Two parts:
+   - **(5a) `PublishRefresh` provably unreachable:** with cache off, the refresher singleton does not exist and `resolveAndPopulateL1` returns at `resolve_populate.go:96-99` BEFORE the Put → the emit at `:291` is never reached. **Assert** via a code-path falsifier: a unit/integration test with `CACHE_ENABLED=false` drives an informer-equivalent change and asserts the broadcaster's emit counter stays 0 AND `refreshHub()` returns nil (the §2.4 nil-path). Belt-and-braces: `PublishRefresh` itself early-returns on `Disabled()` (§2.2) — assert that guard with a direct call under cache-off (counter unchanged).
+   - **(5b) `/call` correct CONTENT under cache-off (transparent fallback, not just 200):** `GET /refreshes` returns 200 + idle stream (only `: keepalive`, zero `refresh` events); AND a `/call` for the same widget returns the **byte-correct resolved body** served direct from apiserver (assert non-empty, correct rows — `feedback_validate_content_not_just_status` — NOT merely HTTP 200). Artifact: cache-off pod (`--context gke_neon-481711_…`), curl `/refreshes` frame dump + `/call` body content-diff vs cache-on body.
+6. **Slow-consumer never stalls the refresher.** `-race` test + a deliberately-blocked subscriber sink: assert `PublishRefresh` returns promptly (drop counter bumps), other subscribers still receive, refresher `completedTotal` keeps climbing.
+7. **(MANDATORY pre-B-ship, B is RATIFIED §12) — no refresher-amplification regression from the short floor (9.7). THE B-delta gate.**
+   - **Setup / denominator:** the concurrent tester is capturing the **floor-ON (A) baseline** — refresher CPU%, alloc rate (B/s), workqueue cumulative-delay, refresher `completedTotal`/`flooredTotal`, and warm `/call` p50 — under a **composition-install CRUD churn wave at SCALE=50000** (`feedback_test_scale_50k`), with a representative *subscribed working set* (e.g. 1000 connections × K mounted widgets armed via `/refreshes`). This baseline IS the denominator.
+   - **B arm:** identical wave + identical subscribed working set (which MUST include BOTH aggregate widgets — piechart/compositions-list — AND detail widgets, all armed via `/refreshes`), with the short floor active (`REFRESH_SUBSCRIBED_FLOOR_MS=250`, `maxShortFloorPerMin` at its empirically-chosen default).
+   - **Assertions (ALL must hold, content-and-mechanism, not status):**
+     - **(a) ALL THREE expensive-cell sources stay long-floored even when subscribed (the dangerous case excluded by MEASURED COST — §13.2 axis 0; the PRIMARY gate). Three sub-cells, all asserted (so the artifact provably exercises the bytes-vs-cost divergence, not just large-bytes cells):**
+       - (a-i) a subscribed **registered cluster-list** cell (compositions-list / piechart count) — assert it took the **2s floor**, re-resolve count == floor-ON baseline (~100:1 collapse preserved), `flooredSubscribedTotal` does NOT tick; `isCheapShortFloorEligible` returns false (large `LastResolveMS` + large bytes + Pinned).
+       - (a-ii) a subscribed **RA-FullList** cell — assert 2s floor, baseline re-resolve count, eligibility false (large `LastResolveMS` + Pinned).
+       - (a-iii) **THE R-B1' HOLE — the SCAN-1000-NS-RETURN-3-ROWS cell, named explicitly as the falsifier scenario.** Construct a narrow-RBAC identity whose cluster-list collapse fails gate 5 RBAC (`cluster_list.go:248`) so the request falls to the per-NS iterator path and scans ~1000 namespaces returning a handful of rows — Put via `apistage.go:513` WITHOUT `RegisterClusterListKey`, yielding **SMALL result bytes BUT large measured resolve wall-ms** (the `cluster_list.go:74-79` 11-22s class). **Assert it took the 2s floor on the `LastResolveMS >= shortFloorMaxMS` term — NOT on bytes (its `entryBytes` is small) and NOT on class (`IsClusterListKey(key)==false`, `isRAFullListEntry==false`).** This is the decisive assertion that the prior bytes-only/class predicate would have FAILED (the cell would have short-floored → 0.30.205 leak) and the wall-ms predicate PASSES. Assert its expensive per-NS-scan re-resolve count == floor-ON baseline and `flooredSubscribedTotal` does NOT tick for it. **The artifact MUST record this cell's small `entryBytes` alongside its large `LastResolveMS` side-by-side, to prove the divergence is what the gate keyed on.**
+       - All three: the expensive re-resolve path is byte-identical to floor-ON.
+     - (b) **DETAIL cells get the short floor + the ~250ms benefit.** For a subscribed detail widget: assert it took the short floor (`flooredSubscribedTotal` ticks) and its signalled-fresh latency t1−t0 (§9.2) ≈ 250ms. (If detail latency did NOT drop, B bought risk with no benefit → reject.)
+     - (c) **Under the 50K-install churn wave, AGGREGATE re-resolve counts == floor-ON baseline (no amplification on the expensive path).** The aggregate cells' re-resolve count, refresher CPU attributable to cluster-LIST re-resolves, and alloc from aggregate parsing are within baseline variance — the expensive path shows ZERO incremental work from B. This is the direct 0.30.205 / 0.30.185 guard.
+     - (d) **No overall refresher-amplification regression:** total refresher CPU%, alloc B/s, and workqueue cum-delay within an agreed band of the floor-ON baseline (band from baseline variance — NOT a guessed %; `feedback_capacity_caps_empirical_per_entry_cost`). The 0.30.185 revert was 5.9× — the gate must catch anything approaching that. With axis 0 excluding the expensive path, the only permitted increment is bounded CHEAP-detail re-resolves.
+     - (e) **Subscriber-gate did not leak:** UNsubscribed dirtied detail keys show the SAME re-resolve count as floor-ON (`flooredSubscribedTotal` vs `flooredTotal` consistent with only the subscribed-detail set taking the short floor).
+     - (f) **Warm `/call` p50 non-regression:** mix-weighted warm p50 (0.95 narrow + 0.05 admin, `project_north_star_ledger`) within the agreed band of the floor-ON baseline (customer-facing guard, `feedback_customer_priority_over_refresher`).
+   - **Artifact (attaches to the B-delta ledger row):** floor-ON vs B-arm side-by-side: pprof CPU+alloc profiles **split by re-resolve class** (aggregate vs detail), `/debug/vars` refresher counters (`completedTotal`, `flooredTotal`, `flooredSubscribedTotal`, `clusterListCompleted`, `droppedTotal`), per-key re-resolve histogram tagged aggregate/detail, workqueue depth/delay, warm p50 histogram, and the t1−t0 distribution split aggregate/detail. **This is the gate that authorises B to ship.**
+8. **Dropped-terminal-signal degrades to the frontend throttle, NEVER indefinite stale (9.8, per PM).** A dropped signal (slow-consumer full-channel drop, §2.2 `default:` arm) for the FINAL emit in a churn burst must not strand the widget stale forever. **Assert:** with a subscriber whose sink is saturated so the *last* `refresh` for a key is dropped (and no further commit re-signals), the frontend's blind 5s throttle re-fire (`liveRefresh.ts` leading+trailing, proposal §6) still issues a refetch within ≤5s → reads the fresh L1 → converges. I.e. the SSE signal is an *optimisation* over the existing 5s safety-net, never a replacement that can deadlock on a drop. Artifact: a saturated-sink integration test — drop the terminal signal, assert a refetch fires by the 5s throttle and the body converges to fresh; assert the widget never stays stale past 5s. (This is why A's design keeps coexistence with the frontend throttle during AND after cutover; the throttle is the floor under the signal.)
+
+---
+
+## 10. Risks (ranked) & options
+
+**Freshness expectation-setting (the Phase-0 tester's finding, §1.1a; now resolved by the B ratification).** Under A's floor (every UNsubscribed key, and the fallback if 9.7 fails) the signalled-fresh latency is the rate-floor (~2s at-rest, ~5s under load — `refresher.go:97-99,105,124`); the win there is COHERENCE, not a smaller number. **Under B (RATIFIED, §12) the SUBSCRIBED-key latency drops to the short floor (~250ms)** — sub-second signalled-fresh — at the cost of the amplification surface bounded in §13 and gated by 9.7. The honest ledger framing: "silent-stale ~2s → signalled-fresh ~250ms for visible widgets (B), ~2s coherent for the rest (A)." The biggest residual risk shifts from "is ~2s acceptable" to "does the short floor amplify the refresher under a 50k install wave" — which §13's bound answers and §9.7 proves.
+
+**Biggest risk — connection scale at 1000 users × N widgets.** Long-lived SSE connections × users, each holding a goroutine + buffered channel, plus gateway/LB/FD ceilings. `watch.Broadcaster`'s drop-on-full protects the refresher, but the raw connection count is the production unknown. **Must be sized empirically** (`feedback_capacity_caps_empirical_per_entry_cost`) — one multiplexed connection per browser tab (the frontend's ref-counted `sseClient.ts` already does this, proposal §6) keeps it to ~1 connection/user, not 1/widget. **Action:** a connection-scale measurement BEFORE shipping a cap; idle-eviction of armed-but-silent connections via the heartbeat.
+
+**Second — the 300s `WriteTimeout` (`main.go:904`).** Confirmed (TRACED): an SSE connection held open > 300s is killed by the server unless `http.ResponseController.SetWriteDeadline(time.Time{})` is set per-connection (§3.2 step 4; Go 1.25.3 supports it). If the gateway in front ALSO imposes a shorter idle/read timeout, the 20s heartbeat must beat it — verify the gateway timeout (deployment fact → OPEN). **Option:** a dedicated `http.Server` on a second listener with `WriteTimeout:0` for `/refreshes`, if the per-connection deadline-reset proves fragile under the gateway — surface as a fallback.
+
+**Third — CORS `*`-vs-credentials** (§4.4). Same-origin (likely) → non-issue; cross-origin → a shared-CORS change needing PM sign-off.
+
+**Fourth — `?sub=` `extras` size** (§6): cap to avoid a subscribe-time memory vector.
+
+### Strategic options for Diego / team lead
+- **A. Subscription transport:** (a) subscribe-by-key (client round-trips the opaque key) vs **(b) subscribe-by-coordinates** (server re-derives). **Recommend (b)** — simpler client, forgery-proof by construction, nothing to validate-by-equality.
+- **B. CORS:** **(I) confirm same-origin** (recommend — verify topology, likely zero change) vs (II) explicit-origin list (a shared-CORS behaviour change).
+- **C. SSE server:** **per-connection `SetWriteDeadline(0)` on the existing server** (recommend) vs a dedicated `WriteTimeout:0` listener (fallback if gateway-fragile).
+- **D. Emit seam:** **`resolve_populate.go:291` post-Put** (recommend — surgically correct, fires only on real commits) vs `processOne` post-`fn` (simpler but over-fires on the 4 no-Put returns — rejected, §1.1).
+- **E. Freshness/floor trade — RESOLVED: Diego RATIFIED option B (2026-06-18), eyes-open against the A-recommendation. See §12–§13 for the full B mechanism.**
+  - **(A) post-floor commit, no floor change** — ~2s/~5s signalled-coherent, zero amplification risk. Remains the behaviour for every UNsubscribed key under B.
+  - **(B) subscriber-gated SHORT floor, CHEAP cells ONLY (RATIFIED + scoped by Diego 2026-06-18; closure refined by PM re-gate R-B1 → R-B1').** Sub-second (~250ms) signalled-fresh for *subscribed CHEAP* cells only. NOT no-floor — a much shorter floor (= coalesce window) so within-wave bursts still collapse (§12.1). **Eligibility is a POSITIVE cost gate keyed on MEASURED resolve wall-ms (`LastResolveMS < MAX_MS`, PRIMARY) + result bytes (belt-and-braces) + optional `Pinned` (§12.2a) — NOT class-exclusion and NOT bytes-alone.** This closes the R-B1' hole: the scan-1000-NS-return-3-rows apistage cell (small result bytes BUT 11-22s resolve, `cluster_list.go:74-79`) is caught by the wall-ms term that bytes-only missed. `entry.Pinned` is RAFullList-only (TRACED, `resolve_populate.go:108-113`) so it is explicitly NOT the cost signal. EVERY expensive cell (registered cluster-list, raFullList, AND the scan-many-return-few per-NS hole) keeps the 2s floor by measured cost. Closure (i) "short-floor widgetContent by class" was REJECTED on coherence (a refreshed envelope reads its apistage L1 intermediate via content-Get-HIT, `apistage.go:479`, so a floored intermediate → stale rows). Safety = measured-cost-exclusion (primary, §13.2 axis 0) + subscriber-gated + still-coalesced + per-cheap-key cap; 9.7 (§9.7) is the MANDATORY pre-ship gate. Emit seam (§1.1), broadcaster, SSE, auth, isolation ALL unchanged — B is a one-gate floor-timing delta (§12.2) + a 2-line cost stamp (§12.2a), touching ONLY the cheap path.
+  - **Decision logged:** B ships behind the 9.7 amplification falsifier passing against the tester's floor-ON baseline. If 9.7 shows a regression approaching the 0.30.185 class, B is held and A is the fallback (the broadcaster/SSE/auth/isolation work is identical and ships regardless).
+
+---
+
+## 11. Open items needing facts I cannot recover from snowplow source (cross-team / deployment)
+- **Portal session cookie name** (for `RefreshAuth` cookie extraction, §4.3) — frontend/portal-chart fact.
+- **Deployed origin topology** (portal SPA vs `/refreshes` same-origin? §4.4) — gateway/chart fact.
+- **Gateway idle/read timeout** in front of snowplow (heartbeat must beat it, §10) — deployment fact.
+- **Empirical connection ceiling** at 1000 users (cap sizing, §7/§10) — the concurrent tester's connection-scale measurement.
+- **Phase-0 stale-window magnitude** (the concurrent tester) — if the window is already vanishingly small under the in-process refresher, re-confirm the build is worth the connection-scale cost at the PM gate (per the brief's revise-at-PM-gate note).
+
+---
+
+## 12. OPTION B — subscriber-gated short-floor (RATIFIED by Diego 2026-06-18, against the A-default recommendation, eyes-open)
+
+> **Status:** B is now in scope, **additive to A**. Everything in §1–§11 (emit seam `resolve_populate.go:291`, broadcaster, SSE, `RefreshAuth`, isolation-by-re-derivation) is **UNCHANGED**. B touches **one gate only**: the per-key re-resolve rate-floor in `processNext`, and **only for keys that have an active `/refreshes` subscriber**. A's ~2s coherence holds for every unsubscribed key; B lowers the floor to the coalesce window (~250ms) for subscribed keys so the signalled-fresh latency drops sub-second.
+
+### 12.1 The mechanism is a SHORTER floor, NOT no-floor (the safety-critical distinction)
+A floor of **zero** would let a CRUD storm become a re-resolve storm (every dirty-mark re-resolves immediately). B uses a **second, much shorter floor for subscribed keys** = the coalesce window (default 250ms, `REFRESH_COALESCE_WINDOW_MS`, §2.3). Within-wave bursts still collapse — the delaying-queue's earliest-wins dedup (§12.4) plus a 250ms floor means a key dirty-marked 50× in a 250ms wave still re-resolves **once**, not 50×. We trade 2s→250ms (an 8× shorter floor), NOT 2s→0.
+
+### 12.2 Where the floor check lives, and the exact alteration (TRACED, file:line)
+The floor gate is `processNext` at **`internal/cache/refresher.go:729-753`**:
+```go
+c := ResolvedCache()
+entry, ok := c.Get(key)                   // :727 — the SINGLE Get (serves the floor's CreatedAt read)
+if floor := r.rateFloor(); floor > 0 && ok && entry != nil {
+    if elapsed := time.Since(entry.CreatedAt); elapsed < floor {
+        q.Forget(key)
+        q.AddAfter(key, floor-elapsed)   // :749 — defer to floor expiry
+        r.flooredTotal.Add(1)
+        return true
+    }
+}
+```
+`r.rateFloor()` (`refresher.go:358-359`) reads `RESOLVED_CACHE_REFRESHER_RATE_FLOOR_SECONDS` (default 2s) fresh per dequeue. **B changes the effective floor to be per-key, consulting subscription state AND cell-class:**
+```go
+// B-delta — replace the single rateFloor() read with a per-key effective floor.
+floor := r.effectiveFloor(key, entry)     // ← NEW (refresher.go ~:729; entry already loaded at :727)
+if floor > 0 && ok && entry != nil {
+    if elapsed := time.Since(entry.CreatedAt); elapsed < floor {
+        q.Forget(key)
+        q.AddAfter(key, floor-elapsed)     // unchanged — same defer + same dedup
+        r.flooredTotal.Add(1)
+        r.flooredSubscribedTotal.Add(boolToU64(floor < r.rateFloor()))  // ← NEW counter (short-floor took effect)
+        return true
+    }
+}
+```
+with the refined helper (in `refresher.go`, ~25 LOC) — **Diego 2026-06-18 + PM R-B1: the short floor is for CHEAP cells ONLY; every EXPENSIVE cell (registered cluster-list, RA-FullList, AND the per-NS-iterator-fallback apistage LIST) keeps the 2s floor even when subscribed, gated by a POSITIVE cost predicate (§12.2a), not by class**:
+```go
+// effectiveFloor returns the SHORT cheap-cell floor (the coalesce window)
+// when key has ≥1 active /refreshes subscriber AND the cell is CHEAP to
+// re-resolve (isCheapShortFloorEligible — PRIMARY: LastResolveMS < MAX_MS;
+// belt-and-braces: entryBytes < MAX_BYTES; optional: !Pinned — §12.2a/R-B1');
+// otherwise the standard #318-R1a 2s floor. Expensive cells keep
+// the long floor unconditionally — they are the continuously-churning
+// 100:1-collapse case the floor exists to protect (the 0.30.205 / full-
+// cluster-LIST class, INCLUDING the per-NS-iterator apistage hole that a
+// class label misses). Nil-safe: no hub / cache-off → standard floor
+// (A-identical).
+func (r *refresher) effectiveFloor(key string, entry *ResolvedEntry) time.Duration {
+    base := r.rateFloor()                   // :358 — the 2s default, unchanged
+    if base <= 0 { return base }            // floor disabled → leave disabled
+    if !HasRefreshSubscriber(key) {         // ← broadcaster O(1) lookup, §12.3
+        return base                         // unsubscribed → standard floor
+    }
+    if !r.isCheapShortFloorEligible(entry) { // ← §12.2a — POSITIVE cheap-cost gate (closure ii)
+        return base                          // subscribed BUT expensive/aggregate → KEEP 2s floor
+    }
+    short := subscribedFloor()               // REFRESH_SUBSCRIBED_FLOOR_MS (default = coalesce window)
+    if short < base { return short }         // NEVER raise a key's floor
+    return base
+}
+```
+**Nothing else in `processNext` changes** — same `q.Forget`/`q.AddAfter` defer, same delaying-queue, same `processOne` dispatch, same emit at `resolve_populate.go:291`. The ONLY behavioural delta is the floor *value*, and only for **subscribed CHEAP** cells (§12.2a defines "cheap" by a positive cost gate, NOT by class-exclusion — see the R-B1 closure verdict below).
+
+### 12.2a — R-B1 CLOSURE: the hole, the data-path verdict, and the corrected predicate (closure ii — positive cheap-cost gate). (TRACED)
+
+**The hole the PM found is REAL (TRACED).** The cluster-list collapse has deny-gates — gate 4 (GVR derivation, `cluster_list.go:215`), gate 5 (RBAC, `:223`/`:248`), gate 8 (cell-cold async, `:318`) — each `return nil, false, N`. On any deny, the caller falls back to the **per-NS iterator path** and the resulting apistage content cell is Put via `apistageContentServe` (`apistage.go:513-539`) WITHOUT `RegisterClusterListKey`. So a class-exclusion predicate (`IsClusterListKey || isRAFullListEntry`) classifies it as detail → short-floor-eligible — yet its per-refresh cost can be the 0.30.205 magnitude (code-pinned: `cluster_list.go:74-79` — "admin warm /call 11-22s, CPU 7.4/8"). Class-exclusion's "structurally impossible" claim held for only the 2 *registered* classes. **The PM is correct.**
+
+**DATA-PATH VERDICT (the decisive trace that picks the closure):** when the refresher re-resolves a `widgetContent`/`widgets` key, does it re-run FRESH from L3, or read the floored apistage L1 intermediate?
+- `resolveOnceProd` (`resolve_populate.go:369-383`) routes `widgetContent` → `resolveWidgetForRefresh` (`:517`), which calls `widgets.Resolve(...)` on the **freshly re-fetched CR** (`got.Unstructured`, re-`objects.Get` at `resolve_populate.go:344`).
+- BUT inside that resolve, an apistage-backed stage goes through `apistageContentServe`, which does `store.Get(contentKey)` (`apistage.go:479`) and **on HIT uses `entry.RawJSON`/`entry.Items` from the apistage L1 cell and SKIPS the fresh dispatch** — the fresh `dispatchViaInformer` is ONLY in the MISS `else` branch (`apistage.go:513-516`).
+
+**∴ a widgetContent refresh reads the apistage L1 intermediate via content-Get-HIT (`apistage.go:479-512`); it does NOT re-dispatch fresh from L3 when that cell is warm.** Therefore **closure (i) "short-floor widgetContent only" is NOT coherent** — it would re-resolve the envelope on the 250ms cadence but serve data only as fresh as the floored (≥2s, or per-NS-hole-2s) apistage intermediate. Closure (i) is REJECTED on coherence grounds.
+
+**R-B1' CORRECTION (PM close-out, verified at source — the predicate above was DEFECTIVE).** Two source facts kill the bytes+Pinned predicate:
+- **`entry.Pinned` is RAFullList-ONLY.** TRACED: the only `Pinned=true` sites are `resolve_populate.go:269` (`Pinned: prePinned`, and `prePinned` is non-false ONLY for `CacheEntryClassRAFullList`, `:108-113`) + `ra_full_list_store.go:66,87`; the `resolved.go:802,808` sites set it `false`. So **`!entry.Pinned` is always true for apistage cells** → it excludes nothing on the apistage path.
+- **`ResolvedEntry` has NO wall-ms/duration field** (struct = RawJSON, CreatedAt, Inputs, Items, ItemsAPIVersion, ItemsKind, Pinned — TRACED), and `entryBytes` (`resolved.go:902-920`) is a **RESULT-SIZE** proxy (`len(RawJSON)` + Items-tree estimate), NOT a cost proxy.
+- ∴ for apistage, the predicate collapses to **bytes-only** → the **scan-1000-NS-return-3-rows** cell (small result bytes, but the `cluster_list.go:74-79` 11-22s / CPU 7.4/8 *resolve*) PASSES → short-floored → the 0.30.205 leak. **The hole stayed open. PM is correct.**
+
+The fix is in my own design lineage: `resolved.go:235` already specifies cost as "resolve wall-ms **OR** envelope bytes over a threshold" — but the *field* carrying wall-ms was never stamped. **R-B1' stamps it and makes wall-ms the primary cost signal.**
+
+**STAMP SITE (file:line) — `internal/handlers/dispatchers/resolve_populate.go:209`.** Wrap the `resolveOnceFn` wall-clock boundary (the resolve runs on the refresher goroutine, which already pays this cost — zero added work):
+```go
+// resolve_populate.go ~:209 — B-delta R-B1' (≈2 lines + 1 struct field)
+t0 := time.Now()
+encoded, err := resolveOnceFn(rctx, inputs)
+resolveMS := time.Since(t0).Milliseconds()
+// … (existing err / encoded==nil / evicted / stage-error gates unchanged) …
+entry := &cache.ResolvedEntry{
+    RawJSON:       encoded,
+    Inputs:        &inputs,
+    Pinned:        prePinned,
+    LastResolveMS: resolveMS,   // ← NEW field on ResolvedEntry; the measured cost signal
+}
+```
+New field: `ResolvedEntry.LastResolveMS int64` (stamped here; on cold-dispatch Puts it can be stamped at the dispatcher resolve boundary too, or left 0 — a 0 value FAILS the `< MAX` cheap test only if we invert; see fail-safe below). The refresher re-stamps it every re-resolve, so it tracks the cell's current cost.
+
+**ADOPT closure (ii), R-B1'-corrected — wall-ms primary, bytes belt-and-braces:**
+```go
+// isCheapShortFloorEligible — §12.2a (R-B1' closure ii). Short floor applies
+// ONLY to entries CHEAP to RE-RESOLVE, by MEASURED resolve wall-ms (primary)
+// AND result bytes (belt-and-braces), regardless of class. Catches cheap
+// widgetContent + cheap apistage GET-by-name; EXCLUDES the expensive
+// per-NS-iterator/LIST apistage envelope AND raFullList — INCLUDING the
+// scan-many-return-few hole (small bytes, large wall-ms) the bytes-only
+// predicate missed.
+func (r *refresher) isCheapShortFloorEligible(entry *ResolvedEntry) bool {
+    if entry == nil || entry.Inputs == nil { return false }       // fail-safe → 2s floor
+    if entry.LastResolveMS <= 0 { return false }                  // un-stamped/cold → fail-safe 2s (until a refresher re-resolve stamps it)
+    if entry.LastResolveMS >= shortFloorMaxMS() { return false }  // ← PRIMARY: measured resolve cost (resolved.go:235 lineage)
+    if entryBytes(entry) >= shortFloorMaxBytes() { return false } // belt-and-braces: result size (resolved.go:902)
+    // entry.Pinned MAY stay as a RAFullList belt-and-braces term, but it is
+    // NOT the cost signal (it is RAFullList-only). Optional:
+    if entry.Pinned { return false }                              // RAFullList belt-and-braces only
+    return true                                                   // cheap → short-floor eligible
+}
+```
+- **`entry.LastResolveMS` (PRIMARY, NEW)** carries the cost load. The scan-1000-NS-return-3-rows cell → small bytes BUT large `LastResolveMS` (2000-22000ms) → caught → 2s floor. Threshold `REFRESH_SHORT_FLOOR_MAX_MS` (R-B2.c). This is the discriminant the hole evaded.
+- **`entryBytes` (belt-and-braces)** still excludes a large-result cheap-per-row cell. Threshold `REFRESH_SHORT_FLOOR_MAX_BYTES` (R-B2.a).
+- **`entry.Pinned` (optional belt-and-braces)** — RAFullList-only; kept as a defensive third term, explicitly NOT load-bearing for cost.
+- **Fail-safe direction:** an un-stamped entry (cold Put before any refresher re-resolve, or a legacy entry) has `LastResolveMS<=0` → NOT cheap → 2s floor. This is the SAFE direction (a cell is short-floored only AFTER a refresher re-resolve has measured it cheap), and it self-corrects: the first refresher re-resolve stamps the real cost, and from then the gate is authoritative. All reads are on the already-in-hand `entry` (loaded at `refresher.go:727`) — **zero extra Get.**
+
+**Why R-B1'-corrected closure (ii) is BOTH amplification-safe AND coherent:**
+- *Amplification-safe:* the expensive per-refresh cost is now measured directly (`LastResolveMS`), so EVERY expensive cell — registered cluster-list, raFullList, AND the scan-many-return-few per-NS-iterator apistage LIST (the hole) — stays 2s-floored by its measured resolve time, independent of result size or class. The 0.30.205/0.30.185 class is excluded by **measured cost**, the exact property that made it dangerous. **This is the honest, hole-closing claim.**
+- *Coherent:* a cheap widgetContent's apistage intermediate, IF also cheap (small wall-ms), is ITSELF short-floor-eligible → both layers refresh on the 250ms cadence → genuinely-fresh data. IF the intermediate is expensive (large wall-ms → 2s-floored), the cheap envelope re-resolves every 250ms but reads the 2s intermediate via content-Get-HIT (`apistage.go:479`) — it converges at the source's 2s cadence and **never serves data older than its source** (coherent; not sub-second for widgets backed by expensive aggregates — exactly correct). No detail widget ever serves stale-beyond-its-source.
+
+**Note vs the old class-exclusion:** `IsClusterListKey`/`isRAFullListEntry` are NO LONGER the predicate (they missed the per-NS hole). They remain useful only as a coarse cross-check in the 9.7 artifact's aggregate/detail bucketing (§9.7). The positive cost gate subsumes them: a registered cluster-list cell is also large-bytes/Pinned, so it is excluded by cost too — belt-and-braces.
+
+### 12.3 "Is this key subscribed?" — the broadcaster's per-key index (reuses A's structure)
+A's broadcaster (§2.1) already holds `subs map[uint64]*refreshSub`, each `refreshSub.keys map[string]struct{}`. For an O(1) subscriber-presence check (called on the hot dequeue path, must NOT scan all subs), B adds a **reverse index** to the broadcaster — a refcount per armed key:
+```go
+// refresh_broadcaster.go (A's file) — add to refreshBroadcaster:
+keyRefs map[string]int   // l1Key → # of subscribers armed for it; guarded by mu
+```
+maintained in `ArmKey`/`DisarmKey`/`SubscribeRefresh`/`unsub` (increment on arm, decrement on disarm, delete at zero). Then:
+```go
+// HasRefreshSubscriber reports whether ≥1 connection is armed for l1Key.
+// O(1) map read under RLock. Nil-safe (cache-off / no hub → false →
+// effectiveFloor falls back to the standard floor → A-identical).
+func HasRefreshSubscriber(l1Key string) bool {
+    if Disabled() { return false }
+    h := refreshHub(); if h == nil { return false }
+    h.mu.RLock(); n := h.keyRefs[l1Key]; h.mu.RUnlock()
+    return n > 0
+}
+```
+This lives in `internal/cache` (no import cycle; the refresher is already in `internal/cache`). **A's broadcaster gains one map + refcount bookkeeping (~15 LOC); the refresher gains `effectiveFloor` + `isCheapShortFloorEligible` (~30 LOC, reusing existing cost signals `entry.Pinned` + `entryBytes`).** That is the entire B production surface beyond A.
+
+### 12.4 The floor-bypass interacts CORRECTLY with the existing dedup + FAIL-OPEN (TRACED — load-bearing)
+Two existing invariants make the shorter floor safe by construction:
+- **Earliest-wins per-key dedup** (`client-go@v0.33.0/util/workqueue/delaying_queue.go:355-368`, `insert[T]`): a deferred `AddAfter` for a key already pending only updates `readyAt` to be sooner (`knownEntries[entry.data]` keyed by the l1Key) — **never a duplicate**. `waitingEntryByData` (:288) holds at most one entry per key. So N concurrent re-marks of ONE subscribed key in a wave collapse to ONE pending re-resolve regardless of floor length. The floor length controls only *how soon*, not *how many*.
+- **FAIL-OPEN on decline** (`refresher.go:743-747`): `CreatedAt` is stamped only by a successful `Put` (`resolved.go:771-772`). A cell that declines to cache (stage-error / never-cache-partials) keeps an old `CreatedAt` → never floored → re-resolves each dequeue. The shorter floor does not change this — declining cells behave identically under A and B.
+
+### 12.5 Cache-off / removability (unchanged from A)
+`HasRefreshSubscriber` returns false under `Disabled()` → `effectiveFloor` falls back to the standard floor → **byte-identical to A, and to pre-B when cache is off.** `REFRESH_SSE_ENABLED=false` (§7) makes the broadcaster a no-op → no subscribers → `keyRefs` empty → standard floor everywhere. B is fully toggle-gated and removable (`project_caching_is_provisional`).
+
+---
+
+## 13. Amplification-safety argument (load-bearing — the #318-R1a / 0.30.185 5.9× / 0.30.205 dangerous case is EXCLUDED BY COST via the positive cheap-cost gate, then a residual bound)
+
+### 13.1 The worst case, made explicit
+**1000 users, each with a `/refreshes` connection armed for K widgets, during a composition-install CRUD wave** (the canonical scale, `project_composition_install_rbac_scale`): the composition-dynamic-controller installs N compositions, each ADD/UPDATE dirty-marking the shared aggregate cells (piechart count, compositions-list, the dashboard Statistics/LineChart) + per-binding dependent detail cells. **The dangerous case is the EXPENSIVE-per-refresh cell:** a single piechart/compositions-list cell is dirty-marked by EVERY one of 50K install ADDs, and each re-resolve is a **full cluster-LIST** (the 0.30.205 class; the 0.30.185 populate-amplification revert was exactly *expensive re-resolve work × churn-rate = wall-clock blow-up*; code-pinned at `cluster_list.go:74-79` — admin warm /call 11-22s, CPU 7.4/8). **Crucially (the R-B1 hole), an expensive cell is NOT always class-labelled "aggregate":** a cluster-list collapse that fails a deny-gate (4/5/8, `cluster_list.go:215/223/318`) falls back to the per-NS iterator path and Puts a plain `apistage` LIST cell — expensive, but NOT `RegisterClusterListKey`'d (`apistage.go:513`) and NOT raFullList. So the safety boundary MUST be *cost*, not *class*. The floor's tester-confirmed value is a **100:1 re-resolve collapse**, concentrated on these continuously-churning EXPENSIVE keys; detail-widget backing objects churn far slower than the 250ms window, so the floor buys them ~nothing.
+
+### 13.2 Why a CRUD storm CANNOT become a re-resolve storm under B — the dangerous case is excluded BY COST, then a residual bound
+
+**Axis 0 — POSITIVE CHEAP-COST GATE by MEASURED RESOLVE WALL-MS (R-B1' closure ii; the primary safety, excludes the dangerous case by the property that MAKES it dangerous — its measured per-refresh cost).** The short floor is gated on `isCheapShortFloorEligible(entry)` (§12.2a, R-B1'-corrected): an entry is short-floor-eligible ONLY if its **measured `entry.LastResolveMS < shortFloorMaxMS()` (PRIMARY)** AND `entryBytes(entry) < shortFloorMaxBytes()` (belt-and-braces) AND `!entry.Pinned` (optional RAFullList belt-and-braces). So EVERY expensive cell keeps the 2s floor unconditionally by its **measured resolve time** — a registered cluster-list cell (large wall-ms + bytes + Pinned), a raFullList cell (Pinned + large wall-ms), AND — critically — **the scan-many-return-few per-NS-iterator apistage LIST cell the deny-gates produce: small RESULT bytes but large measured wall-ms (the `cluster_list.go:74-79` 11-22s resolve), caught by the wall-ms term that the prior bytes-only predicate MISSED.** The 0.30.205/0.30.185 amplification class is **structurally excluded by measured cost**, not by a class label nor by a result-size proxy that the scan-many-return-few hole evades. This is the honest, hole-closing claim: the measured per-refresh COST that made the dangerous case dangerous is precisely the gate's primary discriminant.
+
+Given axis 0, the residual short-floored population is **CHEAP-TO-RE-RESOLVE cells only** (small measured wall-ms AND small bytes, un-pinned: cheap widgetContent, cheap apistage GET-by-name, cheap detail widgets) — sub-`MAX_MS` re-resolves, backing objects that churn slower than the window. The residual is then bounded on three further axes:
+
+1. **Subscriber-gated (bounded population).** The short floor applies ONLY to `HasRefreshSubscriber(key)==true` (§12.2) — the set of cheap cells *mounted in a live browser tab*, bounded by `users × mounted-cheap-widgets-per-tab`, NOT the 50K install fan-out. Every unsubscribed cell keeps the 2s floor.
+2. **Still-coalesced per key.** The delaying-queue earliest-wins dedup (§12.4, delaying_queue.go:355-368) collapses any within-window burst of re-marks for one key to ONE re-resolve. A cheap cell dirty-marked 50× in a 250ms window re-resolves once, not 50×. Per-key re-resolve rate ≤ 1 / coalesce-window by an existing, proven mechanism.
+3. **Per-cheap-key bypass-rate cap (defense-in-depth, NEW; guards the cheap residual ONLY).** A subscribed cheap cell may take the SHORT floor at most `maxShortFloorPerMin` times/min (R-B2 derivation, §R-B2 — empirically derived, NOT guessed, `feedback_capacity_caps_empirical_per_entry_cost`); beyond that it reverts to the 2s floor for the rest of the window. Per-key token check inside `effectiveFloor` — no unbounded map (bounded by the subscribed-cheap-key set, itself bounded by axis 1). Same poison-pill philosophy as `maxRefreshRequeues` (refresher.go:137). With expensive cells excluded by axis 0, this cap now protects only against an unusually fast-churning *cheap* object — a far less likely and far cheaper pathology than the expensive case it previously had to backstop.
+
+**Composed worst-case re-resolve rate under B** = `(subscribed CHEAP cells) × min(1/coalesce-window, maxShortFloorPerMin/60s) × (cheap re-resolve cost)` — every factor bounded AND the expensive-per-resolve term is absent by axis 0. Compare the floor-ON denominator: `(all dirtied keys incl. expensive) × 1/2s`. B's incremental refresher work over floor-ON is **(subscribed-cheap-set × extra re-resolves from the 8× shorter window, capped by axis 3, at cheap cost)** — a small, bounded increment on the CHEAP path only. The expensive path is byte-identical to floor-ON. **This is the argument the PM close-out must confirm; 9.7 (§9.7) proves it empirically — including the per-NS-iterator apistage assertion (9.7a) so the hole cannot re-open silently.**
+
+### 13.3 What B does NOT change (so the amplification surface is precisely scoped)
+- **Expensive cells (registered cluster-list, raFullList, AND the per-NS-iterator-fallback apistage LIST): byte-identical to A/floor-ON** (axis 0 cost gate) — the expensive re-resolve cadence is unchanged for ALL of them.
+- No new populate/resolve work per cycle (0.30.185 class) — B only shifts *when* an already-scheduled re-resolve fires, for a bounded *cheap* subset.
+- No change to the customer-priority yield (`refresher.go:124,580`) — a subscribed-cheap short floor still yields to in-flight `/call` first (the yield is upstream of the floor gate at `refresher.go:694`). Customer `/call` retains absolute priority (`feedback_customer_priority_over_refresher`).
+- No change to the two-tier cluster_list priority queue (`refresher.go:207-219`) — cluster_list cells refresh on their own tier AND keep the 2s floor (axis 0 cost gate); B's short floor applies orthogonally and only to cheap cells.
+
+---
+
+## R-B2 — derivation of the three numbers (NO design-time guesses; `feedback_capacity_caps_empirical_per_entry_cost`)
+
+All three are DERIVED from the C-0 floor-ON baseline (the tester is capturing it; all land on the B-delta ledger row). No value is chosen at design time.
+
+### R-B2.c — `shortFloorMaxMS()` (`REFRESH_SHORT_FLOOR_MAX_MS`) — the PRIMARY cheap/expensive resolve-cost boundary (§12.2a, R-B1')
+The load-bearing threshold (closes the R-B1' hole). Derivation: from the C-0 baseline, record measured `LastResolveMS` (stamped at `resolve_populate.go:209`) for (1) the expensive re-resolves — registered cluster-list, raFullList, AND the **scan-many-return-few per-NS-iterator apistage LIST** at 50K scale (2000-22000ms per the `cluster_list.go:74-79` code pin) — and (2) the cheap re-resolves — a typical detail widgetContent / apistage GET-by-name (single-object re-dispatch, ~50-100ms). These populations are **orders of magnitude apart in wall-ms** (tens-of-ms vs seconds), so the threshold sits in the wide gap: `shortFloorMaxMS = cheap-population p99 ms × safety-margin`, with the margin chosen so the threshold is still ≤ `expensive-population p1 ms / 10`. **Arithmetic on the ledger row:** `cheap p99 = A ms; expensive p1 = B ms; threshold M s.t. A·margin ≤ M ≤ B/10`. This is the discriminant the scan-1000-NS-return-3-rows cell evaded under bytes-only (small bytes, but `LastResolveMS` lands in the expensive population) — the ms-gap is what catches it.
+
+### R-B2.a — `shortFloorMaxBytes()` (`REFRESH_SHORT_FLOOR_MAX_BYTES`) — the belt-and-braces result-size boundary (§12.2a)
+Derivation: from the C-0 baseline, record `entryBytes` (resolved.go:912) for (1) the expensive cells — registered cluster-list, raFullList, and the per-NS-iterator-fallback apistage LIST envelope at 50K scale (the compositions LIST is ~12.9 MB / ~30-174 MiB cluster-list per the code pins, helpers.go:405 + cluster_list.go:209-211) — and (2) the cheap cells — a typical detail widgetContent / apistage GET-by-name envelope (single-object, low-KB). These populations are **orders of magnitude apart** (KB vs MB), so the threshold sits in the wide empty gap between them: set `shortFloorMaxBytes = max(cheap-population p99 bytes) × safety-margin`, with the margin chosen so the threshold is still ≤ `min(expensive-population p1 bytes) / 10`. **Arithmetic shown on the ledger row:** `cheap p99 = X KB; expensive p1 = Y MB; threshold T s.t. X·margin ≤ T ≤ Y/10`. The 180×-estimation-error lesson (0.30.151) is why this is measured per-entry, not estimated; the KB-vs-MB gap makes the threshold robust (no knife-edge). Cross-check: every `Pinned` cell must also exceed T (belt-and-braces — Pinned already excludes the prewarmed-expensive set).
+
+### R-B2.b — `maxShortFloorPerMin` (`REFRESH_MAX_SHORT_FLOOR_PER_MIN`) — the per-cheap-key bypass-rate cap (§13.2 axis 3)
+Derivation arithmetic, from the floor-ON 100:1-collapse ceiling:
+- The 2s floor's ceiling is **1 re-resolve / 2s = 30 re-resolves/min/key** (the floor-ON per-key maximum; this is the "100:1 collapse" denominator the tester confirms).
+- A 250ms short floor's raw ceiling is **1 / 0.25s = 240 re-resolves/min/key** — 8× the floor-ON ceiling. The cap exists to claw an *outlier* cheap key back toward the floor-ON ceiling.
+- Set `maxShortFloorPerMin = ceil(30 × allowed-multiplier)`, where `allowed-multiplier` is the per-key amplification we will tolerate on the CHEAP path, chosen from the baseline so that the AGGREGATE permitted increment — `subscribed-cheap-set-size × maxShortFloorPerMin × measured-cheap-re-resolve-cost-ms` — stays within the 9.7(d) refresher-CPU band. **Arithmetic shown:** with measured cheap re-resolve cost `c` ms (C-0 baseline; the ~50-100ms detail figure is the placeholder until measured) and subscribed-cheap-set size `S` (from the connection-scale measurement, §10), pick the largest `maxShortFloorPerMin` s.t. `S × maxShortFloorPerMin × c / 60000 ≤ band-fraction × (refresher core budget)`. Default lands once `c` and `S` are measured; the PM close-out records the exact value + the inequality it satisfied.
+
+Both numbers' final values + the arithmetic that produced them attach to the B-delta ledger row (the falsifier-first artifact, `feedback_falsifier_first_before_ship`). If the C-0 baseline shows the cheap/expensive byte-gap is NOT orders apart (it should be — KB vs MB), R-B2.a's robustness assumption is re-examined at the close-out before B builds.
+
+---
+
+### Anchor corrections summary (for the brief's "correct me with file:line")
+1. **Emit point:** your `processOne` post-`fn` (refresher.go:836) is one layer too shallow — it over-fires on `resolveAndPopulateL1`'s 4 no-Put success-returns. **Correct seam: `internal/handlers/dispatchers/resolve_populate.go:291`, immediately after `c.Put(key, entry)`** (refresher-only path; post-commit; fires only when L1 actually changed). `SetRefreshHook` (deps.go:407, fired at deps.go:539) as the wrong/pre-resolve seam — CONFIRMED.
+2. **Auth:** `xcontext.UserInfo` is populated **header-Bearer-only** today (`userconfig.go:134-151,231`) — so the default `/call` middleware WOULD 401 an `EventSource`. **NOT a hard blocker** because `jwtutil.Validate` is stateless (`validate.go:16`) — the same JWT validates from a cookie. Needs a ~45-LOC `RefreshAuth` sibling + a CORS-origin decision (current `*`+credentials, `cors.go:256-271`, is browser-rejected cross-origin).
+3. **Isolation:** `RepresentativeUsername` is the WRONG basis (per-binding shared cell; `resolved.go:305-330`). **Correct: server re-derives the key under the CONNECTION's `UserInfo` via the existing `dispatchCacheLookupKey` path (helpers.go:200-242)** — forgery-proof, no provenance map. `widgetContent` (identity-free, `resolved.go:652`) is a documented non-leak.

--- a/docs/live-refresh-stalewindow-phase0-2026-06-18.md
+++ b/docs/live-refresh-stalewindow-phase0-2026-06-18.md
@@ -1,0 +1,86 @@
+# Live-refresh coherence — Phase-0 falsifier artifact + floor-ON amplification baseline
+
+**Date:** 2026-06-18
+**Plan:** `~/.claude/plans/snowplow-live-refresh-coherence-plan.md`
+**Proposal:** `~/.claude/plans/snowplow-live-refresh-coherence-proposal.md`
+**Design (ratified option B — floor-bypass bundled):** `docs/live-refresh-coherence-design-2026-06-18.md`
+**Permanent test (the falsifier, lands before code per `feedback_falsifier_first_before_ship`):**
+`internal/cache/refresher_live_refresh_coherence_test.go`
+
+This file persists the Phase-0 proof that was previously narrated-only (the PM gate flagged it missing on disk). It attaches to the ledger row for the live-refresh-coherence ship. Test-only; no product `.go` was changed. All numbers are in-process (real dispatcher→L1→deps→refresher path, no apiserver), reproduced under `-race` across iterations.
+
+---
+
+## A. Stale-window falsifier — the premise REPRODUCES, ~3 orders larger than the proposal assumed
+
+**Premise (proposal §2):** after a backing resource changes, `/call` serves a STALE widget result for a window — between the informer dirty-marking the dependent L1 key (`deps.go` `OnUpdate`→enqueue) and the refresher re-resolving + committing it (stale-while-revalidate). The proposal hedged "sub-ms–ms… usually fresh."
+
+**Finding:** the window is **not** ms-scale. It is dominated by two on-by-default delay gates the proposal/plan never mention:
+1. **#318-R1a per-key re-resolve rate-floor — default 2s** (`refresher.go:105 defaultRefresherRateFloorSeconds=2`; gate at `refresher.go:729-752`: a dirty-marked entry younger than the floor is `AddAfter(key, floor-elapsed)`-deferred, not re-resolved now). A live-refresh refetch hits a *young* entry (the first `/call` just populated it), so this fires on exactly the proposal's scenario.
+2. **Ship #98 customer-priority yield — cap 5s** (`refresher.go:580 yieldToCustomer`, `refresherYieldMaxParked=5s` at `:124`). Under sustained `/call` traffic the refresher parks before the handler.
+
+The code's own SLA docstring (`refresher.go:97-99`): **"yield 5s + resolve ≤3s + floor 2s = 10s."**
+
+| Scenario | Stale window (reconcile → first fresh served) | Commit latency | Notes |
+|---|---|---|---|
+| **Production default** (floor=2s, no `/call` load) | **~1.96s** (1.955–1.963s across runs) | ~1.955s | Pure rate-floor. ~160× the proposal's "ms". |
+| **Floor + sustained customer `/call`** (yield active) | **~5.01s** | ~5.006s | Hits the 5s yield cap; stacks on the floor. |
+| floor=0 baseline (proposal's *assumed* world) | **~11ms** | ~6ms | Isolates the floor's contribution. |
+| Pure refresher mechanism overhead (floor=0, 0 resolve cost) | **~11ms** | **40–400µs** | Dequeue→Put is genuinely sub-ms. |
+| **Refetch-landing** (floor=2s, 26 refetches spread 0–2500ms post-reconcile) | — | — | **20/26 = 77% landed stale.** |
+
+**Interpretation:**
+- The raw refresher *mechanism* is sub-ms (40–400µs dequeue→commit), so the proposal's "sub-ms" intuition is right *about the mechanism* — but the **production window is owned by the floor/yield gates**, not the resolve.
+- 77% of refetches in the first 2.5s read stale. The frontend fires its refetch *on the SSE event* (arriving ~at the front of the floor window), so real refetches are biased toward the worst part of the window — 77% is a lower bound. The frontend's ≤1-refetch/5s throttle means a stale-landing refetch isn't retried for up to 5s.
+- This **strengthens** the feature's justification (the gap is deterministic seconds, not a marginal lost-race tail) and confirms the emit point: a coherent `/refreshes` signal must fire at the **post-commit** point, never the pre-resolve `SetRefreshHook` (`deps.go:407`, wired `refresher.go:400`) — emitting at dirty-mark would announce ~2s *before* L1 is fresh.
+
+---
+
+## B. Floor-ON amplification baseline — the denominator option B's floor-bypass must NOT regress
+
+**Why this matters:** option B bundles a floor-bypass to close the stale window for *subscribed* keys. The floor exists (#318-R1a) to **collapse a CRUD-install churn wave into few re-resolves**. The bypass must shrink the stale-window WITHOUT turning the churn wave back into N re-resolves (the pre-#318 amplification the floor prevents). This baseline is what the architect's 9.7 comparison plugs into.
+
+**Method:** fire `marks=200` rapid `Deps().OnUpdate` dirty-marks on ONE subscribed key over a 400ms spread (whole wave inside the 2s floor), 4 workers (production default parallelism), aged seed entry so the first mark re-resolves immediately and the rest land young→floored. Re-resolves-run is sourced from the **real `completedTotal`** counter; floored cycles from **real `flooredTotal`** (`refresher.go:260` — under the install storm "completed_total collapses while flooredTotal rises"); alloc from `runtime.MemStats.TotalAlloc` delta over the wave. Handler models a compacted ~2ms per-user widget re-resolve and writes a monotonic version (last-write-wins convergence confirmed).
+
+| Config | marks | **re-resolves run** | collapse | floored cycles | enqueued | alloc (Δ TotalAlloc) | converge → v2 |
+|---|---|---|---|---|---|---|---|
+| **Floor ON (prod default 2s)** | 200 | **2** | **100:1** | 199 | 200 | ~350–490 KiB | **2.005s** |
+| Floor OFF contrast (floor=0) | 200 | **200** | ~1:1 | 0 | 200 | ~350–490 KiB | ~0.45s |
+
+**Interpretation:**
+- **The floor turns 200 re-resolves into 2** — a **~100× reduction in refresher re-resolve work** for a single-key churn wave, at the cost of a ~2s convergence window. That is the exact CPU/freshness tension option B navigates.
+- Re-resolves-run (**2**) is the load-bearing baseline figure — it is sourced from `completedTotal`, deterministic across `-race` iterations. `flooredCycles` (199) is ≥ the collapse delta (per the C1 accounting at `refresher.go:262-269`); do NOT equate it to the collapse delta.
+- Alloc Δ is logged, not asserted: `TotalAlloc` deltas vary run-to-run (346–486 KiB) under concurrent GC. Directionally the floor-ON and floor-OFF allocs are comparable per-wave because both run the same enqueue path; the floor's win is in **re-resolve count** (CPU + downstream resolve alloc avoided), captured here by `resolves_run`. The production-scale alloc/CPU magnitude is a **50K-bench deploy-gate concern** (see below), not measurable at unit scale.
+
+**The regression contract for option B:** for a *churn* (non-subscribed, or many-keys-changing) wave the floor-bypass must keep `resolves_run` at the collapsed level (≈ the floor-ON baseline), only shrinking the stale-window for a *subscribed* key whose freshness a client is actively waiting on. A naive always-bypass would land at the floor-OFF contrast (200 re-resolves) — the explicit anti-goal.
+
+### 50K-bench production-scale confirmation (separate deploy gate)
+
+This unit baseline proves the **collapse mechanism and ratio** in-process. It does **not** measure production-scale refresher CPU/alloc/cum-delay under a real composition-install storm (50K compositions × RBAC fan × per-user cells). That requires the Phase-6 50K bench under a CRUD-install churn wave with the candidate floor-bypass deployed, measuring refresher CPU/alloc and customer `/call` p50/p99 during the wave — the **deploy gate**, distinct from this pre-code falsifier. Flagged explicitly so the 9.7 comparison's unit-level numbers are not mistaken for the production sign-off.
+
+---
+
+## Reproduce
+
+```
+cd ~/krateo/snowplow-cache/snowplow
+unset KUBECONFIG   # never ./internal/rbac/... (destructive TestMain)
+go test ./internal/cache/ -run 'TestLiveRefreshCoherence' -count=1 -v
+# under race (concurrent refetch readers vs the refresher):
+go test ./internal/cache/ -run 'TestLiveRefreshCoherence' -count=2 -race -v
+```
+
+**Tests (all in `internal/cache/refresher_live_refresh_coherence_test.go`):**
+
+- `TestLiveRefreshCoherence_StaleWindow_ProductionDefault` — headline: ~2s floored window; RED if floor stops applying to a young dirty-marked entry.
+- `TestLiveRefreshCoherence_StaleWindow_FloorZeroBaseline` — isolates the floor (window collapses to ~ms).
+- `TestLiveRefreshCoherence_StaleWindow_FloorPlusCustomerYield` — documented worst case (~5s, yield cap stacks on floor).
+- `TestLiveRefreshCoherence_RefetchLandsInsideWindow` — 77% stale-landing fraction; concurrent readers, `-race`.
+- `TestLiveRefreshCoherence_RefresherMechanismOverhead` — mechanism is sub-ms (commit ≤50ms guard).
+- `TestLiveRefreshCoherence_FloorOnAmplificationBaseline` — **the 9.7 denominator**: 200 marks → 2 re-resolves (100:1).
+- `TestLiveRefreshCoherence_FloorOffAmplificationContrast` — RED contrast: floor=0 → 200 re-resolves, what the bypass must avoid for churn.
+
+**Real path exercised (no apiserver, no mechanism faked):**
+`ResolvedCache().Put` (first `/call` commit) → `Deps().Record` (real dep edge) → `Deps().OnUpdate` (the real informer-event entry point `watcher.go`'s `AddEventHandler` calls) → real refresh hook (`refresher.go:400`) → real refresher queue + `processNext` (rate-floor + yield gates active) → registered `RefreshFunc` re-resolve → `ResolvedCache().Get` (the same read `/call` serves from). Reuses the shipped harness helpers `withCleanRefresher` / `resetRefresherForTest` / `RegisterRefreshFunc` / `StartRefresher` / `putAged`-pattern (`agedBackoff`) from `refresher_rate_floor_test.go`.
+
+**Constraints honored:** test-only (no product `.go` change); `internal/cache/` only, KUBECONFIG unset (`feedback_no_go_test_against_remote_kubeconfig`); pure in-memory (`feedback_no_fake_production_scenarios` — the mechanism under test is real, only the resolve cost + backing-object content are modeled).

--- a/internal/cache/refresh_broadcaster.go
+++ b/internal/cache/refresh_broadcaster.go
@@ -1,0 +1,374 @@
+// refresh_broadcaster.go — Ship 1 (live-refresh-coherence, option A).
+//
+// A purpose-built per-key fan-out hub for the live-refresh signal. After
+// the refresher commits a fresh entry to L1 (resolve_populate.go:291) it
+// calls PublishRefresh(l1Key); the hub fans that l1Key out to every SSE
+// connection (internal/handlers/refreshes.go) that armed it, so the
+// frontend learns precisely when to refetch — and the refetch is a
+// guaranteed L1 HIT (no apiserver read). Design:
+// docs/live-refresh-coherence-design-2026-06-18.md §2.
+//
+// PRIOR ART (feedback_check_k8s_clientgo_prior_art): we BORROW the proven
+// per-watcher discipline of k8s.io/apimachinery/pkg/watch.Broadcaster
+// (mux.go: per-watcher buffered channel + DropIfChannelFull so one slow
+// consumer never blocks the producer), but NOT the type — watch.Broadcaster
+// fans EVERY event to EVERY watcher with no per-key/per-subject routing,
+// which would leak the cluster-wide churn set to all 1000 users. This hub
+// adds per-key subscription routing + a per-key subscriber reverse-index.
+//
+// CONCURRENCY (feedback_shared_vs_copy_is_a_concurrency_change): PublishRefresh
+// is called from the refresher worker goroutine(s), off the customer request
+// path; SubscribeRefresh / unsub / Arm / Disarm run on /refreshes connection
+// goroutines. All shared state is guarded by mu (subs + keyRefs) and the
+// coalesce map by cmu. The fan-out loop holds only an RLock and does NO I/O
+// inside it (a full sink takes the non-blocking default: arm). Exercised by
+// the -race falsifier 9.6.
+//
+// REMOVABILITY (project_cache_off_is_transparent_fallback, project_caching_
+// is_provisional): refreshHub() returns nil under RefreshSSEEnabled()==false
+// (which is false whenever CACHE_ENABLED=false). Every public entry point is
+// nil-safe and no-ops in that state. The whole layer is gated by one env
+// toggle (REFRESH_SSE_ENABLED) and is cleanly switch-off-able.
+
+package cache
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// envRefreshSSEEnabled is the Ship 1 per-feature toggle for the
+	// live-refresh SSE layer (broadcaster + /refreshes). Default ON when
+	// the cache subsystem is on, mirroring WidgetContentL1Enabled; explicit
+	// "false"/"0"/"no" disables it (broadcaster becomes a no-op, /refreshes
+	// an idle stream) without losing L1. Gated UNDER ResolvedCacheEnabled().
+	envRefreshSSEEnabled = "REFRESH_SSE_ENABLED"
+
+	// envRefreshCoalesceWindowMS bounds per-key fan-out under churn: a
+	// second emit for the same key within the window is coalesced away
+	// (the frontend refetches on the next signal, and a refetch is
+	// idempotent, so a coalesced duplicate is harmless). Design §2.3.
+	envRefreshCoalesceWindowMS = "REFRESH_COALESCE_WINDOW_MS"
+
+	// defaultRefreshCoalesceWindowMS — 250ms (design §2.3 / §7). The
+	// frontend ALSO throttles per widget (~5s); server coalescing is the
+	// cheaper first line.
+	defaultRefreshCoalesceWindowMS int64 = 250
+
+	// refreshSubChanCap is the per-connection buffered-channel depth. A
+	// full channel DROPS (coalesce-by-design); the value is the burst the
+	// hub absorbs before a slow consumer starts shedding duplicate signals.
+	// Borrowed sizing intent from watch.Broadcaster's per-watcher queue.
+	refreshSubChanCap = 64
+)
+
+// RefreshSSEEnabled reports whether the Ship 1 live-refresh SSE layer is
+// active. TWO gates, both must hold (same shape as WidgetContentL1Enabled):
+//
+//  1. ResolvedCacheEnabled() — CACHE_ENABLED=true AND RESOLVED_CACHE_ENABLED
+//     !=false (the refresher + L1 store the signal rides on).
+//  2. REFRESH_SSE_ENABLED!="false" — the per-feature toggle, default ON.
+//
+// When false the broadcaster is a no-op and /refreshes is an idle stream —
+// transparent fallback (project_cache_off_is_transparent_fallback).
+func RefreshSSEEnabled() bool {
+	if !ResolvedCacheEnabled() {
+		return false
+	}
+	switch os.Getenv(envRefreshSSEEnabled) {
+	case "false", "0", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// refreshCoalesceWindow returns the active per-key coalesce window. A value
+// <= 0 disables coalescing (every emit fans out). Read fresh per emit so a
+// deployer can re-tune at pod start (matches the rateFloor env-read idiom).
+func refreshCoalesceWindow() time.Duration {
+	return time.Duration(int64FromEnv(envRefreshCoalesceWindowMS, defaultRefreshCoalesceWindowMS)) * time.Millisecond
+}
+
+// refreshSub is one SSE connection's sink. ch is buffered; a full channel
+// DROPS (the refresher never blocks on a slow consumer). keys is the set of
+// l1Keys this connection is armed for; it is consulted under the hub mu.
+type refreshSub struct {
+	id   uint64
+	hub  *refreshBroadcaster
+	keys map[string]struct{}
+	ch   chan string
+}
+
+// refreshBroadcaster is the per-key fan-out hub. One process-singleton,
+// lazily built; nil when the layer is disabled (refreshHub()).
+type refreshBroadcaster struct {
+	mu   sync.RWMutex
+	subs map[uint64]*refreshSub
+	// keyRefs is the per-key subscriber reverse-index — l1Key -> number of
+	// connections armed for it. Maintained in lockstep with subs[*].keys
+	// under mu. Backs HasRefreshSubscriber's O(1) presence check (design
+	// §12.3); A populates and maintains it (it is a broadcaster feature, a
+	// no-op consumer until a later ship reads it on the floor path).
+	keyRefs map[string]int
+	next    uint64
+
+	// coalesce state: per-key last-emit timestamp, guarded by cmu (a
+	// separate lock so coalescing never contends with the fan-out RLock).
+	cmu      sync.Mutex
+	lastEmit map[string]time.Time
+}
+
+var (
+	refreshHubInstance *refreshBroadcaster
+	refreshHubMu       sync.Mutex // guards lazy construction + reset-for-test
+)
+
+// refreshHub returns the process-wide broadcaster, or nil when the
+// live-refresh layer is disabled (RefreshSSEEnabled()==false, which is also
+// false under cache-off). Nil-safe: every caller nil-checks and no-ops.
+//
+// Lazy construction is a plain mutex-guarded double-check (NOT sync.Once) so
+// resetRefreshBroadcasterForTest can rebuild the singleton between tests — the
+// same discipline resetRefresherForTest uses (refresher.go).
+func refreshHub() *refreshBroadcaster {
+	if !RefreshSSEEnabled() {
+		return nil
+	}
+	refreshHubMu.Lock()
+	defer refreshHubMu.Unlock()
+	if refreshHubInstance == nil {
+		refreshHubInstance = &refreshBroadcaster{
+			subs:     map[uint64]*refreshSub{},
+			keyRefs:  map[string]int{},
+			lastEmit: map[string]time.Time{},
+		}
+	}
+	return refreshHubInstance
+}
+
+// coalesced reports whether an emit for l1Key should be suppressed because
+// the previous emit for the SAME key was within the coalesce window. On a
+// non-suppressed emit it stamps lastEmit[l1Key]=now. A window <= 0 disables
+// coalescing entirely (always returns false). Design §2.3.
+func (h *refreshBroadcaster) coalesced(l1Key string, now time.Time) bool {
+	win := refreshCoalesceWindow()
+	if win <= 0 {
+		return false
+	}
+	h.cmu.Lock()
+	defer h.cmu.Unlock()
+	if last, ok := h.lastEmit[l1Key]; ok && now.Sub(last) < win {
+		return true
+	}
+	h.lastEmit[l1Key] = now
+	return false
+}
+
+// PublishRefresh announces that l1Key was just committed to L1. Non-blocking:
+// it fans the key out to every connection armed for it; a full sink is
+// dropped (refreshDroppedTotal bump) rather than blocking the refresher
+// goroutine. No-op when the layer is disabled or no hub exists.
+//
+// Called from internal/handlers/dispatchers/resolve_populate.go:291,
+// immediately after c.Put — strictly post-commit, on the refresher path
+// only, so it fires only when L1 actually changed (design §1.1).
+func PublishRefresh(l1Key string) {
+	h := refreshHub()
+	if h == nil {
+		return // disabled / cache-off — transparent no-op
+	}
+	now := time.Now()
+	if h.coalesced(l1Key, now) {
+		refreshCoalescedTotal.Add(1)
+		return
+	}
+	h.mu.RLock()
+	for _, s := range h.subs {
+		if _, armed := s.keys[l1Key]; !armed {
+			continue
+		}
+		select {
+		case s.ch <- l1Key:
+			refreshDeliveredTotal.Add(1)
+		default:
+			// Slow consumer: its buffer is full. Drop — the next committed
+			// refresh for this key re-signals and the frontend's refetch is
+			// idempotent. A dropped TERMINAL signal degrades to the frontend
+			// 5s throttle (falsifier 9.8), never indefinite stale.
+			refreshDroppedTotal.Add(1)
+		}
+	}
+	h.mu.RUnlock()
+	refreshPublishedTotal.Add(1)
+}
+
+// SubscribeRefresh registers a connection armed for the given validated
+// l1Key set (the caller — handlers.Refreshes — has already re-derived these
+// keys under the connection's authenticated identity; §5). Returns the sink
+// channel to read signals from and an idempotent unsubscribe func that the
+// handler MUST defer.
+//
+// When the layer is disabled it returns a closed channel + a no-op unsub, so
+// the handler degrades to a clean idle stream (transparent fallback).
+func SubscribeRefresh(armedKeys map[string]struct{}) (<-chan string, func()) {
+	h := refreshHub()
+	if h == nil {
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	keys := make(map[string]struct{}, len(armedKeys))
+	for k := range armedKeys {
+		keys[k] = struct{}{}
+	}
+	s := &refreshSub{
+		hub:  h,
+		keys: keys,
+		ch:   make(chan string, refreshSubChanCap),
+	}
+	h.mu.Lock()
+	h.next++
+	s.id = h.next
+	h.subs[s.id] = s
+	for k := range keys {
+		h.keyRefs[k]++
+	}
+	h.mu.Unlock()
+
+	var once sync.Once
+	unsub := func() {
+		once.Do(func() {
+			h.mu.Lock()
+			if _, ok := h.subs[s.id]; ok {
+				for k := range s.keys {
+					if h.keyRefs[k] <= 1 {
+						delete(h.keyRefs, k)
+					} else {
+						h.keyRefs[k]--
+					}
+				}
+				delete(h.subs, s.id)
+			}
+			h.mu.Unlock()
+			// Do NOT close s.ch — PublishRefresh may hold the RLock and be
+			// mid-send under a concurrent publish. The handler stops reading
+			// after unsub; the channel is GC'd with the sub. (watch.Broadcaster
+			// uses the same "producer never sends to a closed chan" discipline.)
+		})
+	}
+	return s.ch, unsub
+}
+
+// ArmKey adds l1Key to a live connection's armed set without reconnecting
+// (the frontend mounts widgets over one multiplexed stream). Idempotent.
+func (s *refreshSub) ArmKey(l1Key string) {
+	if s == nil || s.hub == nil {
+		return
+	}
+	s.hub.mu.Lock()
+	if _, ok := s.keys[l1Key]; !ok {
+		s.keys[l1Key] = struct{}{}
+		s.hub.keyRefs[l1Key]++
+	}
+	s.hub.mu.Unlock()
+}
+
+// DisarmKey removes l1Key from a live connection's armed set (the frontend
+// unmounted the widget). Idempotent.
+func (s *refreshSub) DisarmKey(l1Key string) {
+	if s == nil || s.hub == nil {
+		return
+	}
+	s.hub.mu.Lock()
+	if _, ok := s.keys[l1Key]; ok {
+		delete(s.keys, l1Key)
+		if s.hub.keyRefs[l1Key] <= 1 {
+			delete(s.hub.keyRefs, l1Key)
+		} else {
+			s.hub.keyRefs[l1Key]--
+		}
+	}
+	s.hub.mu.Unlock()
+}
+
+// HasRefreshSubscriber reports whether >=1 connection is armed for l1Key.
+// O(1) map read under RLock. Nil-safe: cache-off / disabled / no hub -> false.
+//
+// A's broadcaster maintains keyRefs so this is available; Ship 1 itself has
+// no in-tree consumer on the hot path (the floor-bypass that reads it is
+// Ship 2 / option B, deliberately out of scope here). It is exercised only
+// by the broadcaster's own tests in Ship 1.
+func HasRefreshSubscriber(l1Key string) bool {
+	h := refreshHub()
+	if h == nil {
+		return false
+	}
+	h.mu.RLock()
+	n := h.keyRefs[l1Key]
+	h.mu.RUnlock()
+	return n > 0
+}
+
+// RefreshSubscriberCount returns the current number of live /refreshes
+// connections. Read-only — used by /debug/vars + tests for connection-scale
+// observability (design §10).
+func RefreshSubscriberCount() int {
+	h := refreshHub()
+	if h == nil {
+		return 0
+	}
+	h.mu.RLock()
+	n := len(h.subs)
+	h.mu.RUnlock()
+	return n
+}
+
+// --- counters (atomic.Uint64; same idiom as cluster_list_metrics.go) --------
+
+var (
+	// refreshPublishedTotal counts PublishRefresh calls that fanned out
+	// (post-coalesce, hub present).
+	refreshPublishedTotal atomic.Uint64
+	// refreshDeliveredTotal counts individual (key -> subscriber) sends that
+	// succeeded.
+	refreshDeliveredTotal atomic.Uint64
+	// refreshDroppedTotal counts (key -> subscriber) sends dropped because
+	// the subscriber's buffer was full (slow consumer).
+	refreshDroppedTotal atomic.Uint64
+	// refreshCoalescedTotal counts emits suppressed by the per-key coalesce
+	// window.
+	refreshCoalescedTotal atomic.Uint64
+)
+
+// RefreshBroadcasterCounters returns (published, delivered, dropped,
+// coalesced) for post-deploy inspection + tests.
+func RefreshBroadcasterCounters() (published, delivered, dropped, coalesced uint64) {
+	return refreshPublishedTotal.Load(),
+		refreshDeliveredTotal.Load(),
+		refreshDroppedTotal.Load(),
+		refreshCoalescedTotal.Load()
+}
+
+// resetRefreshBroadcasterForTest tears the singleton down and zeroes the
+// counters. Test-only — production code MUST NOT call this. Mirrors
+// resetRefresherForTest's singleton-rebuild discipline.
+func resetRefreshBroadcasterForTest() {
+	refreshHubMu.Lock()
+	refreshHubInstance = nil
+	refreshHubMu.Unlock()
+	refreshPublishedTotal.Store(0)
+	refreshDeliveredTotal.Store(0)
+	refreshDroppedTotal.Store(0)
+	refreshCoalescedTotal.Store(0)
+}
+
+// ResetRefreshBroadcasterForTest is the exported wrapper for cross-package
+// tests (internal/handlers/dispatchers' emit-seam falsifiers). Production
+// code MUST NOT call it. Mirrors ResetRefresherForTest.
+func ResetRefreshBroadcasterForTest() {
+	resetRefreshBroadcasterForTest()
+}

--- a/internal/cache/refresh_broadcaster_expvar.go
+++ b/internal/cache/refresh_broadcaster_expvar.go
@@ -1,0 +1,47 @@
+// refresh_broadcaster_expvar.go — Ship 1 (live-refresh-coherence, option A).
+//
+// expvar exposure for the live-refresh broadcaster counters at
+// /debug/vars/snowplow_refresh_broadcaster. Mirrors the established cache
+// expvar pattern (crd_discovery_expvar.go, fallthrough_meter_expvar.go):
+// sync.Once-guarded expvar.Publish from init(), skipped under
+// CACHE_ENABLED=false (the cache subsystem does not exist there, so these
+// gauges MUST NOT register — project_cache_off_is_transparent_fallback).
+//
+// These counters back the falsifier artifacts: refreshDeliveredTotal proves
+// signals reach subscribers (9.2), refreshDroppedTotal proves the slow-
+// consumer drop arm fired without stalling the refresher (9.6), and
+// subscribers is the connection-scale gauge (design §10).
+
+package cache
+
+import (
+	"expvar"
+	"sync"
+)
+
+var refreshBroadcasterExpvarOnce sync.Once
+
+func init() {
+	if Disabled() {
+		return
+	}
+	registerRefreshBroadcasterExpvar()
+}
+
+// registerRefreshBroadcasterExpvar publishes the broadcaster counters. The
+// handler reads the atomics via RefreshBroadcasterCounters so every scrape
+// observes a coherent point-in-time snapshot.
+func registerRefreshBroadcasterExpvar() {
+	refreshBroadcasterExpvarOnce.Do(func() {
+		expvar.Publish("snowplow_refresh_broadcaster", expvar.Func(func() any {
+			published, delivered, dropped, coalesced := RefreshBroadcasterCounters()
+			return map[string]any{
+				"published":   published,
+				"delivered":   delivered,
+				"dropped":     dropped,
+				"coalesced":   coalesced,
+				"subscribers": RefreshSubscriberCount(),
+			}
+		}))
+	})
+}

--- a/internal/cache/refresh_broadcaster_test.go
+++ b/internal/cache/refresh_broadcaster_test.go
@@ -1,0 +1,413 @@
+// refresh_broadcaster_test.go — Ship 1 (live-refresh-coherence, option A)
+// cache-layer falsifiers. feedback_falsifier_first_before_ship: these are A's
+// gate. Pure in-memory (in-process broadcaster); KUBECONFIG unset; NEVER
+// touches ./internal/rbac.
+//
+// Covers:
+//   9.5a — PublishRefresh provably unreachable under cache-off (hub nil,
+//          counters stay 0; the §2.4 nil-path).
+//   9.6  — slow-consumer never stalls the producer (-race; blocked sink, drop
+//          counter climbs, OTHER subscribers still receive, publish returns
+//          promptly).
+//   9.8  — a dropped TERMINAL signal does not strand state: after the last
+//          signal is dropped (saturated sink), the cell is still fresh and a
+//          later read (modelling the frontend's 5s-throttle refetch) sees it
+//          — the SSE signal is an optimisation over the throttle, never a
+//          deadlock-on-drop replacement.
+//   plus broadcaster mechanics: coalesce-per-key, keyRefs/HasRefreshSubscriber
+//   refcount under arm/disarm/unsub, per-key routing (a sub only gets its own
+//   armed keys).
+
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// withRefreshLayer enables the SSE layer for a test and resets the singleton +
+// counters before and after. Mirrors withCleanRefresher's setenv discipline.
+func withRefreshLayer(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv(envRefreshSSEEnabled, "")        // default ON
+	t.Setenv(envRefreshCoalesceWindowMS, "0") // coalescing OFF by default so
+	// per-signal tests are deterministic; coalesce test sets it explicitly.
+	resetRefreshBroadcasterForTest()
+	t.Cleanup(resetRefreshBroadcasterForTest)
+}
+
+// drainOne reads one value from ch with a timeout; returns (val, true) or
+// ("", false) on timeout.
+func drainOne(t *testing.T, ch <-chan string, d time.Duration) (string, bool) {
+	t.Helper()
+	select {
+	case v, ok := <-ch:
+		return v, ok
+	case <-time.After(d):
+		return "", false
+	}
+}
+
+// --- 9.5a — cache-off: PublishRefresh provably unreachable -------------------
+
+// TestRefreshBroadcaster_CacheOff_PublishUnreachable asserts that with the
+// cache subsystem off, refreshHub() returns nil and PublishRefresh is a no-op:
+// the broadcaster counters NEVER move. This is the §2.4 / falsifier-9.5a
+// nil-path — the belt-and-braces guard complementing resolve_populate's
+// pre-Put early return.
+func TestRefreshBroadcaster_CacheOff_PublishUnreachable(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false") // master off
+	resetRefreshBroadcasterForTest()
+	t.Cleanup(resetRefreshBroadcasterForTest)
+
+	if RefreshSSEEnabled() {
+		t.Fatalf("RefreshSSEEnabled()=true under CACHE_ENABLED=false — gate broken")
+	}
+	if h := refreshHub(); h != nil {
+		t.Fatalf("refreshHub() != nil under cache-off — want nil (the §2.4 transparent no-op path)")
+	}
+
+	// Direct PublishRefresh under cache-off must be a no-op.
+	PublishRefresh("any-key")
+	PublishRefresh("any-key")
+	pub, del, drop, coal := RefreshBroadcasterCounters()
+	if pub|del|drop|coal != 0 {
+		t.Fatalf("counters moved under cache-off: published=%d delivered=%d dropped=%d coalesced=%d — PublishRefresh is NOT unreachable",
+			pub, del, drop, coal)
+	}
+
+	// Subscribe under cache-off returns a closed channel (idle stream) + a
+	// no-op unsub — the handler degrades to heartbeat-only.
+	ch, unsub := SubscribeRefresh(map[string]struct{}{"k": {}})
+	defer unsub()
+	if _, ok := <-ch; ok {
+		t.Fatalf("SubscribeRefresh under cache-off returned an OPEN channel — want a closed/idle channel")
+	}
+	if HasRefreshSubscriber("k") {
+		t.Fatalf("HasRefreshSubscriber true under cache-off — want false")
+	}
+}
+
+// TestRefreshBroadcaster_ToggleOff_PublishUnreachable asserts the per-feature
+// REFRESH_SSE_ENABLED=false back-out knob also makes the layer a no-op while
+// the cache itself stays on (provisional/removable, project_caching_is_provisional).
+func TestRefreshBroadcaster_ToggleOff_PublishUnreachable(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv(envRefreshSSEEnabled, "false") // feature off, cache on
+	resetRefreshBroadcasterForTest()
+	t.Cleanup(resetRefreshBroadcasterForTest)
+
+	if RefreshSSEEnabled() {
+		t.Fatalf("RefreshSSEEnabled()=true under REFRESH_SSE_ENABLED=false")
+	}
+	if refreshHub() != nil {
+		t.Fatalf("refreshHub() != nil under REFRESH_SSE_ENABLED=false")
+	}
+	PublishRefresh("k")
+	if pub, del, drop, coal := RefreshBroadcasterCounters(); pub|del|drop|coal != 0 {
+		t.Fatalf("counters moved with feature toggled off: %d/%d/%d/%d", pub, del, drop, coal)
+	}
+}
+
+// --- per-key routing + delivery ---------------------------------------------
+
+// TestRefreshBroadcaster_PerKeyRouting asserts a subscriber receives ONLY the
+// keys it armed, and that an unarmed key is not delivered to it.
+func TestRefreshBroadcaster_PerKeyRouting(t *testing.T) {
+	withRefreshLayer(t)
+
+	chA, unsubA := SubscribeRefresh(map[string]struct{}{"key-A": {}})
+	defer unsubA()
+	chB, unsubB := SubscribeRefresh(map[string]struct{}{"key-B": {}})
+	defer unsubB()
+
+	PublishRefresh("key-A")
+	if v, ok := drainOne(t, chA, time.Second); !ok || v != "key-A" {
+		t.Fatalf("A did not receive its armed key-A: got %q ok=%v", v, ok)
+	}
+	// B must NOT receive key-A (per-key routing).
+	if v, ok := drainOne(t, chB, 150*time.Millisecond); ok {
+		t.Fatalf("B received %q for key-A — per-key routing leaked", v)
+	}
+
+	PublishRefresh("key-B")
+	if v, ok := drainOne(t, chB, time.Second); !ok || v != "key-B" {
+		t.Fatalf("B did not receive its armed key-B: got %q ok=%v", v, ok)
+	}
+	// An entirely unsubscribed key delivers to nobody.
+	PublishRefresh("key-UNSUB")
+	if v, ok := drainOne(t, chA, 150*time.Millisecond); ok {
+		t.Fatalf("A received unsubscribed key: %q", v)
+	}
+}
+
+// --- keyRefs / HasRefreshSubscriber refcount --------------------------------
+
+// TestRefreshBroadcaster_KeyRefsRefcount asserts the per-key subscriber
+// reverse-index refcounts correctly across Subscribe / ArmKey / DisarmKey /
+// unsub, and that HasRefreshSubscriber reflects it (the §12.3 O(1) presence
+// check that A maintains for a later ship to consume).
+func TestRefreshBroadcaster_KeyRefsRefcount(t *testing.T) {
+	withRefreshLayer(t)
+
+	if HasRefreshSubscriber("shared") {
+		t.Fatalf("HasRefreshSubscriber(shared) true before any subscribe")
+	}
+
+	_, unsub1 := SubscribeRefresh(map[string]struct{}{"shared": {}})
+	if !HasRefreshSubscriber("shared") {
+		t.Fatalf("HasRefreshSubscriber(shared) false after 1 subscriber")
+	}
+	if n := RefreshSubscriberCount(); n != 1 {
+		t.Fatalf("subscriber count=%d want 1", n)
+	}
+
+	// Second subscriber arms the same key -> refcount 2.
+	_, unsub2 := SubscribeRefresh(map[string]struct{}{"shared": {}})
+	if n := RefreshSubscriberCount(); n != 2 {
+		t.Fatalf("subscriber count=%d want 2", n)
+	}
+
+	// Drop one — still armed by the other.
+	unsub1()
+	if !HasRefreshSubscriber("shared") {
+		t.Fatalf("HasRefreshSubscriber(shared) false after 1 of 2 unsub — refcount underflow")
+	}
+	// Drop the other — now nobody is armed.
+	unsub2()
+	if HasRefreshSubscriber("shared") {
+		t.Fatalf("HasRefreshSubscriber(shared) true after all unsub — keyRefs leak")
+	}
+	if n := RefreshSubscriberCount(); n != 0 {
+		t.Fatalf("subscriber count=%d want 0 after all unsub", n)
+	}
+
+	// Idempotent unsub must not underflow.
+	unsub1()
+	unsub2()
+	if HasRefreshSubscriber("shared") {
+		t.Fatalf("HasRefreshSubscriber(shared) true after idempotent re-unsub")
+	}
+}
+
+// TestRefreshBroadcaster_ArmDisarmLive asserts a live connection can add/remove
+// keys without reconnecting, and delivery follows the armed set.
+func TestRefreshBroadcaster_ArmDisarmLive(t *testing.T) {
+	withRefreshLayer(t)
+
+	// Subscribe with no keys, then arm one live.
+	ch, unsub := SubscribeRefresh(map[string]struct{}{})
+	defer unsub()
+
+	// Reach the live *refreshSub to call Arm/Disarm (the handler holds it;
+	// the test reaches it through the hub for the unit assertion).
+	h := refreshHub()
+	h.mu.RLock()
+	var s *refreshSub
+	for _, sub := range h.subs {
+		s = sub
+	}
+	h.mu.RUnlock()
+	if s == nil {
+		t.Fatalf("no live sub found")
+	}
+
+	s.ArmKey("late-key")
+	if !HasRefreshSubscriber("late-key") {
+		t.Fatalf("ArmKey did not register late-key in keyRefs")
+	}
+	PublishRefresh("late-key")
+	if v, ok := drainOne(t, ch, time.Second); !ok || v != "late-key" {
+		t.Fatalf("did not receive late-armed key: got %q ok=%v", v, ok)
+	}
+
+	s.DisarmKey("late-key")
+	if HasRefreshSubscriber("late-key") {
+		t.Fatalf("DisarmKey did not clear late-key from keyRefs")
+	}
+	PublishRefresh("late-key")
+	if v, ok := drainOne(t, ch, 150*time.Millisecond); ok {
+		t.Fatalf("received %q after DisarmKey", v)
+	}
+}
+
+// --- coalesce ----------------------------------------------------------------
+
+// TestRefreshBroadcaster_CoalescePerKey asserts that N publishes for the SAME
+// key within the coalesce window collapse to ONE fan-out (design §2.3), while
+// a publish for a DIFFERENT key in the same window is NOT coalesced.
+func TestRefreshBroadcaster_CoalescePerKey(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv(envRefreshSSEEnabled, "")
+	t.Setenv(envRefreshCoalesceWindowMS, "500") // 500ms window
+	resetRefreshBroadcasterForTest()
+	t.Cleanup(resetRefreshBroadcasterForTest)
+
+	ch, unsub := SubscribeRefresh(map[string]struct{}{"k1": {}, "k2": {}})
+	defer unsub()
+
+	// Burst of 5 publishes for k1 inside the window -> 1 delivered, 4 coalesced.
+	for i := 0; i < 5; i++ {
+		PublishRefresh("k1")
+	}
+	// k2 once -> delivered (different key, not coalesced against k1).
+	PublishRefresh("k2")
+
+	// Collect what arrives within a short drain.
+	got := map[string]int{}
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		v, ok := drainOne(t, ch, 50*time.Millisecond)
+		if !ok {
+			continue
+		}
+		got[v]++
+	}
+	if got["k1"] != 1 {
+		t.Fatalf("k1 delivered %d times in coalesce window — want exactly 1 (burst not collapsed)", got["k1"])
+	}
+	if got["k2"] != 1 {
+		t.Fatalf("k2 delivered %d times — want 1 (different key wrongly coalesced)", got["k2"])
+	}
+	_, _, _, coalesced := RefreshBroadcasterCounters()
+	if coalesced != 4 {
+		t.Fatalf("coalesced counter=%d want 4 (the 4 suppressed k1 re-emits)", coalesced)
+	}
+}
+
+// --- 9.6 — slow consumer never stalls the producer (-race) ------------------
+
+// TestRefreshBroadcaster_SlowConsumerNeverStalls is falsifier 9.6. Run under
+// -race. A subscriber whose sink is never drained must NOT block PublishRefresh:
+// once its buffer (cap refreshSubChanCap) fills, further sends DROP (counter
+// climbs) and the producer returns promptly. A second, healthy subscriber must
+// keep receiving throughout. Concurrent publishers + a concurrent (blocked)
+// reader exercise the RWMutex fan-out path for the race detector.
+func TestRefreshBroadcaster_SlowConsumerNeverStalls(t *testing.T) {
+	withRefreshLayer(t)
+
+	// Slow sink: subscribe, never read from chSlow.
+	chSlow, unsubSlow := SubscribeRefresh(map[string]struct{}{"hot": {}})
+	defer unsubSlow()
+	_ = chSlow // deliberately never drained
+
+	// Healthy sink on the same key.
+	chFast, unsubFast := SubscribeRefresh(map[string]struct{}{"hot": {}})
+	defer unsubFast()
+
+	var fastReceived atomic.Int64
+	fastDone := make(chan struct{})
+	go func() {
+		defer close(fastDone)
+		for {
+			select {
+			case _, ok := <-chFast:
+				if !ok {
+					return
+				}
+				fastReceived.Add(1)
+			case <-time.After(2 * time.Second):
+				return // no more signals
+			}
+		}
+	}()
+
+	// Fire far more than the slow sink's buffer can hold, from several
+	// goroutines (race coverage on the fan-out RLock).
+	const publishers = 4
+	const perPublisher = 200 // 800 >> refreshSubChanCap (64)
+	publishStart := time.Now()
+	var wg sync.WaitGroup
+	for p := 0; p < publishers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perPublisher; i++ {
+				PublishRefresh("hot")
+			}
+		}()
+	}
+	wg.Wait()
+	publishElapsed := time.Since(publishStart)
+
+	// The producer must never have blocked on the full slow sink. 800
+	// non-blocking publishes are sub-ms work; a generous ceiling that still
+	// catches a real stall (a blocked send would hang indefinitely).
+	if publishElapsed > 2*time.Second {
+		t.Fatalf("PublishRefresh took %s for %d publishes — a slow consumer STALLED the producer (the default: drop arm failed)",
+			publishElapsed, publishers*perPublisher)
+	}
+
+	// The slow sink must have caused drops (its buffer filled).
+	_, delivered, dropped, _ := RefreshBroadcasterCounters()
+	if dropped == 0 {
+		t.Fatalf("dropped counter=0 — the slow sink never overflowed; the drop arm was not exercised")
+	}
+
+	// The healthy sink must have received signals throughout (it was not
+	// starved by the slow one).
+	<-fastDone
+	if fastReceived.Load() == 0 {
+		t.Fatalf("healthy subscriber received 0 signals — the slow consumer starved it")
+	}
+	t.Logf("9.6 slow-consumer: %d publishes in %s, delivered=%d dropped=%d, healthy_received=%d (producer never stalled)",
+		publishers*perPublisher, publishElapsed.Round(time.Millisecond), delivered, dropped, fastReceived.Load())
+}
+
+// --- 9.8 — dropped TERMINAL signal degrades to the throttle, never stale ----
+
+// TestRefreshBroadcaster_DroppedTerminalSignalDegrades is falsifier 9.8 at the
+// cache layer. A saturated sink drops the FINAL signal for a key (no further
+// commit re-signals). The invariant: a dropped signal must NOT strand the
+// widget — because the dropped signal carried no payload, the L1 entry is
+// ALREADY fresh, so the frontend's blind 5s-throttle refetch (modelled here as
+// a plain Get after the drop) reads the fresh value. The SSE signal is an
+// optimisation over the throttle, never a deadlock-on-drop replacement.
+func TestRefreshBroadcaster_DroppedTerminalSignalDegrades(t *testing.T) {
+	withRefreshLayer(t)
+	t.Setenv("RESOLVED_CACHE_TTL_SECONDS", "3600")
+
+	c := ResolvedCache()
+	if c == nil {
+		t.Fatalf("ResolvedCache nil")
+	}
+	in := ResolvedKeyInputs{CacheEntryClass: "widgets", Namespace: "team-a", Name: "w"}
+	key := ComputeKey(in)
+
+	// A saturated subscriber on the key: never drained, buffer will fill.
+	chSlow, unsub := SubscribeRefresh(map[string]struct{}{key: {}})
+	defer unsub()
+	_ = chSlow
+
+	// Refresher commits the FRESH value to L1 (this is what makes the signal
+	// coherent: the data is in L1 before the signal fires).
+	const fresh = `{"phase":"v2-FRESH"}`
+	c.Put(key, &ResolvedEntry{RawJSON: []byte(fresh), Inputs: &in})
+
+	// Now flood signals so the slow sink's buffer fills and the TERMINAL
+	// signal for this key is dropped.
+	for i := 0; i < refreshSubChanCap+50; i++ {
+		PublishRefresh(key)
+	}
+	if _, _, dropped, _ := RefreshBroadcasterCounters(); dropped == 0 {
+		t.Fatalf("setup: no drop occurred; cannot test the dropped-terminal case")
+	}
+
+	// The frontend's 5s throttle eventually refetches REGARDLESS of the
+	// dropped signal — modelled as a Get. The entry must be FRESH (the drop
+	// did not strand it stale), proving degrade-to-throttle convergence.
+	entry, ok := c.Get(key)
+	if !ok || entry == nil {
+		t.Fatalf("entry absent after dropped terminal signal — widget stranded")
+	}
+	if string(entry.RawJSON) != fresh {
+		t.Fatalf("throttle refetch read stale body %q want %q — dropped signal stranded the widget stale (9.8 FAIL)",
+			entry.RawJSON, fresh)
+	}
+}

--- a/internal/cache/refresher_live_refresh_coherence_test.go
+++ b/internal/cache/refresher_live_refresh_coherence_test.go
@@ -1,0 +1,497 @@
+// refresher_live_refresh_coherence_test.go — Phase-0 falsifier + baseline for
+// the snowplow per-key live-refresh-coherence feature (plan:
+// ~/.claude/plans/snowplow-live-refresh-coherence-plan.md; design:
+// docs/live-refresh-coherence-design-2026-06-18.md; artifact:
+// docs/live-refresh-stalewindow-phase0-2026-06-18.md).
+//
+// Two concerns, both PRE-CODE gates (feedback_falsifier_first_before_ship):
+//
+//   A. STALE-WINDOW falsifier (the premise). After a backing resource
+//      changes, snowplow /call serves a STALE widget result for a window —
+//      between the informer dirty-marking the dependent L1 key (deps.go
+//      OnUpdate -> enqueue) and the refresher re-resolving + committing it
+//      (stale-while-revalidate). The proposal hedged "sub-ms–ms, usually
+//      fresh"; these tests prove the window is dominated by the #318-R1a
+//      rate-floor (default 2s; refresher.go:105) and the Ship #98 customer
+//      yield (cap 5s; refresher.go:124), NOT the ms-scale resolve. This is
+//      the deterministic 2.0s / up-to-~5s window option B's floor-bypass
+//      must close.
+//
+//   B. FLOOR-ON AMPLIFICATION baseline (the denominator option B must NOT
+//      regress). With the floor ON (today's behaviour), a CRUD-install churn
+//      wave of N rapid OnUpdates on the same subscribed key collapses into
+//      FEW re-resolves. We quantify the collapse (re-resolves run vs marks
+//      fired, sourced from the real completedTotal/flooredTotal counters) and
+//      the refresher cost (alloc bytes + wall) so the floor-bypass design can
+//      be measured against it.
+//
+// Drives the REAL path end-to-end: ResolvedCache().Put (models the first
+// /call commit) -> Deps().Record (real dep edge) -> Deps().OnUpdate (the real
+// informer-event entry point watcher.go calls) -> real refresh hook -> real
+// refresher queue + processNext (rate-floor + yield active) -> a registered
+// RefreshFunc that re-resolves -> ResolvedCache().Get (the same read /call
+// serves from). NO apiserver, NO mechanism faked.
+//
+// Pure in-memory (in-process ResolvedCache + fake handler) — satisfies
+// feedback_no_go_test_against_remote_kubeconfig; run in internal/cache/ with
+// KUBECONFIG unset, NEVER ./internal/rbac/...
+//
+// Real-clock windows per the suite idiom (no clock-injection seam in the
+// refresher/workqueue — see refresher_rate_floor_test.go header).
+
+package cache
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// coherenceProbeGVR is an arbitrary backing-object GVR for the dep edge —
+// shaped like a composition claim (the live-refresh feature's headline case:
+// a composition reconcile fans to its widget cards).
+func coherenceProbeGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "composition.krateo.io", Version: "v1alpha1", Resource: "democlaims"}
+}
+
+const (
+	coherenceV1 = `{"status":{"widgetData":{"phase":"v1-OLD"}}}`
+	coherenceV2 = `{"status":{"widgetData":{"phase":"v2-FRESH"}}}`
+)
+
+// servedSample is one observation of what the dispatcher read returns.
+type servedSample struct {
+	at    time.Time
+	fresh bool
+}
+
+// runStaleWindowProbe runs ONE stale-window scenario and returns the measured
+// stale window (reconcile -> first fresh served via the dispatcher read), the
+// commit latency (reconcile -> handler Put), and observed/sample counts.
+//
+//   - floorSeconds: RESOLVED_CACHE_REFRESHER_RATE_FLOOR_SECONDS ("" = prod
+//     default 2s; "0" = kill-switch baseline).
+//   - customerInflight: pin a sustained customer /call so the refresher
+//     yields (models a busy 1000-user deployment; adds the 5s yield cap).
+//   - resolveCost: models the in-process resolve+populate latency.
+func runStaleWindowProbe(t *testing.T, floorSeconds string, customerInflight bool, resolveCost time.Duration) (staleWindow time.Duration, observedFresh bool, refetchSamples int, commitLatency time.Duration) {
+	t.Helper()
+	cleanup := withCleanRefresher(t, 4, 0) // 4 workers = production default parallelism
+	defer cleanup()
+	t.Setenv(envRefresherRateFloorSeconds, floorSeconds)
+	resetRefresherForTest()
+
+	c := ResolvedCache()
+	Deps().SetStore(c)
+
+	gvr := coherenceProbeGVR()
+	const ns, objName = "team-a", "demo-1"
+	in := ResolvedKeyInputs{CacheEntryClass: "widgets", Namespace: ns, Name: "widget-detail"}
+	key := ComputeKey(in)
+
+	// (1) Commit the first /call result (v1). Put stamps CreatedAt=now — the
+	// realistic case: a live-refresh refetch hits an entry the first /call
+	// JUST populated, i.e. YOUNGER than the 2s floor.
+	c.Put(key, &ResolvedEntry{RawJSON: []byte(coherenceV1), Inputs: &in})
+	// (2) Real dep edge: widget L1 key depends on the backing object.
+	Deps().Record(key, gvr, ns, objName)
+
+	// Registered RefreshFunc re-resolves to v2 (models the resolver re-running
+	// against the now-reconciled cluster state).
+	var committedAt atomic.Int64
+	RegisterRefreshFunc("widgets", func(_ context.Context, k string, used ResolvedKeyInputs) error {
+		if resolveCost > 0 {
+			time.Sleep(resolveCost)
+		}
+		c.Put(k, &ResolvedEntry{RawJSON: []byte(coherenceV2), Inputs: &used})
+		committedAt.Store(time.Now().UnixNano())
+		return nil
+	})
+
+	if customerInflight {
+		SetCustomerInflightHook(func() bool { return true })
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartRefresher(ctx)
+
+	// Entry ages a beat (the refetch lands shortly after the first /call) but
+	// stays well inside the floor. 50ms << 2s.
+	time.Sleep(50 * time.Millisecond)
+
+	// (3)+(4) The reconcile happens and the REAL informer-event entry point
+	// fires the dirty-mark. reconcileAt is when true cluster state flipped to
+	// v2 — the stale window is measured from here.
+	reconcileAt := time.Now()
+	marked := Deps().OnUpdate(gvr, ns, objName)
+	if marked != 1 {
+		t.Fatalf("OnUpdate dirty-marked %d keys, want 1 (dep edge not wired)", marked)
+	}
+
+	// (5) Frontend-refetch loop: read L1 via the dispatcher read path at
+	// ~100Hz; record the first sample that sees fresh v2. Cap at 15s (above
+	// the documented 10s worst-case SLA).
+	var (
+		samples     []servedSample
+		firstFresh  time.Time
+		sawFresh    bool
+		observeStop = reconcileAt.Add(15 * time.Second)
+	)
+	for time.Now().Before(observeStop) {
+		e, ok := c.Get(key)
+		now := time.Now()
+		isFresh := ok && e != nil && string(e.RawJSON) == coherenceV2
+		samples = append(samples, servedSample{at: now, fresh: isFresh})
+		if isFresh && !sawFresh {
+			sawFresh = true
+			firstFresh = now
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Release the customer pin so the deferred refresh proceeds and cleanup's
+	// worker-drain does not hang on a 5s park.
+	if customerInflight {
+		SetCustomerInflightHook(func() bool { return false })
+	}
+
+	if sawFresh {
+		staleWindow = firstFresh.Sub(reconcileAt)
+	} else {
+		staleWindow = 15 * time.Second // floor of the unobserved window
+	}
+	if ca := committedAt.Load(); ca != 0 {
+		commitLatency = time.Unix(0, ca).Sub(reconcileAt)
+	}
+	return staleWindow, sawFresh, len(samples), commitLatency
+}
+
+// --- A. STALE-WINDOW falsifier ----------------------------------------------
+
+// TestLiveRefreshCoherence_StaleWindow_ProductionDefault is THE headline
+// falsifier: floor at the production default (2s, env unset), no customer
+// load, a sub-ms-modelled resolve. A fresh L1 entry (just served by the first
+// /call) is dirty-marked by a reconcile; the refetch reads stale v1 until the
+// FLOORED re-resolve commits v2. The window is ~2s (the rate-floor), NOT the
+// "sub-ms–ms" the proposal assumed.
+func TestLiveRefreshCoherence_StaleWindow_ProductionDefault(t *testing.T) {
+	win, observed, n, commit := runStaleWindowProbe(t, "", false, 5*time.Millisecond)
+	t.Logf("STALE-WINDOW[prod-default floor=2s, no customer load]: stale_window=%s observed_fresh=%v refetch_samples=%d commit_latency_from_reconcile=%s",
+		win.Round(time.Millisecond), observed, n, commit.Round(time.Millisecond))
+	if !observed {
+		t.Fatalf("never observed fresh within 15s — would indicate a hang, not a window")
+	}
+	// Guard the FINDING: the window must be floor-dominated (>= ~1.5s), well
+	// above the ms-scale resolve. RED if a future change makes the floor stop
+	// applying to a young dirty-marked entry (the premise would dissolve).
+	if win < 1500*time.Millisecond {
+		t.Fatalf("stale_window=%s < 1.5s — the 2s rate-floor no longer dominates the window; re-baseline the premise", win)
+	}
+}
+
+// TestLiveRefreshCoherence_StaleWindow_FloorZeroBaseline is the proposal's
+// ASSUMED world: floor=0 (kill-switch), no load, sub-ms resolve. Isolates the
+// floor's contribution — the window collapses to ~ms here.
+func TestLiveRefreshCoherence_StaleWindow_FloorZeroBaseline(t *testing.T) {
+	win, observed, n, commit := runStaleWindowProbe(t, "0", false, 5*time.Millisecond)
+	t.Logf("STALE-WINDOW[floor=0 baseline, no customer load]: stale_window=%s observed_fresh=%v refetch_samples=%d commit_latency_from_reconcile=%s",
+		win.Round(time.Millisecond), observed, n, commit.Round(time.Millisecond))
+	if !observed {
+		t.Fatalf("never observed fresh within 15s on floor=0 — unexpected")
+	}
+	// On floor=0 the window is mechanism+resolve only — assert it is small,
+	// confirming the floor (not the mechanism) owns the production window.
+	if win > 500*time.Millisecond {
+		t.Fatalf("floor=0 window=%s > 500ms — the mechanism itself is slow; re-investigate (premise attribution wrong)", win)
+	}
+}
+
+// TestLiveRefreshCoherence_StaleWindow_FloorPlusCustomerYield is the
+// documented WORST CASE: production floor (2s) + a sustained customer /call in
+// flight (refresher yields up to the 5s cap). The window pushes toward the
+// yield cap. Records; does not hard-fail on the cap (the refresher proceeds
+// after 5s regardless).
+func TestLiveRefreshCoherence_StaleWindow_FloorPlusCustomerYield(t *testing.T) {
+	win, observed, n, commit := runStaleWindowProbe(t, "2", true, 5*time.Millisecond)
+	t.Logf("STALE-WINDOW[floor=2s + sustained customer-inflight yield]: stale_window=%s observed_fresh=%v refetch_samples=%d commit_latency_from_reconcile=%s",
+		win.Round(time.Millisecond), observed, n, commit.Round(time.Millisecond))
+	if !observed {
+		t.Logf("NOTE: did not observe fresh within 15s under sustained yield — window >= 15s")
+		return
+	}
+	// Under sustained yield the window must exceed the floor-only case — the
+	// yield cap stacks on top. Assert it cleared the 5s yield cap region.
+	if win < 4500*time.Millisecond {
+		t.Fatalf("yield window=%s < 4.5s — the 5s customer-yield cap did not stack on the floor as documented", win)
+	}
+}
+
+// TestLiveRefreshCoherence_RefetchLandsInsideWindow quantifies HOW OFTEN a
+// realistic frontend refetch lands inside the stale window. The frontend
+// fires the refetch on the SSE event (arriving ~when the change is observed
+// cluster-side, i.e. ~reconcile time). We fire refetches at fixed offsets
+// 0..2500ms post-reconcile, each a concurrent dispatcher read, and report the
+// stale fraction. Run under -race (concurrent readers vs the refresher).
+func TestLiveRefreshCoherence_RefetchLandsInsideWindow(t *testing.T) {
+	cleanup := withCleanRefresher(t, 4, 0)
+	defer cleanup()
+	t.Setenv(envRefresherRateFloorSeconds, "") // production default 2s
+	resetRefresherForTest()
+
+	c := ResolvedCache()
+	Deps().SetStore(c)
+	gvr := coherenceProbeGVR()
+	const ns, objName = "team-a", "demo-1"
+	in := ResolvedKeyInputs{CacheEntryClass: "widgets", Namespace: ns, Name: "widget-detail"}
+	key := ComputeKey(in)
+
+	c.Put(key, &ResolvedEntry{RawJSON: []byte(coherenceV1), Inputs: &in})
+	Deps().Record(key, gvr, ns, objName)
+
+	RegisterRefreshFunc("widgets", func(_ context.Context, k string, used ResolvedKeyInputs) error {
+		time.Sleep(5 * time.Millisecond)
+		c.Put(k, &ResolvedEntry{RawJSON: []byte(coherenceV2), Inputs: &used})
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartRefresher(ctx)
+	time.Sleep(50 * time.Millisecond) // entry is young (just served)
+
+	reconcileAt := time.Now()
+	Deps().OnUpdate(gvr, ns, objName)
+
+	var offsets []time.Duration
+	for ms := 0; ms <= 2500; ms += 100 {
+		offsets = append(offsets, time.Duration(ms)*time.Millisecond)
+	}
+	var stale, fresh atomic.Int32
+	var wg sync.WaitGroup
+	for _, off := range offsets {
+		wg.Add(1)
+		go func(d time.Duration) {
+			defer wg.Done()
+			fire := reconcileAt.Add(d)
+			for time.Now().Before(fire) {
+				time.Sleep(2 * time.Millisecond)
+			}
+			e, ok := c.Get(key)
+			if ok && e != nil && string(e.RawJSON) == coherenceV2 {
+				fresh.Add(1)
+			} else {
+				stale.Add(1)
+			}
+		}(off)
+	}
+	wg.Wait()
+	total := stale.Load() + fresh.Load()
+	t.Logf("REFETCH-LANDING[floor=2s]: %d refetches across 0-2500ms post-reconcile -> STALE=%d FRESH=%d (%.0f%% landed in the stale window)",
+		total, stale.Load(), fresh.Load(), 100*float64(stale.Load())/float64(total))
+	// A majority of refetches in the first 2.5s must land stale — the premise.
+	if stale.Load() <= fresh.Load() {
+		t.Fatalf("stale=%d <= fresh=%d — refetches no longer predominantly land stale; the premise weakened", stale.Load(), fresh.Load())
+	}
+}
+
+// TestLiveRefreshCoherence_RefresherMechanismOverhead confirms the refresher
+// re-resolve is the sub-ms in-process work the proposal assumes (floor=0, zero
+// modelled resolve cost) — so the proposed /refreshes signal closes only the
+// residual queue+commit gap, and the production window is owned by the
+// floor/yield gates, not the resolve.
+func TestLiveRefreshCoherence_RefresherMechanismOverhead(t *testing.T) {
+	win, observed, n, commit := runStaleWindowProbe(t, "0", false, 0)
+	t.Logf("MECHANISM-OVERHEAD[floor=0, zero resolve cost]: stale_window=%s observed_fresh=%v refetch_samples=%d commit_latency_from_reconcile=%s",
+		win.Round(time.Microsecond), observed, n, commit.Round(time.Microsecond))
+	if !observed {
+		t.Fatalf("never observed fresh — unexpected")
+	}
+	if commit > 50*time.Millisecond {
+		t.Fatalf("mechanism commit latency=%s > 50ms — the dequeue->Put path is not sub-ms; re-investigate", commit)
+	}
+}
+
+// --- B. FLOOR-ON AMPLIFICATION baseline -------------------------------------
+
+// burstCollapseResult is the measured outcome of one floor-ON churn-wave.
+type burstCollapseResult struct {
+	floor          time.Duration
+	marksFired     int    // OnUpdate dirty-marks issued by the churn wave
+	resolvesRun    uint64 // completedTotal — actual re-resolves the refresher ran
+	flooredCycles  uint64 // flooredTotal — floored re-cycles (>= collapse delta, per C1)
+	enqueued       uint64 // enqueueTotal
+	allocBytes     uint64 // refresher-attributed heap alloc delta over the wave
+	wall           time.Duration
+	convergeToV2   time.Duration // reconcile-wave-start -> final v2 committed
+}
+
+// runFloorOnBurstCollapse fires a CRUD-install churn wave: `marks` rapid
+// OnUpdates on ONE subscribed key over `spread`, with the floor at
+// `floorSeconds`. It measures how many re-resolves actually run (the collapse)
+// and the refresher cost. The handler writes a monotonically-increasing
+// version so we can confirm last-write-wins convergence.
+func runFloorOnBurstCollapse(t *testing.T, floorSeconds string, marks int, spread time.Duration) burstCollapseResult {
+	t.Helper()
+	cleanup := withCleanRefresher(t, 4, 0)
+	defer cleanup()
+	t.Setenv(envRefresherRateFloorSeconds, floorSeconds)
+	resetRefresherForTest()
+
+	c := ResolvedCache()
+	Deps().SetStore(c)
+	gvr := coherenceProbeGVR()
+	const ns, objName = "team-a", "claim-1"
+	in := ResolvedKeyInputs{CacheEntryClass: "widgets", Namespace: ns, Name: "widget-card"}
+	key := ComputeKey(in)
+
+	// Seed an aged entry so the FIRST mark re-resolves immediately (sets the
+	// "1 immediate + collapsed-rest" shape deterministically — mirrors
+	// putAgedEntry's intent in refresher_rate_floor_test.go). agedBackoff
+	// (30s) is past every test floor yet under the cache TTL.
+	c.Put(key, &ResolvedEntry{RawJSON: []byte(coherenceV1), Inputs: &in, CreatedAt: time.Now().Add(-agedBackoff)})
+	Deps().Record(key, gvr, ns, objName)
+
+	var resolves atomic.Int32
+	var lastCommitAt atomic.Int64
+	RegisterRefreshFunc("widgets", func(_ context.Context, k string, used ResolvedKeyInputs) error {
+		// Models a real ~50-100ms per-user widget re-resolve compacted to a
+		// small but non-zero cost so the alloc/wall figures are meaningful
+		// without making the test slow.
+		time.Sleep(2 * time.Millisecond)
+		c.Put(k, &ResolvedEntry{RawJSON: []byte(coherenceV2), Inputs: &used})
+		resolves.Add(1)
+		lastCommitAt.Store(time.Now().UnixNano())
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartRefresher(ctx)
+
+	r := refresherSingleton()
+	complBefore := r.completedTotal.Load()
+	flBefore := r.flooredTotal.Load()
+	enqBefore := r.enqueueTotal.Load()
+
+	var ms0, ms1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&ms0)
+	waveStart := time.Now()
+
+	// The churn wave: `marks` OnUpdates on the same key, spread over `spread`.
+	// All but the first land while the entry is young -> floored (deferred),
+	// collapsing into ~1 deferred re-resolve at expiry regardless of `marks`.
+	gap := spread / time.Duration(marks)
+	for i := 0; i < marks; i++ {
+		Deps().OnUpdate(gvr, ns, objName)
+		if gap > 0 {
+			time.Sleep(gap)
+		}
+	}
+
+	// Let the wave fully converge: wait past the floor for the final deferred
+	// re-resolve to commit, then settle.
+	floor := r.rateFloor()
+	settleDeadline := time.Now().Add(floor + 3*time.Second)
+	for time.Now().Before(settleDeadline) {
+		// Converged when the last commit is older than the floor (no pending
+		// deferred re-resolve) AND queue drained.
+		if r.queue.Len() == 0 && r.clusterListQueue.Len() == 0 {
+			lc := lastCommitAt.Load()
+			if lc != 0 && time.Since(time.Unix(0, lc)) > floor+200*time.Millisecond {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	wall := time.Since(waveStart)
+	runtime.ReadMemStats(&ms1)
+
+	var converge time.Duration
+	if lc := lastCommitAt.Load(); lc != 0 {
+		converge = time.Unix(0, lc).Sub(waveStart)
+	}
+
+	// Confirm convergence correctness: the cell holds fresh v2.
+	if e, ok := c.Get(key); !ok || string(e.RawJSON) != coherenceV2 {
+		t.Fatalf("post-wave cell not converged to v2: ok=%v", ok)
+	}
+
+	return burstCollapseResult{
+		floor:         floor,
+		marksFired:    marks,
+		resolvesRun:   r.completedTotal.Load() - complBefore,
+		flooredCycles: r.flooredTotal.Load() - flBefore,
+		enqueued:      r.enqueueTotal.Load() - enqBefore,
+		allocBytes:    ms1.TotalAlloc - ms0.TotalAlloc,
+		wall:          wall,
+		convergeToV2:  converge,
+	}
+}
+
+// TestLiveRefreshCoherence_FloorOnAmplificationBaseline is the DENOMINATOR
+// option B's floor-bypass must NOT regress: with the floor ON (production
+// default 2s), a 200-mark churn wave on one subscribed key over ~400ms
+// collapses into a SMALL number of re-resolves (the floor's whole purpose —
+// #318-R1a docstring: "under the install storm completed_total collapses while
+// flooredTotal rises"). Captures re-resolves-run, floored-cycles, alloc, wall.
+//
+// This is the baseline the architect's 9.7 comparison plugs into. The
+// floor-bypass design must keep re-resolves-run at this collapsed level for a
+// CHURN wave (only the stale-window for a SUBSCRIBED key shrinks) — it must
+// NOT turn N marks back into N re-resolves (that would reintroduce the
+// pre-#318 amplification the floor exists to prevent).
+func TestLiveRefreshCoherence_FloorOnAmplificationBaseline(t *testing.T) {
+	const marks = 200
+	const spread = 400 * time.Millisecond // whole wave inside the 2s floor
+	res := runFloorOnBurstCollapse(t, "", marks, spread)
+
+	collapseRatio := float64(res.marksFired) / float64(res.resolvesRun)
+	t.Logf("FLOOR-ON-BASELINE[floor=%s]: %d marks over %s -> resolves_run=%d (collapse %.0f:1) floored_cycles=%d enqueued=%d alloc=%d KiB wall=%s converge_to_v2=%s",
+		res.floor, res.marksFired, spread, res.resolvesRun, collapseRatio, res.flooredCycles, res.enqueued,
+		res.allocBytes/1024, res.wall.Round(time.Millisecond), res.convergeToV2.Round(time.Millisecond))
+
+	// The floor MUST collapse the wave: re-resolves far below marks fired.
+	if res.resolvesRun >= uint64(marks)/2 {
+		t.Fatalf("resolves_run=%d for %d marks — the floor did not collapse the wave (expected a small handful)", res.resolvesRun, marks)
+	}
+	if res.flooredCycles == 0 {
+		t.Fatalf("floored_cycles=0 — the floor gate never fired under a 200-mark wave inside the 2s floor")
+	}
+	// Convergence is bounded by ~floor + resolve (last-write-wins at expiry).
+	if res.convergeToV2 > res.floor+2*time.Second {
+		t.Fatalf("converge_to_v2=%s exceeded floor+2s (%s) — wave did not converge within the documented bound", res.convergeToV2, res.floor+2*time.Second)
+	}
+}
+
+// TestLiveRefreshCoherence_FloorOffAmplificationContrast is the RED contrast:
+// floor=0 (the kill-switch) on the SAME wave. Each fully-distinct mark that
+// the worker drains before the next re-resolves, so the collapse is far weaker
+// and re-resolves climb toward marks. This is what the floor BUYS today, and
+// what a naive always-bypass would cost — the explicit amplification the
+// floor-bypass design must avoid for churn (non-subscribed) keys.
+func TestLiveRefreshCoherence_FloorOffAmplificationContrast(t *testing.T) {
+	const marks = 200
+	const spread = 400 * time.Millisecond
+	res := runFloorOnBurstCollapse(t, "0", marks, spread)
+	t.Logf("FLOOR-OFF-CONTRAST[floor=0]: %d marks over %s -> resolves_run=%d floored_cycles=%d enqueued=%d alloc=%d KiB wall=%s converge_to_v2=%s",
+		res.marksFired, spread, res.resolvesRun, res.flooredCycles, res.enqueued,
+		res.allocBytes/1024, res.wall.Round(time.Millisecond), res.convergeToV2.Round(time.Millisecond))
+	// floor=0 ⇒ the gate never defers.
+	if res.flooredCycles != 0 {
+		t.Fatalf("floor=0 floored_cycles=%d want 0 (kill-switch must short-circuit the gate)", res.flooredCycles)
+	}
+	// And it must run MORE re-resolves than the floor-ON baseline (the whole
+	// point of the contrast) — workqueue dedup still coalesces in-flight marks,
+	// so this is "materially more", not literally `marks`.
+	if res.resolvesRun < 2 {
+		t.Fatalf("floor=0 resolves_run=%d — expected materially more than the floor-ON collapsed handful", res.resolvesRun)
+	}
+}

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -396,6 +396,24 @@ func encodeResolvedJSON(res any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// refreshKeyHeader is the response header carrying the L1 subscription key
+// for the live-refresh signal (Ship 1). The frontend reads it to arm a
+// /refreshes subscription for this widget (design §6). Additive and invisible
+// to the JSON body contract; it MUST be in CORS ExposedHeaders (main.go) so a
+// cross-origin fetch/react-query layer can read it.
+const refreshKeyHeader = "X-Snowplow-Refresh-Key"
+
+// setRefreshKeyHeader stamps the live-refresh subscription key on the response,
+// before WriteHeader. No-op on an empty key (L1 disabled / RBAC-skipped /
+// cache-off) — the header is purely additive and must never appear empty.
+// MUST be called before writeResolvedJSON (which calls WriteHeader).
+func setRefreshKeyHeader(wri http.ResponseWriter, key string) {
+	if key == "" {
+		return
+	}
+	wri.Header().Set(refreshKeyHeader, key)
+}
+
 // writeResolvedJSON writes the canonical Content-Type + 200 + payload.
 // We deliberately do NOT log here on errors writing to the wire — a
 // client disconnect mid-write is normal and not actionable.
@@ -431,6 +449,7 @@ func writeResolvedJSON(wri http.ResponseWriter, payload []byte) {
 //     to the background re-resolve context (the 0.30.113 Part B fix
 //     surface, where the SA is transport-only and per-user identity comes
 //     from the cached Inputs).
+//
 // 0.30.166 extends the SAME attach to the per-request restactions.go +
 // widgets.go dispatcher entries — the previously-unpatched surface that
 // is the actual cache-off /call request path. See ship-307-tls-x509-cache-

--- a/internal/handlers/dispatchers/refresh_emit_seam_test.go
+++ b/internal/handlers/dispatchers/refresh_emit_seam_test.go
@@ -1,0 +1,237 @@
+// refresh_emit_seam_test.go — Ship 1 (live-refresh-coherence, option A)
+// emit-seam falsifiers. feedback_falsifier_first_before_ship: these are A's
+// gate for the emit point (resolve_populate.go:291). Hermetic: the
+// setResolveOnceForTest seam + in-process ResolvedCache + in-process
+// broadcaster — NO live cluster, NO apiserver (KUBECONFIG unset). NEVER
+// ./internal/rbac.
+//
+// Covers:
+//   9.2 / 9.3 — coherence + emit-once: a refresher cycle that Puts fires
+//          EXACTLY ONE PublishRefresh, and the signal arrives only AFTER the
+//          fresh bytes are committed to L1 (the cell holds FRESH at signal
+//          time — emit is strictly post-Put).
+//   9.3 — the §1.1 CORRECTION: a cycle that hits any of the FOUR no-Put
+//          success-returns (cache-off, declined encoded==nil, evicted-during-
+//          refresh, stage-error decline) fires ZERO PublishRefresh. This is
+//          the encoded test that the emit seam is at the Put, not in processOne
+//          (which would over-fire on all four).
+//   9.1 — the cache-respecting invariant: after the signal, the refetch reads
+//          the freshly-committed L1 entry as a HIT (fresh bytes present); no
+//          apiserver read is involved (there is none in the harness — a
+//          non-HIT would mean the refetch had to leave L1).
+
+package dispatchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+const (
+	emitStaleBytes = `{"phase":"v1-OLD"}`
+	emitFreshBytes = `{"phase":"v2-FRESH"}`
+)
+
+// withEmitSeamHarness enables cache + the SSE layer (coalescing OFF so each
+// emit is observable) and resets all singletons. Returns the inputs + key the
+// refresher will Put.
+func withEmitSeamHarness(t *testing.T) (cache.ResolvedKeyInputs, string) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0") // no coalescing — observe every emit
+	cache.ResetResolvedCacheForTest()
+	cache.ResetDepsForTest()
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(func() {
+		cache.ResetRefreshBroadcasterForTest()
+		cache.ResetDepsForTest()
+		cache.ResetResolvedCacheForTest()
+	})
+	inputs := cache.ResolvedKeyInputs{
+		CacheEntryClass:        "widgets",
+		Group:                  "widgets.templates.krateo.io",
+		Version:                "v1beta1",
+		Resource:               "buttons",
+		Namespace:              "demo",
+		Name:                   "save-btn",
+		BindingUID:             "uid-c01dface",
+		RepresentativeUsername: "cyberjoker",
+		RepresentativeGroups:   []string{"devs"},
+	}
+	return inputs, cache.ComputeKey(inputs)
+}
+
+// --- 9.2 / 9.3 — real Put fires exactly one coherent signal -----------------
+
+// TestEmitSeam_PutFiresExactlyOneCoherentSignal asserts that a refresher cycle
+// which commits a fresh entry fires EXACTLY ONE PublishRefresh, the signal
+// carries the committed key, and at signal-arrival time L1 already holds the
+// FRESH bytes (coherent-by-construction: emit is strictly post-Put). It then
+// asserts the refetch is an L1 HIT for the fresh bytes (9.1, cache-respecting).
+func TestEmitSeam_PutFiresExactlyOneCoherentSignal(t *testing.T) {
+	inputs, key := withEmitSeamHarness(t)
+
+	c := cache.ResolvedCache()
+	// Seed the prior (stale) entry — the realistic live-refresh case.
+	c.Put(key, &cache.ResolvedEntry{RawJSON: []byte(emitStaleBytes), Inputs: &inputs})
+
+	// Arm a /refreshes subscriber for this key BEFORE the re-resolve.
+	ch, unsub := cache.SubscribeRefresh(map[string]struct{}{key: {}})
+	defer unsub()
+
+	// The re-resolve commits the FRESH bytes.
+	restore := setResolveOnceForTest(func(_ context.Context, _ cache.ResolvedKeyInputs) ([]byte, error) {
+		return []byte(emitFreshBytes), nil
+	})
+	t.Cleanup(restore)
+
+	pubBefore, _, _, _ := cache.RefreshBroadcasterCounters()
+
+	if err := resolveAndPopulateL1(context.Background(), inputs, nil, nil); err != nil {
+		t.Fatalf("resolveAndPopulateL1 returned error: %v", err)
+	}
+
+	// The signal must arrive (post-Put).
+	select {
+	case got := <-ch:
+		if got != key {
+			t.Fatalf("signal carried key %q want %q", got, key)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no PublishRefresh signal after a real Put — the emit seam did not fire")
+	}
+
+	// COHERENCE (9.2): at signal time L1 holds the FRESH bytes (emit is
+	// strictly AFTER c.Put). The refetch reads them as a HIT (9.1) — no
+	// apiserver involved.
+	entry, ok := c.Get(key)
+	if !ok || entry == nil {
+		t.Fatalf("entry absent after refresh — incoherent")
+	}
+	if string(entry.RawJSON) != emitFreshBytes {
+		t.Fatalf("9.2 incoherent: signal fired but L1 holds %q want %q (emit fired before/without the fresh Put)",
+			entry.RawJSON, emitFreshBytes)
+	}
+
+	// EMIT-ONCE (9.3): exactly one PublishRefresh for the one Put.
+	pubAfter, _, _, _ := cache.RefreshBroadcasterCounters()
+	if pubAfter != pubBefore+1 {
+		t.Fatalf("published counter %d -> %d; want +1 (one Put must fire exactly one signal)", pubBefore, pubAfter)
+	}
+	// And no further signal queued (the Put fired once, not per-stage).
+	select {
+	case extra := <-ch:
+		t.Fatalf("a SECOND signal %q arrived for one Put — emit over-fires", extra)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// --- 9.3 — the four no-Put success-returns fire ZERO signals ----------------
+
+// runNoPutCase seeds a prior entry, arms a subscriber, runs resolveAndPopulateL1
+// with the given stub, and returns the PublishRefresh delta + whether a signal
+// was observed on the channel. Used by each no-Put case.
+func runNoPutCase(t *testing.T, stub func(ctx context.Context, in cache.ResolvedKeyInputs) ([]byte, error), preSeed bool) (delta uint64, signalled bool) {
+	t.Helper()
+	inputs, key := withEmitSeamHarness(t)
+	c := cache.ResolvedCache()
+	if preSeed && c != nil {
+		c.Put(key, &cache.ResolvedEntry{RawJSON: []byte(emitStaleBytes), Inputs: &inputs})
+	}
+	ch, unsub := cache.SubscribeRefresh(map[string]struct{}{key: {}})
+	defer unsub()
+
+	restore := setResolveOnceForTest(stub)
+	t.Cleanup(restore)
+
+	pubBefore, _, _, _ := cache.RefreshBroadcasterCounters()
+	if err := resolveAndPopulateL1(context.Background(), inputs, nil, nil); err != nil {
+		// declined / evicted / stage-error cases all return nil; a non-nil
+		// error here is a different failure.
+		t.Fatalf("resolveAndPopulateL1 returned error: %v", err)
+	}
+	pubAfter, _, _, _ := cache.RefreshBroadcasterCounters()
+
+	select {
+	case <-ch:
+		signalled = true
+	case <-time.After(150 * time.Millisecond):
+	}
+	return pubAfter - pubBefore, signalled
+}
+
+// TestEmitSeam_DeclinedEncodedNil_NoSignal — resolve_populate.go:214-218: the
+// handler declined (encoded==nil). No Put -> no signal.
+func TestEmitSeam_DeclinedEncodedNil_NoSignal(t *testing.T) {
+	delta, signalled := runNoPutCase(t, func(_ context.Context, _ cache.ResolvedKeyInputs) ([]byte, error) {
+		return nil, nil // declined
+	}, true)
+	if delta != 0 || signalled {
+		t.Fatalf("declined (encoded==nil) fired %d signals (observed=%v) — want 0; emit must not fire on the no-Put decline return",
+			delta, signalled)
+	}
+}
+
+// TestEmitSeam_StageErrorDecline_NoSignal — resolve_populate.go:243-260: the
+// re-resolve observed a stage error; the Put is declined to keep the prior good
+// entry. No Put -> no signal.
+func TestEmitSeam_StageErrorDecline_NoSignal(t *testing.T) {
+	delta, signalled := runNoPutCase(t, func(ctx context.Context, _ cache.ResolvedKeyInputs) ([]byte, error) {
+		if sink := cache.StageErrorSinkFromContext(ctx); sink != nil {
+			sink.Bump("test-stage", "emulated stage error")
+		}
+		return []byte(`{"list":[]}`), nil // under-served result, declined by the gate
+	}, true)
+	if delta != 0 || signalled {
+		t.Fatalf("stage-error decline fired %d signals (observed=%v) — want 0; emit must not fire when the Put is declined",
+			delta, signalled)
+	}
+}
+
+// TestEmitSeam_EvictedDuringRefresh_NoSignal — resolve_populate.go:223-229: the
+// entry was DELETE-evicted during the re-resolve; the fresh bytes are dropped
+// (not resurrected). No Put -> no signal. We model the eviction by NOT
+// pre-seeding the entry: the re-Get at :223 finds it absent.
+func TestEmitSeam_EvictedDuringRefresh_NoSignal(t *testing.T) {
+	delta, signalled := runNoPutCase(t, func(_ context.Context, _ cache.ResolvedKeyInputs) ([]byte, error) {
+		return []byte(emitFreshBytes), nil // resolve succeeds...
+	}, false) // ...but the entry is gone (never seeded) -> :223 alive==false -> no Put
+	if delta != 0 || signalled {
+		t.Fatalf("evicted-during-refresh fired %d signals (observed=%v) — want 0; a non-resurrecting refresh must not signal",
+			delta, signalled)
+	}
+}
+
+// TestEmitSeam_CacheOff_NoSignal — resolve_populate.go:96-99: cache off, the
+// function returns before the Put. No Put -> no signal. (Belt-and-braces to the
+// broadcaster's own cache-off unreachability test 9.5a.)
+func TestEmitSeam_CacheOff_NoSignal(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+	cache.ResetResolvedCacheForTest()
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(func() {
+		cache.ResetRefreshBroadcasterForTest()
+		cache.ResetResolvedCacheForTest()
+	})
+	inputs := cache.ResolvedKeyInputs{CacheEntryClass: "widgets", Namespace: "demo", Name: "save-btn"}
+
+	restore := setResolveOnceForTest(func(_ context.Context, _ cache.ResolvedKeyInputs) ([]byte, error) {
+		return []byte(emitFreshBytes), nil
+	})
+	t.Cleanup(restore)
+
+	pubBefore, _, _, _ := cache.RefreshBroadcasterCounters()
+	if err := resolveAndPopulateL1(context.Background(), inputs, nil, nil); err != nil {
+		t.Fatalf("resolveAndPopulateL1 returned error under cache-off: %v", err)
+	}
+	pubAfter, _, _, _ := cache.RefreshBroadcasterCounters()
+	if pubAfter != pubBefore {
+		t.Fatalf("cache-off fired %d signals — want 0; the emit line is unreachable when cache is off (resolve_populate.go:96-99 returns first)",
+			pubAfter-pubBefore)
+	}
+}

--- a/internal/handlers/dispatchers/refresh_isolation_falsifier_test.go
+++ b/internal/handlers/dispatchers/refresh_isolation_falsifier_test.go
@@ -1,0 +1,275 @@
+// refresh_isolation_falsifier_test.go — Ship 1 (live-refresh-coherence,
+// option A) cross-user isolation falsifier (9.4a + the 9.4b mechanism
+// invariant). feedback_l1_per_user_keyed_never_cohort + feedback_no_special_cases.
+//
+// Hermetic: an in-process RBAC ResourceWatcher (fake dynamic client; NO
+// apiserver, KUBECONFIG unset). NEVER ./internal/rbac (destructive TestMain).
+//
+//   9.4a — IDENTITY-BOUND classes: the server re-derives the L1 key UNDER the
+//          CONNECTION'S authenticated identity (dispatchers.DeriveSubscriptionKey,
+//          the exact seam /refreshes' validateSubscription calls). Two users
+//          granted compositions by DIFFERENT bindings get DIFFERENT BindingUIDs
+//          -> DIFFERENT keys for the SAME coordinates. A connection as A that
+//          sends B's coordinates derives A's key, NOT B's -> when B's cell
+//          refreshes (publishes B's key), A (armed for A's key only) gets
+//          nothing. Forgery-proof by construction: BindingUID comes from the
+//          connection's JWT identity, never from the wire.
+//
+//   9.4b mechanism — IDENTITY-FREE widgetContent: the shared shell key is the
+//          SAME for A and B (nobody owns it). So a widgetContent SIGNAL is
+//          content-free and CANNOT carry subject-specific information; the
+//          per-user ROW gating happens at /call serve time (gateWidgetEnvelope,
+//          covered by widget_content_rbac_sensitive_falsifier_test.go). This
+//          test proves the SSE key layer is content-free; the per-row CONTENT
+//          assertion through a live widget-serve is the cluster falsifier
+//          (design §9.4b: runtime falsifiers run against the GKE context).
+//
+//   fail-closed — a connection with NO identity derives the empty-identity key,
+//          distinct from any granted user's key (the dispatchCacheLookupKey
+//          FAIL-CLOSED posture).
+
+package dispatchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// buildTwoUserRBACWatcher seeds a fake RBAC snapshot granting compositions to
+// userA via CRB uid-A and to userB via CRB uid-B (distinct bindings ->
+// distinct BindingUIDs). Published as cache.Global() for the test duration.
+func buildTwoUserRBACWatcher(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+	}
+	compRule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"composition.krateo.io"}, Resources: []string{"compositions"}}}
+	mkCR := func(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
+		return &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}, Rules: rules}
+	}
+	mkCRB := func(name, uid, role string, sub rbacv1.Subject) *rbacv1.ClusterRoleBinding {
+		return &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(uid)},
+			Subjects:   []rbacv1.Subject{sub},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: role},
+		}
+	}
+	seed := []runtime.Object{
+		mkCR("comp-reader", compRule),
+		// Two distinct bindings to the SAME role for two distinct users ->
+		// the per-binding cell identity (BindingUID) differs per user.
+		mkCRB("a-bind", "uid-A", "comp-reader", rbacv1.Subject{Kind: "User", Name: "userA"}),
+		mkCRB("b-bind", "uid-B", "comp-reader", rbacv1.Subject{Kind: "User", Name: "userB"}),
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+// ctxAs builds a request-shaped ctx carrying ONLY UserInfo (exactly what
+// middleware.RefreshAuth places on the /refreshes connection ctx).
+func ctxAs(username string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username}),
+	)
+}
+
+// compositionsCoords is the identity-bound coordinate set for a compositions
+// widget (the headline live-refresh case: a composition reconcile fans to its
+// cards).
+func compositionsCoords() SubscriptionCoordinates {
+	return SubscriptionCoordinates{
+		Class:     classWidgets,
+		Group:     "composition.krateo.io",
+		Version:   "v1alpha1",
+		Resource:  "compositions",
+		Namespace: "team-a",
+		Name:      "demo-1",
+	}
+}
+
+// TestRefreshIsolation_IdentityBound_DistinctKeysPerSubject is falsifier 9.4a.
+// The SAME coordinates derive DIFFERENT keys under A's vs B's identity, and the
+// forgery attempt (A sending B's coordinates) derives A's key, not B's.
+func TestRefreshIsolation_IdentityBound_DistinctKeysPerSubject(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+
+	coords := compositionsCoords()
+
+	keyA, okA := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	keyB, okB := DeriveSubscriptionKey(ctxAs("userB"), coords)
+	if !okA || !okB {
+		t.Fatalf("derivation failed: okA=%v okB=%v (RBAC snapshot not granting compositions?)", okA, okB)
+	}
+	if keyA == "" || keyB == "" {
+		t.Fatalf("empty key(s): keyA=%q keyB=%q — BindingUID not derived (RBAC snapshot wrong)", keyA, keyB)
+	}
+	// THE ISOLATION INVARIANT: distinct subjects -> distinct per-binding keys
+	// for the SAME identity-bound coordinates.
+	if keyA == keyB {
+		t.Fatalf("9.4a FAIL: userA and userB derived the SAME key %q for the same coordinates — "+
+			"the per-binding cell identity did not separate them (cross-user signal leak)", keyA)
+	}
+
+	// FORGERY: A's connection sends B's coordinates. Since B's coordinates are
+	// identical to A's here (same composition), the point is sharper: the key
+	// is a function of the CONNECTION identity, never the wire. A connection
+	// authenticated as A ALWAYS derives keyA regardless of what coordinates it
+	// claims — it can never derive keyB. Re-derive under A and assert it equals
+	// keyA (A's own key), NOT keyB.
+	forged, _ := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	if forged == keyB {
+		t.Fatalf("9.4a FORGERY FAIL: connection-as-A derived B's key %q — a client forged another subject's subscription", keyB)
+	}
+	if forged != keyA {
+		t.Fatalf("9.4a: connection-as-A derived %q, expected its own key %q", forged, keyA)
+	}
+	t.Logf("9.4a OK: keyA=%s keyB=%s (distinct per-binding keys; connection-as-A can only ever derive keyA)", keyA[:12], keyB[:12])
+}
+
+// TestRefreshIsolation_ForgeryRejectedViaBroadcaster wires the derivation into
+// the broadcaster: A arms ONLY the key it legitimately derives; when B's cell
+// publishes (B's key), A receives NOTHING. This is the end-to-end forgery-proof
+// assertion at the signal layer.
+func TestRefreshIsolation_ForgeryRejectedViaBroadcaster(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0")
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	coords := compositionsCoords()
+	keyA, okA := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	keyB, okB := DeriveSubscriptionKey(ctxAs("userB"), coords)
+	if !okA || !okB || keyA == keyB {
+		t.Fatalf("setup: keys not distinct (keyA=%q keyB=%q okA=%v okB=%v)", keyA, keyB, okA, okB)
+	}
+
+	// A's connection arms ONLY the key A's identity produced (what
+	// validateSubscription does). It does NOT and cannot arm keyB.
+	chA, unsubA := cache.SubscribeRefresh(map[string]struct{}{keyA: {}})
+	defer unsubA()
+
+	// B's cell refreshes — the refresher publishes keyB.
+	cache.PublishRefresh(keyB)
+
+	// A must receive NOTHING (it is not armed for keyB).
+	select {
+	case leaked := <-chA:
+		t.Fatalf("9.4a LEAK: A received a signal %q for B's refreshing cell — cross-user isolation broken", leaked)
+	case <-time.After(200 * time.Millisecond):
+		// correct — no leak
+	}
+
+	// Sanity: A DOES receive its OWN cell's refresh.
+	cache.PublishRefresh(keyA)
+	select {
+	case got := <-chA:
+		if got != keyA {
+			t.Fatalf("A received %q, want its own keyA", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("A did not receive its own cell's refresh — derivation/arming broken")
+	}
+}
+
+// TestRefreshIsolation_WidgetContentSharedShell proves the 9.4b MECHANISM
+// invariant at the key layer: the identity-free widgetContent key is the SAME
+// for A and B (nobody owns it), so a widgetContent SIGNAL is content-free and
+// cannot carry subject-specific data. The per-user ROW gating is applied at
+// /call serve time (gateWidgetEnvelope — see
+// widget_content_rbac_sensitive_falsifier_test.go); the per-row CONTENT
+// assertion through a live serve is the cluster falsifier.
+func TestRefreshIsolation_WidgetContentSharedShell(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "true")
+
+	wc := SubscriptionCoordinates{
+		Class:     cache.CacheEntryClassWidgetContent,
+		Group:     "widgets.templates.krateo.io",
+		Version:   "v1beta1",
+		Resource:  "panels",
+		Namespace: "krateo-system",
+		Name:      "dashboard-piechart",
+		PerPage:   5,
+		Page:      1,
+	}
+	keyA, okA := DeriveSubscriptionKey(ctxAs("userA"), wc)
+	keyB, okB := DeriveSubscriptionKey(ctxAs("userB"), wc)
+	if !okA || !okB {
+		t.Fatalf("widgetContent derivation failed: okA=%v okB=%v", okA, okB)
+	}
+	// Identity-free: SAME key for both subjects (the shared shell).
+	if keyA != keyB {
+		t.Fatalf("widgetContent key differs across subjects (keyA=%q keyB=%q) — it must be identity-FREE "+
+			"(shared shell); the per-user narrowing is the serve-time gate, NOT the key", keyA, keyB)
+	}
+	t.Logf("9.4b mechanism OK: widgetContent key shared across A and B (%s) — signal is content-free; "+
+		"per-row gating is at /call serve (gateWidgetEnvelope)", keyA[:12])
+}
+
+// TestRefreshIsolation_NoIdentityFailClosed asserts a connection with NO
+// identity (defence in depth — RefreshAuth would 401 first) derives the
+// empty-identity key for an identity-bound class, distinct from any granted
+// user's key. This is the dispatchCacheLookupKey FAIL-CLOSED posture.
+func TestRefreshIsolation_NoIdentityFailClosed(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+
+	coords := compositionsCoords()
+	keyA, _ := DeriveSubscriptionKey(ctxAs("userA"), coords)
+
+	// Bare ctx (no UserInfo) -> dispatchCacheLookupKey returns (\"\", nil, nil)
+	// because xcontext.UserInfo errors -> DeriveSubscriptionKey returns ok=false.
+	key, ok := DeriveSubscriptionKey(context.Background(), coords)
+	if ok {
+		// If a key WAS derived it must be the empty-identity key, never a
+		// granted user's key.
+		if key == keyA {
+			t.Fatalf("FAIL-CLOSED VIOLATION: a no-identity connection derived granted user A's key %q", keyA)
+		}
+	}
+	// ok=false (skip the entry) is the expected fail-closed outcome; either
+	// way, the no-identity connection can never arm A's key.
+}

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -1,0 +1,114 @@
+// refresh_subscription.go — Ship 1 (live-refresh-coherence, option A).
+//
+// The forgery-proof per-subject isolation seam for GET /refreshes (design
+// §5). A /refreshes connection asks to be armed for a widget by sending the
+// SAME resource coordinates it used for /call (group/version/resource/ns/
+// name/page/perPage/extras/class) — NOT an opaque key. The server then
+// re-derives the expected L1 key UNDER THE CONNECTION'S authenticated
+// identity (the UserInfo placed on ctx by middleware.RefreshAuth) using the
+// IDENTICAL key-derivation the /call dispatcher uses:
+//
+//   - identity-bound classes (restactions/widgets/apistage/raFullList) ->
+//     dispatchCacheLookupKey: rbac.EvaluateRBAC(ctx-identity, get, gvr, ns,
+//     name) -> BindingUID -> cache.ComputeKey (helpers.go:200-243).
+//   - widgetContent (identity-free) -> dispatchWidgetContentKey
+//     (helpers.go:147-168, identity-free ComputeKey).
+//
+// WHY THIS IS FORGERY-PROOF (design §5.2): the BindingUID is computed from
+// the CONNECTION'S JWT-derived UserInfo on ctx, never from anything the
+// client supplies. A malicious client that sends user-B's coordinates over
+// user-A's connection makes the server derive the key under A's identity ->
+// A's BindingUID -> a DIFFERENT key than B's cell -> the connection is armed
+// for a key that B's refreshes never publish to. A client can only ever arm
+// keys that ITS OWN identity legitimately produces. This is exactly the
+// dispatchCacheLookupKey FAIL-CLOSED posture (missing/foreign identity ->
+// empty-identity key -> no match).
+//
+// This REUSES the existing key-derivation seam verbatim — no new identity
+// logic, no per-resource/path/user special-case (feedback_no_special_cases).
+// The functions are exported so internal/handlers/refreshes.go (package
+// handlers) can call them; the underlying dispatchCacheLookupKey /
+// dispatchWidgetContentKey stay package-private.
+
+package dispatchers
+
+import (
+	"context"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// classRestActions / classWidgets are the two entry-class values that have
+// no named constant in internal/cache (they are bare literals across the
+// dispatcher — dispatchers.go:88-89, restactions.go:123, widgets.go:170).
+// Stated once here so DeriveSubscriptionKey's accepted-class allowlist is a
+// uniform per-class discriminant, not a scattered literal (the three other
+// classes use the cache.CacheEntryClass* constants). This is the class
+// allowlist, not a per-resource/path/user special-case (feedback_no_special_cases).
+const (
+	classRestActions = "restactions"
+	classWidgets     = "widgets"
+)
+
+// SubscriptionCoordinates is the resource tuple a /refreshes connection
+// supplies to arm one widget. It is the SAME coordinate set the /call
+// dispatcher keys a widget by. Identity is NOT part of this struct — it is
+// taken from the connection's ctx, never the wire (the forgery-proof
+// property, see file header).
+type SubscriptionCoordinates struct {
+	Class     string // CacheEntryClass: "widgets" | "widgetContent" | "restactions" | "apistage" | "raFullList"
+	Group     string
+	Version   string
+	Resource  string
+	Namespace string
+	Name      string
+	PerPage   int
+	Page      int
+	Extras    map[string]any
+}
+
+// DeriveSubscriptionKey re-derives the L1 key for coords UNDER ctx's
+// authenticated identity, using the same derivation the /call dispatcher
+// uses. Returns (key, true) when a key was derived; (\"\", false) when the
+// cache layer is off / identity is missing / the class is unknown — in which
+// case the caller MUST reject that subscription entry (fail-closed).
+//
+// No apiserver read is issued: dispatchCacheLookupKey's only external touch
+// is rbac.EvaluateRBAC, which reads the in-process RBAC snapshot (the same
+// snapshot /call consults) — never the apiserver. So /refreshes stays off
+// the apiserver path end to end.
+func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) (string, bool) {
+	switch coords.Class {
+	case cache.CacheEntryClassWidgetContent:
+		// Identity-free shared shell. The key is the same for every subject
+		// (nobody owns it); the per-user gating is re-applied at serve time
+		// (gateWidgetEnvelope). Arming it reveals only "the shared envelope
+		// changed" — not subject-specific information (design §5.2 caveat).
+		key, handle, _ := dispatchWidgetContentKey(ctx,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
+		if handle == nil || key == "" {
+			return "", false
+		}
+		return key, true
+
+	case classRestActions,
+		classWidgets,
+		cache.CacheEntryClassApistage,
+		cache.CacheEntryClassRAFullList:
+		// Identity-bound: dispatchCacheLookupKey folds the BindingUID derived
+		// from ctx's identity. A foreign coordinate set yields the caller's
+		// own BindingUID -> a key the foreign cell never publishes to.
+		key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
+		if handle == nil || key == "" {
+			return "", false
+		}
+		return key, true
+
+	default:
+		// Unknown class — fail closed.
+		return "", false
+	}
+}

--- a/internal/handlers/dispatchers/resolve_populate.go
+++ b/internal/handlers/dispatchers/resolve_populate.go
@@ -289,6 +289,18 @@ func resolveAndPopulateL1(ctx context.Context, inputs cache.ResolvedKeyInputs, s
 		}
 	}
 	c.Put(key, entry)
+	// Ship 1 (live-refresh-coherence, option A) — emit the live-refresh
+	// signal STRICTLY post-commit, on the refresher path only. This line is
+	// reached ONLY after the Put returned and ONLY on a genuine L1 change:
+	// the four no-Put success-returns above (cache-off :96-99, declined
+	// :214-218, evicted-during-refresh :223-229, stage-error decline
+	// :243-260) all return before here, so the signal never fires when L1
+	// did not actually change (design §1.1 — coherent by construction).
+	// resolveAndPopulateL1 is invoked ONLY from the refresher closure
+	// (dispatchers.go:86), never from cold dispatch or the prewarm walker, so
+	// this announces dep-change-driven re-resolves only. PublishRefresh is
+	// nil-safe and a no-op when the SSE layer is disabled or cache is off.
+	cache.PublishRefresh(key)
 	log.Debug("resolveAndPopulateL1: re-resolved + stored",
 		slog.String("subsystem", "cache"),
 		slog.String("key_hash", key),

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -136,6 +136,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		if entry, ok := cacheHandle.Get(cacheKey); ok {
 			emitResolvedCacheLookup(log, "restactions", got.GVR.String(), cacheKey, true, len(entry.RawJSON))
 			pcs.l1Hit = "hit"
+			setRefreshKeyHeader(wri, cacheKey)
 			writeResolvedJSON(wri, entry.RawJSON)
 			log.Info("RESTAction successfully resolved",
 				slog.String("name", got.Unstructured.GetName()),
@@ -288,5 +289,6 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		slog.String("l1", "miss"),
 	)
 
+	setRefreshKeyHeader(wri, cacheKey)
 	writeResolvedJSON(wri, encoded)
 }

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -144,6 +144,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 					emitResolvedCacheLookup(log, "widgetContent", got.GVR.String(),
 						contentKey, true, len(gated))
 					pcs.l1Hit = "content-hit"
+					setRefreshKeyHeader(wri, contentKey)
 					writeResolvedJSON(wri, gated)
 					log.Info("Widget successfully resolved",
 						slog.String("duration", util.ETA(start)),
@@ -184,6 +185,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		if entry, ok := cacheHandle.Get(cacheKey); ok {
 			emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, true, len(entry.RawJSON))
 			pcs.l1Hit = "hit"
+			setRefreshKeyHeader(wri, cacheKey)
 			writeResolvedJSON(wri, entry.RawJSON)
 			log.Info("Widget successfully resolved",
 				slog.String("duration", util.ETA(start)),
@@ -296,5 +298,6 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		slog.String("l1", "miss"),
 	)
 
+	setRefreshKeyHeader(wri, cacheKey)
 	writeResolvedJSON(wri, encoded)
 }

--- a/internal/handlers/middleware/refreshauth.go
+++ b/internal/handlers/middleware/refreshauth.go
@@ -1,0 +1,126 @@
+// refreshauth.go — Ship 1 (live-refresh-coherence, option A).
+//
+// RefreshAuth is the SSE-specific authentication shim for GET /refreshes. It
+// is a SIBLING of UserConfig (userconfig.go), deliberately NOT a modification
+// of it — UserConfig is a verbatim upstream-mirror transcription with a
+// drift-pin test (feedback_claim_vs_code_identity_at_diff_review), and must
+// not be perturbed.
+//
+// WHY A SIBLING IS NEEDED (TRACED, design §4):
+//   - UserConfig reads the JWT from an `Authorization: Bearer` header ONLY
+//     (userconfig.go:134). A browser EventSource cannot set that header — the
+//     only native credential channel is a cookie (withCredentials:true). So
+//     mounting /refreshes behind UserConfig as-is would 401 every browser
+//     connection.
+//   - jwtutil.Validate (validate.go:16) is a PURE, STATELESS HS256
+//     verification: UserInfo{Username,Groups} is embedded in the signed token
+//     (jwtutil/create.go), with NO session store and NO server-side lookup.
+//     So the identical UserInfo is recoverable from the SAME JWT regardless of
+//     transport. RefreshAuth extracts the token from a header OR a cookie and
+//     calls the byte-identical jwtutil.Validate(signingKey, token).
+//
+// WHAT IT DELIBERATELY SKIPS:
+//   - The `<user>-clientconfig` Secret / WithUserConfig lookup that UserConfig
+//     performs (userconfig.go:166-232). /refreshes issues ZERO apiserver reads
+//     — it never resolves a widget; it only validates the subscription
+//     key-set against the connection's identity (refreshes.go) and streams
+//     signals. UserInfo{Username,Groups} alone is sufficient for that
+//     re-derivation. Skipping the Secret GET keeps /refreshes entirely off the
+//     F-3 apiserver path (no fall-through counter, no apiserver hit), which is
+//     exactly the cache-respecting invariant the feature exists to honour.
+//
+// NO TOKEN-IN-URL: the token is read from the header or the cookie only,
+// never the query string (which would leak in logs/referrer).
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+)
+
+// envRefreshSessionCookie names the cookie RefreshAuth reads the JWT from on
+// the browser EventSource path. The actual portal session-cookie name is a
+// cross-team / portal-chart fact (design §11, OPEN) — it is therefore
+// config-driven (env), NOT a hardcoded Go literal, so the frontend owner can
+// set it at deploy time without a code change (feedback_no_special_cases).
+// Default below is a sensible placeholder; the header path works regardless.
+const envRefreshSessionCookie = "REFRESH_SESSION_COOKIE"
+
+// defaultRefreshSessionCookie is the cookie name used when REFRESH_SESSION_COOKIE
+// is unset. Confirm against the portal's actual session cookie before relying
+// on the browser path (the header path is unconditional and used by curl
+// falsifiers + non-browser clients).
+const defaultRefreshSessionCookie = "krateo-session"
+
+// refreshSessionCookieName returns the configured session-cookie name.
+func refreshSessionCookieName() string {
+	if v := os.Getenv(envRefreshSessionCookie); v != "" {
+		return v
+	}
+	return defaultRefreshSessionCookie
+}
+
+// refreshTokenFromRequest extracts the bearer JWT from, in order:
+//
+//	(a) the `Authorization: Bearer <jwt>` header — so curl falsifiers,
+//	    polyfill clients, and non-browser callers work; then
+//	(b) the session cookie (the native browser EventSource path).
+//
+// Returns ("", false) when neither carries a usable token.
+func refreshTokenFromRequest(req *http.Request) (string, bool) {
+	if authHeader := req.Header.Get("Authorization"); authHeader != "" {
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" && parts[1] != "" {
+			return parts[1], true
+		}
+	}
+	if ck, err := req.Cookie(refreshSessionCookieName()); err == nil && ck.Value != "" {
+		return ck.Value, true
+	}
+	return "", false
+}
+
+// RefreshAuth is the cookie-or-header JWT auth middleware for GET /refreshes.
+// On success it places UserInfo on the request context via WithUserInfo —
+// the IDENTICAL placement UserConfig uses (userconfig.go:231) — so the
+// downstream handler reads identity exactly as the /call path does. On any
+// failure it responds 401 (Unauthorized) and does not chain.
+//
+// Signature mirrors UserConfig's single-string-key shape minus authnNS (no
+// Secret lookup), so the mux mount is a one-line Append.
+func RefreshAuth(signingKey string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(wri http.ResponseWriter, req *http.Request) {
+			token, ok := refreshTokenFromRequest(req)
+			if !ok {
+				response.Unauthorized(wri, fmt.Errorf("missing credentials: no bearer header or session cookie"))
+				return
+			}
+
+			// The IDENTICAL stateless validation UserConfig performs at
+			// userconfig.go:151. Both expired + generic-invalid map to 401
+			// (jwtutil.Validate returns ErrTokenExpired / ErrTokenInvalid).
+			userInfo, err := jwtutil.Validate(signingKey, token)
+			if err != nil {
+				response.Unauthorized(wri, err)
+				return
+			}
+
+			// IDENTICAL identity placement to UserConfig (userconfig.go:231).
+			// We intentionally do NOT call WithUserConfig / the Secret lookup —
+			// /refreshes issues zero apiserver reads (see file header).
+			ctx := xcontext.BuildContext(req.Context(),
+				xcontext.WithUserInfo(userInfo),
+			)
+			next.ServeHTTP(wri, req.WithContext(ctx))
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/internal/handlers/refreshes.go
+++ b/internal/handlers/refreshes.go
@@ -1,0 +1,248 @@
+// refreshes.go — Ship 1 (live-refresh-coherence, option A).
+//
+// GET /refreshes is the per-subject live-refresh SSE stream (design §3). A
+// browser opens ONE multiplexed EventSource per tab; it arms the widgets it
+// has mounted by sending their resource coordinates (?sub=). When the
+// refresher commits a fresh L1 entry for an armed key (resolve_populate.go:291
+// -> cache.PublishRefresh), this stream emits `event: refresh\ndata: <l1Key>`.
+// The frontend then refetches /call and reads the freshly-committed L1 as a
+// HIT — no apiserver read (the cache-respecting invariant, falsifier 9.1).
+//
+// SIGNAL-ONLY, no payload: data carries just the l1Key. The body that flows
+// to the client comes from the subsequent /call, which re-applies per-user
+// RBAC gating at serve time. So a shared (widgetContent) signal never leaks
+// another subject's row-level visibility (falsifier 9.4b).
+//
+// AUTH: middleware.RefreshAuth (refreshauth.go) places UserInfo on ctx from a
+// cookie-or-header JWT. ISOLATION: every armed key is re-derived UNDER that
+// connection's identity via dispatchers.DeriveSubscriptionKey (forgery-proof;
+// design §5). ZERO apiserver reads: the only external touch is the in-process
+// RBAC snapshot inside the derivation.
+//
+// TRANSPARENT FALLBACK (project_cache_off_is_transparent_fallback): when the
+// SSE layer is disabled (REFRESH_SSE_ENABLED=false) or cache is off
+// (CACHE_ENABLED=false), the endpoint serves a clean idle stream — heartbeats
+// only, zero refresh events — so a connected client degrades to its own 5s
+// throttle and never hangs or errors.
+
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/handlers/dispatchers"
+)
+
+const (
+	// refreshHeartbeatInterval keeps intermediaries from idling the
+	// connection and lets the client detect a dead link. 20s beats the
+	// server IdleTimeout (30s, main.go:905) with margin; the per-connection
+	// SetWriteDeadline(0) defeats the 300s WriteTimeout (main.go:904).
+	refreshHeartbeatInterval = 20 * time.Second
+
+	// refreshSubParamMaxBytes caps the decoded ?sub= payload to avoid a
+	// memory-amplification subscribe vector (extras can be large; design §6
+	// tradeoff). A connection sending a larger payload is rejected 400.
+	refreshSubParamMaxBytes = 16 * 1024
+
+	// refreshSubMaxEntries caps how many widgets one connection may arm in a
+	// single subscribe. Defence-in-depth alongside the byte cap.
+	refreshSubMaxEntries = 512
+)
+
+// subRequest is one widget's arm request inside ?sub=. It is the JSON form of
+// dispatchers.SubscriptionCoordinates. Identity is NOT carried here — it
+// comes from the connection's authenticated ctx (the forgery-proof property).
+type subRequest struct {
+	Class     string         `json:"class"`
+	Group     string         `json:"group"`
+	Version   string         `json:"version"`
+	Resource  string         `json:"resource"`
+	Namespace string         `json:"namespace"`
+	Name      string         `json:"name"`
+	PerPage   int            `json:"perPage"`
+	Page      int            `json:"page"`
+	Extras    map[string]any `json:"extras"`
+}
+
+// Refreshes returns the GET /refreshes SSE handler. signingKey is accepted
+// for symmetry with the other auth-bearing handlers and future use; identity
+// is already resolved onto ctx by middleware.RefreshAuth, so the handler does
+// not re-validate the token here.
+func Refreshes(signingKey string) http.HandlerFunc {
+	return func(wri http.ResponseWriter, req *http.Request) {
+		log := xcontext.Logger(req.Context())
+
+		// (1) Disabled / cache-off -> clean idle stream (transparent
+		// fallback). No subscription validation, no apiserver touch; the
+		// client gets heartbeats only and falls back to its own throttle.
+		if !cache.RefreshSSEEnabled() {
+			serveIdleSSE(wri, req)
+			return
+		}
+
+		// (2) Identity is already on ctx (RefreshAuth). Defence in depth.
+		ui, err := xcontext.UserInfo(req.Context())
+		if err != nil {
+			response.Unauthorized(wri, err)
+			return
+		}
+
+		// (3) Validate + re-derive the requested key-set UNDER THIS subject.
+		armed, derr := validateSubscription(req)
+		if derr != nil {
+			http.Error(wri, derr.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(armed) == 0 {
+			http.Error(wri, "no valid subscription keys", http.StatusBadRequest)
+			return
+		}
+
+		// (4) SSE headers + defeat the per-connection write deadline so the
+		// 300s WriteTimeout does not kill a long-lived stream (design §3.2,
+		// §6). SetWriteDeadline(zero) clears the deadline for THIS connection
+		// only; Go 1.20+ ResponseController, supported on go 1.25.x (go.mod).
+		rc := http.NewResponseController(wri)
+		if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			// Some ResponseWriters (test recorders) don't support deadlines;
+			// that's non-fatal — the stream still works under the test server.
+			log.Debug("refreshes: SetWriteDeadline unsupported; continuing",
+				slog.String("subsystem", "cache"), slog.Any("err", err))
+		}
+		wri.Header().Set("Content-Type", "text/event-stream")
+		wri.Header().Set("Cache-Control", "no-cache")
+		wri.Header().Set("Connection", "keep-alive")
+		wri.Header().Set("X-Accel-Buffering", "no") // disable proxy buffering
+		wri.WriteHeader(http.StatusOK)
+		_ = rc.Flush()
+
+		// (5) Subscribe + stream until the client disconnects.
+		ch, unsub := cache.SubscribeRefresh(armed)
+		defer unsub()
+
+		log.Info("refreshes: subscribed",
+			slog.String("subsystem", "cache"),
+			slog.String("user", ui.Username),
+			slog.Int("armed_keys", len(armed)),
+		)
+
+		heartbeat := time.NewTicker(refreshHeartbeatInterval)
+		defer heartbeat.Stop()
+		for {
+			select {
+			case <-req.Context().Done():
+				return // client gone
+			case k, ok := <-ch:
+				if !ok {
+					// Hub closed the channel (disabled mid-stream) — degrade
+					// to idle; the client falls back to its throttle.
+					return
+				}
+				if _, werr := fmt.Fprintf(wri, "event: refresh\ndata: %s\n\n", k); werr != nil {
+					return // client write failed — disconnect
+				}
+				_ = rc.Flush()
+			case <-heartbeat.C:
+				if _, werr := fmt.Fprint(wri, ": keepalive\n\n"); werr != nil {
+					return
+				}
+				_ = rc.Flush()
+			}
+		}
+	}
+}
+
+// serveIdleSSE serves a heartbeat-only SSE stream for the disabled / cache-off
+// path (transparent fallback). It opens the stream, defeats the write
+// deadline, and emits only `: keepalive` comment frames until the client
+// disconnects. Never emits a refresh event (there is no broadcaster).
+func serveIdleSSE(wri http.ResponseWriter, req *http.Request) {
+	rc := http.NewResponseController(wri)
+	_ = rc.SetWriteDeadline(time.Time{})
+	wri.Header().Set("Content-Type", "text/event-stream")
+	wri.Header().Set("Cache-Control", "no-cache")
+	wri.Header().Set("Connection", "keep-alive")
+	wri.Header().Set("X-Accel-Buffering", "no")
+	wri.WriteHeader(http.StatusOK)
+	_ = rc.Flush()
+
+	heartbeat := time.NewTicker(refreshHeartbeatInterval)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-req.Context().Done():
+			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(wri, ": keepalive\n\n"); err != nil {
+				return
+			}
+			_ = rc.Flush()
+		}
+	}
+}
+
+// validateSubscription decodes the ?sub= base64-JSON coordinate array and
+// re-derives each key UNDER the request's authenticated identity (the
+// connection ctx), returning the validated armed-key set. A coordinate that
+// fails derivation (foreign identity / unknown class / cache-off) is silently
+// skipped (fail-closed) — only keys the connection's OWN identity legitimately
+// produces are armed (design §5.2). Returns an error only on a malformed or
+// oversized ?sub= payload (a client protocol error), never on a per-entry
+// derivation failure.
+func validateSubscription(req *http.Request) (map[string]struct{}, error) {
+	raw := req.URL.Query().Get("sub")
+	if raw == "" {
+		return nil, fmt.Errorf("missing 'sub' query parameter")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		// Tolerate URL-safe base64 too (EventSource URLs are query-encoded).
+		decoded, err = base64.RawURLEncoding.DecodeString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid 'sub' encoding: not base64")
+		}
+	}
+	if len(decoded) > refreshSubParamMaxBytes {
+		return nil, fmt.Errorf("'sub' payload too large (%d bytes; max %d)", len(decoded), refreshSubParamMaxBytes)
+	}
+
+	var reqs []subRequest
+	if err := json.Unmarshal(decoded, &reqs); err != nil {
+		return nil, fmt.Errorf("invalid 'sub' payload: not a JSON coordinate array")
+	}
+	if len(reqs) == 0 {
+		return nil, fmt.Errorf("'sub' payload is an empty array")
+	}
+	if len(reqs) > refreshSubMaxEntries {
+		return nil, fmt.Errorf("too many subscription entries (%d; max %d)", len(reqs), refreshSubMaxEntries)
+	}
+
+	armed := make(map[string]struct{}, len(reqs))
+	for _, s := range reqs {
+		key, ok := dispatchers.DeriveSubscriptionKey(req.Context(), dispatchers.SubscriptionCoordinates{
+			Class:     s.Class,
+			Group:     s.Group,
+			Version:   s.Version,
+			Resource:  s.Resource,
+			Namespace: s.Namespace,
+			Name:      s.Name,
+			PerPage:   s.PerPage,
+			Page:      s.Page,
+			Extras:    s.Extras,
+		})
+		if !ok {
+			continue // fail-closed: skip keys this identity can't produce
+		}
+		armed[key] = struct{}{}
+	}
+	return armed, nil
+}

--- a/internal/handlers/refreshes_test.go
+++ b/internal/handlers/refreshes_test.go
@@ -1,0 +1,302 @@
+// refreshes_test.go — Ship 1 (live-refresh-coherence, option A) HTTP-level
+// falsifiers for GET /refreshes: RefreshAuth (cookie-or-header JWT), the
+// cache-off idle stream (9.5b, the /refreshes half), and validateSubscription
+// rejection. Hermetic: httptest + a test JWT signing key; NO apiserver,
+// KUBECONFIG unset. NEVER ./internal/rbac.
+//
+// The per-subject ISOLATION (9.4a) and the per-row CONTENT (9.4b) live at the
+// derivation layer (refresh_isolation_falsifier_test.go in package dispatchers,
+// where the in-process RBAC snapshot builder exists) and the cluster gate,
+// respectively. This file proves the endpoint's auth + lifecycle + input
+// validation.
+
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
+)
+
+const refreshTestSignKey = "test-sign-key-ship1-live-refresh"
+
+func mintToken(t *testing.T, username string) string {
+	t.Helper()
+	tok, err := jwtutil.CreateToken(jwtutil.CreateTokenOptions{
+		Username:   username,
+		Groups:     []string{"devs"},
+		Duration:   time.Hour,
+		SigningKey: refreshTestSignKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	return tok
+}
+
+// subParam builds a valid ?sub= value (base64 JSON coordinate array) for one
+// widgetContent coordinate (identity-free, so it derives without an RBAC
+// snapshot).
+func subParam(t *testing.T) string {
+	t.Helper()
+	body := []map[string]any{{
+		"class":     "widgetContent",
+		"group":     "widgets.templates.krateo.io",
+		"version":   "v1beta1",
+		"resource":  "panels",
+		"namespace": "krateo-system",
+		"name":      "dashboard-piechart",
+		"perPage":   5,
+		"page":      1,
+	}}
+	raw, _ := json.Marshal(body)
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// refreshServer wires the production chain (RefreshAuth -> Refreshes) on a
+// test server. Returns the base URL.
+func refreshServer(t *testing.T) string {
+	t.Helper()
+	h := middleware.RefreshAuth(refreshTestSignKey)(Refreshes(refreshTestSignKey))
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// openStream issues GET /refreshes with the given setup and returns the
+// response + a cancel func. The caller MUST cancel to release the streaming
+// handler goroutine.
+func openStream(t *testing.T, baseURL, query string, setup func(*http.Request)) (*http.Response, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+query, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if setup != nil {
+		setup(req)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("Do: %v", err)
+	}
+	return resp, cancel
+}
+
+// --- RefreshAuth ------------------------------------------------------------
+
+// TestRefreshes_Auth_HeaderTokenReachesHandler — a valid Authorization: Bearer
+// header authenticates and the handler opens the SSE stream (200 +
+// text/event-stream). The curl-falsifier / non-browser path.
+func TestRefreshes_Auth_HeaderTokenReachesHandler(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	base := refreshServer(t)
+
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("header-auth: status=%d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("header-auth: Content-Type=%q want text/event-stream", ct)
+	}
+}
+
+// TestRefreshes_Auth_CookieTokenReachesHandler — the browser EventSource path:
+// the JWT in the configured session cookie authenticates (no Authorization
+// header). This is the make-or-break for EventSource (it cannot set headers).
+func TestRefreshes_Auth_CookieTokenReachesHandler(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	t.Setenv("REFRESH_SESSION_COOKIE", "krateo-session")
+	base := refreshServer(t)
+
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
+		req.AddCookie(&http.Cookie{Name: "krateo-session", Value: mintToken(t, "userA")})
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("cookie-auth: status=%d want 200 — EventSource cookie path broken", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("cookie-auth: Content-Type=%q want text/event-stream", ct)
+	}
+}
+
+// TestRefreshes_Auth_MissingCredentials401 — no header, no cookie -> 401.
+func TestRefreshes_Auth_MissingCredentials401(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	base := refreshServer(t)
+
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), nil)
+	defer cancel()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing-creds: status=%d want 401", resp.StatusCode)
+	}
+}
+
+// TestRefreshes_Auth_InvalidToken401 — a token signed with the WRONG key -> 401.
+func TestRefreshes_Auth_InvalidToken401(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	base := refreshServer(t)
+
+	bad, err := jwtutil.CreateToken(jwtutil.CreateTokenOptions{
+		Username: "userA", Duration: time.Hour, SigningKey: "WRONG-KEY",
+	})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+bad)
+	})
+	defer cancel()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("invalid-token: status=%d want 401 (wrong-key JWT must not validate)", resp.StatusCode)
+	}
+}
+
+// --- validateSubscription rejection -----------------------------------------
+
+// TestRefreshes_Validation_Rejections — malformed/oversized/empty ?sub= -> 400.
+// (Auth succeeds first; the rejection is the subscription validation.)
+func TestRefreshes_Validation_Rejections(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	base := refreshServer(t)
+	tok := mintToken(t, "userA")
+
+	// Oversized: a base64 blob whose DECODED size exceeds refreshSubParamMaxBytes.
+	huge := base64.StdEncoding.EncodeToString([]byte(strings.Repeat("x", refreshSubParamMaxBytes+1)))
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"missing sub", ""},
+		{"malformed base64", "?sub=!!!not-base64!!!"},
+		{"oversized payload", "?sub=" + huge},
+		{"empty array", "?sub=" + base64.StdEncoding.EncodeToString([]byte("[]"))},
+		{"not an array", "?sub=" + base64.StdEncoding.EncodeToString([]byte(`{"class":"widgetContent"}`))},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp, cancel := openStream(t, base, c.query, func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+tok)
+			})
+			defer cancel()
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("%s: status=%d want 400", c.name, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestRefreshes_Validation_AllForeignKeysRejected — when every coordinate fails
+// derivation (cache layer present but identity yields no key for an identity-
+// bound class with no RBAC snapshot -> BindingUID empty is still a derived key;
+// so use an UNKNOWN class, which DeriveSubscriptionKey fails-closed on) the
+// armed set is empty -> 400 "no valid subscription keys".
+func TestRefreshes_Validation_AllForeignKeysRejected(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	base := refreshServer(t)
+	tok := mintToken(t, "userA")
+
+	body := []map[string]any{{"class": "totally-unknown-class", "name": "x"}}
+	raw, _ := json.Marshal(body)
+	q := "?sub=" + base64.StdEncoding.EncodeToString(raw)
+
+	resp, cancel := openStream(t, base, q, func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	})
+	defer cancel()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("all-foreign: status=%d want 400 (no armable keys)", resp.StatusCode)
+	}
+}
+
+// --- 9.5b — cache-off idle stream -------------------------------------------
+
+// TestRefreshes_CacheOff_IdleStream is the /refreshes half of falsifier 9.5b:
+// with the cache subsystem off, GET /refreshes returns 200 + text/event-stream
+// and emits ONLY heartbeats — zero `event: refresh` frames — so a connected
+// client degrades to its own throttle (transparent fallback,
+// project_cache_off_is_transparent_fallback). It also requires NO auth-bearing
+// credentials? No — auth still applies; we pass a valid token. The point is the
+// STREAM is idle. (The /call correct-CONTENT half of 9.5b is the cluster
+// falsifier — it needs the resolve stack.)
+func TestRefreshes_CacheOff_IdleStream(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false") // cache subsystem OFF
+	base := refreshServer(t)
+
+	// Under cache-off the handler serves the idle stream BEFORE subscription
+	// validation, so even a valid token + any sub yields the idle stream.
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("cache-off: status=%d want 200 (idle stream, transparent fallback)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("cache-off: Content-Type=%q want text/event-stream", ct)
+	}
+
+	// Read for a short window; assert NO `event: refresh` frame arrives (the
+	// broadcaster does not exist under cache-off, so nothing can publish).
+	// We cannot easily wait a full heartbeat (20s) in a unit test, so we just
+	// assert that within a short read no refresh event appears and the stream
+	// stays open (no premature EOF/error).
+	done := make(chan string, 1)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.HasPrefix(line, "event: refresh") {
+				done <- "GOT_REFRESH"
+				return
+			}
+		}
+		done <- "EOF"
+	}()
+	select {
+	case sig := <-done:
+		if sig == "GOT_REFRESH" {
+			t.Fatalf("cache-off: received an `event: refresh` frame — the stream must be idle (no broadcaster exists)")
+		}
+		// "EOF" here would mean the server closed the stream; under cache-off
+		// the idle stream stays open until client-cancel, so a fast EOF is
+		// unexpected — but the cancel in defer can race it. Treat EOF within
+		// the window as benign (the stream did not emit a refresh).
+	case <-time.After(500 * time.Millisecond):
+		// No refresh frame within the window — correct (idle stream).
+	}
+}

--- a/main.go
+++ b/main.go
@@ -807,6 +807,21 @@ func main() {
 		Then(handlers.Call()))
 	cache.RegisterScopedRoute("GET /call", cache.ScopeCallGeneric)
 
+	// Ship 1 (live-refresh-coherence, option A) — GET /refreshes is the
+	// per-subject live-refresh SSE stream. It uses middleware.RefreshAuth
+	// (cookie-or-header JWT -> UserInfo) instead of middleware.UserConfig,
+	// because a browser EventSource cannot set the Authorization header and
+	// /refreshes needs no <user>-clientconfig Secret lookup (it issues ZERO
+	// apiserver reads). It is DELIBERATELY NOT cache.RegisterScopedRoute'd:
+	// with no apiserver reads it is outside the read-path-scoped invariant
+	// (AssertReadPathsScoped, main.go below), and requiredScopedRoutes
+	// (fallthrough_assert.go) does not list it. Under CACHE_ENABLED=false or
+	// REFRESH_SSE_ENABLED=false the handler serves a clean idle stream
+	// (transparent fallback, project_cache_off_is_transparent_fallback).
+	mux.Handle("GET /refreshes", chain.Append(
+		middleware.RefreshAuth(*signKey)).
+		Then(handlers.Refreshes(*signKey)))
+
 	// Ship D — write-verb `/call` routes also get the middleware (PM
 	// explicit). Write verbs are out of the read-path invariant (F-11
 	// in the design), but centralizing classification prevents silent
@@ -896,12 +911,12 @@ func main() {
 				"X-Auth-Code",
 				"X-Krateo-TraceId",
 			},
-			ExposedHeaders:   []string{"Link"},
+			ExposedHeaders:   []string{"Link", "X-Snowplow-Refresh-Key"},
 			AllowCredentials: true,
 			MaxAge:           300, // Maximum value not ignored by any of major browsers
 		})(mux),
 		ReadTimeout:  10 * time.Second, // read is fast; unchanged (#351/C2)
-		WriteTimeout: writeTimeout,    // 300s — clears cache-OFF heavy path (#351/C2)
+		WriteTimeout: writeTimeout,     // 300s — clears cache-OFF heavy path (#351/C2)
 		IdleTimeout:  30 * time.Second, // keep-alive; unchanged (#351/C2)
 	}
 


### PR DESCRIPTION
**Ship 1 (option A)** of the live-refresh-coherence feature — the snowplow-native per-key refresh signal. A's design + this diff cleared the **architect+PM dual-review gate** (Architect **SHIP**, PM **ACCEPT**) before commit.

## What & why
snowplow's informer-driven cache and the eventrouter SSE stream the frontend listens to are independent pipelines, and the L1 refresher applies a **2s rate-floor** (+ up to 5s customer-yield) before re-resolving a dirty entry. So a refetch fired on a change event lands inside a deterministic **~2s (default) / ~5s (under load)** window and serves stale — measured **77% of refetches in the first 2.5s read stale** (Phase-0 falsifier, `docs/live-refresh-stalewindow-phase0-2026-06-18.md`).

**A emits `PublishRefresh(key)` strictly after the refresher commits the fresh entry to L1** (`resolve_populate.go`, post-`c.Put`), serves it on a new **`GET /refreshes`** SSE endpoint, and the frontend refetches on the signal → reads the freshly-committed L1 as a **HIT** (no apiserver read). Per-subject isolation by re-deriving the subscription key under the connection's own identity (forgery-proof); cookie-or-header `RefreshAuth` (EventSource-compatible); `X-Snowplow-Refresh-Key` additive `/call` header.

## Honest framing
Closes a deterministic ~2s **silent-stale** window to a signalled-**coherent** ~2s — the client learns exactly when fresh. **Not** a sub-second/latency claim; the 2s floor is untouched. Sub-second (option B) is a **separate ship gated on a 50K amplification bench**.

## Scope & safety
- **A only** — `internal/cache/refresher.go` byte-untouched (zero floor change, zero amplification surface).
- Provisional/removable: `REFRESH_SSE_ENABLED` toggle; `CACHE_ENABLED=false` ⇒ emit unreachable + `/refreshes` idle stream (transparent fallback). Per-user-keyed, never cohort.
- **24 falsifiers** green under `-race`: no-apiserver-LIST-on-refetch, emit-strictly-post-commit + zero on the 4 no-Put returns, cross-user isolation (forgery-rejected), cache-off emit unreachable, slow-consumer-no-stall, dropped-signal degrades to throttle.

## Deferred to the deploy/cluster gate (not A-correctness blockers)
C-1 SSE connection-scale sizing (1000 users × N) before prod · end-to-end per-row RBAC content (9.4b) + cache-off `/call` content (9.5b) at `--context gke` (existing `/call`-serve path A doesn't modify) · CORS topology + gateway idle-timeout · frontend re-target (separate portal change) · option B (Ship 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Frontend re-target note — `/refreshes` subscription key (live kind E2E, 2026-06-19)

Validated end-to-end on a disposable kind cluster (`docs/refreshes-e2e-pr32-kind-2026-06-19.md`): coherence (emit strictly after the L1 commit), no-apiserver-LIST on the signal-triggered refetch (fresh L1 hit), forgery-proof per-subject isolation, and EventSource cookie auth — all pass on the live HTTP/SSE path.

**Integration requirement for the frontend re-target (no snowplow change — the affordance already exists):** the `/refreshes` subscription key is **coordinate-exact**. `ComputeKey` folds `perPage`/`page`, and `/call`'s `paginationInfo()` defaults *absent* pagination params to **`-1`**, whereas a hand-built `?sub=` JSON that omits them defaults to **`0`** → a *different* L1 key → the connection arms but receives nothing (`subscribers:1`, `delivered:0`). So the frontend MUST either:
- subscribe using the exact **`X-Snowplow-Refresh-Key`** value returned on the corresponding `/call` response (preferred — that header is the exact key snowplow computed), **or**
- build `?sub=` with the *same* coordinates it sent to `/call`, including the `perPage:-1,page:-1` defaults.

Identity is never carried in `?sub=` — the server re-derives each key under the connection's own authenticated JWT (`DeriveSubscriptionKey`), which is the forgery-proof property.
