### PR TITLE
fix(cache): kill composition-detail hot-path discovery storm (A1 per-group dedup + A2 cached/forceFresh discovery)

### DIFF
--- a/internal/cache/crd_add_discovery_test.go
+++ b/internal/cache/crd_add_discovery_test.go
@@ -56,6 +56,7 @@ func withCleanCRDDiscovery(t *testing.T) {
 	ResetNavigationDiscoveredGroupsForTest()
 	ResetDiscoveryCountersForTest()
 	ResetDiscoverySingleflightForTest()
+	resetCachedDiscoveryForTest()
 	prevDC := discoveryClientBuilder
 	prevRC := ProcessSARestConfig()
 	t.Cleanup(func() {
@@ -66,6 +67,7 @@ func withCleanCRDDiscovery(t *testing.T) {
 		ResetNavigationDiscoveredGroupsForTest()
 		ResetDiscoveryCountersForTest()
 		ResetDiscoverySingleflightForTest()
+		resetCachedDiscoveryForTest()
 	})
 }
 

--- a/internal/cache/crd_discovery_side_effect.go
+++ b/internal/cache/crd_discovery_side_effect.go
@@ -424,7 +424,13 @@ func triggerCRDDiscovery(obj interface{}, kind crdLifecycleKind) {
 	// DiscoverGroupResources at discovery_lookup.go:255-258 +
 	// :270-275).
 	ctx := context.Background()
-	if _, derr := DiscoverGroupResources(ctx, saRC, group); derr != nil {
+	// Fix A2 — the CRD-event path MUST force-fresh: Invalidate the cached
+	// discovery surface (a GLOBAL memcache wipe — all groups) and re-read
+	// the apiserver BEFORE the registration walk, so a CREATE/UPDATE never
+	// registers against a stale cached read (the S4/F-4 stuck-zero
+	// regression class). The hot /call walker keeps the cached/short-
+	// circuit DiscoverGroupResources.
+	if _, derr := DiscoverGroupResourcesFresh(ctx, saRC, group); derr != nil {
 		slog.Warn("cache.crd_discovery.discover_group_failed",
 			slog.String("subsystem", "cache"),
 			slog.String("group", group),

--- a/internal/cache/discovery_lookup.go
+++ b/internal/cache/discovery_lookup.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
@@ -163,15 +164,146 @@ var discoveryClientBuilder = func(rc *rest.Config) (discovery.DiscoveryInterface
 // each goroutine would issue its own discovery LIST.
 var discoverGroupSingleflight sync.Map // group(string) -> *sync.Mutex
 
-// discoverGroupOnce guards the per-group "discovery has completed at
-// least once" flag. v6 NOTE: we do NOT permanently cache the
-// discovered set — a re-walk on widget CRUD must be able to detect
-// newly-added composition GVRs. The mutex serializes concurrent calls
-// only; the discovery hop itself is repeated on every walker re-entry
-// (idempotent via EnsureResourceType).
+// discoverGroupLock returns the per-group serialize-only mutex. The
+// mutex serializes concurrent calls for the SAME group only; calls for
+// distinct groups proceed in parallel.
+//
+// 2026-06-22 Fix A2 (discovery storm) — the discovery hop is NO LONGER
+// unconditionally repeated on every walker re-entry. The apiserver
+// round-trips are now served from a process-singleton cache-local
+// CachedDiscoveryInterface (cachedDiscoveryClient below), and the hot
+// (forceFresh:false) path short-circuits to (0,nil) when the cache is
+// Fresh() AND every registerable GVR of every currently-served version
+// is already registered (versionCompleteForGroup). This kills the
+// ~21-round-trip residual the v6 "repeat every walk" design paid on
+// already-known state, WITHOUT a once-flag: the short-circuit predicate
+// is RECOMPUTED every call, so a newly-served version (spec.versions[]
+// widen) leaves a GVR un-registered → predicate false → full discovery
+// walk. The CRD-event path (DiscoverGroupResourcesFresh, forceFresh:
+// true) Invalidate()s the cached discovery surface (memcache.Invalidate
+// is a GLOBAL wipe — all groups; client-go has no per-group shard) and
+// re-reads the apiserver BEFORE the registration walk, so a CREATE/UPDATE
+// never reads stale. The global wipe is a bounded, accepted cost: after a
+// (rare) CRD event the next hot-path call for ANY nav-group sees
+// Fresh()==false and pays ONE shared aggregated-discovery refresh
+// (refreshLocked downloads the whole surface in a single hop,
+// memcache.go:242-260), NOT N storms. Registration itself stays
+// idempotent via EnsureResourceType.
 func discoverGroupLock(group string) *sync.Mutex {
 	v, _ := discoverGroupSingleflight.LoadOrStore(group, &sync.Mutex{})
 	return v.(*sync.Mutex)
+}
+
+// --- Fix A2 — cache-local cached discovery client -------------------------
+
+// cachedDiscoveryClient is the process-singleton CachedDiscoveryInterface
+// that serves ServerGroups + ServerResourcesForGroupVersion from an
+// in-memory cache (k8s.io/client-go/discovery/cached/memory —
+// NewMemCacheClient, the SAME prior art internal/dynamic/client.go:30
+// uses). The first read per process downloads the API surface; every
+// subsequent read on the hot (forceFresh:false) path is an O(1) in-memory
+// lookup — eliminating the ~21 apiserver round-trips/call the raw v6
+// client paid (discovery storm RC-1 residual).
+//
+// LAYERING — built cache-LOCAL in internal/cache; does NOT import the
+// internal/dynamic SA-discovery singleton (internal/cache is BELOW
+// internal/dynamic — importing up would invert the layering wall). It
+// wraps whatever discoveryClientBuilder returns (the same test seam the
+// fakes already swap), so unit tests need no new wiring.
+//
+// CACHE-OFF — built LAZILY and ONLY from inside discoverGroupResources,
+// AFTER the modePassthrough guard. A CACHE_ENABLED=false process never
+// reaches the build site, so the raw-apiserver path stays byte-identical
+// (project_cache_off_is_transparent_fallback).
+//
+// CONCURRENCY — the singleton POINTER is guarded by cachedDiscoveryMu
+// (built once under the write lock; read on the hot path). The memcache
+// client's own mutation surface (Fresh()/Invalidate()/refreshLocked) is
+// lock-guarded inside client-go (memcache.go:209/220/235), so a concurrent
+// Invalidate() (forceFresh path) against a Fresh()/ServerGroups() read
+// (hot path) is race-safe by construction. The shared-vs-private
+// conversion (the 0.30.128 hazard class,
+// feedback_shared_vs_copy_is_a_concurrency_change) is gated by the
+// concurrent -race falsifier (discovery_storm_a2_race_test.go).
+var (
+	cachedDiscoveryMu     sync.RWMutex
+	cachedDiscoveryClient discovery.CachedDiscoveryInterface
+)
+
+// getCachedDiscovery returns the process-singleton cached discovery
+// client, building it lazily from rc on first use. MUST be called only
+// AFTER the modePassthrough guard (so cache-off never builds it). The
+// built client wraps discoveryClientBuilder(rc) in a memCacheClient.
+//
+// Goroutine-safe: build-once under the write lock, warm reads under the
+// read lock. Mirrors the SharedSADiscoveryClient build-once shape
+// (internal/dynamic/cached_client.go:181) but cache-local.
+func getCachedDiscovery(rc *rest.Config) (discovery.CachedDiscoveryInterface, error) {
+	cachedDiscoveryMu.RLock()
+	if cachedDiscoveryClient != nil {
+		c := cachedDiscoveryClient
+		cachedDiscoveryMu.RUnlock()
+		return c, nil
+	}
+	cachedDiscoveryMu.RUnlock()
+
+	cachedDiscoveryMu.Lock()
+	defer cachedDiscoveryMu.Unlock()
+	if cachedDiscoveryClient != nil {
+		return cachedDiscoveryClient, nil
+	}
+	raw, err := discoveryClientBuilder(rc)
+	if err != nil {
+		return nil, err
+	}
+	cachedDiscoveryClient = cacheddiscovery.NewMemCacheClient(raw)
+	return cachedDiscoveryClient, nil
+}
+
+// resetCachedDiscoveryForTest clears the cached-discovery singleton so
+// each test rebuilds it from the freshly-installed discoveryClientBuilder
+// fake. TEST-ONLY.
+func resetCachedDiscoveryForTest() {
+	cachedDiscoveryMu.Lock()
+	cachedDiscoveryClient = nil
+	cachedDiscoveryMu.Unlock()
+}
+
+// versionCompleteForGroup reports whether every registerable GVR of every
+// currently-served version of group is already registered in rw. The hot
+// (forceFresh:false) short-circuit predicate — RECOMPUTED every call (NOT
+// a once-flag): a newly-served version (spec.versions[] widen) lists a GVR
+// that rw.IsRegistered reports false for → returns false → caller runs the
+// full discovery walk. Reads served versions from the (possibly cached)
+// disco client; a per-version discovery error is treated as "not complete"
+// (conservative — forces the full walk, which re-attempts + soft-fails per
+// version exactly as the non-short-circuit path does).
+func versionCompleteForGroup(disco discovery.DiscoveryInterface, rw *ResourceWatcher, group string) bool {
+	versions, err := serverVersionsForGroup(disco, group)
+	if err != nil || len(versions) == 0 {
+		return false
+	}
+	for _, version := range versions {
+		gv := schema.GroupVersion{Group: group, Version: version}
+		list, lerr := disco.ServerResourcesForGroupVersion(gv.String())
+		if lerr != nil || list == nil {
+			return false
+		}
+		for _, el := range list.APIResources {
+			if !discoveryIsRegisterableResource(el) {
+				continue
+			}
+			gvk := gv.WithKind(el.Kind)
+			if isBuiltInKind(gvk) {
+				continue
+			}
+			gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: el.Name}
+			if !rw.IsRegistered(gvr) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // Counters — observability for the discovery hop. Mirror the
@@ -215,14 +347,47 @@ var (
 // mode are all soft no-ops returning (0, nil) so callers can wire
 // this unconditionally.
 func DiscoverGroupResources(ctx context.Context, rc *rest.Config, group string) (int, error) {
+	return discoverGroupResources(ctx, rc, group, false)
+}
+
+// DiscoverGroupResourcesFresh is the CRD-event-path entry point
+// (crd_discovery_side_effect.go). forceFresh:true → it Invalidate()s the
+// cached discovery surface (memcache.Invalidate is a GLOBAL wipe — all
+// groups) and re-reads the apiserver BEFORE the registration walk, so a
+// CRD CREATE/UPDATE can NEVER register against a
+// stale cached read (the S4/F-4 stuck-zero regression class,
+// docs/ship-0.30.233-s4-cache-invalidation-trace). No version-complete
+// short-circuit on this path: a CREATE/UPDATE is exactly the case where a
+// newly-served version's GVR is not yet registered, so a fresh full walk
+// is mandatory.
+func DiscoverGroupResourcesFresh(ctx context.Context, rc *rest.Config, group string) (int, error) {
+	return discoverGroupResources(ctx, rc, group, true)
+}
+
+// discoverGroupResources is the shared implementation behind
+// DiscoverGroupResources (forceFresh:false, hot /call walker) and
+// DiscoverGroupResourcesFresh (forceFresh:true, CRD-event path).
+//
+//   - forceFresh:false — the hot path. Short-circuits to (0,nil) when the
+//     cached discovery client is Fresh() AND every served version's
+//     registerable GVR is already registered (versionCompleteForGroup).
+//     Otherwise runs the full walk against the (cached) client — already-
+//     known state is served from memory, so a non-short-circuited walk
+//     still pays ZERO apiserver round-trips while the cache stays warm.
+//   - forceFresh:true — the CRD-event path. Invalidate()s the cached
+//     discovery surface (memcache.Invalidate is a GLOBAL wipe — all
+//     groups; a superset invalidation is always safe), forcing the next
+//     read to re-download, then ALWAYS runs the full walk against the
+//     freshly re-read apiserver state.
+func discoverGroupResources(ctx context.Context, rc *rest.Config, group string, forceFresh bool) (int, error) {
 	if group == "" {
 		return 0, nil
 	}
 	rw := Global()
 	if rw == nil || rw.mode == modePassthrough {
-		// Cache off / passthrough — no informer to spawn, but record
-		// the group anyway so a future cache-on transition has the
-		// nav-discovered set ready.
+		// Cache off / passthrough — no informer to spawn, and the
+		// cached-discovery client is NEVER built (byte-identical raw
+		// path). Record nothing; a future cache-on transition rebuilds.
 		return 0, nil
 	}
 
@@ -236,7 +401,10 @@ func DiscoverGroupResources(ctx context.Context, rc *rest.Config, group string) 
 		return 0, ctx.Err()
 	}
 
-	disco, err := discoveryClientBuilder(rc)
+	// Build (lazily, post-passthrough-guard) the process-singleton cached
+	// discovery client. Replaces the per-call raw client — the apiserver
+	// round-trips are now served from the memcache after the first read.
+	disco, err := getCachedDiscovery(rc)
 	if err != nil {
 		slog.Warn("cache.discovery.client_build_failed",
 			slog.String("subsystem", "cache"),
@@ -244,6 +412,19 @@ func DiscoverGroupResources(ctx context.Context, rc *rest.Config, group string) 
 			slog.Any("err", err),
 		)
 		return 0, err
+	}
+
+	if forceFresh {
+		// CRD CREATE/UPDATE — drop the cached discovery surface (a GLOBAL
+		// memcache wipe, all groups) so the walk below re-reads the
+		// apiserver and sees the newly-served version's GVRs.
+		disco.Invalidate()
+	} else if disco.Fresh() && versionCompleteForGroup(disco, rw, group) {
+		// Hot path, cache warm + every served version fully registered —
+		// nothing to do. Recomputed every call (NOT a once-flag): a newly-
+		// served version leaves a GVR un-registered → predicate false →
+		// fall through to the full walk below.
+		return 0, nil
 	}
 
 	// Enumerate every version of `group` via ServerGroups().

--- a/internal/cache/discovery_storm_a2_race_test.go
+++ b/internal/cache/discovery_storm_a2_race_test.go
@@ -1,0 +1,154 @@
+// discovery_storm_a2_race_test.go — Fix A2 falsifier F-A2d (the mandatory
+// concurrent -race test for the private->shared conversion, the 0.30.128
+// hazard class — feedback_shared_vs_copy_is_a_concurrency_change).
+//
+// A2 converts the per-call PRIVATE raw discovery client into ONE
+// process-singleton cache-local CachedDiscoveryInterface read by every hot
+// /call walker goroutine (DiscoverGroupResources, forceFresh:false) AND
+// mutated by the CRD-event path (DiscoverGroupResourcesFresh →
+// cached.Invalidate()). This test races concurrent hot-path readers
+// (distinct groups) against a SEPARATE goroutine looping the forceFresh
+// Invalidate()+re-read path.
+//
+// Run with: go test -race -count=1 ./internal/cache/...
+// PASS criterion: zero data races AND no panic.
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// multiGroupFlipDiscovery serves several groups, each with one CRD-backed
+// resource. Goroutine-safe (the embedded counters are mutex-guarded). It
+// is wrapped by NewMemCacheClient inside getCachedDiscovery.
+type multiGroupFlipDiscovery struct {
+	discovery.DiscoveryInterface // embed nil — unreached methods panic
+
+	mu     sync.Mutex
+	groups map[string][]string                        // group -> versions
+	res    map[string]map[string][]metav1.APIResource // group -> version -> resources
+	gCalls int64
+	rCalls int64
+}
+
+func (f *multiGroupFlipDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gCalls++
+	out := make([]metav1.APIGroup, 0, len(f.groups))
+	for g, vs := range f.groups {
+		gvfd := make([]metav1.GroupVersionForDiscovery, 0, len(vs))
+		for _, v := range vs {
+			gvfd = append(gvfd, metav1.GroupVersionForDiscovery{Version: v, GroupVersion: g + "/" + v})
+		}
+		out = append(out, metav1.APIGroup{Name: g, Versions: gvfd})
+	}
+	return &metav1.APIGroupList{Groups: out}, nil
+}
+
+func (f *multiGroupFlipDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rCalls++
+	for g, byV := range f.res {
+		for v, rs := range byV {
+			if gv == g+"/"+v {
+				return &metav1.APIResourceList{GroupVersion: gv, APIResources: rs}, nil
+			}
+		}
+	}
+	return &metav1.APIResourceList{GroupVersion: gv}, nil
+}
+
+// TestA2_Race_ConcurrentHotReadersVsForceFreshInvalidator is F-A2d.
+func TestA2_Race_ConcurrentHotReadersVsForceFreshInvalidator(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	ResetDepsForTest()
+	t.Cleanup(ResetDepsForTest)
+	ResetNavigationDiscoveredGroupsForTest()
+	t.Cleanup(ResetNavigationDiscoveredGroupsForTest)
+	ResetDiscoverySingleflightForTest()
+	t.Cleanup(ResetDiscoverySingleflightForTest)
+
+	groups := []string{"g0.example.io", "g1.example.io", "g2.example.io", "g3.example.io"}
+	res := func(plural, kind string) []metav1.APIResource {
+		return []metav1.APIResource{{Name: plural, Kind: kind, Namespaced: true}}
+	}
+	grpVersions := map[string][]string{}
+	grpRes := map[string]map[string][]metav1.APIResource{}
+	gvrs := make([]schema.GroupVersionResource, 0, len(groups))
+	for i, g := range groups {
+		grpVersions[g] = []string{"v1"}
+		plural := "kind" + string(rune('a'+i)) + "s"
+		grpRes[g] = map[string][]metav1.APIResource{"v1": res(plural, "Kind"+string(rune('A'+i)))}
+		gvrs = append(gvrs, schema.GroupVersionResource{Group: g, Version: "v1", Resource: plural})
+	}
+
+	rw := newSyntheticRemoveWatcher(t, gvrs...)
+	rw.SetRESTConfig(&rest.Config{Host: "https://stub.invalid"})
+	SetGlobal(rw)
+	t.Cleanup(func() { SetGlobal(nil); rw.Stop() })
+
+	fake := &multiGroupFlipDiscovery{groups: grpVersions, res: grpRes}
+	prev := discoveryClientBuilder
+	discoveryClientBuilder = func(rc *rest.Config) (discovery.DiscoveryInterface, error) { return fake, nil }
+	resetCachedDiscoveryForTest()
+	t.Cleanup(func() { discoveryClientBuilder = prev; resetCachedDiscoveryForTest() })
+
+	rc := &rest.Config{Host: "https://fake.test"}
+
+	// Build the singleton up front so all goroutines share it.
+	if _, err := getCachedDiscovery(rc); err != nil {
+		t.Fatalf("initial cached client build: %v", err)
+	}
+
+	const (
+		readers       = 12
+		readsPerRdr   = 200
+		invalidations = 150
+	)
+	var (
+		wg   sync.WaitGroup
+		stop atomic.Bool
+	)
+
+	// READER goroutines — concurrent forceFresh:false hot-path discovery
+	// over distinct groups (the shared cached client's read side).
+	wg.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func(r int) {
+			defer wg.Done()
+			g := groups[r%len(groups)]
+			for i := 0; i < readsPerRdr && !stop.Load(); i++ {
+				_, _ = DiscoverGroupResources(context.Background(), rc, g)
+			}
+		}(r)
+	}
+
+	// INVALIDATOR goroutine — SEPARATE from the readers (the new shared-
+	// mutation surface). Loops the forceFresh path which Invalidate()s the
+	// shared cached client then re-reads.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < invalidations && !stop.Load(); i++ {
+			g := groups[i%len(groups)]
+			_, _ = DiscoverGroupResourcesFresh(context.Background(), rc, g)
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	wg.Wait()
+	stop.Store(true)
+	// Reaching here without a -race report or a panic is the PASS gate.
+}

--- a/internal/cache/discovery_storm_a2_test.go
+++ b/internal/cache/discovery_storm_a2_test.go
@@ -1,0 +1,305 @@
+// discovery_storm_a2_test.go — Fix A2 (discovery storm) falsifier suite.
+//
+// A2 swaps the per-call RAW discovery client for a process-singleton
+// cache-local CachedDiscoveryInterface (memcache.NewMemCacheClient) and
+// splits DiscoverGroupResources into:
+//
+//   - DiscoverGroupResources (forceFresh:false) — the hot /call walker
+//     path; version-complete short-circuit when the cache is Fresh() AND
+//     every served version's GVR is already registered.
+//   - DiscoverGroupResourcesFresh (forceFresh:true) — the CRD-event path;
+//     Invalidate()s this group then re-reads the apiserver BEFORE the
+//     registration walk (no stale read on CREATE/UPDATE).
+//
+// Falsifiers:
+//   F-A2a (HARD GATE) — CRD UPDATE that newly-serves G@v2 REGISTERS the
+//     v2 GVR (not just ticks DiscoveryInvoked). Fails a blind-permanent
+//     cache, passes forceFresh.
+//   F-A2b — a 2nd hot-path call on a fully-registered group does ZERO
+//     apiserver round-trips (ServerResourcesForGroupVersion call-count
+//     unchanged).
+//   F-A2c — modePassthrough (cache off) never builds the cached client;
+//     raw path identical (no discovery hop).
+//
+// The -race falsifier F-A2d lives in discovery_storm_a2_race_test.go.
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// flipDiscovery is a discovery.DiscoveryInterface stub for one group that
+// can be flipped from serving one version-set to another at runtime, and
+// counts ServerGroups + ServerResourcesForGroupVersion calls (the
+// apiserver round-trip proxies). It is wrapped by NewMemCacheClient inside
+// getCachedDiscovery, so a cache HIT serves from memory and these counters
+// DO NOT advance — that is exactly what F-A2b asserts.
+type flipDiscovery struct {
+	discovery.DiscoveryInterface // embed nil — unreached methods panic
+
+	group string
+
+	mu            sync.Mutex
+	versions      []string                        // served versions (flippable)
+	resByVersion  map[string][]metav1.APIResource // GVRs per version
+	groupsCalls   int
+	resourceCalls int
+}
+
+func (f *flipDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.groupsCalls++
+	gvfd := make([]metav1.GroupVersionForDiscovery, 0, len(f.versions))
+	for _, v := range f.versions {
+		gvfd = append(gvfd, metav1.GroupVersionForDiscovery{Version: v, GroupVersion: f.group + "/" + v})
+	}
+	return &metav1.APIGroupList{Groups: []metav1.APIGroup{{Name: f.group, Versions: gvfd}}}, nil
+}
+
+func (f *flipDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resourceCalls++
+	for _, v := range f.versions {
+		if gv == f.group+"/"+v {
+			return &metav1.APIResourceList{GroupVersion: gv, APIResources: f.resByVersion[v]}, nil
+		}
+	}
+	return &metav1.APIResourceList{GroupVersion: gv}, nil
+}
+
+func (f *flipDiscovery) flipTo(versions []string) {
+	f.mu.Lock()
+	f.versions = versions
+	f.mu.Unlock()
+}
+
+func (f *flipDiscovery) resourceCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.resourceCalls
+}
+
+// installFlipDiscovery swaps the cache discoveryClientBuilder seam to
+// return fake AND resets the cached-discovery singleton so getCachedDiscovery
+// rebuilds around it.
+func installFlipDiscovery(t *testing.T, fake *flipDiscovery) {
+	t.Helper()
+	prev := discoveryClientBuilder
+	discoveryClientBuilder = func(rc *rest.Config) (discovery.DiscoveryInterface, error) {
+		return fake, nil
+	}
+	resetCachedDiscoveryForTest()
+	t.Cleanup(func() {
+		discoveryClientBuilder = prev
+		resetCachedDiscoveryForTest()
+	})
+}
+
+// ghscpGVR / gvr helpers — the synthetic composition resource the fake serves.
+const (
+	a2Group  = "composition.krateo.io"
+	a2Plural = "githubscaffoldingwithcompositionpages"
+	a2Kind   = "GHSCP"
+)
+
+func a2GVR(version string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: a2Group, Version: version, Resource: a2Plural}
+}
+
+func a2Resources() []metav1.APIResource {
+	return []metav1.APIResource{{Name: a2Plural, Kind: a2Kind, Namespaced: true}}
+}
+
+// a2RealWatcher builds a CACHE_ENABLED watcher seeded for the composition
+// GVRs at v1 + v2, sets it as Global, and registers cleanup.
+func a2RealWatcher(t *testing.T) *ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	rw := newSyntheticRemoveWatcher(t, a2GVR("v1"), a2GVR("v2"))
+	rw.SetRESTConfig(&rest.Config{Host: "https://stub.invalid"})
+	SetGlobal(rw)
+	t.Cleanup(func() { SetGlobal(nil); rw.Stop() })
+	return rw
+}
+
+// --- F-A2a (HARD GATE) — CRD UPDATE newly-serves v2 → v2 GVR REGISTERED ---
+
+// TestA2_ForceFresh_RegistersNewlyServedVersion is F-A2a.
+//
+// Primes the group at v1 (DiscoverGroupResources → cache populated, v1 GVR
+// registered). Then flips the fake to serve v1+v2 and fires a CRD UPDATE
+// through the real handlers.UpdateFunc. Post-fix, the forceFresh CRD-event
+// path Invalidate()s the cache, re-reads the apiserver, and REGISTERS the
+// v2 GVR.
+//
+// RED against a blind-permanent cache: a memoized A2 with NO forceFresh
+// would serve the stale v1-only discovery on the UPDATE → v2 GVR never
+// registered → IsRegistered(v2)==false. The HARD GATE is the
+// IsRegistered(v2) assertion, NOT merely DiscoveryInvoked ticking.
+func TestA2_ForceFresh_RegistersNewlyServedVersion(t *testing.T) {
+	withCleanCRDDiscovery(t)
+	ResetDepsForTest()
+	t.Cleanup(ResetDepsForTest)
+
+	rw := a2RealWatcher(t)
+
+	fake := &flipDiscovery{
+		group:    a2Group,
+		versions: []string{"v1"},
+		resByVersion: map[string][]metav1.APIResource{
+			"v1": a2Resources(),
+			"v2": a2Resources(),
+		},
+	}
+	installFlipDiscovery(t, fake)
+	SetProcessSARestConfig(&rest.Config{Host: "https://fake.test"})
+
+	// PRIME: hot-path discovery at v1 → v1 GVR registered, cache populated.
+	if _, err := DiscoverGroupResources(context.Background(), ProcessSARestConfig(), a2Group); err != nil {
+		t.Fatalf("prime DiscoverGroupResources(v1): %v", err)
+	}
+	if !rw.IsRegistered(a2GVR("v1")) {
+		t.Fatalf("prime FAIL: v1 GVR not registered after initial discovery")
+	}
+	if rw.IsRegistered(a2GVR("v2")) {
+		t.Fatalf("prime FAIL: v2 GVR registered before it was served (test setup bug)")
+	}
+	spawnedBefore := DiscoveryGVRsSpawned(a2Group)
+
+	// FLIP: apiserver now serves v1+v2.
+	fake.flipTo([]string{"v1", "v2"})
+
+	// Fire a CRD UPDATE through the REAL handler closure (the production
+	// path: handlers.UpdateFunc → submitCRDLifecycleEvent → worker →
+	// triggerCRDDiscovery → DiscoverGroupResourcesFresh).
+	crdGVR := CRDGVRForTest()
+	gw := newGateWatcher()
+	ch := make(chan struct{})
+	close(ch)
+	gw.syncCh[crdGVR] = ch
+	handlers := gw.depEventHandlers(crdGVR)
+
+	oldBO := crdBytesObjMultiVersion(t, "ghscp."+a2Group, a2Group, a2Plural,
+		[]versionSpec{{Name: "v1", Served: true}})
+	newBO := crdBytesObjMultiVersion(t, "ghscp."+a2Group, a2Group, a2Plural,
+		[]versionSpec{{Name: "v1", Served: true}, {Name: "v2", Served: true}})
+
+	handlers.UpdateFunc(oldBO, newBO)
+
+	if !WaitCRDDiscoveryProcessedForTest(1, 3000) {
+		t.Fatalf("F-A2a FAIL: worker did not process the CRD UPDATE in 3s; %s",
+			crdDiscoveryStatsString())
+	}
+
+	// HARD GATE: the v2 GVR was REGISTERED (not just DiscoveryInvoked).
+	if !rw.IsRegistered(a2GVR("v2")) {
+		t.Fatalf("F-A2a FAIL (HARD GATE): CRD UPDATE serving the new v2 version did NOT "+
+			"register the v2 GVR. A blind-permanent A2 cache served stale v1-only "+
+			"discovery. forceFresh must Invalidate + re-read BEFORE the walk. %s",
+			crdDiscoveryStatsString())
+	}
+	if got := DiscoveryGVRsSpawned(a2Group); got <= spawnedBefore {
+		t.Fatalf("F-A2a FAIL: DiscoveryGVRsSpawned(%s)=%d did not increase past %d "+
+			"(the v2 GVR registration must bump the spawned counter)", a2Group, got, spawnedBefore)
+	}
+}
+
+// --- F-A2b — hot-path warm short-circuit: ZERO apiserver round-trips ------
+
+// TestA2_HotPath_WarmShortCircuit_NoRoundTrips is F-A2b.
+//
+// Primes the group fully (v1 registered, cache Fresh). A 2nd hot-path
+// DiscoverGroupResources call — with every served version already
+// registered — must short-circuit with ZERO new apiserver round-trips
+// (ServerResourcesForGroupVersion call-count unchanged), because the
+// version-complete predicate is satisfied and reads come from the memcache.
+func TestA2_HotPath_WarmShortCircuit_NoRoundTrips(t *testing.T) {
+	withCleanCRDDiscovery(t)
+	ResetDepsForTest()
+	t.Cleanup(ResetDepsForTest)
+
+	rw := a2RealWatcher(t)
+
+	fake := &flipDiscovery{
+		group:        a2Group,
+		versions:     []string{"v1"},
+		resByVersion: map[string][]metav1.APIResource{"v1": a2Resources()},
+	}
+	installFlipDiscovery(t, fake)
+	rc := &rest.Config{Host: "https://fake.test"}
+
+	// PRIME — first call does the full walk + populates the cache.
+	if _, err := DiscoverGroupResources(context.Background(), rc, a2Group); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	if !rw.IsRegistered(a2GVR("v1")) {
+		t.Fatalf("prime FAIL: v1 GVR not registered")
+	}
+	callsAfterPrime := fake.resourceCallCount()
+
+	// 2nd + 3rd hot-path calls — warm cache + every served version
+	// registered → version-complete short-circuit → ZERO new round-trips.
+	for i := 0; i < 2; i++ {
+		if _, err := DiscoverGroupResources(context.Background(), rc, a2Group); err != nil {
+			t.Fatalf("warm call %d: %v", i, err)
+		}
+	}
+
+	if got := fake.resourceCallCount(); got != callsAfterPrime {
+		t.Fatalf("F-A2b FAIL: ServerResourcesForGroupVersion call-count moved from %d to %d "+
+			"on warm hot-path calls; want UNCHANGED (the version-complete short-circuit "+
+			"must serve from the memcache with ZERO apiserver round-trips)", callsAfterPrime, got)
+	}
+}
+
+// --- F-A2c — cache off (modePassthrough) never builds the cached client ----
+
+// TestA2_CacheOff_NoCachedClientBuilt is F-A2c.
+//
+// Under modePassthrough the cached discovery client is NEVER built (the
+// build site is AFTER the passthrough guard), so DiscoverGroupResources is
+// a (0,nil) no-op and the raw path stays byte-identical. We assert the
+// fake discovery client received ZERO calls AND the singleton stays nil.
+func TestA2_CacheOff_NoCachedClientBuilt(t *testing.T) {
+	withCleanCRDDiscovery(t)
+
+	// A passthrough-mode watcher as Global.
+	rw := &ResourceWatcher{mode: modePassthrough}
+	SetGlobal(rw)
+	t.Cleanup(func() { SetGlobal(nil) })
+
+	fake := &flipDiscovery{
+		group:        a2Group,
+		versions:     []string{"v1"},
+		resByVersion: map[string][]metav1.APIResource{"v1": a2Resources()},
+	}
+	installFlipDiscovery(t, fake)
+	rc := &rest.Config{Host: "https://fake.test"}
+
+	n, err := DiscoverGroupResources(context.Background(), rc, a2Group)
+	if err != nil || n != 0 {
+		t.Fatalf("F-A2c FAIL: passthrough DiscoverGroupResources returned (%d,%v); want (0,nil)", n, err)
+	}
+	if fake.groupsCalls != 0 || fake.resourceCalls != 0 {
+		t.Fatalf("F-A2c FAIL: cache-off path made discovery calls (groups=%d res=%d); "+
+			"want 0/0 (raw path must be byte-identical, no cached client built)",
+			fake.groupsCalls, fake.resourceCalls)
+	}
+	cachedDiscoveryMu.RLock()
+	built := cachedDiscoveryClient != nil
+	cachedDiscoveryMu.RUnlock()
+	if built {
+		t.Fatalf("F-A2c FAIL: cached discovery client was built under modePassthrough; " +
+			"the build site must be AFTER the passthrough guard")
+	}
+}

--- a/internal/resolvers/restactions/api/lazy_register_storm_test.go
+++ b/internal/resolvers/restactions/api/lazy_register_storm_test.go
@@ -1,0 +1,133 @@
+// lazy_register_storm_test.go — Fix A1 (discovery storm) falsifier F-A1.
+//
+// The composition-detail discovery storm (docs/troubleshoot-composition-
+// detail-discovery-storm-2026-06-22.md, RC-1): a composition-detail stage
+// emits ONE RequestOptions entry per iterator dispatch (28 composition
+// kinds for composition.krateo.io), every entry carrying the SAME static
+// group. Pre-fix, the AddNavigationDiscoveredGroup+DiscoverGroupResources
+// block fired once PER entry → 28× the same synchronous discovery hop on
+// the hot resolve path.
+//
+// F-A1 asserts the per-group dedup: with N entries in group G plus M in a
+// distinct group H, DiscoverGroupResources fires EXACTLY ONCE per distinct
+// group (2 total here, NOT N+M), AND every distinct GVR is still
+// EnsureResourceType'd (the GVR `seen` dedup is unchanged — N+M GVRs
+// registered, GVR-deduped).
+//
+// FAILS pre-fix: discoverGroupResourcesFn would be invoked N+M times (one
+// per opts entry sharing a group). PASSES post-fix: 1 per distinct group.
+
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+// TestLazyRegister_PerGroupDedup_KillsStorm is F-A1.
+func TestLazyRegister_PerGroupDedup_KillsStorm(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("PREWARM_ENABLED", "true")
+
+	if !cache.PrewarmEnabled() {
+		t.Fatalf("test precondition: PrewarmEnabled() must be true for the discovery block to run")
+	}
+
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(
+		newSchemeForResolverLazyRegister(), listKindsForResolverLazyRegister())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	defer rw.Stop()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+
+	// Count discoverGroupResourcesFn invocations per group. Swap the
+	// package seam; restore on cleanup.
+	var (
+		mu        sync.Mutex
+		callsByGr = map[string]int{}
+	)
+	prevFn := discoverGroupResourcesFn
+	discoverGroupResourcesFn = func(ctx context.Context, rc *rest.Config, group string) (int, error) {
+		mu.Lock()
+		callsByGr[group]++
+		mu.Unlock()
+		return 0, nil
+	}
+	t.Cleanup(func() { discoverGroupResourcesFn = prevFn })
+
+	// Internal rest config on the context — the SA-credentialed walker
+	// pattern that gates the discovery hop (resolve.go).
+	ctx := cache.WithInternalRESTConfig(context.Background(), &rest.Config{Host: "https://fake.test"})
+
+	// N=4 entries in composition.krateo.io (distinct namespaces → distinct
+	// paths, but the SAME static group + same GVR), M=2 entries in a
+	// second distinct group "apps".
+	const (
+		groupG = "composition.krateo.io"
+		groupH = "apps"
+	)
+	mkPath := func(group, ns, plural string) string {
+		return "/apis/" + group + "/v1/namespaces/" + ns + "/" + plural
+	}
+	opts := []httpcall.RequestOptions{
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupG, "ns-01", "compositions")}},
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupG, "ns-02", "compositions")}},
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupG, "ns-03", "compositions")}},
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupG, "ns-04", "compositions")}},
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupH, "ns-05", "deployments")}},
+		{RequestInfo: httpcall.RequestInfo{Verb: ptr.To(http.MethodGet), Path: mkPath(groupH, "ns-06", "deployments")}},
+	}
+
+	lazyRegisterInnerCallPaths(ctx, slog.Default(), opts)
+
+	// PRIMARY F-A1 ASSERTION: exactly 1 discovery call per DISTINCT group.
+	mu.Lock()
+	defer mu.Unlock()
+	if got := callsByGr[groupG]; got != 1 {
+		t.Fatalf("F-A1 FAIL: DiscoverGroupResources fired %d× for %s; want exactly 1 "+
+			"(per-group dedup must collapse the 4 same-group entries into one hop — the storm)",
+			got, groupG)
+	}
+	if got := callsByGr[groupH]; got != 1 {
+		t.Fatalf("F-A1 FAIL: DiscoverGroupResources fired %d× for %s; want exactly 1 "+
+			"(a 2nd DISTINCT group must STILL register+discover, not be collapsed by a bare once)",
+			got, groupH)
+	}
+	if len(callsByGr) != 2 {
+		t.Fatalf("F-A1 FAIL: discovery fired for %d distinct groups; want 2 (%v)", len(callsByGr), callsByGr)
+	}
+
+	// AC — AddNavigationDiscoveredGroup still fires for EVERY distinct
+	// group (not collapsed to a bare sync.Once).
+	if !cache.IsNavigationDiscoveredGroup(groupG) {
+		t.Errorf("F-A1 FAIL: %s not in navDiscoveredGroups", groupG)
+	}
+	if !cache.IsNavigationDiscoveredGroup(groupH) {
+		t.Errorf("F-A1 FAIL: 2nd distinct group %s not in navDiscoveredGroups (collapse bug)", groupH)
+	}
+
+	// AC — the GVR `seen` dedup + EnsureResourceType touch count is
+	// UNCHANGED: both distinct GVRs are registered (compositions, widgets).
+	for _, gvr := range []schema.GroupVersionResource{
+		{Group: groupG, Version: "v1", Resource: "compositions"},
+		{Group: groupH, Version: "v1", Resource: "deployments"},
+	} {
+		if rw.ListObjects(gvr, "") == nil {
+			t.Errorf("F-A1 FAIL: GVR %s not registered — A1 must not change EnsureResourceType behavior", gvr)
+		}
+	}
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -1458,6 +1458,13 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 	return r.dict
 }
 
+// discoverGroupResourcesFn is the package-private indirection over
+// cache.DiscoverGroupResources so the Fix A1 per-group-dedup falsifier
+// (lazy_register_storm_test.go) can count invocations per distinct group
+// without standing up a real discovery client. Production path is
+// unchanged. Mirrors cache.discoveryClientBuilder (discovery_lookup.go:151).
+var discoverGroupResourcesFn = cache.DiscoverGroupResources
+
 // lazyRegisterInnerCallPaths walks the per-stage RequestOptions slice
 // (one entry per iterator dispatch — the iterator + non-iterator paths
 // share this code) and calls cache.Global().EnsureResourceType for the
@@ -1482,6 +1489,19 @@ func lazyRegisterInnerCallPaths(ctx context.Context, log *slog.Logger, opts []ht
 		return
 	}
 	seen := map[schema.GroupVersionResource]struct{}{}
+	// 2026-06-22 Fix A1 (discovery storm) — per-group dedup. A
+	// composition-detail stage emits ONE RequestOptions entry per
+	// iterator dispatch (28 composition kinds for composition.krateo.io),
+	// every one carrying the SAME static group. Without this gate the
+	// AddNavigationDiscoveredGroup+DiscoverGroupResources block below
+	// fires once PER entry → 28× the same synchronous discovery hop on
+	// the hot resolve path (each hop = ServerGroups + a
+	// ServerResourcesForGroupVersion loop over the group's full version
+	// union, all returning already-known state). seenGroups collapses
+	// that to once per DISTINCT group per resolve. It is a SIBLING of the
+	// GVR `seen` map (which only guards EnsureResourceType below) — NOT a
+	// bare sync.Once: a 2nd DISTINCT group still registers + discovers.
+	seenGroups := map[string]struct{}{}
 	for i := range opts {
 		path := opts[i].Path
 
@@ -1518,21 +1538,28 @@ func lazyRegisterInnerCallPaths(ctx context.Context, log *slog.Logger, opts []ht
 		// too (it IS navigation-reached).
 		if cache.PrewarmEnabled() {
 			if grp, grpOK := cache.ExtractAPIServerGroupFromTemplatedPath(path); grpOK {
-				cache.AddNavigationDiscoveredGroup(grp)
-				// The walker's *rest.Config is wired through
-				// cache.WithInternalRESTConfig during Phase 1 (SA-
-				// credentialed walk). When absent (e.g. a non-Phase-1
-				// /call), the discovery hop is skipped — the only
-				// caller pattern that requires it is the SA-credentialed
-				// walker, which DOES set it.
-				if rcAny, ok := cache.InternalRESTConfigFromContext(ctx); ok {
-					if cfg, ok := rcAny.(*rest.Config); ok && cfg != nil {
-						if _, err := cache.DiscoverGroupResources(ctx, cfg, grp); err != nil {
-							log.Warn("cache.discovery.group_resources_fetch_failed",
-								slog.String("subsystem", "cache"),
-								slog.String("group", grp),
-								slog.Any("err", err),
-							)
+				// Fix A1 — gate on first-sight of this DISTINCT group in
+				// the current opts slice. A 2nd distinct group still
+				// passes this gate (registers + discovers); a repeat of an
+				// already-seen group is skipped, killing the storm.
+				if _, dupGrp := seenGroups[grp]; !dupGrp {
+					seenGroups[grp] = struct{}{}
+					cache.AddNavigationDiscoveredGroup(grp)
+					// The walker's *rest.Config is wired through
+					// cache.WithInternalRESTConfig during Phase 1 (SA-
+					// credentialed walk). When absent (e.g. a non-Phase-1
+					// /call), the discovery hop is skipped — the only
+					// caller pattern that requires it is the SA-credentialed
+					// walker, which DOES set it.
+					if rcAny, ok := cache.InternalRESTConfigFromContext(ctx); ok {
+						if cfg, ok := rcAny.(*rest.Config); ok && cfg != nil {
+							if _, err := discoverGroupResourcesFn(ctx, cfg, grp); err != nil {
+								log.Warn("cache.discovery.group_resources_fetch_failed",
+									slog.String("subsystem", "cache"),
+									slog.String("group", grp),
+									slog.Any("err", err),
+								)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Problem (RC-1)

A composition-detail `/call` resolve fired **~560 synchronous apiserver discovery round-trips on the hot path** — 28 composition kinds × ~21 version-union entries, all returning already-known state — the observed **4.7–5.5s** per widget on `krateo-enterprise` (snowplow 1.4.1, `l1_hit:"miss"` every nav). TRACED to `lazyRegisterInnerCallPaths` firing the discovery block once **per RequestOptions entry** above the GVR dedup, and `DiscoverGroupResources` being deliberately un-memoized (raw client every call). Design: `docs/troubleshoot-composition-detail-discovery-storm-2026-06-22.md`.

## Fix

**A1 — per-group dedup** (`resolve.go`): a `seenGroups` map (sibling of the GVR `seen` map) gates the `AddNavigationDiscoveredGroup`+`DiscoverGroupResources` block on first-sight of each DISTINCT group. **28 → 1** hop per distinct group per resolve (~96% RT cut, ~560 → ~21). `AddNavigationDiscoveredGroup` still fires per distinct group (not a bare `sync.Once`); GVR dedup + `EnsureResourceType` untouched.

**A2 — cached / forceFresh discovery** (`discovery_lookup.go`): swap the per-call raw client for a process-singleton cache-local `memcache.NewMemCacheClient` (built lazily, ONLY after the `modePassthrough` guard → `CACHE_ENABLED=false` byte-identical; no `internal/dynamic` import → layering wall held). Split into `discoverGroupResources(...,forceFresh)`:
- **forceFresh:false** (hot `/call` walker) — short-circuits to `(0,nil)` when `cached.Fresh()` AND every served-version GVR is already `IsRegistered` (`versionCompleteForGroup`, **recomputed every call, not a once-flag** — a newly-served version forces a full walk). Residual **~21 → ~0** on unchanged.
- **forceFresh:true** (new `DiscoverGroupResourcesFresh`, CRD-event path) — `Invalidate()`s the cached discovery surface (a **global** memcache wipe; client-go has no per-group shard — superset invalidation is safe, the next hot call pays ONE shared aggregated-discovery refresh, not N storms) THEN re-reads the apiserver **before** the registration walk, so a CRD CREATE/UPDATE provably never registers against a stale read (closes the S4/F-4 stuck-zero regression class). `crd_discovery_side_effect.go:427` switches to this variant.

## Falsifiers (kind/in-process/fake only — no remote kubeconfig)

| Falsifier | Asserts | RED-first |
|---|---|---|
| **F-A1** `lazy_register_storm_test.go` | exactly 1 discovery call per DISTINCT group; both nav-registered; GVRs EnsureResourceType'd | ✅ (no-dedup → 4× storm) |
| **F-A2a** `discovery_storm_a2_test.go` (HARD GATE) | CRD UPDATE newly-serving v2 **REGISTERS** the v2 GVR (`IsRegistered(v2)`, not just `DiscoveryInvoked`) + `DiscoveryGVRsSpawned` bumped | ✅ (blind cache → `Invoked=1` but `IsRegistered(v2)=false`) |
| **F-A2b** | warm hot-path call → ZERO apiserver round-trips | — |
| **F-A2c** | `modePassthrough` never builds the cached client (cache-off identical) | — |
| **F-A2d** `discovery_storm_a2_race_test.go` | concurrent forceFresh:false readers vs a forceFresh:true Invalidator, `-race` clean | — |

**No-regression:** existing `TestCRDAdd/Update_TriggersGroupDiscovery*` + full CRD-lifecycle suite still pass. `go build` + `go vet` clean; `internal/cache` + `internal/resolvers/restactions/api` + `internal/handlers/dispatchers` `-race -count=1` clean. **No CRD change** (`make generate` unaffected).

## Review

Pre-commit dual review CLEARED: **architect SIGN-OFF** (forceFresh ordered before the walk; -race object-lifetime safe by construction; version-complete recomputed; layering clean; cache-off byte-identical; A1 28→1) + **PM SIGN-OFF** (all falsifiers re-run; F-A2a independently RED-verified). Doc nits addressed (global-wipe comment wording; test comment).

## Scope notes

- **Ledger: MECHANISM-ONLY** — round-trip-count + GVR-registration falsifiers; **no live Chrome / north-star score** (deploy intentionally avoided this ship).
- **RC-2** (`vacuum` 404 → permanent uncacheability) is a **separate follow-up**, out of scope here.
- Not tagged / not chart-lockstepped / not deployed — **PARKED for Diego.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1