### PR TITLE
docs: document 1.2.0 features (/refreshes, YAML api-step + ADR 0006, inline extras, non-truncation)

### DIFF
--- a/docs/adr/0006-snowplow-owned-external-fetch.md
+++ b/docs/adr/0006-snowplow-owned-external-fetch.md
@@ -1,0 +1,66 @@
+# ADR 0006 — Snowplow owns the external api-step HTTP fetch (accept YAML as well as JSON)
+
+- **Status:** Accepted (snowplow 1.2.0)
+- **Lead (verify against code):** `internal/resolvers/restactions/api/external_fetch.go`
+  (`httpFetchAllowingNonJSON`), wired at the external branch of
+  `internal/resolvers/restactions/api/resolve.go`.
+- **Deep dive:** [`request-lifecycle.md`](../architecture/request-lifecycle.md) §2.9.
+
+## Context
+
+A `RESTAction` `spec.api[]` stage that targets an external `endpointRef` is dispatched
+through `github.com/krateoplatformops/plumbing` `http/request.Do`. That function **rejects any
+non-JSON `Content-Type` with HTTP 406 *before* the `ResponseHandler` is invoked**
+(`plumbing@v0.9.x http/request/request.go:118-119`, identical through the latest `v1.9.0`), and
+its handler type is `func(io.ReadCloser) error` (request.go:25) — the `*http.Response`/headers
+are **not** passed to snowplow. snowplow cannot patch plumbing (never-upstream, ADR convention).
+
+The portal Marketplace blueprint-discovery RA must GET a Helm repo `index.yaml` — which repos
+commonly serve as `text/plain` / `text/yaml` / `application/x-yaml`. Under the plumbing path that
+body is 406'd and never reaches jq, so the RA cannot consume it. More generally, no RESTAction api
+step could consume *any* YAML endpoint.
+
+## Decision
+
+**For the external api-step branch, snowplow owns the HTTP round-trip** rather than calling
+plumbing's gating `Do`. `httpFetchAllowingNonJSON` (`external_fetch.go`) is a faithful
+transcription of `plumbing` `request.Do` (`request.go:38-116`) **minus only the 406 JSON gate**,
+and it **reuses every security-critical path verbatim** via plumbing's *exported* helpers:
+
+- `HTTPClientForEndpoint` — TLS, custom CA, client certs, proxy, timeouts, **and** the
+  bearer / basic / AWS-SigV4 auth roundtrippers.
+- `util.NewRetryClient` / `RetryClient.Do` — QPS limiter + 429/5xx retry.
+- `ComputeAwsHeaders` — SigV4 header pre-compute.
+
+Only ~40–50 LOC of pure *request assembly* + the non-2xx → `response.Status` error-envelope
+shaping (transcribed byte-identical to `request.go:102-116`) is snowplow-local. With the response
+in hand, snowplow now sees the `Content-Type` and **accepts JSON or YAML transparently**: a
+JSON-shaped body passes through unchanged; otherwise (YAML content-type, or a body that fails
+`json.Unmarshal`) it is converted with `sigs.k8s.io/yaml` `YAMLToJSON` before the existing decode.
+`YAMLToJSON` round-trips valid JSON losslessly, so the JSON fast-path is byte-identical.
+
+## Consequences
+
+- **A RESTAction api step can consume any YAML *or* JSON external endpoint** (Helm `index.yaml`,
+  `Chart.yaml`, any `*.yaml`). Purely **additive**: non-JSON was a hard 406 before, so nothing that
+  worked previously changes (the application/json control is byte-identical).
+- **The security surface stays minimal.** TLS / CA / client-certs / bearer-basic-AWS creds / proxy
+  / retry all remain delegated to plumbing's exported helpers; only stable request *assembly* is
+  transcribed. A future plumbing change to assembly must be mirrored; the volatile parts evolve
+  under us for free.
+- **One new, bounded error edge.** A 2xx body that is neither JSON nor YAML now reaches the decode
+  and errors there (instead of an upstream 406) — caught by the per-item error path
+  (`recordItemError`), no panic, no credential leak (the request still carried creds via the reused
+  roundtrippers).
+- **Cache posture unchanged.** External-endpoint results were never L1-pivot-cacheable and still
+  aren't — they ride the live fetch each request. This change touches only the transport, downstream
+  of every cache branch.
+- **Toggle-able / removable** per ADR 0004: the conversion is on the live external path; under
+  `CACHE_ENABLED=false` the same fetch runs (the cache toggle is orthogonal).
+
+## Related
+
+- ADR 0004 — caching is provisional and removable.
+- The companion correctness fix shipped alongside (snowplow 1.2.0): a per-item **feed/decode error
+  on any served dispatch branch records into `errorKey` and does *not* truncate the resolve** (the
+  #313 Option C-A contract) — see [`request-lifecycle.md`](../architecture/request-lifecycle.md) §3.

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -97,6 +97,13 @@ table:
 - `POST/PUT/PATCH/DELETE /call` (main.go:809-831) — same `UserConfig` middleware
   and a write-scope `FallthroughScopeMiddleware`, but **no** `Dispatcher` in the
   chain; they go straight to `handlers.Call()`.
+- `GET /refreshes` (main.go:810) — the per-subject live-refresh **SSE** stream
+  (Ship 1, option A). Uses `middleware.RefreshAuth` and issues **zero** apiserver
+  reads (no `<user>-clientconfig` lookup). The connection re-derives each
+  subscription key under the caller's own JWT (`DeriveSubscriptionKey`), so a
+  `?sub=` coordinate cannot forge another subject's stream. The cache calls
+  `PublishRefresh(key)` after an L1 commit; the matching subscriber receives a
+  signal and refetches a guaranteed-fresh entry (instead of racing the cache).
 - `GET /debug/vars` → `expvar.Handler()` (main.go:869), with snapshot/authz-memo
   expvars registered just before the mount (main.go:862, :868).
 - `GET /debug/pprof/*` (main.go:837-841) registered on this mux directly (the
@@ -239,6 +246,12 @@ over the dict (restactions.go:58-68); otherwise the dict is marshalled as-is
 `runtime.RawExtension` (restactions.go:77-79), with `last-applied-configuration`
 and `managedFields` stripped (restactions.go:81-86).
 
+A stage that targets an external `endpointRef` is dispatched through snowplow's
+own HTTP fetch (`api/external_fetch.go` `httpFetchAllowingNonJSON`), which reuses
+plumbing's client / auth roundtrippers / retry but drops the JSON-only `406` gate
+— so the stage may receive **YAML or JSON**, and a YAML body is converted to JSON
+before the stage jq. See [ADR 0006](../adr/0006-snowplow-owned-external-fetch.md).
+
 The RESTAction emits *unordered* data. It contains **no widget-shaping logic** —
 the layering boundary is asserted in the refilter package doc (refilter.go:16-18):
 RBAC narrowing lives in the resolver/per-API-stage layer, never in widget
@@ -361,6 +374,13 @@ apiRef→RESTAction and render-eligible resourcesRefs deps
    the Put path and the write path (helpers.go:386-396).
 7. **Only clean resolves are cached.** A per-item stage error serves the partial
    body but declines the Put (restactions.go:249, widgets.go:266).
+8. **A per-item feed/decode error does not truncate the resolve.** On every served
+   dispatch branch (external fetch, in-process nested `/call`, informer-pivot,
+   internal-rest-config), a stage whose body fails to decode / jq-filter records
+   the error into `errorKey` (or surfaces it per `continueOnError`) and returns
+   `nil` for that item — remaining items and downstream stages still run (the #313
+   Option C-A contract). Branches that previously raw-`return err`'d and abandoned
+   the whole resolve were corrected in snowplow 1.2.0.
 
 ---
 

--- a/howto/extras.md
+++ b/howto/extras.md
@@ -74,6 +74,31 @@ alike (`extras` is one of `widgetContent`'s key components,
 
 ---
 
+## Author-declared (inline) defaults
+
+Besides the per-request `?extras=`, a **widget CR** may declare *static* extras on
+its spec, scoped per surface and merged **under** the request `extras` (the
+request always wins on collision):
+
+- `spec.apiRef.extras` — scoped to the widget's `apiRef` RESTAction fetch (so it
+  also reaches `ds` transitively). Read by `GetApiRefExtras`
+  (`internal/resolvers/widgets/widgets.go`).
+- `spec.resourcesRefsTemplateExtras` — scoped to the `resourcesRefsTemplate` jq
+  **only**. Read by `GetResourcesRefsExtras`.
+
+The dispatcher folds the **union** of (apiRef-inline ∪ resourcesRefs-inline ∪
+request) into the L1 keys (`unionForKey`, `helpers.go`), and the prewarm seed
+applies the same union so the first paint is a hit, not a miss. Precedence is
+request-wins via `mergeRequestWins` (`widgets/resolve.go`); both inline maps are
+input-only and deep-copied (they never alias the shared CR). A widget that
+declares neither is **byte-identical** to before.
+
+> The inline fields live on the **widget CRD**, which ships from the portal
+> chart — not snowplow. Until that CRD declares them the accessors read `{}`
+> (a no-op), so the feature is latent-but-safe on a snowplow-only upgrade.
+
+---
+
 ## The full path
 
 ### RESTAction (direct `/call`)

--- a/howto/restactions.md
+++ b/howto/restactions.md
@@ -103,6 +103,17 @@ A `/call` may carry `?extras={…}` — a per-request JSON object that **seeds t
 resolve dict** (the API stage outputs overwrite it) and is folded into the cache
 key. See [extras.md](extras.md).
 
+## Response body: JSON or YAML
+
+An api stage that targets an external `endpointRef` may receive a **YAML *or*
+JSON** response body. snowplow owns the external fetch for these stages
+(`api/external_fetch.go`) and accepts a non-JSON `Content-Type` — a plain
+upstream client would reject it `406` before the body is read. A YAML body is
+converted to JSON **before** any stage `filter`/jq runs, so the jq sees the same
+structure either way; a JSON body is passed through unchanged (byte-identical).
+This lets a `RESTAction` consume e.g. a Helm repo `index.yaml`. See
+[ADR 0006](../docs/adr/0006-snowplow-owned-external-fetch.md).
+
 ## Example
 
 ```yaml


### PR DESCRIPTION
Documents what shipped in **snowplow 1.2.0** in the canonical doc set (the prior PRs updated journals/PR-bodies but not the architecture/howto/ADR docs).

## Changes (docs-only, +122 lines)
- **`howto/restactions.md`** — an api stage's external `endpointRef` response may be **YAML or JSON** (#35).
- **`howto/extras.md`** — **author-declared inline extras** (`spec.apiRef.extras`, `spec.resourcesRefsTemplateExtras`): per-surface, merged *under* request `extras` (request wins), union-folded into the L1 key + prewarm seed (#33). Notes the fields live on the portal-chart widget CRD (latent-but-safe on a snowplow-only upgrade).
- **`docs/architecture/request-lifecycle.md`** — `GET /refreshes` SSE route in §2.1 (#32); the snowplow-owned external-fetch path in §2.9 (#35); new **invariant #8** — a per-item feed/decode error records into `errorKey` and does **not** truncate the resolve, on every served dispatch branch (#36, #313 Option C-A).
- **`docs/adr/0006-snowplow-owned-external-fetch.md`** — new ADR: own the external HTTP round-trip (reuse plumbing's client/auth/retry, drop only the JSON-only 406 gate) to accept YAML.

All claims cite the shipped code. No code changes. Parked for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)