### PR TITLE
feat(restactions): accept YAML (as well as JSON) external api-step GET response

### DIFF
--- a/internal/resolvers/restactions/api/external_fetch.go
+++ b/internal/resolvers/restactions/api/external_fetch.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/http/util"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+// maxUnstructuredResponseTextBytes mirrors plumbing v0.9.3
+// http/request/request.go:19 — the 2048-byte cap on the non-2xx body
+// snippet folded into the error envelope. Kept verbatim so the
+// truncation (falsifier (j)) is byte-identical.
+const maxUnstructuredResponseTextBytes = 2048
+
+// httpFetchAllowingNonJSON is the snowplow-owned external-GET fetch for
+// the EXTERNAL api-step branch (resolve.go:822). It is a FAITHFUL
+// transcription of plumbing v0.9.3 http/request/request.go:35-130
+// (`request.Do`) MINUS the 406 JSON content-type gate at :118-120, with
+// two deliberate deltas:
+//
+//  1. It does NOT invoke opts.ResponseHandler. Instead it reads the 2xx
+//     body, detects JSON-vs-YAML, converts YAML→JSON (a no-op for JSON,
+//     since sigs.k8s.io/yaml.YAMLToJSON round-trips valid JSON
+//     losslessly), and RETURNS the JSON bytes. The caller feeds those
+//     bytes into the EXISTING unchanged handler chain (feedBytes →
+//     jsonHandlerBytes → jsonHandlerCore), so the JSON-passthrough,
+//     internal-rest-config, and in-process-nested-call paths are
+//     untouched by construction (AC3/AC4).
+//
+//  2. The non-2xx body is shaped into a *response.Status envelope
+//     BYTE-IDENTICALLY to request.go:102-116 (LimitReader(2048) →
+//     json.Unmarshal into Status, else raw-string response.New) and
+//     returned so the caller's existing StatusFailure path
+//     (resolve.go:823-856 → recordItemError) honours
+//     ContinueOnError/ErrorKey identically (AC5).
+//
+// The TLS/CA/client-cert/proxy/timeout/auth apparatus
+// (HTTPClientForEndpoint, the bearer/basic/AWS roundtrippers,
+// util.NewRetryClient, ComputeAwsHeaders) is REUSED verbatim from
+// plumbing — the only hand-written part is the request assembly and the
+// 2xx body conversion (AC7; falsifier (k) asserts the auth header on the
+// wire).
+//
+// Return contract:
+//   - On transport / request-build failure: (StatusFailure envelope,
+//     nil, "", goErr) — the goErr mirrors request.go's
+//     response.New(500, err) cases; the caller treats a non-nil err as a
+//     hard fault exactly as before.
+//   - On a non-2xx response: (StatusFailure envelope, nil, contentType,
+//     nil) — surfaced through recordItemError like an httpcall.Do
+//     failure; no go error so the resolve is not truncated.
+//   - On a 2xx response that does NOT convert (malformed YAML / HTML
+//     garbage): (StatusFailure envelope, nil, contentType, nil) — same
+//     recordItemError path, no panic, no creds leak (the envelope
+//     message is the conversion error, never the endpoint auth) (AC6;
+//     falsifiers (e),(g)).
+//   - On a 2xx response that converts: (Success envelope, jsonBytes,
+//     contentType, nil).
+func httpFetchAllowingNonJSON(ctx context.Context, opts httpcall.RequestOptions) (*response.Status, []byte, string, error) {
+	// --- request assembly (transcribed from request.go:36-95) ---
+	uri := strings.TrimSuffix(opts.Endpoint.ServerURL, "/")
+	if len(opts.Path) > 0 {
+		uri = fmt.Sprintf("%s/%s", uri, strings.TrimPrefix(opts.Path, "/"))
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return response.New(http.StatusInternalServerError, err), nil, "", err
+	}
+
+	verb := ptr.Deref(opts.Verb, http.MethodGet)
+
+	var body io.Reader
+	if s := ptr.Deref(opts.Payload, ""); len(s) > 0 {
+		body = strings.NewReader(s)
+	}
+
+	call, err := http.NewRequestWithContext(ctx, verb, u.String(), body)
+	if err != nil {
+		return response.New(http.StatusInternalServerError, err), nil, "", err
+	}
+
+	// Additional headers for AWS Signature 4 algorithm — transcribed
+	// verbatim from request.go:57-72 so AWS-signed external GETs keep
+	// working through the owned fetch (AC7).
+	if opts.Endpoint.HasAwsAuth() {
+		headers, _, _, _, _, _ := httpcall.ComputeAwsHeaders(opts.Endpoint, &opts.RequestInfo)
+		opts.Headers = append(opts.Headers, headers...)
+		opts.Headers = append(opts.Headers, xcontext.LabelKrateoTraceId+":"+xcontext.TraceId(ctx, true))
+		// Set all headers to lower case for AWS signature
+		for i := range opts.Headers {
+			hParts := strings.Split(opts.Headers[i], ":")
+			opts.Headers[i] = strings.ToLower(strings.Trim(hParts[0], " ")) + ":" + strings.Trim(hParts[1], " ")
+		}
+		sort.Strings(opts.Headers)
+	} else {
+		call.Header.Set(xcontext.LabelKrateoTraceId, xcontext.TraceId(ctx, true))
+	}
+
+	if len(opts.Headers) > 0 {
+		for _, el := range opts.Headers {
+			idx := strings.Index(el, ":")
+			if idx <= 0 {
+				continue
+			}
+			key := el[:idx]
+			val := strings.TrimSpace(el[idx+1:])
+			call.Header.Set(key, val)
+		}
+	}
+
+	// REUSED verbatim: builds the HTTP client (TLS/CA/client-certs/proxy/
+	// timeouts + bearer/basic/AWS auth roundtrippers) from the Endpoint.
+	cli, err := httpcall.HTTPClientForEndpoint(opts.Endpoint, &opts.RequestInfo)
+	if err != nil {
+		werr := fmt.Errorf("unable to create HTTP Client for endpoint: %w", err)
+		return response.New(http.StatusInternalServerError, werr), nil, "", werr
+	}
+
+	// REUSED verbatim: retry wrapper.
+	retryCli := util.NewRetryClient(cli)
+
+	respo, err := retryCli.Do(call)
+	if err != nil {
+		return response.New(http.StatusInternalServerError, err), nil, "", err
+	}
+	defer respo.Body.Close()
+
+	ct := respo.Header.Get("Content-Type")
+
+	// --- non-2xx shaping (transcribed BYTE-IDENTICALLY from
+	// request.go:98-116) --- (AC5; falsifier (j)).
+	statusOK := respo.StatusCode >= 200 && respo.StatusCode < 300
+	if !statusOK {
+		dat, rerr := io.ReadAll(io.LimitReader(respo.Body, maxUnstructuredResponseTextBytes))
+		if rerr != nil {
+			return response.New(http.StatusInternalServerError, rerr), nil, ct, rerr
+		}
+
+		res := &response.Status{}
+		if jerr := json.Unmarshal(dat, res); jerr != nil {
+			res = response.New(respo.StatusCode, fmt.Errorf("%s", string(dat)))
+			return res, nil, ct, nil
+		}
+		return res, nil, ct, nil
+	}
+
+	// --- 2xx body: detect + convert (the new, snowplow-owned step;
+	// request.go:118-120 406 gate DELETED) ---
+	dat, rerr := io.ReadAll(respo.Body)
+	if rerr != nil {
+		return response.New(http.StatusInternalServerError, rerr), nil, ct, rerr
+	}
+
+	jsonBytes, cerr := toJSONBytes(ct, dat)
+	if cerr != nil {
+		// Conversion failed (malformed YAML / HTML garbage). Surface as a
+		// StatusFailure envelope so the caller's recordItemError honours
+		// ContinueOnError/ErrorKey — NO go error (do not truncate the
+		// resolve), NO panic. The envelope message is the conversion
+		// error only; the endpoint auth never appears in it (AC6;
+		// falsifiers (e),(g)).
+		return response.New(http.StatusUnprocessableEntity, cerr), nil, ct, nil
+	}
+
+	return response.New(http.StatusOK, nil), jsonBytes, ct, nil
+}
+
+// toJSONBytes returns JSON bytes for a 2xx external body, converting from
+// YAML when the Content-Type sniff (convert.go:50 pattern) says YAML, OR
+// as a body-shape fallback when the sniff is inconclusive. YAMLToJSON
+// round-trips valid JSON losslessly, so the JSON fast-path is safe and
+// value-preserving (AC3; falsifier (d)).
+//
+// Detection order:
+//  1. Explicit YAML content-type → YAMLToJSON.
+//  2. Otherwise try the body as JSON first (the dominant, byte-identical
+//     path). If it parses, return it unchanged.
+//  3. JSON parse failed → last-resort YAMLToJSON (covers YAML served
+//     under text/plain, the Helm index.yaml case (AC1; falsifier (a))).
+//     If that also fails, return the error (malformed / non-structured
+//     body → falsifiers (e),(g)).
+func toJSONBytes(contentType string, dat []byte) ([]byte, error) {
+	if isYAMLContentType(contentType) {
+		out, err := yaml.YAMLToJSON(dat)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert YAML response to JSON: %w", err)
+		}
+		// Architect note A — apply the structured-shape guard SYMMETRICALLY
+		// with the last-resort path below. A bare top-level YAML scalar
+		// (e.g. a body that is just `"v1.2.3"`) round-trips to a bare JSON
+		// scalar, which is NOT a shape a stage filter consumes. Rejecting it
+		// here too keeps the convert contract uniform regardless of whether
+		// YAML was detected by content-type or by body-shape fallback — no
+		// asymmetry where an explicit text/yaml scalar slips through but the
+		// same scalar under text/plain is rejected. Strictly additive: such
+		// a body was 406'd pre-ship, so "still fails, cleaner error" is no
+		// regression.
+		if !isJSONObjectOrArray(out) {
+			return nil, fmt.Errorf("YAML response converted to a non-structured (scalar) value (content-type %q)", contentType)
+		}
+		return out, nil
+	}
+
+	// JSON fast-path: valid JSON passes through byte-identical in VALUE
+	// (json.Valid avoids a full unmarshal; the bytes are returned as-is).
+	if json.Valid(dat) {
+		return dat, nil
+	}
+
+	// Inconclusive content-type and not valid JSON: last-resort YAML.
+	// (Helm repos commonly serve index.yaml as text/plain.)
+	out, err := yaml.YAMLToJSON(dat)
+	if err != nil {
+		return nil, fmt.Errorf("response body is neither JSON nor convertible YAML: %w", err)
+	}
+	// YAMLToJSON happily turns a bare HTML/garbage scalar into a JSON
+	// string ("<!DOCTYPE...>"), which is NOT a usable structured stage
+	// result. Require the converted result to be a JSON object or array —
+	// the only shapes a stage filter consumes — so HTML garbage surfaces
+	// as a clean conversion failure (AC6; falsifier (g)) rather than a
+	// silently-wrapped string.
+	if !isJSONObjectOrArray(out) {
+		return nil, fmt.Errorf("response body is neither JSON nor structured YAML (content-type %q)", contentType)
+	}
+	return out, nil
+}
+
+// isYAMLContentType mirrors handlers/convert.go:50 — the explicit YAML
+// media types the convert endpoint recognises.
+func isYAMLContentType(contentType string) bool {
+	return strings.Contains(contentType, "application/x-yaml") ||
+		strings.Contains(contentType, "text/yaml")
+}
+
+// isJSONObjectOrArray reports whether b's first non-whitespace byte is
+// '{' or '[' — i.e. a structured JSON value a stage filter can consume.
+func isJSONObjectOrArray(b []byte) bool {
+	s := strings.TrimLeft(string(b), " \t\r\n")
+	return strings.HasPrefix(s, "{") || strings.HasPrefix(s, "[")
+}

--- a/internal/resolvers/restactions/api/external_fetch_ac6_e2e_test.go
+++ b/internal/resolvers/restactions/api/external_fetch_ac6_e2e_test.go
@@ -1,0 +1,476 @@
+//go:build unit
+// +build unit
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/ptr"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	"k8s.io/client-go/rest"
+)
+
+// external_fetch_ac6_e2e_test.go — AC6 END-TO-END falsifier
+// (feat/restaction-yaml-response).
+//
+// PM-requested gap closure: the (e)/(g) unit falsifiers in
+// external_fetch_falsifier_test.go assert httpFetchAllowingNonJSON's
+// RETURN TUPLE (StatusFailure envelope shape on malformed YAML / HTML
+// garbage). AC6 is stated against the recordItemError CONTRACT
+// (resolve.go:823-856) — ContinueOnError / ErrorKey honouring — which is
+// only exercised through the full dispatchOneCall path. These tests
+// drive the REAL api.Resolve over an httptest server (same harness model
+// as resolve_iter_continue_test.go: WithInternalEndpoint → external
+// branch → httpFetchAllowingNonJSON → recordItemError), so they prove:
+//
+//   - ContinueOnError=true  → the malformed-YAML stage does NOT abort the
+//     resolve; the downstream JSON stage still populates; dict[errorKey]
+//     carries the failure value (the contract C-A/W-A path).
+//   - ContinueOnError=false → the failing stage truncates the resolve (the
+//     downstream stage does NOT run), exactly as an httpcall.Do
+//     StatusFailure did pre-ship.
+//   - dict[errorKey] / the surfaced message NEVER contains the endpoint
+//     bearer token (no-creds-leak, end-to-end — closes the PM's question
+//     that the unit (g) only checked st.Message, not the errorKey path).
+//
+// No kubeconfig, no kind cluster — pure in-process
+// (feedback_no_go_test_against_remote_kubeconfig). Reuses iterResolveCtx
+// / keysOf / errEntryMentions from resolve_iter_continue_test.go.
+
+// ac6BearerToken is the endpoint credential the no-leak assertions hunt
+// for in the surfaced failure value / message.
+const ac6BearerToken = "ac6-secret-bearer-DO-NOT-LEAK"
+
+// ac6Fixture serves a fixed (status, content-type, body) at /bad and a
+// good JSON object at /good, recording the inbound Authorization header.
+type ac6Fixture struct {
+	server   *httptest.Server
+	gotAuth  string
+	badCT    string
+	badBody  string
+	badCode  int
+}
+
+func newAC6Fixture(t *testing.T, badCode int, badCT, badBody string) *ac6Fixture {
+	t.Helper()
+	f := &ac6Fixture{badCT: badCT, badBody: badBody, badCode: badCode}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.gotAuth = r.Header.Get("Authorization")
+		switch r.URL.Path {
+		case "/good":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"ok":true,"name":"downstream-ran"}`)
+		default: // "/bad"
+			if f.badCT != "" {
+				w.Header().Set("Content-Type", f.badCT)
+			}
+			w.WriteHeader(f.badCode)
+			fmt.Fprint(w, f.badBody)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	f.server = srv
+	return f
+}
+
+// runAC6Resolve drives the REAL api.Resolve over the fixture with the
+// endpoint carrying ac6BearerToken (so the no-leak check is meaningful:
+// the token rides the same call.Endpoint into httpFetchAllowingNonJSON).
+func runAC6Resolve(f *ac6Fixture, stages []*templates.API) map[string]any {
+	ctx := cache.WithInternalEndpoint(iterResolveCtx(), &endpoints.Endpoint{
+		ServerURL: f.server.URL,
+		Token:     ac6BearerToken,
+	})
+	return Resolve(ctx, ResolveOptions{
+		RC:                  &rest.Config{},
+		Items:               stages,
+		RESTActionNamespace: "default",
+		RESTActionName:      "ac6-yaml-falsifier",
+	})
+}
+
+// badStage builds a single external GET stage hitting /bad with the given
+// ContinueOnError + ErrorKey.
+func badStage(continueOnError bool) *templates.API {
+	return &templates.API{
+		Name:            "bad",
+		Path:            "/bad",
+		Verb:            ptr.To(http.MethodGet),
+		ContinueOnError: ptr.To(continueOnError),
+		ErrorKey:        ptr.To("badErr"),
+	}
+}
+
+// goodDownstream depends on "bad" so topologicalSort runs bad first; its
+// presence in the dict proves the resolve did NOT truncate.
+func goodDownstream() *templates.API {
+	return &templates.API{
+		Name:      "good",
+		Path:      "/good",
+		Verb:      ptr.To(http.MethodGet),
+		DependsOn: &templates.Dependency{Name: "bad"},
+		Filter:    ptr.To(".good"),
+	}
+}
+
+// assertNoTokenLeak fails if the endpoint bearer token appears anywhere
+// in the JSON-rendered dict (errorKey value, message, etc.).
+func assertNoTokenLeak(t *testing.T, dict map[string]any) {
+	t.Helper()
+	rendered := fmt.Sprintf("%#v", dict)
+	if strings.Contains(rendered, ac6BearerToken) {
+		t.Fatalf("CREDS LEAK: endpoint bearer token surfaced in the resolved dict: %s", rendered)
+	}
+}
+
+// failFastRetries pins the RetryClient knobs so a 5xx /bad fails on the
+// first attempt (mirrors iterFailFastRetries).
+func ac6FailFast(t *testing.T) {
+	t.Helper()
+	t.Setenv("CLIENT_MAX_RETRIES", "0")
+	t.Setenv("CLIENT_BASE_BACKOFF", "1ms")
+	t.Setenv("CLIENT_MAX_BACKOFF", "1ms")
+}
+
+// AC6 (i): malformed YAML 200 + ContinueOnError=true → resolve continues,
+// downstream JSON stage populates, dict[errorKey] carries the failure, no
+// token leak.
+func TestAC6_MalformedYAML_ContinueOnError_True(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	malformed := "entries:\n  - a: 1\n   : broken indent\n\tbad"
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", malformed)
+
+	dict := runAC6Resolve(f, []*templates.API{badStage(true), goodDownstream()})
+
+	// errorKey carries the conversion failure value (W-A accumulating slice
+	// or scalar — both acceptable; the contract is "errorKey populated").
+	if _, ok := dict["badErr"]; !ok {
+		t.Fatalf("AC6: dict[\"badErr\"] absent on a continueOnError=true malformed-YAML stage — "+
+			"recordItemError did not honour ErrorKey. dict keys=%v", keysOf(dict))
+	}
+	// Downstream stage MUST have run (no truncation).
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("AC6: downstream stage \"good\" absent — the malformed-YAML stage truncated the "+
+			"resolve despite continueOnError=true. dict keys=%v", keysOf(dict))
+	}
+	assertNoTokenLeak(t, dict)
+}
+
+// AC6 (ii): HTML/garbage 200 + ContinueOnError=true → same contract
+// (clean failure, continue, errorKey populated, no leak). Covers the (g)
+// path end-to-end including the errorKey surface the unit (g) did not.
+func TestAC6_HTMLGarbage_ContinueOnError_True(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	html := "<!DOCTYPE html><html><body>upstream 503</body></html>"
+	f := newAC6Fixture(t, http.StatusOK, "text/html", html)
+
+	dict := runAC6Resolve(f, []*templates.API{badStage(true), goodDownstream()})
+
+	if _, ok := dict["badErr"]; !ok {
+		t.Fatalf("AC6: dict[\"badErr\"] absent on a continueOnError=true HTML-garbage stage. dict keys=%v", keysOf(dict))
+	}
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("AC6: downstream stage absent — HTML garbage truncated the resolve. dict keys=%v", keysOf(dict))
+	}
+	assertNoTokenLeak(t, dict)
+}
+
+// AC6 (iii): malformed YAML 200 + ContinueOnError=FALSE → the failing
+// stage's error is recorded under errorKey BYTE-IDENTICALLY to the
+// pre-ship httpcall.Do StatusFailure path (resolve.go:823-856 is
+// UNCHANGED by this ship). No token leak.
+//
+// IMPORTANT behavioural note discovered by this falsifier (and verified
+// against the unchanged StatusFailure code path): since Ship 0.30.257
+// (#313, Option C-A) a per-item hard error — even with
+// ContinueOnError=false — does NOT cancel the errgroup; the worker
+// records itemErr into its disjoint itemErrs[i] slot and returns nil, so
+// g.Wait() returns nil and the resolve does NOT truncate. The
+// false-vs-true distinction at resolve.go:878-881 is ONLY whether the
+// lazy fmt.Errorf itemErr is built (it lands in itemErrs[i] → a Debug
+// join line, NOT the dict). dict[errorKey] is populated in BOTH cases.
+// My ship feeds the SAME StatusFailure envelope into that SAME unchanged
+// code, so the observable dict result is byte-identical to the pre-ship
+// httpcall.Do path for both ContinueOnError values. (The earlier draft of
+// this test wrongly expected false → truncate, a pre-#313 mental model;
+// the falsifier caught the stale assumption.)
+func TestAC6_MalformedYAML_ContinueOnError_False(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	malformed := "entries:\n  - a: 1\n   : broken indent\n\tbad"
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", malformed)
+
+	dict := runAC6Resolve(f, []*templates.API{badStage(false), goodDownstream()})
+
+	// The failure is recorded under errorKey (the StatusFailure path runs
+	// for both ContinueOnError values; only the Debug itemErr differs).
+	if _, ok := dict["badErr"]; !ok {
+		t.Fatalf("AC6: dict[\"badErr\"] absent on a continueOnError=false malformed-YAML stage — "+
+			"the StatusFailure path did not record ErrorKey. dict keys=%v", keysOf(dict))
+	}
+	// Per #313 C-A the resolve still completes (does not panic / hard-abort);
+	// the downstream stage runs exactly as for the pre-ship httpcall.Do
+	// StatusFailure (this same unchanged code).
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("AC6: downstream stage \"good\" absent — #313 C-A semantics broken. dict keys=%v", keysOf(dict))
+	}
+	assertNoTokenLeak(t, dict)
+}
+
+// AC6 (iv): the no-leak guard is meaningful — assert the token actually
+// reached the wire (so a passing no-leak check is not a false negative
+// from the token never being sent). If this fails, the endpoint auth was
+// not exercised and the no-leak assertions above are vacuous.
+func TestAC6_TokenReachedWire(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", "entries:\n  bad\n\t: x")
+	_ = runAC6Resolve(f, []*templates.API{badStage(true)})
+
+	if f.gotAuth != "Bearer "+ac6BearerToken {
+		t.Fatalf("AC6: endpoint token did not reach the wire (got %q) — the no-leak checks would be "+
+			"vacuous. The owned fetch must send Authorization through the reused roundtripper.", f.gotAuth)
+	}
+	_ = context.Background()
+}
+
+// errKeyMessage extracts the surfaced failure message from dict[errorKey].
+// The StatusFailure path records accumVal = response.AsMap(res) (a map
+// carrying "message"), accumulated under errorKey as a W-A slice (first
+// error) or a bare value. This mirrors the Status.Message the unit (g)
+// checked — so asserting on it closes PM's "errorKey path AND st.Message"
+// gap end-to-end.
+func errKeyMessage(t *testing.T, dict map[string]any, errorKey string) string {
+	t.Helper()
+	v, ok := dict[errorKey]
+	if !ok {
+		t.Fatalf("(l): dict[%q] absent — recordItemError did not honour ErrorKey. keys=%v", errorKey, keysOf(dict))
+	}
+	// W-A accumulating slice: take the first entry; else the value itself.
+	entry := v
+	if s, isSlice := v.([]any); isSlice {
+		if len(s) == 0 {
+			t.Fatalf("(l): dict[%q] is an empty slice — no failure recorded", errorKey)
+		}
+		entry = s[0]
+	}
+	switch e := entry.(type) {
+	case map[string]any:
+		if msg, ok := e["message"].(string); ok {
+			return msg
+		}
+		t.Fatalf("(l): dict[%q] entry has no string message field: %#v", errorKey, e)
+	case string:
+		return e
+	}
+	t.Fatalf("(l): dict[%q] entry is unexpected type %T: %#v", errorKey, entry, entry)
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Falsifier (l) — team-lead spec: end-to-end via runStage/dispatchOneCall,
+// exercising the CHANGED dispatch routing (the new `else { feedBytes }`
+// success branch + the StatusFailure fall-through → recordItemError).
+// ---------------------------------------------------------------------------
+
+// (l): stage1 = external malformed-YAML 2xx, ContinueOnError=true + ErrorKey;
+// stage2 = a normal external stage that MUST still populate. Asserts: no
+// hard-abort; stage2 populates; dict[errorKey] carries the failure; the auth
+// token is absent from BOTH dict[errorKey] (whole value) AND the surfaced
+// failure MESSAGE (the asMap "message" the StatusFailure path records — the
+// end-to-end equivalent of the unit (g)'s st.Message check).
+func TestFalsifierL_MalformedYAML_ContinueTrue_E2E(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	malformed := "entries:\n  - a: 1\n   : broken indent\n\tbad"
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", malformed)
+
+	dict := runAC6Resolve(f, []*templates.API{badStage(true), goodDownstream()})
+
+	// No hard-abort: the downstream normal stage populated.
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("(l): downstream stage \"good\" absent — malformed-YAML stage hard-aborted the resolve "+
+			"despite continueOnError=true. keys=%v", keysOf(dict))
+	}
+	// errorKey carries the failure.
+	if _, ok := dict["badErr"]; !ok {
+		t.Fatalf("(l): dict[\"badErr\"] absent — recordItemError did not honour ErrorKey. keys=%v", keysOf(dict))
+	}
+	// No leak in the WHOLE errorKey value.
+	if rendered := fmt.Sprintf("%#v", dict["badErr"]); strings.Contains(rendered, ac6BearerToken) {
+		t.Fatalf("(l) CREDS LEAK in dict[errorKey]: %s", rendered)
+	}
+	// No leak in the surfaced failure MESSAGE specifically (end-to-end
+	// equivalent of unit (g)'s st.Message check); and the message IS the
+	// conversion failure, not the endpoint detail.
+	msg := errKeyMessage(t, dict, "badErr")
+	if strings.Contains(msg, ac6BearerToken) {
+		t.Fatalf("(l) CREDS LEAK in surfaced failure message: %q", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "yaml") && !strings.Contains(strings.ToLower(msg), "convert") &&
+		!strings.Contains(strings.ToLower(msg), "json") {
+		t.Errorf("(l): surfaced message does not look like a conversion failure: %q", msg)
+	}
+	// Belt-and-suspenders whole-dict leak scan.
+	assertNoTokenLeak(t, dict)
+}
+
+// (l-variant): malformed-YAML 2xx + ContinueOnError=FALSE.
+//
+// SPEC vs CODE: the team-lead spec calls for "hard-abort" here. The CODE
+// (resolve.go:854-886, UNCHANGED by this ship) does NOT hard-abort a
+// StatusFailure for either ContinueOnError value — since Ship 0.30.257
+// (#313 Option C-A) the StatusFailure branch records the item error via
+// recordItemError and FALLS THROUGH (returns nil); g.Wait() only
+// truncates on a genuine ctx-cancel (resolve.go:1189-1198). (NOTE: as of
+// the B-regression fix in this ship, a success-branch feedBytes/decode
+// error is ALSO shaped into a StatusFailure → recordItemError → no
+// truncate, matching the pre-ship httpcall.Do ResponseHandler-error path —
+// see TestFalsifierB_SuccessBranchDecodeFailure_NoTruncate. So the only
+// remaining truncation source is ctx-cancel.) A malformed-YAML body is
+// surfaced as a StatusFailure ENVELOPE (never reaching feedBytes), so it
+// takes the no-truncate path regardless of ContinueOnError.
+//
+// This is NOT introduced by the ship — it is the unchanged #313 contract;
+// the pre-ship httpcall.Do StatusFailure fed the same block. Writing a
+// test that asserted a hard-abort here would FAIL (or could only pass by
+// faking), so per feedback_no_fake_production_scenarios this test pins the
+// ACTUAL behaviour: false → errorKey recorded, the lazily-built itemErr
+// is present in the Debug join (not the dict), resolve completes, no leak.
+// The spec/code divergence is raised to PM + team-lead.
+func TestFalsifierL_Variant_MalformedYAML_ContinueFalse_E2E(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	malformed := "entries:\n  - a: 1\n   : broken indent\n\tbad"
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", malformed)
+
+	dict := runAC6Resolve(f, []*templates.API{badStage(false), goodDownstream()})
+
+	// Actual #313 contract: errorKey recorded, resolve does NOT truncate.
+	if _, ok := dict["badErr"]; !ok {
+		t.Fatalf("(l-variant): dict[\"badErr\"] absent — StatusFailure path did not record ErrorKey. keys=%v", keysOf(dict))
+	}
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("(l-variant): downstream stage absent — the #313 no-truncate contract (unchanged by this "+
+			"ship) was broken. keys=%v", keysOf(dict))
+	}
+	// No leak (same surface as (l)).
+	if msg := errKeyMessage(t, dict, "badErr"); strings.Contains(msg, ac6BearerToken) {
+		t.Fatalf("(l-variant) CREDS LEAK in surfaced failure message: %q", msg)
+	}
+	assertNoTokenLeak(t, dict)
+}
+
+// Architect note B (non-blocking, folded in): explicit external-JSON
+// fall-through. A normal external GET returning a 2xx JSON object takes
+// the new `else { feedBytes }` SUCCESS branch (the changed routing) and
+// must populate dict[id] byte-identically to the pre-ship httpcall.Do
+// ResponseHandler path. This is the success-side companion to the
+// (l)/(l-variant) failure-side e2e coverage — it exercises the SAME
+// changed dispatch routing end-to-end, proving the no-regression for the
+// common JSON external stage (AC3) through runStage, not just the unit
+// (d).
+func TestFalsifierL_ExternalJSONFallThrough_E2E(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	// /good returns {"ok":true,"name":"downstream-ran"} as application/json.
+	f := newAC6Fixture(t, http.StatusOK, "application/json", "")
+
+	jsonStage := &templates.API{
+		Name:   "j",
+		Path:   "/good",
+		Verb:   ptr.To(http.MethodGet),
+		Filter: ptr.To(".j"),
+	}
+	dict := runAC6Resolve(f, []*templates.API{jsonStage})
+
+	got, ok := dict["j"].(map[string]any)
+	if !ok {
+		t.Fatalf("note-B: dict[\"j\"] is %T, want map (external JSON did not populate via feedBytes). keys=%v",
+			dict["j"], keysOf(dict))
+	}
+	if got["ok"] != true || got["name"] != "downstream-ran" {
+		t.Fatalf("note-B: external JSON 2xx not byte-identical through the success branch: %#v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Falsifier B-regression (team-lead) — success-branch DECODE-FAILURE path,
+// arbitrated against the pre-ship httpcall.Do oracle.
+// ---------------------------------------------------------------------------
+//
+// SCENARIO: a 2xx body that CONVERTS cleanly to JSON (so it reaches the new
+// `else { feedBytes }` SUCCESS branch — NOT the StatusFailure branch) but
+// whose stage Filter then forces a jsonHandlerCore error. A jq filter of
+// `empty` yields zero values → jsonHandlerCore returns
+// `fmt.Errorf("jq filter %q yielded no value")` (handler.go) → feedBytes
+// returns that error.
+//
+// PRE-SHIP ORACLE (httpcall.Do, request.go:121-126): the handler ran as
+// call.ResponseHandler(body); a ResponseHandler error was wrapped
+// `return response.New(http.StatusInternalServerError, err)` → a
+// StatusFailure → at resolve.go the `res.Status == StatusFailure` branch ran
+// recordItemError and FELL THROUGH returning nil → under #313 C-A NO
+// truncation (downstream stages still run).
+//
+// NEW CODE (resolve.go:899-901): `if err := feedBytes(jsonBytes); err != nil
+// { return err }` returns the error RAW to dispatchOneCall → the errgroup
+// worker returns non-nil → g.Wait() returns non-nil → TRUNCATION.
+//
+// => If this falsifier is RED (downstream "good" absent), the new success
+// branch truncates where pre-ship continued — a REAL REGRESSION. The fix is
+// to route a feedBytes error through the SAME StatusFailure → recordItemError
+// fall-through the old ResponseHandler-error path used (shape it as a
+// per-item StatusFailure, NOT a raw return err).
+//
+// The oracle is captured empirically in the report by re-running this exact
+// test against pre-ship resolve.go (git checkout of the transport path).
+func TestFalsifierB_SuccessBranchDecodeFailure_NoTruncate(t *testing.T) {
+	ac6FailFast(t)
+	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
+
+	// /bad returns a VALID-converting YAML object (2xx, text/yaml) → reaches
+	// the success branch. Its filter `empty` forces a jsonHandlerCore
+	// zero-yield error inside feedBytes.
+	f := newAC6Fixture(t, http.StatusOK, "text/yaml", "entries:\n  - name: a\n  - name: b\n")
+
+	decodeFailStage := &templates.API{
+		Name:            "bad",
+		Path:            "/bad",
+		Verb:            ptr.To(http.MethodGet),
+		ContinueOnError: ptr.To(true),
+		ErrorKey:        ptr.To("badErr"),
+		Filter:          ptr.To("empty"), // zero-yield → jsonHandlerCore error
+	}
+
+	dict := runAC6Resolve(f, []*templates.API{decodeFailStage, goodDownstream()})
+
+	// ORACLE assertion: pre-ship did NOT truncate on a ResponseHandler error
+	// (it became a StatusFailure → recordItemError → nil). The downstream
+	// stage MUST still populate. RED here = the new success branch truncates
+	// → real regression.
+	if _, ok := dict["good"]; !ok {
+		t.Fatalf("B-REGRESSION: downstream stage \"good\" ABSENT — the new success-branch feedBytes "+
+			"error TRUNCATED the resolve, where pre-ship httpcall.Do turned a ResponseHandler error into "+
+			"a StatusFailure → recordItemError → no-truncate. keys=%v", keysOf(dict))
+	}
+}

--- a/internal/resolvers/restactions/api/external_fetch_falsifier_test.go
+++ b/internal/resolvers/restactions/api/external_fetch_falsifier_test.go
@@ -1,0 +1,420 @@
+//go:build unit
+// +build unit
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/ptr"
+)
+
+// external_fetch_falsifier_test.go — the (a)-(k) falsifiers for the
+// snowplow-side JSON-or-YAML external-GET relaxation
+// (feat/restaction-yaml-response).
+//
+// These exercise httpFetchAllowingNonJSON directly against an
+// httptest.Server, which drives the REUSED plumbing apparatus
+// (HTTPClientForEndpoint → auth roundtrippers, util.NewRetryClient,
+// the non-2xx error envelope) plus the new content-type detection +
+// YAMLToJSON conversion. The handler-chain consumer ACs assert the
+// converted JSON bytes drive jsonHandlerCore + a jq stage filter
+// identically to a real blueprint stage (which is what the resolver
+// feeds the bytes into via feedBytes at resolve.go:822).
+//
+// No kubeconfig, no kind cluster — pure in-process
+// (feedback_no_go_test_against_remote_kubeconfig).
+
+// helmIndexYAML is a faithful Helm repository index.yaml shape — the
+// canonical consumer the ship enables (AC1).
+const helmIndexYAML = `apiVersion: v1
+entries:
+  postgresql:
+    - name: postgresql
+      version: 12.1.0
+      appVersion: "15.1.0"
+    - name: postgresql
+      version: 12.0.0
+      appVersion: "15.0.0"
+  redis:
+    - name: redis
+      version: 17.0.0
+      appVersion: "7.0.0"
+generated: "2026-06-20T00:00:00Z"
+`
+
+// fetchAgainst spins an httptest.Server returning the given status,
+// content-type, and body, then runs httpFetchAllowingNonJSON against
+// it. The returned recordedAuth is the inbound Authorization header
+// the server saw (falsifier (k)).
+func fetchAgainst(t *testing.T, status int, contentType, body string, ep func(serverURL string) endpoints.Endpoint) (st *response.Status, jsonBytes []byte, ct string, recordedAuth string, err error) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordedAuth = r.Header.Get("Authorization")
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	endpoint := ep(srv.URL)
+	verb := http.MethodGet
+	call := httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{
+			Verb: &verb,
+		},
+		Endpoint: &endpoint,
+	}
+	st, jsonBytes, ct, err = httpFetchAllowingNonJSON(context.Background(), call)
+	return st, jsonBytes, ct, recordedAuth, err
+}
+
+func noAuth(serverURL string) endpoints.Endpoint {
+	return endpoints.Endpoint{ServerURL: serverURL}
+}
+
+// runStageFilter feeds jsonBytes into the exact handler chain a real
+// stage uses (jsonHandlerBytesApply → jsonHandlerCore) with the given
+// jq filter, and returns the accumulated dict[key].
+func runStageFilter(t *testing.T, key, filter string, jsonBytes []byte) any {
+	t.Helper()
+	out := map[string]any{}
+	opts := jsonHandlerOptions{
+		key:    key,
+		out:    out,
+		dict:   out,
+		filter: ptr.To(filter),
+	}
+	if err := jsonHandlerBytesApply(context.Background(), opts, jsonBytes); err != nil {
+		t.Fatalf("jsonHandlerBytesApply failed: %v", err)
+	}
+	return out[key]
+}
+
+// (a) index.yaml served text/plain → converts → jq blueprint filter
+// returns expected entries (where today the call 406s before the body
+// is read).
+func TestFalsifierA_HelmIndexTextPlain(t *testing.T) {
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/plain", helmIndexYAML, noAuth)
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	if st.Status == response.StatusFailure {
+		t.Fatalf("expected success status, got failure: %+v", st)
+	}
+	// Blueprint-style filter: pluck the postgresql versions. Production
+	// stage filters reference the stage key (jsonHandlerCore evaluates the
+	// filter against the WRAPPED envelope `{<key>: <body>}`), so the filter
+	// is rooted at `.idx`.
+	got := runStageFilter(t, "idx", `.idx.entries.postgresql | map(.version)`, jsonBytes)
+	want := []any{"12.1.0", "12.0.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("blueprint filter mismatch.\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// (b) text/yaml content-type sniff path.
+func TestFalsifierB_TextYAML(t *testing.T) {
+	_, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/yaml", helmIndexYAML, noAuth)
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	got := runStageFilter(t, "idx", `.idx.entries.redis | map(.version)`, jsonBytes)
+	if !reflect.DeepEqual(got, []any{"17.0.0"}) {
+		t.Fatalf("text/yaml conversion mismatch: %#v", got)
+	}
+}
+
+// (c) application/x-yaml content-type sniff path.
+func TestFalsifierC_ApplicationXYAML(t *testing.T) {
+	_, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "application/x-yaml", helmIndexYAML, noAuth)
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	got := runStageFilter(t, "idx", `.idx.apiVersion`, jsonBytes)
+	if got != "v1" {
+		t.Fatalf("application/x-yaml conversion mismatch: %#v", got)
+	}
+}
+
+// (d) application/json control → passthrough byte-identical
+// (no-regression). YAMLToJSON round-trips valid JSON losslessly, but the
+// dict result must be value-identical to a direct json.Unmarshal.
+func TestFalsifierD_JSONPassthroughByteIdentical(t *testing.T) {
+	jsonBody := `{"entries":{"postgresql":[{"name":"postgresql","version":"12.1.0"}]},"apiVersion":"v1"}`
+	_, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "application/json", jsonBody, noAuth)
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	// Decoded value must equal a plain json.Unmarshal of the original
+	// body — the conversion must be a no-op for JSON.
+	var viaFetch, direct any
+	if err := json.Unmarshal(jsonBytes, &viaFetch); err != nil {
+		t.Fatalf("fetch bytes not valid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(jsonBody), &direct); err != nil {
+		t.Fatalf("control body not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(viaFetch, direct) {
+		t.Fatalf("JSON passthrough not value-identical.\n got: %#v\nwant: %#v", viaFetch, direct)
+	}
+}
+
+// (e) malformed YAML → conversion fails → returned as a Failure status
+// so the resolver's existing recordItemError honours
+// ContinueOnError/ErrorKey. The fetch itself must NOT panic and must NOT
+// return a non-nil go error that would truncate the resolve; it returns
+// a StatusFailure envelope (mirroring how httpcall.Do surfaced failures).
+func TestFalsifierE_MalformedYAML(t *testing.T) {
+	bad := "entries:\n  - this: is\n   : not valid yaml\n\t bad indent"
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/yaml", bad, noAuth)
+	if err != nil {
+		t.Fatalf("fetch must not return a hard go error for malformed body; got %v", err)
+	}
+	if st == nil || st.Status != response.StatusFailure {
+		t.Fatalf("expected StatusFailure envelope for malformed YAML, got %+v", st)
+	}
+	if jsonBytes != nil {
+		t.Fatalf("expected nil json bytes on conversion failure, got %q", string(jsonBytes))
+	}
+}
+
+// Architect note A — symmetric structured-shape guard. A bare top-level
+// YAML SCALAR served under an EXPLICIT yaml content-type (text/yaml) must
+// be rejected as a clean conversion failure, identically to the same
+// scalar arriving via the body-shape fallback path. This pins the
+// uniform-convert contract: no asymmetry where text/yaml scalars slip
+// through but text/plain scalars are rejected. (Such a body was 406'd
+// pre-ship, so the clean failure is no regression.)
+func TestFalsifierE2_YAMLScalarExplicitContentTypeRejected(t *testing.T) {
+	scalar := `"v1.2.3"`
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/yaml", scalar, noAuth)
+	if err != nil {
+		t.Fatalf("fetch must not return a hard go error for a scalar body; got %v", err)
+	}
+	if st == nil || st.Status != response.StatusFailure {
+		t.Fatalf("expected StatusFailure for a bare YAML scalar under text/yaml, got %+v", st)
+	}
+	if jsonBytes != nil {
+		t.Fatalf("expected nil json bytes on scalar rejection, got %q", string(jsonBytes))
+	}
+}
+
+// (f) bearer-auth Endpoint → call succeeds (auth apparatus reused).
+func TestFalsifierF_BearerAuthSucceeds(t *testing.T) {
+	bearerEP := func(serverURL string) endpoints.Endpoint {
+		return endpoints.Endpoint{ServerURL: serverURL, Token: "s3cr3t-token"}
+	}
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/yaml", helmIndexYAML, bearerEP)
+	if err != nil {
+		t.Fatalf("bearer-auth fetch error: %v", err)
+	}
+	if st.Status == response.StatusFailure {
+		t.Fatalf("bearer-auth fetch returned failure: %+v", st)
+	}
+	got := runStageFilter(t, "idx", `.idx.apiVersion`, jsonBytes)
+	if got != "v1" {
+		t.Fatalf("bearer-auth conversion mismatch: %#v", got)
+	}
+}
+
+// (g) 200 + HTML/garbage → clean error (conversion failure), no panic,
+// no creds leak in the surfaced message.
+func TestFalsifierG_HTMLGarbageCleanError(t *testing.T) {
+	html := "<!DOCTYPE html><html><body><h1>503 upstream</h1></body></html>"
+	garbageEP := func(serverURL string) endpoints.Endpoint {
+		return endpoints.Endpoint{ServerURL: serverURL, Token: "leak-me-if-you-can"}
+	}
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "text/html", html, garbageEP)
+	if err != nil {
+		t.Fatalf("HTML garbage must not return a hard go error; got %v", err)
+	}
+	if st == nil || st.Status != response.StatusFailure {
+		t.Fatalf("expected StatusFailure for HTML garbage, got %+v", st)
+	}
+	if jsonBytes != nil {
+		t.Fatalf("expected nil json bytes on conversion failure")
+	}
+	if strings.Contains(st.Message, "leak-me-if-you-can") {
+		t.Fatalf("credential leaked into error message: %q", st.Message)
+	}
+}
+
+// (j) non-2xx error-status byte-identical to plumbing request.go:102-116
+// — both the JSON-Status branch and the raw-string branch, incl. the
+// 2048-byte truncation.
+func TestFalsifierJ_Non2xxByteIdentical(t *testing.T) {
+	t.Run("json-status-body", func(t *testing.T) {
+		statusJSON := `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"forbidden","reason":"Forbidden","code":403}`
+		st, _, _, _, err := fetchAgainst(t, http.StatusForbidden, "application/json", statusJSON, noAuth)
+		if err != nil {
+			t.Fatalf("unexpected go error: %v", err)
+		}
+		if st.Code != 403 || st.Message != "forbidden" || st.Reason != response.StatusReasonForbidden {
+			t.Fatalf("json-status non-2xx not byte-identical: %+v", st)
+		}
+	})
+	t.Run("raw-string-body", func(t *testing.T) {
+		// Use a 4xx (404). The non-2xx BODY-shaping branch
+		// (request.go:102-116) only runs for codes the RetryClient does
+		// NOT retry — i.e. non-5xx, non-429. 5xx is retried 5× and then
+		// surfaced as a `server error after N retries` go error +
+		// response.New(500, err), NOT the body envelope; that 5xx path is
+		// asserted byte-identical in the "5xx-retry-error" subtest below.
+		raw := "plain text upstream error"
+		st, _, _, _, err := fetchAgainst(t, http.StatusNotFound, "text/plain", raw, noAuth)
+		if err != nil {
+			t.Fatalf("unexpected go error: %v", err)
+		}
+		// request.go raw branch: response.New(statusCode, fmt.Errorf("%s", dat)).
+		if st.Code != http.StatusNotFound || st.Message != raw {
+			t.Fatalf("raw non-2xx not byte-identical: %+v", st)
+		}
+	})
+	t.Run("2048-truncation", func(t *testing.T) {
+		big := strings.Repeat("A", 4096)
+		st, _, _, _, err := fetchAgainst(t, http.StatusBadRequest, "text/plain", big, noAuth)
+		if err != nil {
+			t.Fatalf("unexpected go error: %v", err)
+		}
+		if len(st.Message) != 2048 {
+			t.Fatalf("expected 2048-byte truncation, got %d bytes", len(st.Message))
+		}
+	})
+	t.Run("5xx-retry-error", func(t *testing.T) {
+		// 5xx: RetryClient retries then returns a go error. request.Do
+		// (and our transcription) both turn that into response.New(500,
+		// err) + a non-nil go error — byte-identical. We cap retries to 0
+		// via env so this subtest does not pay 5× backoff.
+		t.Setenv("CLIENT_MAX_RETRIES", "0")
+		st, _, _, _, err := fetchAgainst(t, http.StatusInternalServerError, "text/plain", "boom", noAuth)
+		if err == nil {
+			t.Fatalf("expected a hard go error for exhausted 5xx retries")
+		}
+		if st == nil || st.Code != http.StatusInternalServerError || st.Status != response.StatusFailure {
+			t.Fatalf("5xx retry-exhaustion envelope not byte-identical: %+v", st)
+		}
+	})
+}
+
+// (k) auth header ON THE WIRE — assert the server received exactly the
+// expected bearer/basic Authorization value (reuse EXERCISED, not just
+// imported).
+func TestFalsifierK_AuthHeaderOnTheWire(t *testing.T) {
+	t.Run("bearer", func(t *testing.T) {
+		bearerEP := func(serverURL string) endpoints.Endpoint {
+			return endpoints.Endpoint{ServerURL: serverURL, Token: "wire-bearer-xyz"}
+		}
+		_, _, _, gotAuth, err := fetchAgainst(t, http.StatusOK, "text/yaml", helmIndexYAML, bearerEP)
+		if err != nil {
+			t.Fatalf("fetch error: %v", err)
+		}
+		if gotAuth != "Bearer wire-bearer-xyz" {
+			t.Fatalf("bearer auth not on the wire: got %q", gotAuth)
+		}
+	})
+	t.Run("basic", func(t *testing.T) {
+		basicEP := func(serverURL string) endpoints.Endpoint {
+			return endpoints.Endpoint{ServerURL: serverURL, Username: "alice", Password: "pw123"}
+		}
+		_, _, _, gotAuth, err := fetchAgainst(t, http.StatusOK, "text/yaml", helmIndexYAML, basicEP)
+		if err != nil {
+			t.Fatalf("fetch error: %v", err)
+		}
+		req := &http.Request{Header: http.Header{"Authorization": []string{gotAuth}}}
+		u, p, ok := req.BasicAuth()
+		if !ok || u != "alice" || p != "pw123" {
+			t.Fatalf("basic auth not on the wire: got %q", gotAuth)
+		}
+	})
+}
+
+// (h) internal-rest-config JSON no-regression: the internal-rest-config
+// dispatch path feeds its in-memory JSON bytes via feedBytes →
+// jsonHandlerBytes, NEVER through httpFetchAllowingNonJSON/toJSONBytes.
+// This asserts that path's handler result is byte-identical to a direct
+// json.Unmarshal of the same bytes — and, critically, that toJSONBytes
+// (the YAML conversion) is NOT in that code path (the conversion lives
+// only in external_fetch.go; the dispatch paths are untouched, AC4).
+func TestFalsifierH_InternalRESTConfigJSONNoRegression(t *testing.T) {
+	jsonBody := []byte(`{"items":[{"metadata":{"name":"a"}},{"metadata":{"name":"b"}}]}`)
+
+	out := map[string]any{}
+	fn := jsonHandlerBytes(context.Background(), jsonHandlerOptions{key: "ks", out: out, dict: out})
+	if err := fn(jsonBody); err != nil {
+		t.Fatalf("jsonHandlerBytes failed: %v", err)
+	}
+
+	var direct any
+	if err := json.Unmarshal(jsonBody, &direct); err != nil {
+		t.Fatalf("control unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(out["ks"], direct) {
+		t.Fatalf("internal-rest-config JSON not byte-identical.\n got: %#v\nwant: %#v", out["ks"], direct)
+	}
+}
+
+// (i) in-process nested-call JSON no-regression: a loopback nested /call
+// returns Status.Raw bytes that the resolver feeds via feedBytes →
+// jsonHandlerBytes (same as (h)). The decoded dict value must be
+// byte-identical to a direct unmarshal of the Status.Raw — proving the
+// nested-call path is untouched and does NOT route through the YAML
+// conversion (AC4).
+func TestFalsifierI_NestedCallJSONNoRegression(t *testing.T) {
+	statusRaw := []byte(`{"kind":"RESTAction","apiVersion":"templates.krateo.io/v1","status":{"foo":"bar"}}`)
+
+	out := map[string]any{}
+	fn := jsonHandlerBytes(context.Background(), jsonHandlerOptions{key: "nested", out: out, dict: out})
+	if err := fn(statusRaw); err != nil {
+		t.Fatalf("jsonHandlerBytes failed: %v", err)
+	}
+
+	var direct any
+	if err := json.Unmarshal(statusRaw, &direct); err != nil {
+		t.Fatalf("control unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(out["nested"], direct) {
+		t.Fatalf("nested-call Status.Raw not byte-identical.\n got: %#v\nwant: %#v", out["nested"], direct)
+	}
+}
+
+// Architect note B — explicit apiserver-fall-through no-regression. When an
+// apiserver-GVR GET/LIST falls through ALL pivot branches (e.g. informer
+// unsynced) to the terminal external branch, it previously hit httpcall.Do
+// and now hits httpFetchAllowingNonJSON. The apiserver returns
+// application/json (a {items:[...]} list envelope), which takes the JSON
+// fast-path (json.Valid → bytes returned unchanged) and must be
+// value-identical to a direct json.Unmarshal. (h)/(i) cover the
+// internal-rest-config + nested-call no-regression; this names the THIRD
+// terminal-branch no-regression case explicitly in the ledger.
+func TestFalsifierB2_ApiserverJSONFallThroughByteIdentical(t *testing.T) {
+	listEnvelope := `{"apiVersion":"v1","kind":"List","items":[{"metadata":{"name":"a"}},{"metadata":{"name":"b"}}]}`
+	st, jsonBytes, _, _, err := fetchAgainst(t, http.StatusOK, "application/json", listEnvelope, noAuth)
+	if err != nil {
+		t.Fatalf("unexpected fetch error: %v", err)
+	}
+	if st.Status == response.StatusFailure {
+		t.Fatalf("apiserver-style JSON returned failure: %+v", st)
+	}
+	var viaFetch, direct any
+	if err := json.Unmarshal(jsonBytes, &viaFetch); err != nil {
+		t.Fatalf("fetch bytes not valid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(listEnvelope), &direct); err != nil {
+		t.Fatalf("control body not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(viaFetch, direct) {
+		t.Fatalf("apiserver-fall-through JSON not value-identical.\n got: %#v\nwant: %#v", viaFetch, direct)
+	}
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -85,7 +85,18 @@ const lazyRegisterSlowThreshold = 250 * time.Millisecond
 
 const (
 	//annotationKeyVerboseAPI = "krateo.io/verbose"
-	headerAcceptJSON = "Accept: application/json"
+	// headerAcceptJSON is the default per-stage Accept header. Since the
+	// feat/restaction-yaml-response ship (snowplow-side JSON-or-YAML
+	// external-GET relaxation) it advertises YAML media types in addition
+	// to JSON — strictly MORE permissive. This only affects the EXTERNAL
+	// HTTP-fetch path (httpFetchAllowingNonJSON); the internal-rest-config
+	// and informer dispatch paths bypass the HTTP client entirely and do
+	// not honour this header, so the no-regression invariant (AC4) holds.
+	// Helm repositories ignore Accept anyway and serve index.yaml as
+	// text/plain or text/yaml regardless — the relaxation is what lets
+	// that body through (the prior plumbing path 406'd it before the body
+	// was read).
+	headerAcceptJSON = "Accept: application/json, application/x-yaml, text/yaml"
 
 	// envVerboseWireDump is the Ship 0.30.121 R1-b operator kill-switch
 	// for httpcall's DumpResponse verbose wire-dump. When false (the
@@ -819,7 +830,54 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 		return nil
 	}
 
-	res := httpcall.Do(gctx, call)
+	// EXTERNAL branch (feat/restaction-yaml-response): the snowplow-owned
+	// fetch replaces plumbing's httpcall.Do. It transcribes request.Do
+	// MINUS the 406 JSON content-type gate, so a 2xx YAML body (e.g. a
+	// Helm repo index.yaml served text/plain or text/yaml) is read,
+	// converted to JSON, and fed onward; a 2xx JSON body passes through
+	// value-identical (AC3). It does NOT invoke call.ResponseHandler —
+	// instead it returns the converted JSON bytes, which we feed via
+	// feedBytes (the dictMu-protected jsonHandlerBytes path) so the EXISTING
+	// handler chain (jq filter + UAF refilter + merge) is unchanged. The
+	// returned *response.Status keeps the StatusFailure shaping below
+	// byte-identical, so recordItemError honours ContinueOnError/ErrorKey
+	// exactly as it did for httpcall.Do (AC5). See external_fetch.go.
+	res, jsonBytes, _, fetchErr := httpFetchAllowingNonJSON(gctx, call)
+	if fetchErr != nil {
+		// A non-nil go error mirrors httpcall.Do's response.New(500, err)
+		// transport/build faults. res already carries the same 500 Failure
+		// envelope; fall through to the StatusFailure shaping below so the
+		// behaviour matches the pre-ship httpcall.Do path (which surfaced
+		// these as res.Status == Failure with the error message).
+		_ = fetchErr
+	}
+
+	// SUCCESS (feat/restaction-yaml-response): on a non-Failure fetch the
+	// owned fetch does NOT invoke call.ResponseHandler (unlike httpcall.Do);
+	// it returned the converted JSON bytes. Feed them through the SAME
+	// dictMu-protected handler chain the in-memory dispatch paths use
+	// (feedBytes → jsonHandlerBytes → jsonHandlerCore: jq filter + UAF
+	// refilter + merge), so the populated dict[id] is byte-identical to the
+	// pre-ship httpcall.Do ResponseHandler result for a JSON body (AC3).
+	//
+	// B-REGRESSION FIX: a feedBytes (handler/jq decode) error MUST NOT be
+	// returned raw to the errgroup — pre-ship that error was the return
+	// value of call.ResponseHandler, which httpcall.Do wrapped as
+	// `response.New(http.StatusInternalServerError, err)` (request.go:121-126)
+	// → a StatusFailure → the recordItemError fall-through below → under #313
+	// C-A NO truncation (downstream stages still run). Returning the raw error
+	// truncated the whole resolve where pre-ship continued (empirically
+	// proven: oracle TestOracle_PreShip dict keys [badErr good] vs new []).
+	// So we shape the feedBytes error into the SAME 500 StatusFailure
+	// envelope and route it through the identical recordItemError handling —
+	// byte-identical to the pre-ship ResponseHandler-error path. (Falsifier
+	// TestFalsifierB_SuccessBranchDecodeFailure_NoTruncate.)
+	if res.Status != response.StatusFailure {
+		if err := feedBytes(jsonBytes); err != nil {
+			res = response.New(http.StatusInternalServerError, err)
+		}
+	}
+
 	if res.Status == response.StatusFailure {
 		r.log.Error("api call response failure", slog.String("name", id),
 			slog.String("host", call.Endpoint.ServerURL),


### PR DESCRIPTION
## What & why

A RESTAction `spec.api[]` GET against an external endpoint (e.g. a Helm repo `index.yaml` served `text/plain`/`text/yaml`) was 406'd by plumbing's `http/request.Do`, which rejects any non-JSON `Content-Type` BEFORE the body is read. This relaxes that snowplow-side: the external-GET branch now flows through a snowplow-owned fetch that transcribes plumbing v0.9.3 `request.Do` **minus the 406 gate**, reuses `HTTPClientForEndpoint` / `ComputeAwsHeaders` / `NewRetryClient` verbatim (TLS/CA/client-cert/proxy/timeout + bearer/basic/AWS auth), and auto-converts a 2xx YAML body to JSON before feeding it to the unchanged jq handler chain.

**Transparent + uniform** (Diego-ratified): JSON passes through value-identical; YAML auto-converts; no opt-in flag, no CRD field, no env/values surface.

## Design

- **`internal/resolvers/restactions/api/external_fetch.go`** (new): `httpFetchAllowingNonJSON` + `toJSONBytes` (content-type sniff → `YAMLToJSON`; JSON fast-path via `json.Valid`; last-resort `YAMLToJSON`; symmetric `isJSONObjectOrArray` structured-shape guard so HTML/garbage and bare scalars surface as clean conversion failures). Non-2xx envelope shaping byte-identical to `request.go:102-116`.
- **`resolve.go`**: external terminal-fallback branch calls the owned fetch; success feeds converted bytes via the existing dictMu `feedBytes` (`jsonHandlerBytes`) chain — **handler.go untouched**, so internal-rest-config + nested-call paths are byte-identical by construction. Accept-header default widened to also advertise `application/x-yaml, text/yaml` (strictly more permissive).

### Includes the Option-B regression fix
A success-branch `feedBytes`/jq-decode error is now shaped into `response.New(500, err)` and routed through the **same** `recordItemError` fall-through as a genuine `StatusFailure` (NOT a raw `return err`) — byte-identical to pre-ship `httpcall.Do`'s ResponseHandler-error path. Without this, a decode failure truncated the resolve where pre-ship continued (#313 C-A). Verified against an empirical pre-ship oracle.

## Acceptance criteria
AC1–AC7 all hold (Helm-index consumer / general JSON-or-YAML / external-JSON byte-identical / internal+nested byte-identical / non-2xx envelope byte-identical / malformed-YAML+HTML-garbage clean failure honoring continueOnError+errorKey with no panic/leak / bearer+basic+AWS auth still sent).

## Tests
27 ship-falsifiers + 7 AC6 end-to-end (real `Resolve → dispatchOneCall → recordItemError`) — all GREEN under `-race -count=1`, in-process `httptest`, no kubeconfig. Includes the **(l) success-branch-decode-failure regression probe** (RED pre-fix `[]` → GREEN post-fix `[badErr good]` vs the pre-ship oracle), apiserver-fall-through, and explicit-yaml-scalar rejection.

**Non-obvious behavioral pin:** since #313 C-A, an external `StatusFailure` does NOT truncate the resolve for either `continueOnError` value — `dict[errorKey]` populates and the resolve completes in both cases (byte-identical to pre-ship `httpcall.Do`). The only external truncation source is genuine ctx-cancel.

## Scope notes
No CRD-regen, no chart lockstep, no north-star ledger row (non-pivot external/control-plane-rate path). The 4 peer in-memory dispatch branches carry the same pre-existing raw-return pattern but are **out of scope** (tracked as a separate backlog item) — this PR fixes only the external branch it introduces.

**PARKED for Diego's merge nod — do not merge/tag/deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1