### PR TITLE
fix(cache): relist running data informer on CRD structural-schema widen (#3)

### DIFF
--- a/internal/cache/crd_discovery_expvar.go
+++ b/internal/cache/crd_discovery_expvar.go
@@ -51,16 +51,19 @@ func registerCRDDiscoveryExpvar() {
 		expvar.Publish("snowplow_crd_discovery", expvar.Func(func() any {
 			s := CRDDiscoveryStatsSnapshot()
 			return map[string]uint64{
-				"events_enqueued":      s.EventsEnqueued,
-				"events_dropped":       s.EventsDropped,
-				"events_processed":     s.EventsProcessed,
+				"events_enqueued":  s.EventsEnqueued,
+				"events_dropped":   s.EventsDropped,
+				"events_processed": s.EventsProcessed,
 				// ADD + UPDATE path
 				"discovery_invoked":    s.DiscoveryInvoked,
 				"discovery_skipped_ng": s.DiscoverySkippedNG,
 				// DELETE path (Ship L)
-				"deletes_processed":    s.DeletesProcessed,
-				"delete_skipped_ng":    s.DeleteSkippedNG,
-				"panics_recovered":     s.PanicsRecovered,
+				"deletes_processed": s.DeletesProcessed,
+				"delete_skipped_ng": s.DeleteSkippedNG,
+				"panics_recovered":  s.PanicsRecovered,
+				// schema-widen relist (followup-crd-schema-widen-informer-relist)
+				"schema_relists_fired": s.SchemaRelistsFired,
+				"schema_unchanged":     s.SchemaUnchanged,
 			}
 		}))
 	})

--- a/internal/cache/crd_discovery_side_effect.go
+++ b/internal/cache/crd_discovery_side_effect.go
@@ -44,6 +44,9 @@ package cache
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"runtime/debug"
 	"sync"
@@ -120,6 +123,24 @@ type crdDiscovery struct {
 	deletesProcessed   atomic.Uint64 // Ship L — DELETE calls that completed teardown (>=1 GVR torn down)
 	deleteSkippedNG    atomic.Uint64 // Ship L — DELETE calls skipped (decode-fail / no plural / no served versions)
 	panicsRecovered    atomic.Uint64 // recover-wrapper panic catches across all lifecycle handlers
+
+	// CRD schema-widen relist (followup-crd-schema-widen-informer-relist).
+	// schemaFingerprints maps CRD object name → the last-seen fingerprint of
+	// its structural schema subtree (spec.versions[].{name,schema}). A
+	// running data informer that LIST/WATCHed under a NARROWER structural
+	// schema caches apiserver-PRUNED objects; widening the CRD at runtime
+	// (e.g. adding spec.apiRef.extras + x-kubernetes-preserve-unknown-fields)
+	// does NOT relist that informer (EnsureResourceType is registration-
+	// idempotent, watcher.go:612), so the cache keeps serving pruned objects
+	// until a manual pod bounce. We detect a real schema delta here and force
+	// a per-GVR relist. Keyed by CRD name; written ONLY by the single worker
+	// goroutine (processEvent serialises ADD/UPDATE/DELETE), so a plain map
+	// guarded by the worker's single-threadedness is sufficient — but we use
+	// sync.Map for defensiveness against a future multi-worker change and so
+	// the test reset can clear it without a lock.
+	schemaFingerprints sync.Map // map[string]string (CRD name → schema fingerprint)
+	schemaRelistsFired atomic.Uint64 // relist passes that tore down >=1 GVR on a detected schema change
+	schemaUnchanged    atomic.Uint64 // ADD/UPDATE where the schema fingerprint was unchanged (no relist — thrash guard hit)
 }
 
 var (
@@ -364,6 +385,16 @@ func triggerCRDDiscovery(obj interface{}, kind crdLifecycleKind) {
 		return
 	}
 
+	// Add to navigation-discovered set FIRST so the watcher's
+	// removable-discriminator (watcher.go:749/:1064) sees the group as
+	// nav-discovered when EnsureResourceType spawns the GVR informer — both
+	// inside DiscoverGroupResources AND inside the schema-relist (the relist's
+	// re-add MUST build a re-creatable STANDALONE informer, not a frozen
+	// shared-factory one; the standalone path is gated on this group being
+	// nav-discovered — watcher.go:1056). Idempotent + order-independent w.r.t.
+	// discovery, so it runs up front, ahead of the SA-rc gate.
+	AddNavigationDiscoveredGroup(group)
+
 	saRC := ProcessSARestConfig()
 	if saRC == nil {
 		c.discoverySkippedNG.Add(1)
@@ -373,16 +404,18 @@ func triggerCRDDiscovery(obj interface{}, kind crdLifecycleKind) {
 			slog.String("hint", "SetProcessSARestConfig was not called at startup — "+
 				"CRD-ADD discovery is degraded to walker-only. Check main.go wiring."),
 		)
+		// followup-crd-schema-widen-informer-relist — the data-informer relist
+		// is INDEPENDENT of the SA rest config (it operates on already-
+		// registered local informers + the WATCH each owns; no discovery hop).
+		// Run it even on the degraded no-SA-rc path so a runtime schema widen
+		// is never silently dropped. The F-4 schema-memo ordering (relist after
+		// the invalidators) is moot here: with no SA-rc there is no
+		// DiscoverGroupResources hop and the invalidators below do not run.
+		c.triggerCRDSchemaRelist(u)
 		return
 	}
 
 	c.discoveryInvoked.Add(1)
-
-	// Add to navigation-discovered set FIRST so the watcher's
-	// removable-discriminator (watcher.go:749/:1064) sees the
-	// group as nav-discovered when EnsureResourceType inside
-	// DiscoverGroupResources spawns the composition GVR informer.
-	AddNavigationDiscoveredGroup(group)
 
 	// Fire-and-forget discovery hop. DiscoverGroupResources is
 	// per-group singleflighted (discovery_lookup.go:228-232) and
@@ -415,6 +448,175 @@ func triggerCRDDiscovery(obj interface{}, kind crdLifecycleKind) {
 	// changes the schema MUST invalidate; this is that path). Soft no-op when
 	// the schema-memo invalidator is unwired (discovery_invalidation_hook.go).
 	invalidateCRDSchemaMemo()
+
+	// followup-crd-schema-widen-informer-relist — the invalidators above
+	// refresh the DISCOVERY client + the compiled-schema VALIDATION memo, but
+	// neither relists the running DATA informer's indexer. Under
+	// CACHE_ENABLED=true objects.Get serves widget/entry-CR reads from that
+	// indexer (objects/get.go:73-142), and apiserver structural-schema pruning
+	// happens at LIST/WATCH time — so an informer that listed under a NARROWER
+	// schema keeps serving PRUNED objects after the CRD is widened, until a
+	// manual bounce. Detect a real structural-schema delta and relist the
+	// affected GVRs. Schema-delta-gated so benign CRD churn (status/printer-
+	// column patches) does NOT thrash informers. Ordered AFTER the invalidators
+	// so the relisted informer's first reads see the fresh discovery + schema
+	// state. Soft no-op when the schema is unchanged.
+	c.triggerCRDSchemaRelist(u)
+}
+
+// crdServedGVRs derives the GroupVersionResource set for every SERVED
+// version of a decoded CRD object. Shared by the DELETE teardown and the
+// schema-widen relist. Returns nil when group / plural is empty or no
+// served version exists (caller soft-skips). Mirrors the derivation in
+// triggerCRDDelete + cache_mode.go:312-321 exactly (served-only).
+func crdServedGVRs(u *unstructured.Unstructured) []schema.GroupVersionResource {
+	group, _, _ := unstructured.NestedString(u.Object, "spec", "group")
+	plural, _, _ := unstructured.NestedString(u.Object, "spec", "names", "plural")
+	if group == "" || plural == "" {
+		return nil
+	}
+	versions, found, err := unstructured.NestedSlice(u.Object, "spec", "versions")
+	if err != nil || !found || len(versions) == 0 {
+		return nil
+	}
+	var out []schema.GroupVersionResource
+	for _, v := range versions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(vm, "name")
+		served, _, _ := unstructured.NestedBool(vm, "served")
+		if name == "" || !served {
+			continue
+		}
+		out = append(out, schema.GroupVersionResource{Group: group, Version: name, Resource: plural})
+	}
+	return out
+}
+
+// crdSchemaFingerprint computes a stable fingerprint of the structural-schema
+// subtree that governs apiserver pruning: per served version, its name plus
+// its `schema.openAPIV3Schema`. A change here is exactly the class that flips
+// which fields survive LIST/WATCH (adding a property, flipping
+// x-kubernetes-preserve-unknown-fields, etc.). Status/printer-column/
+// conversion churn lives OUTSIDE this subtree, so it does NOT change the
+// fingerprint — that is the thrash guard. Returns "" when the schema subtree
+// cannot be read (caller treats "" as "unknown" → no relist; a later event
+// with a readable schema will reconcile).
+func crdSchemaFingerprint(u *unstructured.Unstructured) string {
+	versions, found, err := unstructured.NestedSlice(u.Object, "spec", "versions")
+	if err != nil || !found {
+		return ""
+	}
+	// Build a deterministic [name, schema] projection. NestedSlice already
+	// returns deep-copied plain Go values; json.Marshal of a
+	// map[string]any sorts keys, so the encoding is canonical.
+	type vfp struct {
+		Name   string      `json:"name"`
+		Schema interface{} `json:"schema"`
+	}
+	proj := make([]vfp, 0, len(versions))
+	for _, v := range versions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(vm, "name")
+		sch, _, _ := unstructured.NestedMap(vm, "schema", "openAPIV3Schema")
+		proj = append(proj, vfp{Name: name, Schema: sch})
+	}
+	b, mErr := json.Marshal(proj)
+	if mErr != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// triggerCRDSchemaRelist relists the running data informers for a CRD whose
+// structural schema changed since the last ADD/UPDATE we observed. No-op when
+// the fingerprint is unchanged (the common case — most CRD UPDATEs are
+// status/printer churn). Runs on the single discovery-worker goroutine
+// (serialised with every other CRD lifecycle side-effect), AFTER the
+// discovery + schema-memo invalidators.
+//
+// Mechanism per served GVR: RemoveResourceType (tears down the stale informer
+// via the R6 per-GVR stop channel, watcher.go:1406) then EnsureResourceType
+// (re-registers → fresh LIST under the now-current schema), and
+// OnResourceTypeSchemaRelisted to dirty-mark L1 entries depending on that GVR
+// so a cached widget resolve recomputes against the now-unpruned objects
+// (same dirty-mark-only set as the DELETE path's OnResourceTypeRemoved, but
+// it logs cache_event.consumed type=SCHEMA_RELIST, not CRD_DELETE). Between
+// teardown and the new informer's HasSynced, objects.Get falls through to the
+// apiserver under the 0.30.97 IsServable guard (correct, just slower).
+func (c *crdDiscovery) triggerCRDSchemaRelist(u *unstructured.Unstructured) {
+	name := u.GetName()
+	if name == "" {
+		return
+	}
+	fp := crdSchemaFingerprint(u)
+	if fp == "" {
+		// Unreadable schema subtree — cannot decide a delta. Do not relist;
+		// do not poison the stored fingerprint (leave any prior value so a
+		// later readable event still detects the real change).
+		return
+	}
+	prev, had := c.schemaFingerprints.Load(name)
+	c.schemaFingerprints.Store(name, fp)
+	if !had {
+		// FIRST observation of this CRD's schema. Any data informer already
+		// registered for its GVR listed under the apiserver's CURRENT schema —
+		// which is exactly the fingerprint we just recorded — so there is no
+		// stale-prune to correct. Record and return; the relist fires only on a
+		// subsequent CHANGE. (This also avoids a spurious relist at startup,
+		// when the CRD informer's initial replay delivers an ADD for every
+		// pre-existing CRD.)
+		return
+	}
+	if prev.(string) == fp {
+		// Schema unchanged since we last saw this CRD — benign churn. This is
+		// the thrash guard: a status/printer-column UPDATE lands here and
+		// does NOT relist.
+		c.schemaUnchanged.Add(1)
+		return
+	}
+	// A real structural-schema CHANGE since we last observed this CRD — the
+	// load-bearing case (a runtime widen of an already-watched CRD). Relist its
+	// registered+served GVRs so the data informer re-LISTs under the new schema.
+	gvrs := crdServedGVRs(u)
+	if len(gvrs) == 0 {
+		return
+	}
+	rw := Global()
+	relisted := 0
+	for _, gvr := range gvrs {
+		if rw == nil {
+			break
+		}
+		// Only relist a GVR we are actually watching. EnsureResourceType is
+		// registration-idempotent, so an unconditional Ensure would SPAWN an
+		// informer for a never-watched GVR (wrong — lazy registration is the
+		// resolver's job). Gate on current registration via IsRegistered.
+		if !rw.IsRegistered(gvr) {
+			continue
+		}
+		rw.RemoveResourceType(gvr)    // R6 per-GVR teardown; idempotent, nil-safe
+		_, _ = rw.EnsureResourceType(gvr)         // re-register → fresh LIST under current schema
+		Deps().OnResourceTypeSchemaRelisted(gvr) // dirty-mark dependent L1 (logs SCHEMA_RELIST, not CRD_DELETE)
+		relisted++
+	}
+	if relisted > 0 {
+		c.schemaRelistsFired.Add(1)
+		slog.Info("cache.crd_discovery.schema_relist",
+			slog.String("subsystem", "cache"),
+			slog.String("crd", name),
+			slog.Int("gvrs_relisted", relisted),
+			slog.String("hint", "CRD structural schema changed at runtime — relisted the data "+
+				"informer(s) so newly-permitted spec fields stop being served pruned from the "+
+				"pre-change indexer (followup-crd-schema-widen-informer-relist)."),
+		)
+	}
 }
 
 // triggerCRDDelete handles a CRD DELETE event: derive the GVRs that
@@ -600,6 +802,9 @@ type CRDDiscoveryStats struct {
 	DeletesProcessed   uint64 // Ship L — successful DELETE teardowns
 	DeleteSkippedNG    uint64 // Ship L — DELETE decode-skip / no-served-versions / no-plural
 	PanicsRecovered    uint64
+	// followup-crd-schema-widen-informer-relist
+	SchemaRelistsFired uint64 // ADD/UPDATE passes that relisted >=1 GVR on a detected structural-schema change
+	SchemaUnchanged    uint64 // ADD/UPDATE where the schema fingerprint was unchanged (thrash guard hit; no relist)
 }
 
 // CRDDiscoveryStatsSnapshot returns the current bridge counters.
@@ -614,6 +819,8 @@ func CRDDiscoveryStatsSnapshot() CRDDiscoveryStats {
 		DeletesProcessed:   c.deletesProcessed.Load(),
 		DeleteSkippedNG:    c.deleteSkippedNG.Load(),
 		PanicsRecovered:    c.panicsRecovered.Load(),
+		SchemaRelistsFired: c.schemaRelistsFired.Load(),
+		SchemaUnchanged:    c.schemaUnchanged.Load(),
 	}
 }
 

--- a/internal/cache/crd_lifecycle_bytesobject_test.go
+++ b/internal/cache/crd_lifecycle_bytesobject_test.go
@@ -611,11 +611,13 @@ func TestProcessEvent_UnknownKind_DefensiveDefault(t *testing.T) {
 //
 // Per the published shape (crd_discovery_expvar.go):
 //
-//	snowplow_crd_discovery → map[string]uint64 with 8 keys:
+//	snowplow_crd_discovery → map[string]uint64 with 10 keys:
 //	  events_enqueued / events_dropped / events_processed
 //	  discovery_invoked / discovery_skipped_ng
 //	  deletes_processed / delete_skipped_ng
 //	  panics_recovered
+//	  schema_relists_fired / schema_unchanged
+//	    (followup-crd-schema-widen-informer-relist)
 func TestCRDDiscoveryExpvarHandler(t *testing.T) {
 	t.Setenv("CACHE_ENABLED", "true")
 	// CFG-1 (Ship 0.30.163): expvar gauges register only when
@@ -684,12 +686,15 @@ func TestCRDDiscoveryExpvarHandler(t *testing.T) {
 		t.Fatalf("snowplow_crd_discovery wrong shape: got %T want map[string]any", rawVal)
 	}
 
-	// All 8 keys must be present.
+	// All 10 keys must be present (incl. the schema-widen relist counters —
+	// followup-crd-schema-widen-informer-relist: guards against a future
+	// expvar-publisher regression that silently drops the relist surface).
 	wantKeys := []string{
 		"events_enqueued", "events_dropped", "events_processed",
 		"discovery_invoked", "discovery_skipped_ng",
 		"deletes_processed", "delete_skipped_ng",
 		"panics_recovered",
+		"schema_relists_fired", "schema_unchanged",
 	}
 	for _, k := range wantKeys {
 		if _, ok := m[k]; !ok {

--- a/internal/cache/crd_schema_relist_test.go
+++ b/internal/cache/crd_schema_relist_test.go
@@ -1,0 +1,245 @@
+// crd_schema_relist_test.go — falsifier for
+// followup-crd-schema-widen-informer-relist.
+//
+// THE BUG (empirically observed in the PR#33 inline-extras FRONTEND E2E,
+// docs/pr33-inline-extras-frontend-e2e-2026-06-19.md): under CACHE_ENABLED
+// the data informer caches apiserver-PRUNED objects when it LIST/WATCHed
+// under a NARROWER structural schema. Widening the CRD at runtime (adding a
+// property / flipping x-kubernetes-preserve-unknown-fields) does NOT relist
+// the running informer — EnsureResourceType is registration-idempotent
+// (watcher.go) — so objects.Get keeps serving pruned objects until a manual
+// pod bounce. The CRD-UPDATE path invalidated the discovery cache + the
+// compiled-schema VALIDATION memo (Tasks #322/#323) but NOT the data informer.
+//
+// THE FIX: triggerCRDSchemaRelist (crd_discovery_side_effect.go) detects a
+// real structural-schema delta (fingerprint over spec.versions[].{name,
+// schema}) and, ONLY then, relists each served+registered GVR via
+// RemoveResourceType + EnsureResourceType + OnResourceTypeSchemaRelisted
+// (dirty-mark dependent L1; logs SCHEMA_RELIST, not CRD_DELETE).
+// Schema-delta-gated so benign churn does not thrash.
+//
+// These tests drive the REAL deps_watch UpdateFunc → bounded worker →
+// triggerCRDDiscovery → triggerCRDSchemaRelist path (not the function in
+// isolation), with a stub-REST watcher so the relisted informer is actually
+// reconstructed. Run under -race.
+
+package cache
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// dirtyRecorder captures the L1 keys the DepTracker dirty-marks via the
+// refresher enqueue hook (deps.go SetRefreshHook), so a test can assert a
+// specific key was marked. Concurrency-safe (the relist runs on the worker
+// goroutine; the test reads from the test goroutine).
+type dirtyRecorder struct {
+	mu   sync.Mutex
+	keys map[string]int
+}
+
+func newDirtyRecorder() *dirtyRecorder { return &dirtyRecorder{keys: map[string]int{}} }
+func (r *dirtyRecorder) hook() func(string) {
+	return func(k string) { r.mu.Lock(); r.keys[k]++; r.mu.Unlock() }
+}
+func (r *dirtyRecorder) marked(k string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.keys[k] > 0
+}
+
+// crdBytesObjWithSchema builds a CRD *bytesObject for a single served version
+// whose spec.versions[0].schema.openAPIV3Schema is the supplied JSON object
+// literal. `extra` is an arbitrary additional top-level spec field (e.g. a
+// printer-column / conversion blob) used to prove that churn OUTSIDE the
+// schema subtree does NOT change the fingerprint.
+func crdBytesObjWithSchema(t *testing.T, name, group, plural, version, openAPIV3SchemaJSON, extraSpecJSON string) *bytesObject {
+	t.Helper()
+	extra := ""
+	if extraSpecJSON != "" {
+		extra = "," + extraSpecJSON
+	}
+	raw := []byte(`{
+		"apiVersion":"apiextensions.k8s.io/v1",
+		"kind":"CustomResourceDefinition",
+		"metadata":{"name":"` + name + `"},
+		"spec":{
+			"group":"` + group + `",
+			"names":{"plural":"` + plural + `","kind":"X"},
+			"versions":[{"name":"` + version + `","served":true,"storage":true,"schema":{"openAPIV3Schema":` + openAPIV3SchemaJSON + `}}]` + extra + `
+		}
+	}`)
+	bo, err := newBytesObjectFromRaw(raw)
+	if err != nil {
+		t.Fatalf("crdBytesObjWithSchema: newBytesObjectFromRaw failed: %v", err)
+	}
+	return bo
+}
+
+// narrow vs widened openAPIV3Schema literals for a button-like widget CRD.
+// The widened one adds spec.apiRef.extras with preserve-unknown — exactly the
+// PR#33 change that the apiserver stops pruning once present.
+const (
+	narrowButtonSchema = `{"type":"object","properties":{"spec":{"type":"object","properties":{` +
+		`"apiRef":{"type":"object","properties":{"name":{"type":"string"},"namespace":{"type":"string"}}}}}}}`
+	widenedButtonSchema = `{"type":"object","properties":{"spec":{"type":"object","properties":{` +
+		`"apiRef":{"type":"object","properties":{"name":{"type":"string"},"namespace":{"type":"string"},` +
+		`"extras":{"type":"object","x-kubernetes-preserve-unknown-fields":true}}}}}}}`
+)
+
+// TestCRDSchemaWiden_RelistsRunningInformer — THE falsifier. A CRD UPDATE that
+// WIDENS the structural schema of an already-registered GVR must relist that
+// GVR's data informer (so it re-LISTs under the new schema and stops serving
+// pruned objects), and must dirty-mark dependent L1.
+func TestCRDSchemaWiden_RelistsRunningInformer(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv(envCompositionStreamingList, "true")
+	withCleanCRDDiscovery(t)
+	ResetDepsForTest()
+	t.Cleanup(ResetDepsForTest)
+	ResetNavigationDiscoveredGroupsForTest()
+	t.Cleanup(ResetNavigationDiscoveredGroupsForTest)
+	SetProcessSARestConfig(nil) // discovery soft-skips (no SA rc) — irrelevant to the relist path
+
+	// The widget GVR whose CRD schema we widen.
+	target := schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "buttons"}
+
+	// Stub-REST watcher that ALSO watches the CRD meta-GVR, so depEventHandlers
+	// for the CRD GVR fire the lifecycle side-effect, and EnsureResourceType
+	// can reconstruct `target` without connecting.
+	crdGVR := CRDGVRForTest()
+	rw := newRouteRaceWatcher(t, true, crdGVR, target)
+	t.Cleanup(func() { rw.Stop() })
+	// Pre-close the CRD meta-GVR syncCh so the CRD AddFunc passes the R1
+	// post-sync gate (addEventPostSync) and the lifecycle side-effect fires —
+	// same arrangement the schema-invalidation tests use.
+	crdSync := make(chan struct{})
+	close(crdSync)
+	rw.mu.Lock()
+	rw.syncCh[crdGVR] = crdSync
+	rw.mu.Unlock()
+	SetGlobal(rw)
+	t.Cleanup(func() { SetGlobal(nil) })
+
+	// Register the target GVR informer (the "running" informer that listed
+	// under the NARROW schema) and confirm it is registered.
+	rw.EnsureResourceType(target)
+	if !rw.IsRegistered(target) {
+		t.Fatalf("precondition: target GVR not registered after EnsureResourceType")
+	}
+
+	// Record a dependent L1 edge + wire a dirty-mark recorder so we can assert
+	// the relist dirty-marks that entry (via OnResourceTypeSchemaRelisted → refresher).
+	Deps().Record("l1-widget-key", target, "demo-system", "button-x")
+	rec := newDirtyRecorder()
+	Deps().SetRefreshHook(rec.hook())
+
+	handlers := rw.depEventHandlers(crdGVR)
+
+	// (1) First observe the CRD at the NARROW schema (seeds the fingerprint).
+	narrowCRD := crdBytesObjWithSchema(t, "buttons.widgets.templates.krateo.io",
+		"widgets.templates.krateo.io", "buttons", "v1beta1", narrowButtonSchema, "")
+	handlers.AddFunc(narrowCRD)
+	if !WaitCRDDiscoveryProcessedForTest(1, 2000) {
+		t.Fatalf("worker did not process CRD ADD: %s", crdDiscoveryStatsString())
+	}
+
+	// (2) Now WIDEN the schema via an UPDATE — the load-bearing event.
+	widenedCRD := crdBytesObjWithSchema(t, "buttons.widgets.templates.krateo.io",
+		"widgets.templates.krateo.io", "buttons", "v1beta1", widenedButtonSchema, "")
+	handlers.UpdateFunc(narrowCRD, widenedCRD)
+	if !WaitCRDDiscoveryProcessedForTest(2, 2000) {
+		t.Fatalf("worker did not process CRD UPDATE: %s", crdDiscoveryStatsString())
+	}
+
+	s := CRDDiscoveryStatsSnapshot()
+	if s.SchemaRelistsFired != 1 {
+		t.Fatalf("SchemaRelistsFired=%d want 1 — a structural-schema WIDEN of a registered "+
+			"GVR MUST relist its data informer (else objects.Get keeps serving pre-widen "+
+			"PRUNED objects until a manual bounce). counters: %s",
+			s.SchemaRelistsFired, crdDiscoveryStatsString())
+	}
+
+	// The relisted GVR must still be registered (RemoveResourceType +
+	// EnsureResourceType re-created a fresh standalone informer — safe because
+	// triggerCRDDiscovery called AddNavigationDiscoveredGroup BEFORE the
+	// relist, so addResourceTypeLocked builds a re-creatable standalone, not a
+	// frozen shared-factory informer).
+	if !rw.IsRegistered(target) {
+		t.Fatalf("after relist the target GVR is no longer registered — remove+re-add must "+
+			"leave a fresh informer in place")
+	}
+
+	// The relist must dirty-mark dependent L1 so a cached widget resolve
+	// recomputes against the now-unpruned objects.
+	if !rec.marked("l1-widget-key") {
+		t.Fatalf("relist did not dirty-mark the dependent L1 entry — a stale (pruned) widget "+
+			"resolve would survive the relist")
+	}
+}
+
+// TestCRDSchemaUnchanged_NoRelist — the THRASH GUARD. A CRD UPDATE that does
+// NOT change the structural schema (only churn outside spec.versions[].schema,
+// e.g. a printer-column / conversion field) must NOT relist — otherwise every
+// controller status/printer patch would tear down + re-LIST the informer.
+func TestCRDSchemaUnchanged_NoRelist(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv(envCompositionStreamingList, "true")
+	withCleanCRDDiscovery(t)
+	ResetDepsForTest()
+	t.Cleanup(ResetDepsForTest)
+	ResetNavigationDiscoveredGroupsForTest()
+	t.Cleanup(ResetNavigationDiscoveredGroupsForTest)
+	SetProcessSARestConfig(nil)
+
+	target := schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "buttons"}
+	crdGVR := CRDGVRForTest()
+	rw := newRouteRaceWatcher(t, true, crdGVR, target)
+	t.Cleanup(func() { rw.Stop() })
+	// Pre-close the CRD meta-GVR syncCh so the CRD AddFunc passes the R1
+	// post-sync gate (addEventPostSync) and the lifecycle side-effect fires —
+	// same arrangement the schema-invalidation tests use.
+	crdSync := make(chan struct{})
+	close(crdSync)
+	rw.mu.Lock()
+	rw.syncCh[crdGVR] = crdSync
+	rw.mu.Unlock()
+	SetGlobal(rw)
+	t.Cleanup(func() { SetGlobal(nil) })
+	rw.EnsureResourceType(target)
+
+	handlers := rw.depEventHandlers(crdGVR)
+
+	// Seed at a schema.
+	v1 := crdBytesObjWithSchema(t, "buttons.widgets.templates.krateo.io",
+		"widgets.templates.krateo.io", "buttons", "v1beta1", widenedButtonSchema, "")
+	handlers.AddFunc(v1)
+	if !WaitCRDDiscoveryProcessedForTest(1, 2000) {
+		t.Fatalf("worker did not process CRD ADD: %s", crdDiscoveryStatsString())
+	}
+	relistsAfterSeed := CRDDiscoveryStatsSnapshot().SchemaRelistsFired
+
+	// UPDATE with the SAME schema but a CHANGED out-of-schema field (a
+	// conversion stanza) — benign churn that must NOT relist.
+	v2 := crdBytesObjWithSchema(t, "buttons.widgets.templates.krateo.io",
+		"widgets.templates.krateo.io", "buttons", "v1beta1", widenedButtonSchema,
+		`"conversion":{"strategy":"None"}`)
+	handlers.UpdateFunc(v1, v2)
+	if !WaitCRDDiscoveryProcessedForTest(2, 2000) {
+		t.Fatalf("worker did not process CRD UPDATE: %s", crdDiscoveryStatsString())
+	}
+
+	s := CRDDiscoveryStatsSnapshot()
+	if s.SchemaRelistsFired != relistsAfterSeed {
+		t.Fatalf("SchemaRelistsFired went %d→%d on an UNCHANGED-schema UPDATE — the thrash "+
+			"guard failed; benign CRD churn must not relist the informer",
+			relistsAfterSeed, s.SchemaRelistsFired)
+	}
+	if s.SchemaUnchanged < 1 {
+		t.Fatalf("SchemaUnchanged=%d want >=1 — the unchanged-schema UPDATE should have hit "+
+			"the thrash guard", s.SchemaUnchanged)
+	}
+}

--- a/internal/cache/deps.go
+++ b/internal/cache/deps.go
@@ -723,6 +723,31 @@ func (d *DepTracker) OnResourceTypeRemoved(gvr schema.GroupVersionResource) int 
 	return d.dirtyMarkResourceType("CRD_DELETE", gvr, matched)
 }
 
+// OnResourceTypeSchemaRelisted is invoked by the CRD schema-widen relist
+// (triggerCRDSchemaRelist, crd_discovery_side_effect.go) when a CRD's
+// structural schema CHANGED at runtime and its data informer was relisted.
+// The GVR is NOT being removed — its informer is re-LISTing under the now-
+// wider schema — but every L1 entry that LIST- or GET-depends on the GVR was
+// resolved against the PRE-widen (pruned) objects and is now stale, so it
+// must dirty-mark the same dependent-bucket set OnResourceTypeRemoved does.
+//
+// Mechanically identical to OnResourceTypeRemoved (same collectTypeMatches
+// scan, same dirty-mark-only, NEVER-evict contract) — it differs ONLY in the
+// telemetry label: it logs cache_event.consumed type=SCHEMA_RELIST, not
+// type=CRD_DELETE, so the relist's dirty-mark does not masquerade as a CRD
+// deletion in logs/metrics. dirtyMarkResourceType already parameterises the
+// event type, so this is a label-only divergence.
+//
+// Returns the number of dependent L1 keys dirty-marked. A no-op (and
+// idempotent) when no dep matches gvr.
+func (d *DepTracker) OnResourceTypeSchemaRelisted(gvr schema.GroupVersionResource) int {
+	if d == nil {
+		return 0
+	}
+	matched := d.collectTypeMatches(gvr, false /* listOnly */)
+	return d.dirtyMarkResourceType("SCHEMA_RELIST", gvr, matched)
+}
+
 // dirtyMarkResourceType dirty-marks every L1 key in matched via the
 // refreshHook — the shared body of OnResourceTypeAvailable +
 // OnResourceTypeRemoved. NEVER evicts. Returns the number marked.

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -1397,12 +1397,19 @@ func (rw *ResourceWatcher) closePerGVRStopLocked(gvr schema.GroupVersionResource
 // goroutine AND no frozen
 // store on recreate.
 //
-// Note: RemoveResourceType is wired ONLY to CRD-delete, which always
-// targets a lazily-registered composition GVR (the CRD-watch fires after
-// factory.Start). Lazy registrations run their (standalone) informer on
-// the per-GVR channel, so closing it genuinely stops the Run goroutine.
-// The four RBAC bootstrap GVRs are factory-driven on rw.stopCh and are
-// structurally never removed.
+// Note: RemoveResourceType has two callers, both targeting lazily-
+// registered (standalone, per-GVR-channel) GVRs whose group the CRD-watch
+// reached after factory.Start:
+//   - CRD DELETE teardown (triggerCRDDelete) — remove, no re-add; and
+//   - the CRD schema-widen relist (triggerCRDSchemaRelist) — remove THEN
+//     EnsureResourceType, which by the R6 contract above constructs a FRESH
+//     standalone informer that re-LISTs under the now-current CRD schema
+//     (the relist fires only AFTER AddNavigationDiscoveredGroup, so the
+//     re-add takes the standalone path, never a frozen shared-factory one).
+// Lazy registrations run their (standalone) informer on the per-GVR
+// channel, so closing it genuinely stops the Run goroutine. The four RBAC
+// bootstrap GVRs are factory-driven on rw.stopCh and are structurally never
+// removed (and never schema-relisted — typed-RBAC GVRs are not widget GVRs).
 func (rw *ResourceWatcher) RemoveResourceType(gvr schema.GroupVersionResource) {
 	if rw == nil || rw.mode == modePassthrough {
 		return


### PR DESCRIPTION
## Status: GATE-COMPLETE — parked for merge nod

Single canonical artifact for the CRD-schema-widen informer-relist gap (#3). Re-homed onto `main` as a **separate ship** from PR #33 (inline-extras): `git diff origin/main` is **relist-only, 6 files all under `internal/cache`**, zero `widgets/resolve.go` / `widgets.go` / dispatcher / `testdata/widgets` / `inline_extras` content.

## The gap (#3) + RCA

A CRD UPDATE that **widens** a watched GVR's structural schema (e.g. adding `spec.apiRef.extras` + `x-kubernetes-preserve-unknown-fields:true`) refreshes the discovery-client cache and the compiled-schema validation memo (#322/#323) but does **not** relist the running data informer. Under `CACHE_ENABLED=true`, `objects.Get` serves widget/entry-CR reads from the informer indexer (`internal/objects/get.go:73-142`), and apiserver structural-schema pruning happens at **LIST/WATCH** time — so an informer that listed under the narrower schema keeps serving **pruned** objects until a manual pod bounce.

**RCA one-liner:** `EnsureResourceType` is registration-idempotent (`watcher.go:612`), so the existing UPDATE side-effect is a no-op for the already-running informer — nothing re-LISTs it under the now-wider schema.

Design brief: `docs/followup-crd-schema-widen-informer-relist-2026-06-19.md`. Surfaced by the PR #33 inline-extras frontend E2E (`docs/pr33-inline-extras-frontend-e2e-2026-06-19.md`).

## The fix

`triggerCRDDiscovery` fingerprints the structural-schema subtree (`spec.versions[].{name,schema}`) per CRD; on a **real** schema change to an already-seen CRD it relists each served+REGISTERED GVR via `RemoveResourceType` + `EnsureResourceType` + `OnResourceTypeSchemaRelisted` (dirty-mark dependent L1). Gated:

- **schema-delta only** — status/printer/conversion churn does not change the fingerprint (thrash guard);
- **first-observation is recorded, never relisted** — startup CRD-replay safe;
- **only GVRs we already watch** (`IsRegistered`) — never spawns a new informer;
- `AddNavigationDiscoveredGroup` runs first → the re-add builds a **re-creatable STANDALONE informer (R6)**, never a frozen shared-factory one;
- **F-4 schema-memo ordering preserved** (relist after the invalidators); also runs on the degraded no-SA-rc path.

Reuses the existing **R6 primitives** (`IsRegistered` / `RemoveResourceType` / `EnsureResourceType`): **identity-free**, **schema-delta-gated**, **`CACHE_ENABLED=false` path untouched** (transparent apiserver fallback unchanged). Per architect: **no standing-CRD-informer re-seed** — that would re-introduce the Ship-0.5-deleted (0.30.223) full LIST+WATCH cost.

## Two pre-merge asks, folded

1. **SCHEMA_RELIST eventType nit** — the relist's L1 dirty-mark goes through a new `DepTracker.OnResourceTypeSchemaRelisted` (same `collectTypeMatches` scan + dirty-mark-only/NEVER-evict contract as `OnResourceTypeRemoved`) but logs `cache_event.consumed type=SCHEMA_RELIST` instead of `type=CRD_DELETE`, so a schema-widen relist no longer masquerades as a CRD deletion. **The CRD-DELETE path's `type=CRD_DELETE` label is unchanged** (`triggerCRDDelete` still calls `OnResourceTypeRemoved`).
2. **expvar** — `schema_relists_fired` + `schema_unchanged` added to the `snowplow_crd_discovery` `/debug/vars` map (`crd_discovery_expvar.go`), so the relist is scrapable in production telemetry, not just the log line. `TestCRDDiscoveryExpvarHandler` extended to require all 10 keys (guards a future drop). The snapshot struct already carried the counters; this is the publisher wiring only.

## Gate trail — COMPLETE

- **Architect: SHIP-AS-IS** — no code change to the trigger; do NOT re-seed a standing CRD informer. Design soundness (R6 reuse, schema-delta gate, standalone re-add, F-4 ordering) cleared.
- **PM: ACCEPT-conditional → conditions MET** — the SCHEMA_RELIST telemetry label and the expvar exposure (the two conditions) are both folded in.
- **Kind E2E: PASSED** on the mechanism-identical commit `c9552df` (relist code byte-identical to this branch). Disposable cluster `p33relist`, snowplow `relist-fix` image, `CACHE_ENABLED=true`: BEFORE widen `/call` served `spec.apiRef={name,namespace}` (extras absent, `label=ns=NO-NS`); runtime widen + re-persist with **0→0 restarts** → relist fired (`cache.crd_discovery.schema_relist gvrs_relisted=1`) → `/call` served `spec.apiRef={extras:{nsName:kube-system},...}` (`label=ns=kube-system`). Single-variable. Recorded in `docs/followup-crd-schema-widen-informer-relist-2026-06-19.md` ("Kind end-to-end falsifier — RESULT (2026-06-20)"). **Proof carries to `517fd76`; not re-run.**
  - A separate later HTTP-driven A/B *against `517fd76` directly* (`docs/crd-schema-relist-kind-e2e-2026-06-20.md`) proved the FIXED-vs-CONTROL **mechanism** (unit falsifier PASS, code+image isolation) but was **inconclusive end-to-end** because that run did not pre-register snowplow's CRD informer (Gap A below), so the widen UPDATE never reached the bridge in either build. Harness shortfall of that attempt, not evidence against the fix — and its central recommendation (publish the relist expvar) is folded here.

## Load-bearing caveat (READ THIS)

**The relist is a no-bounce *optimization*, not the correctness guarantee.** It only fires once snowplow's `customresourcedefinitions` informer is **registered** — which is **demand-driven** (lazily, on the first `/call` path that records a dep-edge on the CRD GVR, i.e. post-first-Compositions-nav in the canonical portal), **NOT at boot**. Per Ship 0.5 / 0.30.223 the CRD informer is no longer a startup seed (`phase1.go:238-243,266-270`).

**Gap A:** a CRD widen that lands *before* that registration is absorbed as a **first-observation** and does **NOT** relist. Therefore the **portal-chart restart mitigation — a pod-template checksum bump on the CRD-fields chart change — is the actual correctness guarantee and MUST ship with the inline-extras CRD rollout.** The relist removes the bounce in the live case only (CRD informer already registered). Both kind-E2E docs independently surface this; it is inherent to the existing bridge, not introduced by this fix.

## Verification (KUBECONFIG unset, kind/unit only — never remote)

- `crd_schema_relist_test.go` — 2 falsifiers green under `-race`: widen relists exactly once + dirty-marks L1 with `type=SCHEMA_RELIST`; unchanged-schema does NOT relist.
- F-4 `crd_schema_invalidation_test.go` ordering tests + extended `TestCRDDiscoveryExpvarHandler` (10 keys) — green.
- Full `internal/cache` (31.3s) + `internal/objects` (2.7s) — green under `-race -count=1`.
- `go build ./...` + `go vet ./internal/cache/... ./internal/objects/...` — clean.

No north-star ledger row (correctness, not latency); a `project_feature_journal.md` row lands on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
