### PR TITLE
feat(widgets,cache): author-declarable per-surface inline extras (design P)

### DIFF
--- a/internal/handlers/dispatchers/extras_cache_key_test.go
+++ b/internal/handlers/dispatchers/extras_cache_key_test.go
@@ -23,7 +23,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 )
 
 // enableWidgetContentL1 turns the whole resolved-output + widgetContent L1
@@ -164,5 +167,279 @@ func TestExtras_WidgetContentCell_NoCrossCollision(t *testing.T) {
 	}
 	if string(got.RawJSON) != string(bodyA) {
 		t.Fatalf("extras-A cell served the wrong body: got %q want %q", got.RawJSON, bodyA)
+	}
+}
+
+// ===========================================================================
+// inline-extras design P — cache-key crux falsifiers (#4a / #4b / #8 / #9).
+//
+// These extend the request-extras analogues ABOVE to the per-surface inline
+// maps. Per PM MUST-FIX #2 they drive the REAL dispatcher key path — the
+// production unionForKey builder + dispatchWidgetContentKey /
+// dispatchCacheLookupKey + RAFullListKeyInputs + real handle.Put/Get — NOT a
+// hand-assembled ResolvedKeyInputs. The widget cell folds the UNION of both
+// inline maps + request; the apiRef sub-cell folds ONLY the apiRef-effective
+// map (apiRef-inline under request) — never rrt-inline (design §1).
+//
+// Per Caveat A (the dominant apiRef+template widget is RBAC-sensitive so its
+// identity-free content cell is SKIPPED): #4a frames distinctness around the
+// per-cohort + RAFullList cells (the real surface for an apiRef widget), and
+// the content-cell distinctness is exercised by an apiRef-LESS widget carrying
+// resourcesRefsTemplateExtras (#4b) — the shape that actually routes through
+// the content cell.
+// ===========================================================================
+
+// widgetCRWithExtras builds the unstructured widget-CR Object shape the
+// dispatcher reads the two inline maps off (spec.apiRef.extras +
+// spec.resourcesRefsTemplateExtras). Either arg may be nil/"" to omit that
+// block — exactly the absence the accessors return {} for.
+func widgetCRWithExtras(t *testing.T, apiRefExtrasJSON, rrtExtrasJSON string) map[string]any {
+	t.Helper()
+	spec := map[string]any{}
+	if apiRefExtrasJSON != "" {
+		spec["apiRef"] = map[string]any{
+			"name":      "some-ra",
+			"namespace": "demo-system",
+			"extras":    parseExtras(t, apiRefExtrasJSON),
+		}
+	}
+	if rrtExtrasJSON != "" {
+		spec["resourcesRefsTemplateExtras"] = parseExtras(t, rrtExtrasJSON)
+	}
+	return map[string]any{"spec": spec}
+}
+
+// keyExtrasFor mirrors the dispatcher's production fold (widgets.go): read both
+// inline maps off the CR via the REAL accessors and union them with the request
+// extras (request wins). This is the exact keyExtras the dispatcher passes to
+// the widget key sites.
+func keyExtrasFor(crObj map[string]any, request map[string]any) map[string]any {
+	return unionForKey(
+		widgets.GetApiRefExtras(crObj),
+		widgets.GetResourcesRefsExtras(crObj),
+		request,
+	)
+}
+
+// ctxWithIdentity returns a context carrying a UserInfo so the per-cohort
+// dispatchCacheLookupKey path (which reads xcontext.UserInfo and derives a
+// BindingUID via rbac.EvaluateRBAC) returns a live handle + key instead of
+// bailing on a missing identity. With no ResourceWatcher wired in these unit
+// tests EvaluateRBAC degrades to bindingUID="" (fail-closed) — identical for
+// every call here, so the keys differ ONLY by the extras union, which is
+// exactly the discriminant these falsifiers probe.
+func ctxWithIdentity() context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "cyberjoker", Groups: []string{"devs"}}))
+}
+
+// TestInlineExtras_4a_ApiRefExtras_DistinctWidgetKeys — falsifier #4a. Two
+// widgets identical except spec.apiRef.extras MUST produce DISTINCT per-cohort
+// widget keys (the apiRef+template widget is RBAC-sensitive so we frame on the
+// per-cohort cell, Caveat A) AND DISTINCT RAFullList sub-cell keys; identical
+// apiRef.extras ⇒ identical keys (a real hit). A collision here would serve
+// one widget's apiRef-parametrised body to the other.
+func TestInlineExtras_4a_ApiRefExtras_DistinctWidgetKeys(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-apiref"
+		perPage, page     = 10, 1
+	)
+	// No request extras — the inline map is the sole discriminant.
+	req := map[string]any{}
+
+	crA := widgetCRWithExtras(t, `{"tenant":"acme"}`, "")
+	crB := widgetCRWithExtras(t, `{"tenant":"globex"}`, "")
+	crA2 := widgetCRWithExtras(t, `{"tenant":"acme"}`, "") // same as A
+
+	// --- per-cohort widget cell (the real surface for an apiRef widget) ---
+	pcA, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(crA, req))
+	pcB, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(crB, req))
+	pcA2, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(crA2, req))
+	if pcA == "" || pcB == "" {
+		t.Fatalf("expected non-empty per-cohort keys (got A=%q B=%q)", pcA, pcB)
+	}
+	if pcA == pcB {
+		t.Fatalf("FALSIFIER #4a FAILED: differing apiRef.extras produced the SAME per-cohort widget key %q — cross-widget collision", pcA)
+	}
+	if pcA != pcA2 {
+		t.Fatalf("#4a: identical apiRef.extras MUST produce identical per-cohort keys, got %q vs %q", pcA, pcA2)
+	}
+
+	// --- RAFullList sub-cell (apiRef-effective map = apiRef-inline ∪ request) ---
+	// The dispatcher's apiRef path threads merge(apiRefInline, request) into
+	// apiref.Resolve → RAFullListKeyInputs. Here request is empty, so the
+	// effective map IS the apiRef-inline map.
+	const rg, rv, rr, rns, rname = "templates.krateo.io", "v1", "restactions", "demo-system", "some-ra"
+	const bUID = "binding-xyz"
+	raA := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, crA, req)))
+	raB := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, crB, req)))
+	raA2 := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, crA2, req)))
+	if raA == raB {
+		t.Fatalf("FALSIFIER #4a FAILED: differing apiRef.extras produced the SAME RAFullList sub-cell key %q — apiRef fetch collision", raA)
+	}
+	if raA != raA2 {
+		t.Fatalf("#4a: identical apiRef.extras MUST produce identical RAFullList keys, got %q vs %q", raA, raA2)
+	}
+}
+
+// keyExtrasForApiRefEffective models the apiRef-EFFECTIVE map the dispatcher
+// threads into the apiRef sub-cell: the apiRef-inline map folded UNDER the
+// request (request wins) — and crucially WITHOUT the rrt-inline map. It is the
+// test-side mirror of resolveApiRef's merge(apiRefInline, request).
+func keyExtrasForApiRefEffective(t *testing.T, crObj map[string]any, request map[string]any) map[string]any {
+	t.Helper()
+	apiRefInline := widgets.GetApiRefExtras(crObj)
+	out := map[string]any{}
+	for k, v := range apiRefInline {
+		out[k] = v
+	}
+	for k, v := range request { // request wins
+		out[k] = v
+	}
+	return out
+}
+
+// TestInlineExtras_4b_RrtExtras_DistinctContentKeys_RAFullListUnchanged —
+// falsifier #4b. An apiRef-LESS widget (routes through the identity-free
+// content cell, Caveat A) carrying resourcesRefsTemplateExtras: two such
+// widgets differing ONLY in the rrt block MUST produce DISTINCT content +
+// per-cohort widget keys (the union folds rrt-inline), while the RAFullList
+// sub-cell key MUST be UNCHANGED (rrt-inline does NOT affect the apiRef cell).
+func TestInlineExtras_4b_RrtExtras_DistinctContentKeys_RAFullListUnchanged(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-static"
+		perPage, page     = 10, 1
+	)
+	req := map[string]any{}
+
+	crA := widgetCRWithExtras(t, "", `{"targetNs":"team-a"}`)
+	crB := widgetCRWithExtras(t, "", `{"targetNs":"team-b"}`)
+	crA2 := widgetCRWithExtras(t, "", `{"targetNs":"team-a"}`)
+
+	// --- identity-free content cell (apiRef-less widget routes here) ---
+	cA, hA, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, keyExtrasFor(crA, req))
+	cB, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, keyExtrasFor(crB, req))
+	cA2, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, keyExtrasFor(crA2, req))
+	if hA == nil {
+		t.Fatal("widgetContent L1 must be enabled")
+	}
+	if cA == cB {
+		t.Fatalf("FALSIFIER #4b FAILED: differing resourcesRefsTemplateExtras produced the SAME content key %q — cross-widget collision on the identity-free cell", cA)
+	}
+	if cA != cA2 {
+		t.Fatalf("#4b: identical rrt extras MUST produce identical content keys, got %q vs %q", cA, cA2)
+	}
+
+	// per-cohort cell must ALSO distinguish (the union folds rrt-inline there too).
+	pcA, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(crA, req))
+	pcB, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(crB, req))
+	if pcA == pcB {
+		t.Fatalf("FALSIFIER #4b FAILED: differing rrt extras produced the SAME per-cohort key %q", pcA)
+	}
+
+	// --- RAFullList sub-cell MUST be UNCHANGED across differing rrt extras ---
+	// rrt-inline does not reach the apiRef-effective map (design §1), so the
+	// apiRef sub-cell key is invariant to it.
+	const rg, rv, rr, rns, rname = "templates.krateo.io", "v1", "restactions", "demo-system", "some-ra"
+	const bUID = "binding-xyz"
+	raA := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, crA, req)))
+	raB := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, crB, req)))
+	if raA != raB {
+		t.Fatalf("FALSIFIER #4b FAILED: differing resourcesRefsTemplateExtras perturbed the RAFullList sub-cell key (%q vs %q) — rrt-inline MUST NOT key the apiRef cell", raA, raB)
+	}
+	// Caveat B (one line): RAFullListKeyInputs strips {slice,page,perPage,offset}
+	// via extrasMinusSlice, so an author declaring one of those four RESERVED
+	// pagination names in apiRef.extras won't perturb the RAFullList key.
+	// Negligible (reserved names), pre-existing for request-extras — noted only.
+}
+
+// TestInlineExtras_8_BackwardCompat_ByteIdenticalKeys — falsifier #8 (key
+// half). A widget CR with NEITHER inline block ⇒ keyExtras == the request
+// extras ⇒ the widget content + per-cohort keys are BYTE-IDENTICAL to a
+// pre-inline-extras request that passed the bare request extras. With no
+// request extras either, both are byte-identical to the no-extras key.
+func TestInlineExtras_8_BackwardCompat_ByteIdenticalKeys(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-bc"
+		perPage, page     = 10, 1
+	)
+
+	bare := map[string]any{} // a CR with no inline blocks
+	noInlineCR := widgetCRWithExtras(t, "", "")
+
+	// (a) no inline blocks + no request extras == today's no-extras key.
+	keyUnion, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, keyExtrasFor(noInlineCR, bare))
+	keyLegacy, _, _ := dispatchWidgetContentKey(ctx, g, v, r, ns, name, perPage, page, bare)
+	if keyUnion != keyLegacy {
+		t.Fatalf("FALSIFIER #8 FAILED: absent-inline-blocks content key %q != pre-feature bare-extras key %q", keyUnion, keyLegacy)
+	}
+
+	// (b) no inline blocks + a REQUEST extras == the legacy request-extras key
+	// (the union degenerates to exactly the request map).
+	reqX := parseExtras(t, `{"tenant":"acme"}`)
+	pcUnion, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(noInlineCR, reqX))
+	pcLegacy, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, reqX)
+	if pcUnion != pcLegacy {
+		t.Fatalf("FALSIFIER #8 FAILED: absent-inline-blocks + request-extras per-cohort key %q != legacy request-extras key %q", pcUnion, pcLegacy)
+	}
+}
+
+// TestInlineExtras_9_UnionForKey_Race — falsifier #9 (key builder half). The
+// dispatcher builds keyExtras concurrently across N in-flight /calls. Run
+// unionForKey + the accessors + the real key builders concurrently under
+// `-race`; the shared widget CR map (read by the accessors) must never be
+// aliased or mutated, and concurrent builds for the SAME inputs must produce
+// the SAME key (deterministic). A data race here = the shared-vs-copy hazard.
+func TestInlineExtras_9_UnionForKey_Race(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-race"
+		perPage, page     = 10, 1
+	)
+	// One SHARED CR object — concurrently read by every goroutine's accessor.
+	sharedCR := widgetCRWithExtras(t, `{"tenant":"acme","nested":{"k":"v"}}`, `{"targetNs":"team-a"}`)
+	req := parseExtras(t, `{"region":"eu"}`)
+
+	want, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(sharedCR, req))
+
+	const goroutines = 32
+	errs := make(chan string, goroutines)
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			ke := keyExtrasFor(sharedCR, req)
+			// Mutate THIS goroutine's union — must not bleed into the shared CR
+			// (the accessors return deep copies; unionForKey returns a fresh map).
+			ke["scratch"] = "mutated"
+			got, _, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtrasFor(sharedCR, req))
+			if got != want {
+				errs <- got
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	close(errs)
+	if bad, ok := <-errs; ok {
+		t.Fatalf("FALSIFIER #9 FAILED: concurrent key build for identical inputs diverged (got %q want %q) — shared CR aliased/mutated", bad, want)
+	}
+	// The shared CR's apiRef.extras must be untouched after all the concurrent
+	// unions + scratch mutations.
+	if got := widgets.GetApiRefExtras(sharedCR)["tenant"]; got != "acme" {
+		t.Fatalf("FALSIFIER #9 FAILED: shared CR apiRef.extras was mutated by a concurrent union (tenant=%v)", got)
 	}
 }

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -242,6 +242,54 @@ func dispatchCacheLookupKey(ctx context.Context, handlerKind, group, version, re
 	return cache.ComputeKey(inputs), c, &inputs
 }
 
+// unionForKey builds the body-dependency fingerprint the widget L1 key must
+// fold under inline-extras design P (§1, §4.3): the UNION of both
+// author-declared inline maps (apiRef.extras + resourcesRefsTemplateExtras)
+// PLUS the per-request extras, with REQUEST WINNING on every collision
+// (mirroring the per-surface request-wins precedence in widgets.Resolve).
+//
+// WHY a flat union is the correct key material: a change to EITHER inline map
+// changes the resolved body (apiRef.extras feeds the apiRef fetch → ds; the
+// rrt block feeds the resourcesRefsTemplate jq), so the widget content +
+// per-cohort keys MUST vary on either. The union is collision-sound because
+// the widget key ALSO folds Group/Version/Resource/Namespace/Name (and, on
+// the per-cohort cell, BindingUID) — so two DIFFERENT widgets never share a
+// cell regardless of extras, and for the SAME widget the inline maps are fixed
+// by its CR (cannot vary request-to-request). The union therefore only needs
+// to discriminate the per-request variable (request extras) and the
+// per-widget-fixed inline contribution — which a flat superset does
+// faithfully (design §1 collision-soundness note).
+//
+// SCOPING: this union keys the WIDGET cell only. The apiRef sub-cell
+// (RAFullList) is keyed separately by the apiRef-EFFECTIVE map
+// (merge(apiRefInline, request)) threaded through apiref.Resolve's Extras —
+// the rrt-inline map MUST NOT enter the apiRef sub-cell (it does not affect
+// the apiRef fetch). See widgets.go's resolveApiRef + ra_full_list.go.
+//
+// All inputs are read off the widget CR via maps.NestedMap (deep copies) or
+// are the per-request extras; the result is a fresh map and never aliases any
+// of them. nil/empty all-round ⇒ a fresh empty map ⇒ ComputeKey's len>0 guard
+// skips the extras fold ⇒ the key is byte-identical to a no-extras request
+// (backward-compat, falsifier #8). Mechanism-uniform (feedback_no_special_cases):
+// every key folds the same way; no widget-name table, no key allowlist.
+func unionForKey(apiRefInline, rrtInline, request map[string]any) map[string]any {
+	out := make(map[string]any, len(apiRefInline)+len(rrtInline)+len(request))
+	// Inline maps first; request overwrites last so the request value wins on
+	// collision — matching the resolved body precedence. (Order between the two
+	// inline maps is irrelevant for a key fingerprint: both are CR-fixed, so
+	// the body is a deterministic function of the CR regardless.)
+	for k, v := range apiRefInline {
+		out[k] = v
+	}
+	for k, v := range rrtInline {
+		out[k] = v
+	}
+	for k, v := range request {
+		out[k] = v
+	}
+	return out
+}
+
 // cacheHandle is the narrow interface the dispatchers depend on. The
 // real implementation is *cache.resolvedCache; tests can substitute
 // stubs without dragging in the whole singleton. Kept package-private
@@ -431,6 +479,7 @@ func writeResolvedJSON(wri http.ResponseWriter, payload []byte) {
 //     to the background re-resolve context (the 0.30.113 Part B fix
 //     surface, where the SA is transport-only and per-user identity comes
 //     from the cached Inputs).
+//
 // 0.30.166 extends the SAME attach to the per-request restactions.go +
 // widgets.go dispatcher entries — the previously-unpatched surface that
 // is the actual cache-off /call request path. See ship-307-tls-x509-cache-

--- a/internal/handlers/dispatchers/inline_extras_seed_parity_test.go
+++ b/internal/handlers/dispatchers/inline_extras_seed_parity_test.go
@@ -1,0 +1,126 @@
+// inline_extras_seed_parity_test.go — falsifier #6 for inline-extras design P
+// (PM MUST-FIX #1). The biggest risk under P is the #317 seed/serve key-
+// mismatch class: the PIP seed historically keyed widget + RAFullList cells on
+// extras=nil at TWO surfaces, while the live dispatcher — after P folds the
+// inline maps into its key-union (§1) — keys on the NON-EMPTY union. If the
+// seed is not taught the same fold, every widget declaring inline extras MISSES
+// its prewarmed cell and resolves cold on first paint.
+//
+// These tests assert seed-key == serve-key at BOTH cells by driving the EXACT
+// production key computations:
+//   - per-cohort widget cell: dispatchCacheLookupKey with the seed's
+//     unionForKey(apiRefInline, rrtInline, nil) vs the dispatcher's
+//     unionForKey(apiRefInline, rrtInline, <empty request>), then a real
+//     handle.Put under the seed key + handle.Get under the serve key → HIT.
+//   - RAFullList sub-cell: RAFullListKeyInputs with the seed's apiRefInline
+//     (no request) vs the dispatcher's apiRef-effective map (apiRefInline under
+//     an empty request) → byte-identical key → HIT.
+//
+// A miss at either cell proves divergence (the bug). The seed BODY parity is
+// automatic (widgets.Resolve reads the inline maps off the seeded CR itself);
+// only the two seed KEY args are computed outside Resolve, which is exactly
+// what these tests cover.
+package dispatchers
+
+import (
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+)
+
+// seedKeyExtrasFor reproduces the seed's per-cohort key-extras fold
+// (phase1_pip_seed.go: unionForKey(GetApiRefExtras, GetResourcesRefsExtras,
+// nil) — the seed has NO request extras).
+func seedKeyExtrasFor(crObj map[string]any) map[string]any {
+	return unionForKey(
+		widgets.GetApiRefExtras(crObj),
+		widgets.GetResourcesRefsExtras(crObj),
+		nil,
+	)
+}
+
+// TestInlineExtras_6_SeedParity_PerCohortWidgetCell — falsifier #6, cell 1.
+// Seed a widget carrying BOTH inline maps under the SEED's per-cohort key, then
+// look up under the DISPATCHER's serve-time key (no ?extras=) → MUST HIT.
+func TestInlineExtras_6_SeedParity_PerCohortWidgetCell(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-seed"
+		perPage, page     = 10, 1
+	)
+	cr := widgetCRWithExtras(t, `{"tenant":"acme"}`, `{"targetNs":"team-a"}`)
+
+	// SEED key: union with NIL request (the seed has no request extras).
+	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, seedKeyExtrasFor(cr))
+	if seedHandle == nil || seedKey == "" {
+		t.Fatal("expected a live per-cohort cache handle + key under the seed ctx")
+	}
+	body := []byte(`{"status":{"widgetData":{"label":"acme"}}}`)
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: body, Inputs: seedInputs})
+
+	// SERVE key: union with the EMPTY request extras (no ?extras= on the /call).
+	serveKey, serveHandle, _ := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, keyExtrasFor(cr, map[string]any{}))
+	if serveHandle == nil || serveKey == "" {
+		t.Fatal("expected a live per-cohort cache handle + key under the serve ctx")
+	}
+	if seedKey != serveKey {
+		t.Fatalf("FALSIFIER #6 FAILED (per-cohort cell): seed key %q != serve key %q — "+
+			"a widget declaring inline extras would MISS its prewarmed cell and resolve cold (the #317 mismatch class)", seedKey, serveKey)
+	}
+	got, hit := serveHandle.Get(serveKey)
+	if !hit {
+		t.Fatal("FALSIFIER #6 FAILED (per-cohort cell): serve-key lookup MISSED the seeded cell — seed/serve key divergence")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("per-cohort cell served the wrong body: got %q want %q", got.RawJSON, body)
+	}
+}
+
+// TestInlineExtras_6_SeedParity_RAFullListSubCell — falsifier #6, cell 2.
+// The RAFullList sub-cell key the seed folds (apiRefInline, no request) MUST
+// byte-match the dispatcher's apiRef-effective key (apiRefInline under an empty
+// request), so the seeded full-list cell is HIT on the first paginated /call.
+// The resourcesRefsTemplateExtras map MUST NOT perturb this cell (§1).
+func TestInlineExtras_6_SeedParity_RAFullListSubCell(t *testing.T) {
+	enableWidgetContentL1(t)
+	const (
+		rg, rv, rr, rns, rname = "templates.krateo.io", "v1", "restactions", "demo-system", "some-ra"
+		bUID                   = "binding-xyz"
+	)
+	// A widget with apiRef.extras AND an rrt block — the rrt block must be
+	// invisible to the RAFullList key.
+	cr := widgetCRWithExtras(t, `{"tenant":"acme"}`, `{"targetNs":"team-a"}`)
+
+	// SEED RAFullList key: seedRAFullListForWidget threads GetApiRefExtras(w)
+	// (no request) as apiref.Resolve Extras → RAFullListKeyInputs(..., apiRefInline).
+	seedRAKey := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		widgets.GetApiRefExtras(cr)))
+
+	// SERVE RAFullList key: the dispatcher's apiRef path threads
+	// merge(apiRefInline, request) — with no ?extras= the request is empty, so
+	// the effective map IS apiRefInline.
+	serveRAKey := cache.ComputeKey(cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		keyExtrasForApiRefEffective(t, cr, map[string]any{})))
+
+	if seedRAKey != serveRAKey {
+		t.Fatalf("FALSIFIER #6 FAILED (RAFullList sub-cell): seed key %q != serve key %q — "+
+			"the prewarmed RAFullList cell would be MISSED on the first paginated /call", seedRAKey, serveRAKey)
+	}
+
+	// Sanity: a real Put-under-seed / Get-under-serve hits (drives the real
+	// handle, not just key equality).
+	c := cache.ResolvedCache()
+	if c == nil {
+		t.Fatal("expected a live resolved cache")
+	}
+	full := map[string]any{"items": []any{map[string]any{"x": float64(1)}}}
+	c.PutRAFullList(seedRAKey, cache.RAFullListKeyInputs(rg, rv, rr, rns, rname, bUID,
+		widgets.GetApiRefExtras(cr)), full)
+	if _, hit := c.Get(serveRAKey); !hit {
+		t.Fatal("FALSIFIER #6 FAILED (RAFullList sub-cell): serve-key lookup MISSED the seeded full-list cell")
+	}
+}

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -1014,7 +1014,7 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	resCtx = cache.WithPIPStageTimingSink(resCtx, stageTimingSink)
 
 	res, err := restactions.Resolve(resCtx, restactions.ResolveOptions{
-		In:      &cr,
+		In: &cr,
 		// Ship 0.30.230 fix-at-root: SArc is the SA *rest.Config carried
 		// on ctx by withCohortSeedContext upstream. Threading it here
 		// ensures the inner endpointReferenceMapper has a non-nil rc for
@@ -1078,6 +1078,26 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 		return nil
 	}
 
+	// inline-extras design P §5 / MUST-FIX #1 — PIP-seed key parity at the
+	// per-cohort widget cell. The dispatcher keys this cell on the UNION of
+	// both inline maps + request (§1); the seed has NO request extras, so the
+	// union degenerates to unionForKey(apiRefInline, rrtInline, nil) read off
+	// the widget CR (e.W). Without this fold the seed would key on extras=nil
+	// while the dispatcher keys on the non-empty union → every widget
+	// declaring inline extras MISSES its prewarmed cell and resolves cold on
+	// first paint (the #317 seed/serve key-mismatch class). The seed BODY
+	// parity is AUTOMATIC: widgets.Resolve reads the inline maps off in.Object
+	// (the seeded CR) itself (resolveApiRef §4.1 + the §4.2 fold), so no
+	// ResolveOptions.Extras field is needed — only this KEY arg is computed
+	// outside Resolve and must be hand-threaded. Absent both blocks ⇒ {} + {}
+	// ⇒ a fresh empty union ⇒ byte-identical to the pre-inline-extras nil arg
+	// (HG-PIP.3 backward-compat). Falsifier #6 asserts the resulting HIT.
+	seedKeyExtras := unionForKey(
+		widgets.GetApiRefExtras(e.W.Object),
+		widgets.GetResourcesRefsExtras(e.W.Object),
+		nil,
+	)
+
 	// Ship 0.30.187 D2: the dispatcher-lookup key uses the KEY tuple
 	// (KeyPerPage, KeyPage) — derived from the /call Path the walker
 	// reached this widget through so the cell matches the dispatcher's
@@ -1087,7 +1107,7 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 	key, handle, inputs := dispatchCacheLookupKey(ctx, "widgets",
 		e.GVR.Group, e.GVR.Version, e.GVR.Resource,
 		e.W.GetNamespace(), e.W.GetName(),
-		e.KeyPerPage, e.KeyPage, nil)
+		e.KeyPerPage, e.KeyPage, seedKeyExtras)
 	// Ship 0.30.188 — diagnostic slog: emit the widget seed Put cache
 	// key + components so it can be diff'd against the dispatcher_get
 	// and per_user_fallback_put log lines at widgets.go.
@@ -1095,7 +1115,7 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 		key, inputs, "widgets",
 		e.GVR.Group, e.GVR.Version, e.GVR.Resource,
 		e.W.GetNamespace(), e.W.GetName(),
-		e.KeyPerPage, e.KeyPage, nil)
+		e.KeyPerPage, e.KeyPage, seedKeyExtras)
 	if handle == nil || key == "" {
 		// L1 disabled or no identity — same defensive skip as
 		// seedOneRestaction.
@@ -1139,7 +1159,7 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 	resCtx = cache.WithPIPStageTimingSink(resCtx, stageTimingSink)
 
 	res, err := widgets.Resolve(resCtx, widgets.ResolveOptions{
-		In:      in,
+		In: in,
 		// Ship 0.30.230 fix-at-root: RC is the SA *rest.Config carried
 		// on ctx by withCohortSeedContext upstream. Threading it here
 		// fixes the nil-rc crash at crdschema.ValidateObjectStatus →
@@ -1206,6 +1226,18 @@ func seedRAFullListForWidget(ctx context.Context, w *unstructured.Unstructured, 
 		// No apiRef (static widget) or unparseable — nothing to prewarm.
 		return
 	}
+	// inline-extras design P §5 / MUST-FIX #1 — PIP-seed key parity at the
+	// RAFullList sub-cell. The dispatcher's apiRef path keys this sub-cell on
+	// the apiRef-EFFECTIVE map (merge(apiRefInline, request)) via
+	// apiref.Resolve → RAFullListKeyInputs (ra_full_list.go). The seed has no
+	// request extras, so the effective map degenerates to the apiRef-inline
+	// map read off the widget CR. Threading it into apiref.Resolve's Extras
+	// below makes the seed's RAFullList key fold the SAME apiRef-inline map the
+	// dispatcher's first /call will → seed-key == serve-key on this sub-cell.
+	// The resourcesRefsTemplateExtras map is correctly NOT folded here — it
+	// does not affect the apiRef fetch (§1). Absent ⇒ {} ⇒ byte-identical to
+	// the pre-inline-extras nil Extras (extrasMinusSlice({}) → nil → no fold).
+	apiRefInline := widgets.GetApiRefExtras(w.Object)
 	// Resolve at a paginated tuple so raFullListServe engages (it requires
 	// perPage>0 && page>0). page 1 + prewarmPageLimit is sufficient: the
 	// byte-verify + pin are per-(RA × shape), NOT per-page, so this single
@@ -1229,6 +1261,10 @@ func seedRAFullListForWidget(ctx context.Context, w *unstructured.Unstructured, 
 		AuthnNS: authnNS,
 		PerPage: pp,
 		Page:    1,
+		// inline-extras P §5 — fold the apiRef-inline map so the RAFullList
+		// key matches the dispatcher's apiRef-effective key (seed has no
+		// request extras). NOT the union — rrt-inline must not key this cell.
+		Extras: apiRefInline,
 	}); rerr != nil {
 		slog.Default().Warn("phase1.seed.rafulllist.skipped",
 			slog.String("subsystem", "cache"),

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -101,6 +101,28 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 
 	perPage, page := paginationInfo(log, req)
 
+	// inline-extras design P §1/§4.3 — the cache-key union. The widget CR is
+	// already in hand (got.Unstructured, fetched above), so read BOTH
+	// author-declared inline maps off it and fold their UNION with the
+	// per-request extras (request wins). keyExtras is the body-dependency
+	// fingerprint passed IN PLACE OF the bare request extras to every widget
+	// key site below (content + per-cohort) and the two diagnostic emits, so
+	// the widget keys vary across either inline map — without which two widgets
+	// sharing the (gvr/ns/name/pagination/request-extras) tuple but differing
+	// in apiRef.extras OR resourcesRefsTemplateExtras would collide on one
+	// identity-free cell and serve each other's body (the make-or-break crux).
+	// The apiRef sub-cell (RAFullList) is keyed separately by the apiRef-
+	// effective map threaded through apiref.Resolve (resolveApiRef §4.1) — the
+	// rrt-inline map deliberately does NOT enter that sub-cell. Absent both
+	// blocks ⇒ both accessors return {} ⇒ keyExtras == request extras ⇒
+	// byte-identical keys (backward-compat). The accessors return deep copies,
+	// so keyExtras never aliases the shared CR.
+	keyExtras := unionForKey(
+		widgets.GetApiRefExtras(got.Unstructured.Object),
+		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
+		extras,
+	)
+
 	// Ship G (0.30.16x) — identity-free widget content L1 lookup runs
 	// FIRST. Same gating semantics as the per-user lookup below
 	// (strictly after EvaluateRBAC at :62-72). The content key is
@@ -135,7 +157,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		contentKey, contentHandle, _ := dispatchWidgetContentKey(req.Context(),
 			got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 			got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
-			perPage, page, extras)
+			perPage, page, keyExtras)
 		if contentHandle != nil {
 			if entry, ok := contentHandle.Get(contentKey); ok {
 				if gated, served := gateWidgetEnvelope(req.Context(), entry.RawJSON); served {
@@ -170,7 +192,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	cacheKey, cacheHandle, cacheInputs := dispatchCacheLookupKey(req.Context(), "widgets",
 		got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 		got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
-		perPage, page, extras)
+		perPage, page, keyExtras)
 	// Ship 0.30.188 — diagnostic slog: emit the dispatcher-side cache
 	// key + its components so it can be diff'd against the PIP seed Put
 	// log line at phase1_pip_seed.go and the per-user-fallback Put line
@@ -179,7 +201,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		cacheKey, cacheInputs, "widgets",
 		got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 		got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
-		perPage, page, extras)
+		perPage, page, keyExtras)
 	if cacheHandle != nil {
 		if entry, ok := cacheHandle.Get(cacheKey); ok {
 			emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, true, len(entry.RawJSON))
@@ -279,7 +301,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 			cacheKey, cacheInputs, "widgets",
 			got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 			got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
-			perPage, page, extras)
+			perPage, page, keyExtras)
 		cacheHandle.Put(cacheKey, &cache.ResolvedEntry{
 			RawJSON: encoded,
 			Inputs:  cacheInputs,

--- a/internal/resolvers/widgets/extras_integration_test.go
+++ b/internal/resolvers/widgets/extras_integration_test.go
@@ -75,9 +75,224 @@ func TestResolveWidgets_Extras(t *testing.T) {
 		// Step 1: apiRef RESTAction path references an extras key.
 		Assess("apiRef widget: extras parametrises the RESTAction fetch path",
 			assertApiRefExtras).
+		// inline-extras design P — per-surface inline maps end-to-end.
+		Assess("#1b/#5 inline resourcesRefsTemplateExtras reaches the rrt jq ONLY (scope isolation)",
+			assertInlineRrtExtrasScoped).
+		Assess("#1a inline apiRef.extras parametrises the RESTAction fetch path (no request)",
+			assertInlineApiRefExtras).
+		Assess("#2a request overrides inline apiRef.extras (request wins)",
+			assertRequestOverridesInlineApiRef).
+		Assess("#7 input-only: inline maps never echo into resolved status",
+			assertInlineExtrasInputOnly).
 		Feature()
 
 	testenv.Test(t, f)
+}
+
+// TWO-REPO SPLIT (design §6 + hard constraints): the widget CRD schema
+// declarations for spec.apiRef.extras + spec.resourcesRefsTemplateExtras are a
+// portal-chart follow-up, OUT of this snowplow ship's scope. The kind harness
+// installs the SHIPPED Button CRD (which declares neither), so a CREATE through
+// the apiserver PRUNES both inline blocks before the resolver could read them
+// (the apiserver logs `unknown field "spec.apiRef.extras"`). The inline
+// falsifiers therefore build the widget unstructured IN-MEMORY carrying the
+// inline blocks and pass it straight to the REAL widgets.Resolve — exactly the
+// object shape the production fetchObject GET will return once the portal CRD
+// ships the fields. Snowplow reads unstructured and tolerates absence ({}); the
+// only thing the apiserver round-trip would add is the prune, which is the very
+// behaviour the two-repo follow-up removes. (The RESTAction the apiRef path
+// resolves IS fetched from the cluster — only the widget object is in-memory.)
+
+// inlineStaticWidget builds the apiRef-LESS scope-isolation fixture in-memory:
+// widgetDataTemplate runs BEFORE the resourcesRefsTemplateExtras fold so it sees
+// `.rrtNs` as ABSENT ("ns=ABSENT"); the resourcesRefsTemplate iterator over the
+// inline `names` fans out one ref per element, each namespaced by the inline
+// `rrtNs`. Mirrors testdata/widgets/button.extras.inline.static.yaml.
+func inlineStaticWidget() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "button-extras-inline-static", "namespace": namespace},
+		"spec": map[string]any{
+			"widgetData": map[string]any{
+				"actions": map[string]any{}, "clickActionId": "nop",
+				"label": "base-label", "icon": "fa-clock", "type": "text",
+			},
+			"widgetDataTemplate": []any{
+				map[string]any{"forPath": "label", "expression": `${ "ns=" + (.rrtNs // "ABSENT") }`},
+			},
+			"resourcesRefsTemplate": []any{
+				// Iterator over the rrt-inline `names` array (evaluated against
+				// ds): fanning out proves `names` reached the rrt jq. Inside the
+				// iterator, `.` is each element string, so namespace=${ . }.
+				map[string]any{
+					"iterator": `${ .names }`,
+					"template": map[string]any{
+						"id": `${ "ns-" + . }`, "apiVersion": "v1", "resource": "namespaces",
+						"namespace": `${ . }`, "verb": "GET",
+					},
+				},
+				// Non-iterator item referencing the rrt-inline SCALAR `rrtNs`
+				// (evaluated against ds): a resolved namespace=inline-team proves
+				// `rrtNs` reached the rrt jq too.
+				map[string]any{
+					"template": map[string]any{
+						"id": `${ "from-rrtNs-" + .rrtNs }`, "apiVersion": "v1",
+						"resource": "namespaces", "namespace": `${ .rrtNs }`, "verb": "GET",
+					},
+				},
+			},
+			"resourcesRefsTemplateExtras": map[string]any{
+				"rrtNs": "inline-team",
+				"names": []any{"alpha", "beta"},
+			},
+		},
+	}}
+}
+
+// inlineApiRefWidget builds the apiRef fixture in-memory with
+// spec.apiRef.extras.nsName. Mirrors button.extras.inline.apiref.yaml; the
+// referenced RESTAction (extras-namespace-by-name) IS fetched from the cluster.
+func inlineApiRefWidget() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "button-extras-inline-apiref", "namespace": namespace},
+		"spec": map[string]any{
+			"widgetData": map[string]any{
+				"actions": map[string]any{}, "clickActionId": "nop",
+				"label": "base-label", "icon": "fa-clock", "type": "text",
+			},
+			"apiRef": map[string]any{
+				"name": "extras-namespace-by-name", "namespace": namespace,
+				"extras": map[string]any{"nsName": "kube-system"},
+			},
+			"widgetDataTemplate": []any{
+				map[string]any{"forPath": "label", "expression": `${ .ns.metadata.name }`},
+			},
+		},
+	}}
+}
+
+// assertInlineRrtExtrasScoped resolves the in-memory inline-static widget with
+// NO request extras and asserts (falsifier #1b + #5):
+//   - the resourcesRefsTemplate jq saw the inline rrt keys (one ref per `names`
+//     element, each namespaced by the inline `rrtNs`) — proves #1b inline-only;
+//   - the widgetDataTemplate did NOT see the rrt-only key `rrtNs`
+//     (status.widgetData.label == "ns=ABSENT") — proves #5 scope isolation
+//     (the rrt fold happens AFTER widgetDataTemplate ran).
+func assertInlineRrtExtrasScoped(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	// NO request extras — the inline resourcesRefsTemplateExtras block is the
+	// sole source of rrtNs + names.
+	obj := resolveInMemoryWidget(ctx, t, c, inlineStaticWidget(), nil)
+
+	// #5 — scope isolation: the rrt-only key MUST be absent in widgetData.
+	wd := nestedMap(t, obj, "status", "widgetData")
+	if got := wd["label"]; got != "ns=ABSENT" {
+		t.Fatalf("#5 scope-isolation FAILED: widgetDataTemplate saw the resourcesRefsTemplateExtras-only key rrtNs; "+
+			"status.widgetData.label got %v want \"ns=ABSENT\" (the rrt fold must be invisible to widgetDataTemplate)", got)
+	}
+
+	// #1b — the resourcesRefsTemplate jq DID see the inline rrt keys:
+	//   - the iterator over `names` fanned out one ref per element (ns-alpha,
+	//     ns-beta) — proves the ARRAY key `names` reached the jq;
+	//   - the scalar item resolved namespace=inline-team — proves the SCALAR
+	//     key `rrtNs` reached the jq.
+	items := nestedSlice(t, obj, "status", "resourcesRefs", "items")
+	if len(items) != 3 {
+		t.Fatalf("#1b FAILED: resourcesRefsTemplate must fan out 2 iterator refs + 1 scalar ref; got %d want 3 (items=%v)", len(items), items)
+	}
+	for _, el := range []string{"alpha", "beta"} {
+		if !hasRefWithID(items, "ns-"+el) {
+			t.Fatalf("#1b FAILED: expected a resourcesRefs item with id ns-%s (from inline names element %q); items=%v", el, el, items)
+		}
+		if !hasRefPathContainingNamespace(items, el) {
+			t.Fatalf("#1b FAILED: expected a ref targeting namespace=%s (from inline names element); items=%v", el, items)
+		}
+	}
+	// The scalar item proves rrtNs reached the jq.
+	if !hasRefWithID(items, "from-rrtNs-inline-team") {
+		t.Fatalf("#1b FAILED: expected a resourcesRefs item id from-rrtNs-inline-team (from inline rrtNs scalar); items=%v", items)
+	}
+	if !hasRefPathContainingNamespace(items, "inline-team") {
+		t.Fatalf("#1b FAILED: expected a ref targeting namespace=inline-team (from inline rrtNs); items=%v", items)
+	}
+	return ctx
+}
+
+// assertInlineApiRefExtras resolves the in-memory inline-apiref widget with NO
+// request extras; the inline spec.apiRef.extras.nsName="kube-system" must
+// parametrise the RESTAction path so status.widgetData.label == "kube-system"
+// (#1a).
+func assertInlineApiRefExtras(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	obj := resolveInMemoryWidget(ctx, t, c, inlineApiRefWidget(), nil)
+	wd := nestedMap(t, obj, "status", "widgetData")
+	if got := wd["label"]; got != "kube-system" {
+		t.Fatalf("#1a FAILED: inline apiRef.extras.nsName must parametrise the RESTAction fetch path; "+
+			"status.widgetData.label got %v want kube-system (if base-label/empty, the inline map did not reach the fetch)", got)
+	}
+	return ctx
+}
+
+// assertRequestOverridesInlineApiRef resolves the SAME in-memory inline-apiref
+// widget but WITH a request extras override (nsName=default). The REQUEST value
+// must win over the inline default, so the fetched namespace is `default` and
+// status.widgetData.label == "default" (#2a — the load-bearing precedence).
+func assertRequestOverridesInlineApiRef(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	obj := resolveInMemoryWidget(ctx, t, c, inlineApiRefWidget(),
+		map[string]any{"nsName": "default"})
+	wd := nestedMap(t, obj, "status", "widgetData")
+	if got := wd["label"]; got != "default" {
+		t.Fatalf("#2a FAILED: the REQUEST extras nsName MUST win over the inline apiRef.extras default; "+
+			"status.widgetData.label got %v want default (got kube-system ⇒ inline shadowed the request — the precedence bug)", got)
+	}
+	return ctx
+}
+
+// assertInlineExtrasInputOnly resolves the in-memory inline-static widget and
+// asserts the inline maps never echo into the resolved status (falsifier #7):
+// no status.apiRef.extras, no status.resourcesRefsTemplateExtras, no
+// status.extras. Inline extras is INPUT-only (seeds ds / the api dict), exactly
+// like request extras.
+func assertInlineExtrasInputOnly(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	obj := resolveInMemoryWidget(ctx, t, c, inlineStaticWidget(), nil)
+	status := nestedMap(t, obj, "status")
+	if status == nil {
+		t.Fatal("#7: resolved widget has no status")
+	}
+	if _, present := status["extras"]; present {
+		t.Fatalf("#7 FAILED: status.extras MUST NOT be written (inline extras is input-only); status=%v", status)
+	}
+	if _, present := status["resourcesRefsTemplateExtras"]; present {
+		t.Fatalf("#7 FAILED: status.resourcesRefsTemplateExtras MUST NOT be written; status=%v", status)
+	}
+	// status.apiRef (if any) must not carry an extras sub-key either.
+	if ar, ok := status["apiRef"].(map[string]any); ok {
+		if _, present := ar["extras"]; present {
+			t.Fatalf("#7 FAILED: status.apiRef.extras MUST NOT be written; status.apiRef=%v", ar)
+		}
+	}
+	return ctx
+}
+
+// resolveInMemoryWidget resolves an in-memory widget unstructured (carrying the
+// inline-extras blocks the shipped CRD would prune on a CREATE round-trip — see
+// the TWO-REPO SPLIT note above) through the REAL widgets.Resolve. AuthnNS is
+// set so the apiRef per-user endpoint resolves (cf. resolveExtrasWidget).
+func resolveInMemoryWidget(ctx context.Context, t *testing.T, c *envconf.Config, in *unstructured.Unstructured, extras map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	obj, err := Resolve(ctx, ResolveOptions{
+		RC:      c.Client().RESTConfig(),
+		AuthnNS: namespace,
+		In:      in,
+		Extras:  extras,
+	})
+	if err != nil {
+		log := xcontext.Logger(ctx)
+		log.Error("unable to resolve in-memory widget", slog.Any("err", err))
+		t.Fatalf("resolve in-memory widget %q with extras=%v: %v", in.GetName(), extras, err)
+	}
+	return obj
 }
 
 // assertStaticExtras resolves button-extras-static with

--- a/internal/resolvers/widgets/extras_merge_test.go
+++ b/internal/resolvers/widgets/extras_merge_test.go
@@ -291,6 +291,240 @@ func TestExtras_NoExtras_TemplateUnchanged(t *testing.T) {
 	}
 }
 
+// ===========================================================================
+// inline-extras design P — resolver-side helper + accessor falsifiers.
+// These unit-test the NEW merge direction (mergeRequestWins: request wins) and
+// the two accessors. The end-to-end per-surface + scope-isolation + input-only
+// proofs live in extras_integration_test.go (real cluster).
+// ===========================================================================
+
+// TestMergeRequestWins_RequestOverridesInline is the per-surface precedence
+// falsifier at the helper level (design §4, falsifier #2 core): a key declared
+// BOTH inline AND via the request resolves to the REQUEST value. This is the
+// load-bearing inversion of mergeExtras — the route is the more-specific
+// intent and MUST win over an inline default.
+func TestMergeRequestWins_RequestOverridesInline(t *testing.T) {
+	inline := parseExtras(t, `{"tenant":"inline-default","onlyInline":"keep"}`)
+	request := parseExtras(t, `{"tenant":"from-request","onlyRequest":"add"}`)
+
+	eff := mergeRequestWins(inline, request)
+
+	assert.Equal(t, "from-request", eff["tenant"],
+		"collision: the REQUEST value MUST win over the inline default (per-surface precedence)")
+	assert.Equal(t, "keep", eff["onlyInline"], "a non-colliding inline key must survive")
+	assert.Equal(t, "add", eff["onlyRequest"], "a request-only key must be present")
+}
+
+// TestMergeRequestWins_EmptyInputs — backward-compat: both empty ⇒ a fresh
+// empty map (an empty effective fold downstream is a no-op). nil inline +
+// request ⇒ exactly the request; inline + nil request ⇒ exactly the inline.
+func TestMergeRequestWins_EmptyInputs(t *testing.T) {
+	assert.Equal(t, map[string]any{}, mergeRequestWins(nil, nil), "both nil ⇒ fresh empty map")
+	assert.Equal(t, map[string]any{}, mergeRequestWins(map[string]any{}, map[string]any{}), "both empty ⇒ fresh empty map")
+
+	req := parseExtras(t, `{"a":"1"}`)
+	assert.Equal(t, map[string]any{"a": "1"}, mergeRequestWins(nil, req), "nil inline ⇒ exactly the request")
+
+	inl := parseExtras(t, `{"b":"2"}`)
+	assert.Equal(t, map[string]any{"b": "2"}, mergeRequestWins(inl, nil), "nil request ⇒ exactly the inline")
+}
+
+// TestMergeRequestWins_DeepCopiesBothInputs — the effective map must NOT alias
+// EITHER source map. Mutating a nested value through the original inline OR
+// request map after the merge must not bleed into the effective map. This is
+// the shared-vs-copy isolation that keeps the per-call effective map self-
+// contained (feedback_shared_vs_copy_is_a_concurrency_change).
+func TestMergeRequestWins_DeepCopiesBothInputs(t *testing.T) {
+	inlineNested := map[string]any{"k": "inline-orig"}
+	requestNested := map[string]any{"k": "request-orig"}
+	inline := map[string]any{"i": inlineNested}
+	request := map[string]any{"r": requestNested}
+
+	eff := mergeRequestWins(inline, request)
+
+	inlineNested["k"] = "inline-MUTATED"
+	requestNested["k"] = "request-MUTATED"
+
+	gi, _ := eff["i"].(map[string]any)
+	gr, _ := eff["r"].(map[string]any)
+	require.NotNil(t, gi)
+	require.NotNil(t, gr)
+	assert.Equal(t, "inline-orig", gi["k"], "effective map must hold a DEEP COPY of the inline source")
+	assert.Equal(t, "request-orig", gr["k"], "effective map must hold a DEEP COPY of the request source")
+}
+
+// TestMergeRequestWins_Race — falsifier #9 (merge-helper half). The dispatcher
+// + seed call the merge helpers concurrently across in-flight /calls reading
+// the SAME shared CR-derived maps. Run mergeRequestWins concurrently over
+// SHARED source maps under `-race`; the sources must never be mutated and
+// every result must be equivalent. A data race here = the shared-vs-copy
+// hazard the design's #9 guards.
+func TestMergeRequestWins_Race(t *testing.T) {
+	sharedInline := parseExtras(t, `{"tenant":"acme","nested":{"k":"v"}}`)
+	sharedRequest := parseExtras(t, `{"region":"eu"}`)
+
+	const goroutines = 32
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			eff := mergeRequestWins(sharedInline, sharedRequest)
+			// Mutate THIS goroutine's result — must not bleed into the shared sources.
+			eff["scratch"] = "x"
+			if n, ok := eff["nested"].(map[string]any); ok {
+				n["k"] = "mutated-locally"
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	// Sources untouched after all concurrent merges + local mutations.
+	assert.Equal(t, "acme", sharedInline["tenant"], "shared inline source must be untouched by concurrent merges")
+	nested, _ := sharedInline["nested"].(map[string]any)
+	require.NotNil(t, nested)
+	assert.Equal(t, "v", nested["k"], "shared inline nested value must be untouched (deep copy isolated it)")
+	assert.Equal(t, "eu", sharedRequest["region"], "shared request source must be untouched")
+}
+
+// TestGetApiRefExtras_ReadsSubKey_AbsentReturnsEmpty — the accessor reads the
+// `extras` SUB-KEY off spec.apiRef directly (NOT through GetApiRef's
+// ObjectReference unmarshal). Present ⇒ the map; absent apiRef OR absent
+// extras OR a typed-miss ⇒ {} (backward-compat no-op). Also proves it does NOT
+// alias the CR (deep copy).
+func TestGetApiRefExtras_ReadsSubKey_AbsentReturnsEmpty(t *testing.T) {
+	// present
+	obj := map[string]any{"spec": map[string]any{"apiRef": map[string]any{
+		"name": "ra", "namespace": "ns", "extras": map[string]any{"tenant": "acme"},
+	}}}
+	got := GetApiRefExtras(obj)
+	assert.Equal(t, "acme", got["tenant"], "must read spec.apiRef.extras")
+	got["tenant"] = "mutated" // must not bleed into the CR
+	reread := GetApiRefExtras(obj)
+	assert.Equal(t, "acme", reread["tenant"], "accessor must return a deep copy — no aliasing of the CR")
+
+	// absent extras sub-key
+	assert.Equal(t, map[string]any{}, GetApiRefExtras(map[string]any{
+		"spec": map[string]any{"apiRef": map[string]any{"name": "ra"}}}),
+		"absent extras sub-key ⇒ {}")
+	// absent apiRef
+	assert.Equal(t, map[string]any{}, GetApiRefExtras(map[string]any{"spec": map[string]any{}}),
+		"absent apiRef ⇒ {}")
+	// typed-miss (extras is not a map)
+	assert.Equal(t, map[string]any{}, GetApiRefExtras(map[string]any{
+		"spec": map[string]any{"apiRef": map[string]any{"extras": "not-a-map"}}}),
+		"typed-miss ⇒ {}")
+}
+
+// TestGetResourcesRefsExtras_ReadsSiblingBlock_AbsentReturnsEmpty — the
+// accessor reads the SIBLING block spec.resourcesRefsTemplateExtras (NOT a
+// sub-key of the resourcesRefsTemplate slice). Present ⇒ the map; absent ⇒ {}.
+func TestGetResourcesRefsExtras_ReadsSiblingBlock_AbsentReturnsEmpty(t *testing.T) {
+	obj := map[string]any{"spec": map[string]any{
+		"resourcesRefsTemplate":       []any{map[string]any{"iterator": "${ .x }"}},
+		"resourcesRefsTemplateExtras": map[string]any{"targetNs": "team-a"},
+	}}
+	got := GetResourcesRefsExtras(obj)
+	assert.Equal(t, "team-a", got["targetNs"], "must read the sibling spec.resourcesRefsTemplateExtras block")
+	got["targetNs"] = "mutated"
+	assert.Equal(t, "team-a", GetResourcesRefsExtras(obj)["targetNs"], "accessor must return a deep copy")
+
+	// absent block ⇒ {}
+	assert.Equal(t, map[string]any{}, GetResourcesRefsExtras(map[string]any{
+		"spec": map[string]any{"resourcesRefsTemplate": []any{}}}),
+		"absent resourcesRefsTemplateExtras ⇒ {}")
+}
+
+// TestInlineExtras_ApiRefInlineReferenceable_InTemplate — falsifier #1a/#2a
+// CORE at the helper level: the apiRef-effective map (inline folded under
+// request) is what reaches the apiRef RA dict + transitively `ds`. With NO
+// request, the inline value is referenceable (#1a); with a colliding request
+// key, the request value wins (#2a). Exercised through the real template eval
+// (the same path ds feeds in production).
+func TestInlineExtras_ApiRefInlineReferenceable_InTemplate(t *testing.T) {
+	// #1a — inline only (request empty): inline value reaches the template.
+	effInlineOnly := mergeRequestWins(parseExtras(t, `{"tenant":"inline-acme"}`), map[string]any{})
+	dsA := map[string]any{}
+	mergeExtras(dsA, effInlineOnly) // ds seeded from the apiRef-effective map (apiRef-less ⇒ no result to win)
+	evA := evalTenant(t, dsA)
+	assert.Equal(t, "inline-acme", evA, "#1a: apiRef-inline value (no request) must be referenceable in the template")
+
+	// #2a — request overrides inline at the apiRef surface.
+	effOverride := mergeRequestWins(parseExtras(t, `{"tenant":"inline-acme"}`), parseExtras(t, `{"tenant":"req-globex"}`))
+	dsB := map[string]any{}
+	mergeExtras(dsB, effOverride)
+	evB := evalTenant(t, dsB)
+	assert.Equal(t, "req-globex", evB, "#2a: the REQUEST value MUST win over the apiRef-inline default")
+}
+
+// TestInlineExtras_3_ApiRefResultWinsOverInline — falsifier #3. The apiRef RA
+// stage output MUST win over an apiRef.extras default on the SAME key (guards
+// against accidentally flipping mergeExtras's direction). Models the production
+// chain: api.Resolve seeds its dict from the apiRef-EFFECTIVE map
+// (mergeRequestWins(apiRefInline, request)) and the API result then OVERWRITES
+// the dict on collision (restactions/api/resolve.go:228-230) — so the result
+// becomes `ds`, where it dominates. Here we model the post-api ds (carrying the
+// result value) and confirm the inline default never displaces it.
+func TestInlineExtras_3_ApiRefResultWinsOverInline(t *testing.T) {
+	// apiRef-effective dict seeded for the fetch (inline default + request).
+	apiRefEff := mergeRequestWins(parseExtras(t, `{"tenant":"inline-default"}`), map[string]any{})
+	assert.Equal(t, "inline-default", apiRefEff["tenant"], "pre-fetch dict carries the inline default")
+
+	// The apiRef RA result overwrites `tenant` on collision (api.Resolve dict
+	// precedence) → ds holds the RESULT value. Model the resulting ds:
+	ds := map[string]any{"tenant": "from-apiRef-result"}
+	// Request extras then merge into ds non-overwriting (resolve.go:103) — does
+	// not displace the result either.
+	mergeExtras(ds, map[string]any{})
+
+	got := evalTenant(t, ds)
+	assert.Equal(t, "from-apiRef-result", got,
+		"#3: the apiRef-RESULT MUST win over the apiRef.extras inline default at template eval (mergeExtras direction must NOT be flipped)")
+}
+
+// TestInlineExtras_2b_RequestOverridesRrtInline — falsifier #2b at the resolver
+// level (resourcesRefsTemplate surface). The request extras are folded into ds
+// at resolve.go:103 (mergeExtras(ds, opts.Extras)) BEFORE the §4.2 rrt-inline
+// fold (mergeExtras(ds, rrtInline)). Since mergeExtras is non-overwriting
+// (ds-wins) and the request value is ALREADY in ds, the rrt-inline value on the
+// same key does NOT displace it → REQUEST wins over rrt-inline. Models that
+// exact two-step ds mutation order and confirms the request value survives.
+func TestInlineExtras_2b_RequestOverridesRrtInline(t *testing.T) {
+	ds := map[string]any{}
+	// Step 1 (resolve.go:103) — request extras into ds.
+	mergeExtras(ds, parseExtras(t, `{"targetNs":"req-team"}`))
+	// Step 2 (§4.2) — rrt-inline into ds, non-overwriting (ds/request wins).
+	mergeExtras(ds, parseExtras(t, `{"targetNs":"rrt-inline-team","onlyRrt":"keep"}`))
+
+	// The resourcesRefsTemplate jq sees the REQUEST value on the colliding key,
+	// and the rrt-only key still fills.
+	items := []templatesv1.ResourceRefTemplate{
+		{Template: templatesv1.ResourceRef{
+			ID: "${ .onlyRrt }", APIVersion: "v1", Resource: "namespaces",
+			Namespace: "${ .targetNs }", Verb: "get",
+		}},
+	}
+	refs, err := resourcesrefstemplate.Resolve(context.Background(), items, ds)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, "req-team", refs[0].Namespace,
+		"#2b: the REQUEST value MUST win over the rrt-inline default on a colliding key")
+	assert.Equal(t, "keep", refs[0].ID, "a non-colliding rrt-inline key is still referenceable")
+}
+
+// evalTenant runs a widgetDataTemplate `${ .tenant }` against ds and returns
+// the resolved value (the real template eval path).
+func evalTenant(t *testing.T, ds map[string]any) any {
+	t.Helper()
+	evals, err := widgetdatatemplate.Resolve(context.Background(), widgetdatatemplate.ResolveOptions{
+		Items:      []templatesv1.WidgetDataTemplate{{ForPath: "data.tenant", Expression: "${ .tenant }"}},
+		DataSource: ds,
+	})
+	require.NoError(t, err)
+	require.Len(t, evals, 1)
+	return evals[0].Value
+}
+
 // toInt narrows jqutil.InferType's integer result (int/int32/int64/float64)
 // to int for width-agnostic numeric assertions.
 func toInt(t *testing.T, v any) int {

--- a/internal/resolvers/widgets/resolve.go
+++ b/internal/resolvers/widgets/resolve.go
@@ -118,6 +118,24 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 		return opts.In, err
 	}
 
+	// inline-extras design P §4.2 — resourcesRefsTemplate surface. Fold the
+	// author-declared spec.resourcesRefsTemplateExtras into `ds` HERE — AFTER
+	// resolveWidgetData has fully returned (above) and BEFORE
+	// resolveResourceRefs (below). This mutation timing IS the scope
+	// isolation (design §2.1): resolveWidgetData never re-reads `ds`, so this
+	// fold is invisible to the widgetDataTemplate jq and reaches ONLY the
+	// resourcesRefsTemplate jq (which evaluates against this same `ds`).
+	// Falsifier #5 guards this boundary.
+	//
+	// REUSE mergeExtras verbatim — its non-overwriting / ds-wins semantics are
+	// EXACTLY right: the apiRef-result (from resolveApiRef) and the per-request
+	// extras (the mergeExtras(ds, opts.Extras) fold above) are ALREADY in `ds`,
+	// so they win; the rrt-inline map only fills keys nobody else set. Net for
+	// this surface: apiRef-result > request > rrt-inline. Empty/absent block ⇒
+	// GetResourcesRefsExtras returns {} ⇒ mergeExtras len-guard no-ops ⇒
+	// byte-identical to pre-inline-extras.
+	mergeExtras(ds, GetResourcesRefsExtras(opts.In.Object))
+
 	resRefsStart := time.Now()
 	resourcesRefsResults, err := resolveResourceRefs(ctx, opts.In, ds)
 	phaseResRefsMs = time.Since(resRefsStart).Milliseconds()
@@ -185,26 +203,40 @@ func resolveApiRef(ctx context.Context, opts ResolveOptions) (map[string]any, er
 		return nil, err
 	}
 
+	// inline-extras design P §4.1 — apiRef surface. Fold the author-declared
+	// spec.apiRef.extras UNDER the per-request extras (request wins) into the
+	// effective map threaded to the apiRef fetch. Net precedence on this
+	// surface: apiRef-RESULT > request > apiRef-inline (the apiRef RA result
+	// overwrites the dict on collision inside api.Resolve, so the result still
+	// wins). The inline map reads the `extras` sub-key off opts.In.Object — the
+	// SAME widget CR the dispatcher reads (got.Unstructured), so key (the
+	// dispatcher's union, §1) and body stay consistent. nil/empty inline +
+	// nil/empty request ⇒ a fresh empty effective map ⇒ byte-identical to the
+	// pre-inline-extras "request-only" thread (mergeRequestWins of two empties
+	// is empty; api.Resolve no-ops on an empty dict). The seed path benefits
+	// automatically — it reads opts.In.Object too (the seeded CR), so the seed
+	// body folds apiRef-inline with no new ResolveOptions field (design §5).
+	apiRefInline := GetApiRefExtras(opts.In.Object)
+	apiRefEff := mergeRequestWins(apiRefInline, opts.Extras)
+
 	return apiref.Resolve(ctx, apiref.ResolveOptions{
 		RC:      opts.RC,
 		ApiRef:  apiRef,
 		AuthnNS: opts.AuthnNS,
 		PerPage: opts.PerPage,
 		Page:    opts.Page,
-		// extras-widgets parity (step 1): thread the per-request extras
-		// into the apiRef fetch — the thread that was previously dropped
-		// here, so any extras a widget received was silently discarded.
-		// extras now flows widget → apiref → restactions.Resolve →
-		// api.Resolve, where api.Resolve seeds the resolve dict via
+		// extras-widgets parity (step 1): thread the EFFECTIVE extras
+		// (apiRef-inline folded under request) into the apiRef fetch.
+		// extras flows widget → apiref → restactions.Resolve → api.Resolve,
+		// where api.Resolve seeds the resolve dict via
 		// maps.DeepCopyJSON(opts.Extras) (restactions/api/resolve.go:228-230).
 		// Effect: the apiRef RESTAction's OWN jq (its `path` / `payload`)
 		// can reference extras keys (parametrise the fetch), and those
 		// extras keys land top-level in the resolved data source `ds` the
-		// widget templates evaluate against. nil/empty extras (the
-		// prewarm/seed/refresher callers, which never set it) is a no-op:
-		// api.Resolve's `if opts.Extras != nil` gate skips the seed for
-		// nil, and an empty map deep-copies to an empty dict.
-		Extras: opts.Extras,
+		// widget templates evaluate against transitively. An empty effective
+		// map deep-copies to an empty dict (no-op) — the prewarm/seed/refresher
+		// callers (no request extras, no inline) stay byte-identical.
+		Extras: apiRefEff,
 	})
 }
 
@@ -362,4 +394,40 @@ func mergeExtras(ds map[string]any, extras map[string]any) {
 			ds[k] = v
 		}
 	}
+}
+
+// mergeRequestWins folds the inline (author-declared) extras UNDER the request
+// (route/query/login) extras, REQUEST WINNING on every key collision, and
+// returns a FRESH map. This is the inline-extras design P per-surface
+// precedence (§4): the route is the more-specific intent, so a request param
+// MUST override an inline default (an inline default shadowing a route param
+// would strand a detail page on the default).
+//
+// It is the INVERSE direction of mergeExtras (which is non-overwriting / ds-
+// wins) and is used at the EARLIER merge — before the effective map ever
+// reaches mergeExtras / the apiRef RA dict. Keeping the two helpers separate
+// is deliberate (design §4): request-wins-over-inline is achieved HERE;
+// apiRef-result-wins-over-everything stays in mergeExtras's ds-wins fold. Do
+// NOT collapse them — flipping mergeExtras's direction would also flip the
+// apiRef-result-vs-extras precedence and break falsifier #3.
+//
+// Both inputs are deep-copied into the result via maps.DeepCopyJSON (the same
+// util mergeExtras + the RESTAction dict seed use), so the returned map never
+// aliases the per-request extras map NOR the inline map read off the shared
+// widget CR — no shared-vs-copy concurrency hazard
+// (feedback_shared_vs_copy_is_a_concurrency_change). Both empty ⇒ a fresh
+// empty map (a no-op effective fold downstream — backward-compat).
+//
+// Mechanism-uniform (feedback_no_special_cases): every key is folded the same
+// way for every widget — no widget-name table, no key allowlist.
+func mergeRequestWins(inline, request map[string]any) map[string]any {
+	out := make(map[string]any, len(inline)+len(request))
+	for k, v := range maps.DeepCopyJSON(inline) {
+		out[k] = v
+	}
+	// Request overwrites any colliding inline key (request wins).
+	for k, v := range maps.DeepCopyJSON(request) {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -13,8 +13,16 @@ const (
 	widgetDataKey            = "widgetData"
 	widgetDataTemplateKey    = "widgetDataTemplate"
 	apiRefKey                = "apiRef"
+	extrasKey                = "extras"
 	resourcesRefsKey         = "resourcesRefs"
 	resourcesRefsTemplateKey = "resourcesRefsTemplate"
+	// resourcesRefsTemplateExtrasKey is the SIBLING block that carries the
+	// author-declarable inline extras scoped to the resourcesRefsTemplate jq
+	// (inline-extras design P §3). It is a sibling — NOT a sub-key of
+	// resourcesRefsTemplate — so GetResourcesRefsTemplate's bare-slice read
+	// (resourcesRefsTemplateKey, below) stays byte-identical and existing
+	// blueprints are untouched (the PM-endorsed non-breaking shape).
+	resourcesRefsTemplateExtrasKey = "resourcesRefsTemplateExtras"
 )
 
 func GetAPIVersion(obj map[string]any) string {
@@ -59,6 +67,55 @@ func GetUID(obj map[string]any) string {
 
 func GetWidgetData(obj map[string]any) map[string]any {
 	data, ok, err := maps.NestedMap(obj, "spec", widgetDataKey)
+	if !ok || err != nil {
+		return map[string]any{}
+	}
+	return data
+}
+
+// GetApiRefExtras reads the author-declarable inline extras scoped to the
+// apiRef RA fetch (inline-extras design P §3, surface 1: spec.apiRef.extras).
+//
+// It reads the `extras` SUB-KEY off the raw unstructured spec.apiRef map
+// DIRECTLY — it deliberately does NOT route through GetApiRef's
+// ObjectReference unmarshal, and there is NO Extras field on
+// templatesv1.ObjectReference (core.go:168). That struct is shared by 7
+// non-widget consumers (the generic /call object ref, fetchObject, and the
+// seed/prewarm/refresher paths) that would silently inherit the field, and
+// GetApiRef's json.Unmarshal would absorb spec.apiRef.extras into the typed
+// ref — coupling the apiRef-fetch identity to extras the seed-literal sites
+// cannot see. Reading the sub-key off the unstructured map keeps
+// ObjectReference + GetApiRef untouched (the load-bearing no-pollution
+// constraint, design §3).
+//
+// maps.NestedMap returns a DEEP COPY (maps.go: NestedMap → DeepCopyJSON), so
+// the returned map never aliases the shared widget CR — the merge helpers can
+// fold it without a shared-vs-copy concurrency hazard
+// (feedback_shared_vs_copy_is_a_concurrency_change). Returns {} on
+// absent/typed-miss → backward-compat no-op (mirrors GetWidgetData).
+func GetApiRefExtras(obj map[string]any) map[string]any {
+	data, ok, err := maps.NestedMap(obj, "spec", apiRefKey, extrasKey)
+	if !ok || err != nil {
+		return map[string]any{}
+	}
+	return data
+}
+
+// GetResourcesRefsExtras reads the author-declarable inline extras scoped to
+// the resourcesRefsTemplate jq ONLY (inline-extras design P §3, surface 2).
+//
+// It reads the SIBLING block spec.resourcesRefsTemplateExtras — the
+// PM-endorsed non-breaking shape — so the existing GetResourcesRefsTemplate
+// bare-slice read (widgets.go: maps.NestedSlice(obj,"spec","resourcesRefsTemplate"))
+// stays byte-identical. (A bare slice has no sibling field to hang a block-
+// level extras map on, so reading from a sibling block avoids restructuring
+// the shipped slice; the widget CRD schema declaration of this field is a
+// portal-chart follow-up — snowplow tolerates its absence by returning {}.)
+//
+// As with GetApiRefExtras, maps.NestedMap returns a deep copy → no aliasing of
+// the shared CR. Returns {} on absent/typed-miss → backward-compat no-op.
+func GetResourcesRefsExtras(obj map[string]any) map[string]any {
+	data, ok, err := maps.NestedMap(obj, "spec", resourcesRefsTemplateExtrasKey)
 	if !ok || err != nil {
 		return map[string]any{}
 	}

--- a/testdata/widgets/button.extras.inline.apiref.yaml
+++ b/testdata/widgets/button.extras.inline.apiref.yaml
@@ -1,0 +1,37 @@
+# inline-extras design P — apiRef fixture proving:
+#   (#1a) inline-only spec.apiRef.extras: the inline `nsName` parametrises the
+#         apiRef RESTAction fetch path with NO ?extras= on the request.
+#   (#2a) request-overrides-inline: resolving WITH ?extras={nsName:...} makes
+#         the REQUEST value win over the inline default (asserted in the test).
+#   (#7)  input-only: neither inline map appears in the resolved status.
+#
+# It reuses the `extras-namespace-by-name` RESTAction defined in
+# button.extras.apiref.yaml (path: ${ "/api/v1/namespaces/" + .nsName }). The
+# widget declares spec.apiRef.extras.nsName = "kube-system"; with no request
+# extras the apiRef-effective map = {nsName: kube-system}, so the RA GETs the
+# kube-system namespace and its name surfaces into status.widgetData.label.
+#
+# cyberjoker (group devs) is granted cluster-wide namespaces get/list by
+# testdata/rbac.namespaces.yaml, so the per-user-token fetch succeeds.
+apiVersion: widgets.templates.krateo.io/v1beta1
+kind: Button
+metadata:
+  namespace: demo-system
+  name: button-extras-inline-apiref
+spec:
+  widgetData:
+    actions: {}
+    clickActionId: nop
+    label: base-label
+    icon: fa-clock
+    type: text
+  apiRef:
+    name: extras-namespace-by-name
+    namespace: demo-system
+    # The author-declared inline extras scoped to the apiRef fetch. With no
+    # ?extras= request, this `nsName` parametrises the RESTAction path.
+    extras:
+      nsName: kube-system
+  widgetDataTemplate:
+    - forPath: label
+      expression: ${ .ns.metadata.name }

--- a/testdata/widgets/button.extras.inline.static.yaml
+++ b/testdata/widgets/button.extras.inline.static.yaml
@@ -1,0 +1,58 @@
+# inline-extras design P — apiRef-LESS fixture proving:
+#   (#1b) inline-only resourcesRefsTemplateExtras: the rrt block's keys reach
+#         the resourcesRefsTemplate jq with NO ?extras= on the request.
+#   (#5)  scope-isolation: a key present ONLY in resourcesRefsTemplateExtras is
+#         NOT visible to the widgetDataTemplate jq (which ran BEFORE the rrt
+#         fold), while the resourcesRefsTemplate jq DOES see it.
+#
+# The widget has NO apiRef, so `ds` starts empty; the ONLY source of the rrt
+# keys is the §4.2 fold (mergeExtras(ds, GetResourcesRefsExtras(...))), which
+# happens AFTER resolveWidgetData. The widgetDataTemplate below references the
+# rrt-only key `rrtNs` defensively (`// "ABSENT"`) so an absent key yields the
+# valid string "ns=ABSENT" (proving non-leak) WITHOUT writing jq-null into the
+# string-typed label field (which would trip CRD validation). The
+# resourcesRefsTemplate iterator over `names` (also rrt-only) fans out one ref
+# per element, each namespaced by `rrtNs` — proving the rrt jq sees both keys.
+apiVersion: widgets.templates.krateo.io/v1beta1
+kind: Button
+metadata:
+  namespace: demo-system
+  name: button-extras-inline-static
+spec:
+  widgetData:
+    actions: {}
+    clickActionId: nop
+    label: base-label
+    icon: fa-clock
+    type: text
+  # widgetDataTemplate runs BEFORE the resourcesRefsTemplateExtras fold, so
+  # `.rrtNs` MUST be absent here → "ns=ABSENT" (scope-isolation proof #5).
+  widgetDataTemplate:
+    - forPath: label
+      expression: ${ "ns=" + (.rrtNs // "ABSENT") }
+  # resourcesRefsTemplate references the rrt-only keys (rrtNs + names) →
+  # proves #1b inline-only AND that the rrt jq DOES see them. The iterator over
+  # `names` (evaluated against ds) fans out one ref per element (proving the
+  # array key reached the jq); inside the iterator `.` is the element string, so
+  # namespace=${ . }. The second, non-iterator item references the SCALAR rrtNs
+  # against ds (proving the scalar key reached the jq).
+  resourcesRefsTemplate:
+    - iterator: ${ .names }
+      template:
+        id: ${ "ns-" + . }
+        apiVersion: v1
+        resource: namespaces
+        namespace: ${ . }
+        verb: GET
+    - template:
+        id: ${ "from-rrtNs-" + .rrtNs }
+        apiVersion: v1
+        resource: namespaces
+        namespace: ${ .rrtNs }
+        verb: GET
+  # The author-declared inline extras scoped to the resourcesRefsTemplate jq.
+  resourcesRefsTemplateExtras:
+    rrtNs: inline-team
+    names:
+      - alpha
+      - beta


### PR DESCRIPTION
## What / why

Adds two **author-declarable, per-surface inline `extras` maps** on the widget CR, so a blueprint author can supply static default extras scoped to a specific consumption surface — without a route/query param:

- **`spec.apiRef.extras`** — scoped to the apiRef RESTAction fetch; transitively reaches the widget data source `ds` via the apiRef result.
- **`spec.resourcesRefsTemplateExtras`** (sibling block) — scoped to the `resourcesRefsTemplate` jq **only**.

Both are merged **UNDER** request-extras (the route/query/login extras **always win** on collision — an inline default must never shadow a more-specific route param) and are **input-only** (never echoed to `status`).

This is **design P** (per-surface), Diego-ratified over the architect's single-map W alternative for the per-surface divergence affordance. **Dual-review-gated:** Architect **SHIP** (design-conformant on all 7 points; no special-cases; no concurrency hazard) + PM **ACCEPT-TO-COMMIT** (both must-fixes honored with teeth; all 9 falsifiers fail-if-broken and green under `-race`; invariants hold).

## How

- **Read sites:** two unstructured accessors (`GetApiRefExtras`, `GetResourcesRefsExtras`) mirroring `GetWidgetData` — `maps.NestedMap` (deep copy, `{}` on miss). No `Extras` field is added to `templatesv1.ObjectReference` (7 shared non-widget consumers + `GetApiRef`'s unmarshal would absorb it); the apiRef accessor reads the `extras` sub-key off the raw unstructured map.
- **Merge (per surface, request wins):** apiRef — `mergeRequestWins(apiRefInline, request)` → `apiref.Resolve` Extras; rrt — `mergeExtras(ds, rrtInline)` (reused verbatim, ds-wins) folded **after** `resolveWidgetData` returns and **before** `resolveResourceRefs`. `mergeExtras`'s direction is **unchanged** (the apiRef-result still wins). Net per surface: apiRef-result > request > inline. The rrt fold's scope isolation is by **mutation timing** (`resolveWidgetData` never re-reads `ds`).
- **Cache-key UNION (the make-or-break):** the dispatcher reads both inline maps off the in-hand widget CR and folds `unionForKey(apiRefInline, rrtInline, request)` into the widget content + per-cohort keys and the two diagnostic emits. The apiRef sub-cell (RAFullList) is keyed **separately** by the apiRef-effective map via `apiref.Resolve`; the rrt-inline map deliberately does **not** key the apiRef sub-cell. **No `ComputeKey`/schema change.**

## Falsifiers (all 9 green under `-race -count=1`)

| # | Property | Where |
|---|---|---|
| 1a/1b | inline-only reaches its surface (apiRef / rrt) | E2E (kind) + unit |
| 2a/2b | **request overrides inline** per surface (the precedence bug) | E2E + unit |
| 3 | apiRef-**result** wins over both (guards `mergeExtras` direction) | unit |
| **4a/4b** | **cache-key UNION distinctness** via the real key path; RAFullList key **invariant** to rrt-inline | dispatcher (real `unionForKey` + `dispatchWidgetContentKey`/`dispatchCacheLookupKey` + `RAFullListKeyInputs` + real `handle.Put/Get`) |
| 5 | scope-isolation (rrt-inline does **not** leak into widgetDataTemplate) | E2E |
| **6** | **PIP-seed parity at BOTH cells** (per-cohort widget + RAFullList) — the #317 seed/serve key-mismatch class | dispatcher (real seed key path → HIT) |
| 7 | input-only (no `status.extras`) | E2E |
| 8 | **backward-compat**: absent blocks ⇒ byte-identical keys | dispatcher |
| 9 | `-race` on the new merge/`unionForKey` (deep-copy, no aliasing of the shared CR) | both pkgs |

E2E falsifiers (`#1a/#1b/#2a/#5/#7`) run against a kind cluster (`TestResolveWidgets_Extras`, 6/6 assessments PASS). Full package suites `widgets` + `dispatchers` + `cache` all PASS under `-race -count=1`.

The two **load-bearing** falsifiers per the PM gate: the cache-key UNION distinctness (#4a/#4b) and the PIP-seed parity at BOTH cells (#6).

## Two-repo split (snowplow ship is independently safe)

Snowplow reads the inline maps off the **unstructured** spec and **tolerates their absence** (accessors → `{}` → no-op everywhere downstream). The widget CRD **schema declaration** of `spec.apiRef.extras` + `spec.resourcesRefsTemplateExtras` is a lockstep **portal-chart follow-up** — not in this PR's scope.

### ⚠️ INERT-until-chart (safe but latent)

Because the production widget CRD does **not yet declare** these fields, the apiserver **prunes them on write**, so **merging this PR alone leaves the feature safe but latent** — it activates only once the portal-chart CRD ships the fields and is reconciled. Backward-compat falsifier **#8** proves zero behavior change while the blocks are absent — the latent state **is** the correct backward-compat behavior. (This was confirmed empirically during the build: the kind apiserver logged `unknown field "spec.apiRef.extras"` on CREATE, so the E2E falsifiers resolve an in-memory widget carrying the inline blocks — the exact object shape `fetchObject` returns once the CRD ships the fields. PM ruled this in-memory test shape **sufficient** for the snowplow ship; the true persist→fetch→resolve E2E is the portal-chart-PR deliverable.)

## widgetDataTemplate asymmetry

P covers `apiRef` + `resourcesRefsTemplate` per the ratified two-surface scope. **(i) accepted** for this ship — `widgetDataTemplate` is covered **transitively** via apiRef-inline (the apiRef result becomes `ds`, which widgetDataTemplate reads). **(ii) a third `spec.widgetDataTemplateExtras` block** is the named clean **additive follow-up** if a widgetDataTemplate-specific default (independent of the apiRef) is later requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)