### PR TITLE
fix(crd): emit helm.sh/resource-policy=keep on RESTActions CRD via marker

### DIFF
--- a/apis/templates/v1/restactions.go
+++ b/apis/templates/v1/restactions.go
@@ -17,6 +17,7 @@ type RESTActionSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced,shortName=ra,categories={krateo,rest,actions}
+// +kubebuilder:metadata:annotations=helm.sh/resource-policy=keep
 
 // RESTAction allows users to declaratively define calls to APIs that may in turn depend on other calls.
 type RESTAction struct {

--- a/apis/templates/v1/restactions_crd_test.go
+++ b/apis/templates/v1/restactions_crd_test.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestGeneratedCRDKeepsResourcePolicyAnnotation is the falsifier guarding the
+// `helm.sh/resource-policy: keep` annotation on the generated RESTActions CRD.
+//
+// Without `keep`, a `helm uninstall` deletes the RESTActions CRD and, with it,
+// every RESTAction CR in the cluster — a data-loss risk at 50K scale. The
+// annotation is emitted by the `+kubebuilder:metadata:annotations=...` marker on
+// the RESTAction type (apis/templates/v1/restactions.go). controller-gen does not
+// emit it on its own, so a controller-gen bump or an accidental marker removal
+// could silently drop it during the next `make generate` / crds-sync. This test
+// fails loudly if that ever happens.
+func TestGeneratedCRDKeepsResourcePolicyAnnotation(t *testing.T) {
+	// crds/ lives at the repo root; this test file is apis/templates/v1.
+	crdPath := filepath.Join("..", "..", "..", "crds", "templates.krateo.io_restactions.yaml")
+
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("read generated CRD %s: %v", crdPath, err)
+	}
+
+	var crd struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations"`
+		} `json:"metadata"`
+	}
+	if err := yaml.Unmarshal(raw, &crd); err != nil {
+		t.Fatalf("unmarshal generated CRD: %v", err)
+	}
+
+	const (
+		key  = "helm.sh/resource-policy"
+		want = "keep"
+	)
+	if got := crd.Metadata.Annotations[key]; got != want {
+		t.Fatalf("generated CRD %s: metadata.annotations[%q] = %q, want %q "+
+			"(the +kubebuilder:metadata:annotations marker on RESTAction must emit it; "+
+			"without it helm uninstall deletes the CRD and all RESTAction CRs)",
+			crdPath, key, got, want)
+	}
+}

--- a/crds/templates.krateo.io_restactions.yaml
+++ b/crds/templates.krateo.io_restactions.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    helm.sh/resource-policy: keep
   name: restactions.templates.krateo.io
 spec:
   group: templates.krateo.io


### PR DESCRIPTION
## Problem
The release-tag crds-sync silently DROPS `metadata.annotations."helm.sh/resource-policy: keep"` from the RESTActions CRD on every regen. controller-gen emits only its version annotation; the chart's CRD had `keep` added manually, so each sync (replacing the chart CRD with the freshly-generated one) loses it — recurred on #25/#26/#27. Without `keep`, a `helm uninstall` deletes the RESTActions CRD **and all RESTAction CRs** — a data-loss risk at 50K scale.

## Fix (generation-only — no resolver/runtime change)
Add a controller-gen marker so `make generate` itself emits the annotation:
```go
// +kubebuilder:metadata:annotations=helm.sh/resource-policy=keep
```
on the `RESTAction` type (`apis/templates/v1/restactions.go`). controller-gen **v0.17.3** registers `kubebuilder:metadata` (`pkg/crd/markers/crd.go:55,360-377`); its `ApplyToCRD` writes the kv into `crd.Annotations`, so the marker is honored — **no** post-generate/CI injection needed. Future crds-syncs now carry the generated `keep`.

## Generated-CRD before/after
`crds/templates.krateo.io_restactions.yaml` `metadata.annotations`:
```diff
   controller-gen.kubebuilder.io/version: v0.17.3
+  helm.sh/resource-policy: keep
```
Only that one line changed. `make generate` is **idempotent** (re-run → no drift).

## Falsifier
`TestGeneratedCRDKeepsResourcePolicyAnnotation` (`apis/templates/v1/restactions_crd_test.go`) — pure file-read, **no kubeconfig**. Asserts the generated CRD's `metadata.annotations["helm.sh/resource-policy"] == "keep"`. Proof: with marker → PASS; strip the keep line → FAIL (`= "", want "keep"`); restore → PASS. A future controller-gen bump or marker removal can never silently drop it again.

## DoD
- `make generate` idempotent (identical md5, no drift)
- `go build ./...` OK, `go vet ./...` OK
- Scope: only the RESTAction CRD (templates.krateo.io); chart repo untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1