### PR TITLE
feat(restactions): expose request extras to the per-stage filter as pig["extras"]

### DIFF
--- a/howto/extras.md
+++ b/howto/extras.md
@@ -48,6 +48,44 @@ for k, v := range extrasCopy {
 The pagination `slice` triple is treated like an API result — it also wins over
 `extras` (`resolve.go:88`, `:96`).
 
+#### The per-stage `filter` also sees `extras` as a reserved sibling key
+
+The per-stage RESTAction filter (`spec.api[].filter`) is evaluated against the
+wrapped envelope `pig`, which carries the stage response under the stage key
+plus two **reserved sibling keys** — `slice` (pagination) and `extras` (the
+*pure* per-request extras). So a step filter can read the request extras
+directly:
+
+```yaml
+spec:
+  api:
+    - name: things
+      path: /apis/.../things
+      filter: '[.things.items[] | select(.metadata.namespace == $__loc__) ]'
+      # …or read extras directly:
+      # filter: '.things.items | map(select(.spec.tenant == ($from_extras))) '
+      #   where the value comes from .extras.<key> in the envelope, e.g.
+      # filter: '{items: .things.items, tenant: .extras.tenant}'
+```
+
+The `extras` the filter sees is the **pure request extras** (`r.opts.Extras`),
+not the accumulated run dict — at later stages the dict has stage outputs and a
+synthetic `slice` merged in, so it is no longer the request extras. The key is
+present only when the request carried a non-empty `extras` (mirrors the `slice`
+guard), so a no-extras resolve is byte-identical to before
+(`internal/resolvers/restactions/api/handler.go` — `pig["extras"]` written under
+the `len(opts.extras) > 0` guard).
+
+**Known asymmetry — `extras`-stage *wins*, `slice`-stage *loses*.** If a stage is
+literally named `extras`, the **stage response wins** the sibling-key collision:
+`pig["extras"]` is written *before* `pig[<stageKey>]`, so the stage's own
+response clobbers the request extras for that stage's filter. This is intentional
+(a stage's own output is the more specific datum). It is the **opposite** of the
+pre-existing `slice` behaviour, where a stage named `slice` *loses* to the
+synthetic pagination `slice` (written *after* the stage key). The two reserved
+keys differ here by history, not by design; the asymmetry is documented and
+considered acceptable (declaring a stage `extras` or `slice` is degenerate).
+
 ### 2. It is input-only
 
 `extras` seeds the resolve; it is **never written back to `status`**. A widget's

--- a/howto/restactions.md
+++ b/howto/restactions.md
@@ -103,6 +103,28 @@ A `/call` may carry `?extras={…}` — a per-request JSON object that **seeds t
 resolve dict** (the API stage outputs overwrite it) and is folded into the cache
 key. See [extras.md](extras.md).
 
+### The per-stage `filter` sees `extras` as a reserved sibling key
+
+A stage `filter` runs against the wrapped envelope `pig`, which holds the stage
+response under the stage `name` plus two **reserved sibling keys**: `slice`
+(pagination) and `extras` (the *pure* per-request `?extras=` object). So a
+filter can read the request extras directly via `.extras.<key>`:
+
+```yaml
+filter: '{items: .things.items, tenant: .extras.tenant}'
+```
+
+`extras` is present only when the request carried a non-empty `?extras=` (so a
+no-extras resolve is unchanged). The value is the **pure request extras**, not
+the accumulated run dict.
+
+**Known asymmetry.** If a stage is literally named `extras`, the **stage
+response wins** the collision (a stage's own output is the more specific datum).
+This is the opposite of a stage named `slice`, which **loses** to the synthetic
+pagination `slice`. The difference is historical, documented, and acceptable —
+naming a stage `extras` or `slice` is degenerate. See [extras.md](extras.md) for
+the full collision/precedence rules.
+
 ## Response body: JSON or YAML
 
 An api stage that targets an external `endpointRef` may receive a **YAML *or*

--- a/internal/resolvers/restactions/api/handler.go
+++ b/internal/resolvers/restactions/api/handler.go
@@ -42,6 +42,15 @@ type jsonHandlerOptions struct {
 	filter      *string
 	uaf         *templates.UserAccessFilterSpec
 	apiCallName string
+	// extras is the PURE per-request extras map (r.opts.Extras), exposed to
+	// the per-stage filter as the reserved sibling key pig["extras"] so the
+	// step filter can read `.extras.*` like every other jq surface. This is
+	// NOT opts.dict: dict starts as a DeepCopy of Extras (resolve.go) but then
+	// accumulates stage outputs + a synthetic `slice`, so at later stages it
+	// is no longer the pure extras. The reference is SHARED, not deep-copied:
+	// gojq is the braghettos COW fork, so the filter cannot mutate the input
+	// (mirrors the existing pig["slice"] shared-map pattern).
+	extras map[string]any
 }
 
 // jsonHandler is the HTTP-body-shaped entry point — the form
@@ -108,9 +117,17 @@ func jsonHandlerBytesApply(ctx context.Context, opts jsonHandlerOptions, dat []b
 func jsonHandlerCore(ctx context.Context, opts jsonHandlerOptions, tmp any) error {
 	log := xcontext.Logger(ctx)
 
-	pig := map[string]any{
-		opts.key: tmp,
+	pig := map[string]any{}
+	// pig["extras"] is written BEFORE pig[opts.key] so a stage literally named
+	// "extras" keeps its OWN response (response wins; collision Option A). The
+	// guard mirrors the `slice` guard below: write nothing when extras is
+	// absent so the no-extras envelope stays byte-identical to pre-feature.
+	// The map is SHARED, not copied — gojq's braghettos COW fork can't mutate
+	// the filter input (same contract as pig["slice"]).
+	if len(opts.extras) > 0 {
+		pig["extras"] = opts.extras
 	}
+	pig[opts.key] = tmp
 	if si, ok := opts.out["slice"]; ok {
 		pig["slice"] = si
 	}

--- a/internal/resolvers/restactions/api/handler_extras_test.go
+++ b/internal/resolvers/restactions/api/handler_extras_test.go
@@ -1,0 +1,226 @@
+//go:build unit
+// +build unit
+
+// handler_extras_test.go — falsifiers for the step-filter `extras` sibling
+// key feature. The per-stage RESTAction filter (spec.api[].filter) is
+// evaluated against the wrapped envelope `pig`. Today `pig` carries only the
+// stage response (under opts.key) plus a synthetic `slice`; this feature
+// exposes the PURE request extras as a reserved sibling key `pig["extras"]`
+// so the step filter can read `.extras.*` like every other jq surface.
+//
+// The five falsifiers below drive jsonHandlerCore directly (the post-decode
+// core, behind every dispatch path):
+//
+//	(a) value present     — extras + `.extras.foo` filter → reads the value
+//	(b) byte-identical     — no extras → pig has NO `extras` key (backward-compat)
+//	(c) -race concurrent   — N goroutines share ONE extras map, COW-mutate +
+//	                         read it; every goroutine sees the original
+//	                         (proves the share-ref-not-deep-copy decision)
+//	(d) cache-key distinct — two extras → distinct ComputeKey → distinct out
+//	(e) stage-named-extras — a stage literally Named "extras" + request extras:
+//	                         response WINS (collision Option A)
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// (a) value present: the step filter reads `.extras.foo` and gets the value.
+func TestStepFilter_ExtrasValuePresent(t *testing.T) {
+	ctx := context.Background()
+	out := map[string]any{}
+	opts := jsonHandlerOptions{
+		key:    "stage",
+		out:    out,
+		extras: map[string]any{"foo": "bar"},
+		filter: ptr.To(".extras.foo"),
+	}
+	if err := jsonHandlerCore(ctx, opts, map[string]any{"ignored": true}); err != nil {
+		t.Fatalf("jsonHandlerCore: %v", err)
+	}
+	got := out["stage"]
+	if got != "bar" {
+		t.Fatalf("FALSIFIER (a) FAILED: step filter `.extras.foo` over extras {foo:bar} should yield %q, got %#v", "bar", got)
+	}
+}
+
+// (b) byte-identical no-extras: with nil/empty extras, pig MUST NOT carry an
+// `extras` key, and a non-`.extras` filter output is byte-identical to the
+// pre-feature behaviour. We assert via a probe filter that yields the WHOLE
+// pig envelope and check the absence of the `extras` key.
+func TestStepFilter_NoExtras_NoExtrasKey(t *testing.T) {
+	ctx := context.Background()
+
+	// nil extras + a filter that returns the full envelope `pig` (a stage
+	// named "stage" wrapping response {n:1}); the envelope must have exactly
+	// the `stage` key — no `extras`, no `slice`.
+	for _, tc := range []struct {
+		name   string
+		extras map[string]any
+	}{
+		{"nil", nil},
+		{"empty", map[string]any{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := map[string]any{}
+			opts := jsonHandlerOptions{
+				key:    "stage",
+				out:    out,
+				extras: tc.extras,
+				filter: ptr.To("."), // identity → the whole pig envelope
+			}
+			if err := jsonHandlerCore(ctx, opts, map[string]any{"n": float64(1)}); err != nil {
+				t.Fatalf("jsonHandlerCore: %v", err)
+			}
+			env, ok := out["stage"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map envelope, got %#v", out["stage"])
+			}
+			if _, hasExtras := env["extras"]; hasExtras {
+				t.Fatalf("FALSIFIER (b) FAILED: no-extras request leaked an `extras` key into pig: %#v", env)
+			}
+			// byte-identical pre-feature shape: only the stage key present.
+			if len(env) != 1 {
+				t.Fatalf("FALSIFIER (b) FAILED: pig envelope should be byte-identical (only `stage`), got %#v", env)
+			}
+		})
+	}
+}
+
+// (c) -race concurrent (MANDATORY): N goroutines run jsonHandlerCore against
+// the SAME shared extras map. Each filter BOTH mutates a derived copy
+// (`.extras + {seen:.x}`, `del(.extras.foo)`) AND reads `.extras.foo`. Every
+// goroutine must observe the ORIGINAL extras.foo unchanged, and `go test
+// -race` must be clean. This proves the COW share-reference decision: gojq is
+// the braghettos COW fork; input maps are never allocated() so mutating ops
+// copy-on-write and reads can't mutate the shared input.
+func TestStepFilter_ConcurrentSharedExtras_Race(t *testing.T) {
+	ctx := context.Background()
+
+	// ONE shared extras map — every goroutine's jsonHandlerCore aliases it.
+	shared := map[string]any{
+		"foo":    "bar",
+		"nested": map[string]any{"k": "v"},
+	}
+
+	const goroutines = 16
+	// Two filter shapes that BOTH derive-mutate and read .extras.foo:
+	//  - `.extras + {seen: .stage.x}` builds a NEW object from extras → COW
+	//  - `del(.extras.foo)` deletes the read key on a COW copy
+	// Each appends `.extras.foo` read by returning it directly so we can
+	// assert it's still "bar".
+	filters := []string{
+		`(.extras + {seen: .stage.x}) | .foo`,
+		`(.extras | del(.foo)) as $d | .extras.foo`,
+	}
+
+	errs := make(chan string, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			out := map[string]any{}
+			opts := jsonHandlerOptions{
+				key:    "stage",
+				out:    out,
+				extras: shared, // SHARED reference, not a copy
+				filter: ptr.To(filters[i%len(filters)]),
+			}
+			if err := jsonHandlerCore(ctx, opts, map[string]any{"x": float64(i)}); err != nil {
+				errs <- fmt.Sprintf("g%d: jsonHandlerCore err: %v", i, err)
+				return
+			}
+			if got := out["stage"]; got != "bar" {
+				errs <- fmt.Sprintf("g%d: expected .extras.foo == bar after COW mutate, got %#v", i, got)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	if bad, ok := <-errs; ok {
+		t.Fatalf("FALSIFIER (c) FAILED: %s", bad)
+	}
+
+	// The shared map must be UNCHANGED after all concurrent COW mutations.
+	if shared["foo"] != "bar" {
+		t.Fatalf("FALSIFIER (c) FAILED: shared extras.foo was mutated cross-goroutine: %#v", shared["foo"])
+	}
+	if n, ok := shared["nested"].(map[string]any); !ok || n["k"] != "v" {
+		t.Fatalf("FALSIFIER (c) FAILED: shared extras.nested was mutated: %#v", shared["nested"])
+	}
+}
+
+// (d) cache-key distinctness: two different `extras` maps → different
+// ComputeKey (mirrors internal/handlers/dispatchers/extras_cache_key_test.go),
+// AND a `.extras`-reading step filter yields a different `out` per extras — so
+// the two requests can't collide on one L1 cell. The key proof guards the L1
+// keying; the out proof guards the served content.
+func TestStepFilter_ExtrasCacheKeyDistinctness(t *testing.T) {
+	ctx := context.Background()
+
+	extrasA := map[string]any{"tenant": "acme"}
+	extrasB := map[string]any{"tenant": "globex"}
+
+	// L1 key half: distinct extras MUST fold to distinct ComputeKey. The
+	// resolved-cache key folds the request extras (len>0) — see
+	// cache.RAFullListKeyInputs / ResolvedKeyInputs.
+	keyA := cache.ComputeKey(cache.ResolvedKeyInputs{Extras: extrasA})
+	keyB := cache.ComputeKey(cache.ResolvedKeyInputs{Extras: extrasB})
+	if keyA == keyB {
+		t.Fatalf("FALSIFIER (d) FAILED: distinct extras produced the SAME ComputeKey %q — L1 collision risk", keyA)
+	}
+
+	// Served-content half: the same step filter `.extras.tenant` yields a
+	// DIFFERENT out per extras, so two requests never serve each other's body.
+	run := func(ex map[string]any) any {
+		out := map[string]any{}
+		opts := jsonHandlerOptions{
+			key:    "stage",
+			out:    out,
+			extras: ex,
+			filter: ptr.To(".extras.tenant"),
+		}
+		if err := jsonHandlerCore(ctx, opts, map[string]any{}); err != nil {
+			t.Fatalf("jsonHandlerCore: %v", err)
+		}
+		return out["stage"]
+	}
+	outA, outB := run(extrasA), run(extrasB)
+	if outA == outB {
+		t.Fatalf("FALSIFIER (d) FAILED: distinct extras yielded the SAME filtered out %#v — content collision", outA)
+	}
+	if outA != "acme" || outB != "globex" {
+		t.Fatalf("FALSIFIER (d) FAILED: filtered out should be acme/globex, got %#v / %#v", outA, outB)
+	}
+}
+
+// (e) stage-named-`extras` collision: a stage literally Named "extras" with a
+// non-empty request extras present → out["extras"] is the STAGE RESPONSE
+// (response wins; collision Option A), and a `.extras` filter in that stage
+// reads its OWN response, not the request extras. This locks in the write
+// order: pig["extras"] (request) BEFORE pig[opts.key] (stage response).
+func TestStepFilter_StageNamedExtras_ResponseWins(t *testing.T) {
+	ctx := context.Background()
+	out := map[string]any{}
+	opts := jsonHandlerOptions{
+		key:    "extras", // the stage is literally named "extras"
+		out:    out,
+		extras: map[string]any{"foo": "request-extras"},
+		// the filter reads .extras.foo — with response-wins, .extras IS the
+		// stage response {foo: stage-response}, so .extras.foo == stage value.
+		filter: ptr.To(".extras.foo"),
+	}
+	if err := jsonHandlerCore(ctx, opts, map[string]any{"foo": "stage-response"}); err != nil {
+		t.Fatalf("jsonHandlerCore: %v", err)
+	}
+	if got := out["extras"]; got != "stage-response" {
+		t.Fatalf("FALSIFIER (e) FAILED: stage named `extras` should keep its OWN response (response wins), filter read %#v", got)
+	}
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -567,6 +567,10 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 		filter:      apiCall.Filter,
 		uaf:         apiCall.UserAccessFilter,
 		apiCallName: apiCall.Name,
+		// PURE request extras (NOT dict — dict has accumulated upstream stage
+		// outputs + a synthetic slice). Exposed to the step filter as the
+		// reserved sibling key pig["extras"]. Shared reference: gojq COW fork.
+		extras: r.opts.Extras,
 	}
 	inner := jsonHandler(gctx, hOpts)
 	innerBytesFn := jsonHandlerBytes(gctx, hOpts)


### PR DESCRIPTION
## What

Expose the **pure per-request `extras`** to the per-stage RESTAction filter (`spec.api[].filter`) as a reserved sibling key `pig["extras"]`. A step filter can now read `.extras.*` — parity with every other jq surface (path / payload / top-level filter / widget templates).

Today `jsonHandlerCore` builds `pig` with only the stage response (under the stage key) plus a synthetic `slice`, so the step filter alone cannot reach `extras`.

## Change (architect + PM ratified)

- `jsonHandlerOptions` gains `extras map[string]any`, set to `r.opts.Extras` — the **pure** request extras, **not** `opts.dict` (dict is `DeepCopyJSON(Extras)` then accumulates stage outputs + a synthetic `slice`, so at later stages it ≠ the request extras).
- `jsonHandlerCore` writes `pig["extras"]` guarded on `len>0` (mirrors the `slice` guard → no-extras envelope byte-identical) and **BEFORE** `pig[opts.key]`, so a stage literally named `extras` keeps its own response (**response wins**; collision Option A).
- Shared reference, **no deep-copy** — gojq is the braghettos COW fork, so a mutating filter copies-on-write and cannot mutate the shared input (same contract as `pig["slice"]`).

**Known asymmetry (intentional, documented):** a stage named `extras` *wins* the collision; a stage named `slice` *loses* to the synthetic pagination `slice`. Historical, not by design; degenerate to declare. Pre-existing `slice` behaviour untouched.

Prod diff = `handler.go` + `resolve.go` only (~6 LOC behaviour). **No CRD / chart / env / flag surface** — unconditional behaviour for valid filters.

## Falsifiers (`handler_extras_test.go`, tag `unit`, in-process only — no remote kubeconfig)

RED-first: with the struct field absent the api pkg fails to compile across all 5 tests (captured pre-change).

- **(a)** value-present — `{foo:bar}` + `.extras.foo` → `"bar"`
- **(b)** byte-identical no-extras — nil + empty → no `extras` key, envelope `len==1`
- **(c)** **-race concurrent (MANDATORY)** — 16 goroutines, one shared extras map, COW-mutate + read; every goroutine sees original, shared map unchanged. `-race` clean.
- **(d)** cache-key distinctness — distinct extras → distinct `ComputeKey` + distinct filtered out
- **(e)** stage-named-`extras` — response wins

Full api pkg `go test -tags unit -race -count=1`: clean (29.5s). `go build ./...` + `go vet`: clean.

## Docs

`howto/extras.md` + `howto/restactions.md` — step filter sees `extras` as a reserved sibling key; asymmetry documented as intentional.

## Reviews

- **Architect** (`arch-stepfilter-extras`): SIGN-OFF — design-sound; COW share-ref + response-wins write order confirmed against source.
- **PM** (`pm-stepfilter-extras`): SIGN-OFF — AC + falsifier coverage verified, re-ran (c) under -race; asymmetry-intentional doc condition met.

**PARKED for Diego's nod — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1