### PR TITLE
fix(resolver): CA-bearing dispatch branch for bare group-discovery api-steps (x509 fix A1)

### DIFF
--- a/internal/cache/discovery_path_test.go
+++ b/internal/cache/discovery_path_test.go
@@ -1,0 +1,66 @@
+// discovery_path_test.go — Fix A1: table coverage for the
+// ParseAPIServerDiscoveryPath shape predicate, the load-bearing RBAC
+// boundary for the discovery dispatch branch
+// (resolvers/restactions/api/discovery_dispatch.go).
+//
+// The predicate MUST return true ONLY for a bare single-GroupVersion
+// discovery path (/apis/<g>/<v> or /api/<v>) and FALSE for every resource
+// path — that false is what structurally prevents the SA-serving discovery
+// branch from leaking a resource path cross-user (PM gate AC2 / F4).
+
+package cache
+
+import "testing"
+
+func TestParseAPIServerDiscoveryPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		wantGV string
+		wantOK bool
+	}{
+		// --- discovery shapes (ok=true) ---
+		{"named group discovery", "/apis/templates.krateo.io/v1", "templates.krateo.io/v1", true},
+		{"apps group discovery", "/apis/apps/v1", "apps/v1", true},
+		{"core group discovery", "/api/v1", "v1", true},
+		{"named group trailing slash", "/apis/templates.krateo.io/v1/", "templates.krateo.io/v1", true},
+		{"core group trailing slash", "/api/v1/", "v1", true},
+		{"named group with query", "/apis/apps/v1?timeout=30s", "apps/v1", true},
+
+		// --- resource paths (ok=false) — the RBAC boundary (F4) ---
+		{"group LIST", "/apis/templates.krateo.io/v1/compositiondefinitions", "", false},
+		{"group GET-by-name", "/apis/templates.krateo.io/v1/compositiondefinitions/foo", "", false},
+		{"group namespaced LIST", "/apis/apps/v1/namespaces/krateo-system/deployments", "", false},
+		{"group namespaced GET", "/apis/apps/v1/namespaces/krateo-system/deployments/x", "", false},
+		{"core LIST", "/api/v1/namespaces", "", false},
+		{"core GET-by-name", "/api/v1/namespaces/krateo", "", false},
+		{"core cluster LIST", "/api/v1/pods", "", false},
+		{"core namespaced LIST", "/api/v1/namespaces/krateo/pods", "", false},
+
+		// --- non-single-GroupVersion roots (ok=false) ---
+		{"multi-group discovery index", "/apis", "", false},
+		{"multi-group discovery index slash", "/apis/", "", false},
+		{"core root", "/api", "", false},
+		{"core root slash", "/api/", "", false},
+		{"group version-list", "/apis/templates.krateo.io", "", false},
+
+		// --- non-apiserver / malformed (ok=false) ---
+		{"external URL", "https://example.com/apis/foo/v1", "", false},
+		{"unresolved JQ", "/apis/${.group}/v1", "", false},
+		{"empty", "", "", false},
+		{"root slash", "/", "", false},
+		{"random", "/healthz", "", false},
+		{"apis empty version", "/apis/apps/", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gv, ok := ParseAPIServerDiscoveryPath(tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("ParseAPIServerDiscoveryPath(%q) ok = %v, want %v (gv=%q)", tc.path, ok, tc.wantOK, gv)
+			}
+			if gv != tc.wantGV {
+				t.Fatalf("ParseAPIServerDiscoveryPath(%q) gv = %q, want %q", tc.path, gv, tc.wantGV)
+			}
+		})
+	}
+}

--- a/internal/cache/inventory.go
+++ b/internal/cache/inventory.go
@@ -332,6 +332,90 @@ func ParseAPIServerPathToDep(path string) (gvr schema.GroupVersionResource, name
 	return schema.GroupVersionResource{}, "", "", false
 }
 
+// ParseAPIServerDiscoveryPath recognises a BARE group-discovery
+// apiserver path and returns its GroupVersion in the canonical
+// "<group>/<version>" (or bare "<version>" for the core group) form
+// that discovery.ServerResourcesForGroupVersion consumes.
+//
+// It is the discovery-shape sibling of ParseAPIServerPathToDep (shares
+// its ${...}-rejection + trailing-slash strip) and is the load-bearing
+// shape predicate for the discovery dispatch branch (dispatchViaDiscovery,
+// resolvers/restactions/api). It returns true ONLY for the two bare
+// group-discovery shapes:
+//
+//   - /apis/<group>/<version>   — exactly 2 segments after "/apis/"
+//   - /api/<version>            — exactly 1 segment after "/api/" (core group)
+//
+// It returns FALSE for EVERY resource path — anything with a resource
+// segment (≥3 segments after "/apis/", ≥2 after "/api/"), namespaced or
+// cluster-scoped, GET-by-name or LIST. This is the code-enforced RBAC
+// boundary: the discovery branch SA-serves the discovery SHAPE only;
+// SA-serving a resource path would be a cross-user leak, so a resource
+// path MUST never be classified here as discovery (it keeps its existing
+// per-user-token dispatch branch unchanged). It also returns FALSE for
+// non-apiserver paths (external URLs, unresolved ${...}), the bare
+// "/apis" / "/api" roots (a multi-group discovery index, not a single
+// GroupVersion), and any malformed shape.
+//
+// No special-cases (feedback_no_special_cases.md): the predicate is keyed
+// purely on path SHAPE — segment count under the apiserver prefix — never
+// on a literal group/version/resource value.
+func ParseAPIServerDiscoveryPath(path string) (groupVersion string, ok bool) {
+	// Strip query string.
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	// Strip trailing slash.
+	path = strings.TrimRight(path, "/")
+
+	// Reject paths with unresolved JQ template fragments.
+	if strings.Contains(path, "${") {
+		return "", false
+	}
+
+	switch {
+	case strings.HasPrefix(path, "/apis/"):
+		// Bare group discovery: /apis/<group>/<version> — EXACTLY two
+		// segments. parts==1 is the bare /apis/<group> (a group's
+		// version list, not a single GroupVersion) → reject. parts>=3
+		// carries a resource segment → reject (RBAC boundary).
+		rest := strings.TrimPrefix(path, "/apis/")
+		if rest == "" {
+			return "", false
+		}
+		parts := strings.Split(rest, "/")
+		if len(parts) != 2 {
+			return "", false
+		}
+		group := parts[0]
+		version := parts[1]
+		if group == "" || version == "" {
+			return "", false
+		}
+		return group + "/" + version, true
+
+	case strings.HasPrefix(path, "/api/"):
+		// Core-group discovery: /api/<version> — EXACTLY one segment.
+		// parts>=2 carries a resource segment → reject (RBAC boundary).
+		// The core-group GroupVersion is the bare version ("v1").
+		rest := strings.TrimPrefix(path, "/api/")
+		if rest == "" {
+			return "", false
+		}
+		parts := strings.Split(rest, "/")
+		if len(parts) != 1 {
+			return "", false
+		}
+		version := parts[0]
+		if version == "" {
+			return "", false
+		}
+		return version, true
+	}
+
+	return "", false
+}
+
 // unstructuredSliceField pulls obj[fields...] as []any. Returns
 // (nil, false, nil) when the path is missing or the leaf is not a
 // slice. An error is returned only when an intermediate node has the

--- a/internal/resolvers/restactions/api/discovery_dispatch.go
+++ b/internal/resolvers/restactions/api/discovery_dispatch.go
@@ -1,0 +1,208 @@
+// discovery_dispatch.go — Fix A1: a CA-bearing dispatch branch for a
+// BARE group-discovery api-step path.
+//
+// THE DEFECT (TRACED — docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md):
+//
+//   A composition-resources RESTAction issues an api-step GET against a
+//   bare group-discovery URL — /apis/<group>/<version> (no resource
+//   segment, no endpointRef) — to enumerate the served resources of each
+//   managed apiVersion (e.g. /apis/templates.krateo.io/v1). That path has
+//   only 2 segments after "/apis/", so cache.ParseAPIServerPathToDep
+//   declines it (inventory.go: needs ≥3 / a resource segment). It then
+//   parse-fails EVERY CA-bearing dispatch branch (informer-pivot /
+//   apistage / internal-rest-config) and falls through to the EXTERNAL
+//   fetch (resolve.go), which builds a plumbing HTTP client from the
+//   per-user `<user>-clientconfig` Endpoint. That endpoint is TOKEN-auth
+//   (bearer JWT + caData, no client cert); plumbing's tlsConfigFor
+//   installs the CA pool ONLY inside the HasCertAuth() branch, so the
+//   cluster caData is DROPPED and the apiserver cert is verified against
+//   the system root store:
+//
+//     Get "https://kubernetes.default.svc/apis/templates.krateo.io/v1":
+//       tls: failed to verify certificate: x509: certificate signed by
+//       unknown authority
+//
+//   This is the SAME plumbing TLS defect internal_dispatch.go documents
+//   for the Phase-1 SA path (0.30.104) — here it bites a per-user request
+//   because no CA-bearing dispatch branch claims the bare-discovery shape.
+//
+// THE FIX (Fix A1, snowplow-side):
+//
+//   Add a dispatch branch keyed on the discovery SHAPE
+//   (cache.ParseAPIServerDiscoveryPath — /apis/<g>/<v> or /api/<v>, no
+//   resource segment) ahead of the external fall-through. The branch
+//   serves group discovery via client-go's discovery client
+//   (ServerResourcesForGroupVersion) on a CA-BEARING SA transport sourced
+//   from dynamic.ServiceAccountRESTConfig() — the process-wide in-cluster
+//   SA *rest.Config singleton (the rest.InClusterConfig() value, which
+//   carries the cluster CA verbatim; client-go's transport installs it
+//   correctly, the load-bearing difference from plumbing's httpcall.Do).
+//   The served body is the marshalled *metav1.APIResourceList.
+//
+//   RBAC POSTURE (load-bearing): the SA-serve exemption is for the
+//   discovery SHAPE ONLY. Group discovery is anonymous-readable (the
+//   system:discovery ClusterRole grants /apis, /apis/<g>/<v>, ... to
+//   system:authenticated and system:unauthenticated) and carries NO
+//   tenant data — only the apiserver's resource catalogue for a
+//   GroupVersion — so serving it under the SA identity leaks nothing. A
+//   RESOURCE path is NEVER routed here (ParseAPIServerDiscoveryPath
+//   returns false for ≥3-segment paths), so it keeps its existing
+//   per-user-token dispatch branch byte-unchanged: SA-serving a resource
+//   path WOULD be a cross-user leak, and the shape predicate is what
+//   structurally prevents it.
+//
+//   CACHE-OFF (AC5): the branch sources the SA rc from the process-wide
+//   dynamic.ServiceAccountRESTConfig() singleton, which exists regardless
+//   of CACHE_ENABLED — NOT the context-carried internal rc (Phase-1-only).
+//   So under cache-off the branch STILL fires (transparent fallback,
+//   project_cache_off_is_transparent_fallback): the same APIResourceList,
+//   not a degraded mode.
+//
+// CRITICAL — like internal_dispatch.go, this unit/httptest falsifier is
+// necessary but NOT sufficient: it runs against an httptest TLS server
+// with a synthetic CA and cannot exercise the real cluster CA or a real
+// apiserver discovery handshake. The on-cluster falsifier is a /call of
+// the triggering RA returning 200 with no x509 in pod logs (tester /
+// post-deploy).
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// discoveryClientCache memoises the client-go discovery client built from
+// a given SA *rest.Config. Every /call's discovery-shaped api-step shares
+// the SAME SA *rest.Config pointer (dynamic.ServiceAccountRESTConfig()
+// returns a process-wide singleton), so rebuilding the discovery client —
+// and its TLS transport — per call would be pure waste. Keyed on the
+// *rest.Config pointer identity, exactly like internalClientCache
+// (internal_dispatch.go). Guarded by discoveryClientMu; the cached
+// discovery.DiscoveryInterface is safe for concurrent use.
+var (
+	discoveryClientMu    sync.Mutex
+	discoveryClientCache = map[*rest.Config]discovery.DiscoveryInterface{}
+)
+
+// saRESTConfigForDiscoveryFn is the package-private seam over the SA
+// *rest.Config source. Production wires dynamic.ServiceAccountRESTConfig
+// (the CA-bearing in-cluster singleton); the falsifier swaps in a builder
+// returning a *rest.Config pointed at an httptest TLS server with a
+// synthetic CA, so the dispatch path can be exercised without a real
+// apiserver. Production code path is unchanged — the variable is set once
+// and only reassigned by test code. Mirrors inClusterConfigFn
+// (dynamic/sa_client.go) and discoveryClientForConfigFn
+// (dynamic/cached_client.go).
+var saRESTConfigForDiscoveryFn = dynamic.ServiceAccountRESTConfig
+
+// discoveryClientFor returns a memoised client-go discovery client for rc,
+// building one on first use. rc is the SA in-cluster *rest.Config and
+// carries the cluster CA + SA bearer token verbatim, so client-go's
+// NewDiscoveryClientForConfig produces a transport that trusts the
+// cluster CA — the load-bearing difference from plumbing's httpcall.Do
+// path, whose tlsConfigFor drops the CA for token-auth endpoints.
+func discoveryClientFor(rc *rest.Config) (discovery.DiscoveryInterface, error) {
+	discoveryClientMu.Lock()
+	defer discoveryClientMu.Unlock()
+	if cli, ok := discoveryClientCache[rc]; ok {
+		return cli, nil
+	}
+	cli, err := discovery.NewDiscoveryClientForConfig(rc)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClientCache[rc] = cli
+	return cli, nil
+}
+
+// resetDiscoveryClientCacheForTest clears the memoised discovery-client
+// map. TEST-ONLY — the production cache is set-once-per-config and never
+// cleared. Exported within-package for the falsifier test.
+func resetDiscoveryClientCacheForTest() {
+	discoveryClientMu.Lock()
+	defer discoveryClientMu.Unlock()
+	discoveryClientCache = map[*rest.Config]discovery.DiscoveryInterface{}
+}
+
+// dispatchViaDiscovery attempts to serve `call` as a BARE group-discovery
+// GET through a client-go discovery client built from the process-wide
+// CA-bearing SA *rest.Config. It is the discovery-shape sibling of
+// dispatchViaInternalRESTConfig and is wired into resolve.go's inner-call
+// worker AHEAD of the external fall-through.
+//
+// Returns (rawBytes, true, nil) when the call was served — the caller
+// feeds rawBytes through the same dictMu-protected handler chain the
+// in-memory dispatch paths use. Returns (nil, false, nil) for every gate
+// that must take the unchanged downstream path:
+//
+//   - non-GET verb (discovery is read-only; a write to a discovery-shaped
+//     path is not a discovery probe and stays on the existing path) — F5;
+//   - a non-discovery shape (any resource path — ≥3 segments / a resource
+//     segment — and any external / ${...} / malformed path):
+//     ParseAPIServerDiscoveryPath returns ok=false — F3/F4. This is the
+//     code-enforced RBAC boundary: a resource path is NEVER SA-served here.
+//
+// Returns (nil, false, err) ONLY when the SA rc could not be built or the
+// discovery call itself errored after the dispatcher committed to serving.
+// resolve.go treats a non-nil err here exactly as it treats an
+// httpcall.Do StatusFailure (it does NOT fall through to the external
+// fetch, which would just re-hit the broken plumbing TLS path and mask
+// the real error behind a second x509 failure).
+//
+// On the served path the body is the marshalled *metav1.APIResourceList —
+// the exact wire shape the apiserver's group-discovery endpoint returns,
+// so the downstream JQ pipeline is invariant
+// (feedback_cache_must_not_constrain_jq.md).
+func dispatchViaDiscovery(ctx context.Context, call httpcall.RequestOptions) ([]byte, bool, error) {
+	// Gate 1: verb. Discovery is read-only; a non-GET to a
+	// discovery-shaped path is not a discovery probe (F5).
+	if verb := ptr.Deref(call.Verb, http.MethodGet); verb != http.MethodGet {
+		return nil, false, nil
+	}
+
+	// Gate 2: shape. ParseAPIServerDiscoveryPath returns ok=true ONLY for
+	// the bare group-discovery shape (/apis/<g>/<v> or /api/<v>, no
+	// resource segment). It returns false for every resource path (F4 —
+	// the RBAC boundary), every non-apiserver / external / ${...} path,
+	// and the bare /apis | /api roots (F3).
+	gv, ok := cache.ParseAPIServerDiscoveryPath(call.Path)
+	if !ok {
+		return nil, false, nil
+	}
+
+	// Source the CA-bearing SA *rest.Config from the process-wide
+	// singleton — present regardless of CACHE_ENABLED (AC5: cache-off
+	// transparent fallback) and NOT the per-user request rc. A build
+	// failure is surfaced (we committed to serving once the shape
+	// matched).
+	rc, rcErr := saRESTConfigForDiscoveryFn()
+	if rcErr != nil {
+		return nil, false, rcErr
+	}
+
+	cli, cliErr := discoveryClientFor(rc)
+	if cliErr != nil {
+		return nil, false, cliErr
+	}
+
+	list, dErr := cli.ServerResourcesForGroupVersion(gv)
+	if dErr != nil {
+		return nil, false, dErr
+	}
+
+	raw, mErr := json.Marshal(list)
+	if mErr != nil {
+		return nil, false, mErr
+	}
+	return raw, true, nil
+}

--- a/internal/resolvers/restactions/api/discovery_dispatch_tls_test.go
+++ b/internal/resolvers/restactions/api/discovery_dispatch_tls_test.go
@@ -1,0 +1,337 @@
+// discovery_dispatch_tls_test.go — Fix A1 falsifiers.
+//
+// Reproduces the bare-group-discovery x509 defect and proves the Fix A1
+// discovery dispatch branch. The bug: a composition-resources RA issues
+// an api-step GET against a bare group-discovery URL /apis/<g>/<v> (no
+// resource segment); that 2-segment path parse-fails every CA-bearing
+// dispatch branch and falls through to the external fetch, which builds a
+// plumbing client from the per-user TOKEN-auth Endpoint. plumbing's
+// tlsConfigFor drops the cluster caData for a token-auth endpoint
+// (HasCertAuth()-only CA install) → x509: certificate signed by unknown
+// authority. TRACED:
+// docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md.
+//
+// Fix A1: a dispatch branch keyed on the discovery SHAPE
+// (cache.ParseAPIServerDiscoveryPath) ahead of the external fetch serves
+// group discovery via client-go's discovery client on a CA-bearing SA
+// *rest.Config — client-go's transport installs the cluster CA correctly.
+//
+// CRITICAL — like internal_dispatch_tls_test.go, these run against an
+// httptest TLS server with a synthetic CA; they structurally cannot
+// exercise the real cluster CA or a real apiserver discovery handshake.
+// Necessary but not sufficient: the on-cluster falsifier is a /call of the
+// triggering RA returning 200 with no x509 in pod logs.
+//
+// Falsifier set (per PM gate):
+//   F1 NEGATIVE — bare /apis/<g>/<v> GET via plumbing httpcall.Do over a
+//      token-auth endpoint carrying a non-system CA → StatusFailure with
+//      x509/certificate (reproduces today's bug, RED before the fix).
+//   F2 POSITIVE — same bare path via dispatchViaDiscovery over a CA-bearing
+//      SA rc → served=true, body = APIResourceList (kind + non-empty
+//      resources), NO x509.
+//   F3 behaviour-neutral — a non-apiserver / non-discovery path is NOT
+//      served by the discovery branch.
+//   F4 LEAK GUARD — a RESOURCE path (/apis/<g>/<v>/<resource> and
+//      /apis/<g>/<v>/<resource>/<name>) and /api/v1/<resource> are NEVER
+//      classified as discovery / routed to the discovery branch.
+//   F5 verb gate — a non-GET (POST) bare-discovery-shaped path is NOT
+//      served by the discovery branch.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/client-go/rest"
+)
+
+const fixtureDiscoveryGV = "templates.krateo.io/v1"
+const fixtureDiscoveryPath = "/apis/templates.krateo.io/v1"
+const fixtureDiscoveryResource1 = "compositiondefinitions"
+const fixtureDiscoveryResource2 = "collections"
+
+// newTLSDiscoveryServer starts an httptest TLS server that answers a bare
+// group-discovery GET (/apis/<g>/<v>) with a minimal APIResourceList
+// envelope carrying two resources. Its auto-generated certificate is
+// signed by a CA that is NOT in the system root store — the same trust
+// posture as a real cluster's self-signed apiserver CA. Returns the
+// server and its CA PEM bytes.
+//
+// The APIResourceList carries TWO real resources so the fix-path test can
+// assert a non-empty `resources` array (AC3 — body = APIResourceList with
+// resources), not merely a 200.
+func newTLSDiscoveryServer(t *testing.T) (*httptest.Server, []byte) {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"`+fixtureDiscoveryGV+`","resources":[`+
+			`{"name":"`+fixtureDiscoveryResource1+`","singularName":"compositiondefinition","namespaced":true,"kind":"CompositionDefinition","verbs":["get","list"]},`+
+			`{"name":"`+fixtureDiscoveryResource2+`","singularName":"collection","namespaced":true,"kind":"Collection","verbs":["get","list"]}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	caPEM := pemEncodeCert(srv.Certificate())
+	return srv, caPEM
+}
+
+// withDiscoverySARESTConfig swaps the package-private SA *rest.Config seam
+// to point at rc (an httptest TLS server with a synthetic CA), restoring
+// it on cleanup. It also resets the discovery-client memo so the test
+// builds a fresh client against the swapped rc.
+func withDiscoverySARESTConfig(t *testing.T, rc *rest.Config) {
+	t.Helper()
+	resetDiscoveryClientCacheForTest()
+	prev := saRESTConfigForDiscoveryFn
+	saRESTConfigForDiscoveryFn = func() (*rest.Config, error) { return rc, nil }
+	t.Cleanup(func() {
+		saRESTConfigForDiscoveryFn = prev
+		resetDiscoveryClientCacheForTest()
+	})
+}
+
+// TestPlumbingHttpcall_BareDiscoveryPath_DropsCA is F1, the NEGATIVE
+// CONTROL. It reproduces today's bug directly: a bare group-discovery GET
+// dispatched through plumbing's httpcall.Do over a token-auth Endpoint
+// carrying the cluster CA gets an HTTP client that does NOT trust that CA
+// — the TLS handshake fails with "certificate signed by unknown
+// authority". This is the path the bare-discovery api-step takes TODAY
+// (external fall-through). If a future plumbing bump fixes tlsConfigFor to
+// honour HasCA() for token-auth endpoints, this test FAILS — flagging that
+// the Fix A1 snowplow-side branch can be removed.
+func TestPlumbingHttpcall_BareDiscoveryPath_DropsCA(t *testing.T) {
+	srv, caPEM := newTLSDiscoveryServer(t)
+
+	// A token-auth endpoint carrying the cluster CA — the exact shape the
+	// per-user <user>-clientconfig endpoint produces (raw-PEM CA, bearer
+	// token, no client cert).
+	ep := &endpoints.Endpoint{
+		ServerURL:                srv.URL,
+		Token:                    "fake-user-jwt",
+		CertificateAuthorityData: string(caPEM),
+	}
+	if ep.HasCertAuth() {
+		t.Fatal("precondition: token-auth endpoint must NOT be cert-auth")
+	}
+	if !ep.HasCA() {
+		t.Fatal("precondition: endpoint must carry a CA")
+	}
+
+	res := httpcall.Do(context.Background(), httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: fixtureDiscoveryPath},
+		Endpoint:    ep,
+	})
+
+	if res.Status != response.StatusFailure {
+		t.Fatalf("NEGATIVE CONTROL BROKEN: expected plumbing httpcall.Do to fail "+
+			"TLS verification for a token-auth endpoint on the bare-discovery "+
+			"path (today's bug), got status=%v message=%q. If plumbing fixed "+
+			"tlsConfigFor to honour HasCA() for token-auth endpoints, the Fix A1 "+
+			"snowplow-side discovery branch can be removed.", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "x509") &&
+		!strings.Contains(res.Message, "certificate") {
+		t.Fatalf("NEGATIVE CONTROL: expected a TLS/x509 verification error, got %q", res.Message)
+	}
+	t.Logf("negative control confirmed — plumbing httpcall.Do drops the CA for a "+
+		"token-auth endpoint on the bare-discovery path: %s", res.Message)
+}
+
+// TestDiscoveryDispatch_TrustsClusterCA is F2, the POSITIVE proof. The same
+// bare group-discovery path dispatched via dispatchViaDiscovery over a
+// CA-bearing SA *rest.Config SUCCEEDS — client-go's transport installs the
+// CA into RootCAs correctly — and the served body is the APIResourceList
+// with a non-empty resources array (AC3), no x509.
+func TestDiscoveryDispatch_TrustsClusterCA(t *testing.T) {
+	srv, caPEM := newTLSDiscoveryServer(t)
+	rc := &rest.Config{
+		Host:        srv.URL,
+		BearerToken: "fake-sa-jwt",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: caPEM,
+		},
+	}
+	withDiscoverySARESTConfig(t, rc)
+
+	raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: fixtureDiscoveryPath},
+	})
+	if err != nil {
+		t.Fatalf("FIX BROKEN: discovery dispatch via CA-bearing SA *rest.Config "+
+			"failed the TLS handshake against a CA it carries verbatim: %v", err)
+	}
+	if !served {
+		t.Fatal("FIX BROKEN: expected the bare group-discovery GET to be served " +
+			"via the discovery dispatch branch")
+	}
+
+	var envelope struct {
+		Kind         string `json:"kind"`
+		GroupVersion string `json:"groupVersion"`
+		Resources    []struct {
+			Name string `json:"name"`
+			Kind string `json:"kind"`
+		} `json:"resources"`
+	}
+	if uErr := json.Unmarshal(raw, &envelope); uErr != nil {
+		t.Fatalf("FIX BROKEN: served bytes are not valid JSON: %v", uErr)
+	}
+	if envelope.Kind != "APIResourceList" {
+		t.Fatalf("AC3: served body kind must be APIResourceList, got %q. body: %q",
+			envelope.Kind, string(raw))
+	}
+	if len(envelope.Resources) == 0 {
+		t.Fatalf("AC3: served APIResourceList must carry a non-empty resources "+
+			"array, got 0. body: %q", string(raw))
+	}
+	got := map[string]bool{}
+	for _, r := range envelope.Resources {
+		got[r.Name] = true
+	}
+	if !got[fixtureDiscoveryResource1] || !got[fixtureDiscoveryResource2] {
+		t.Fatalf("AC3: served resources missing an entry — want %q + %q, got %v",
+			fixtureDiscoveryResource1, fixtureDiscoveryResource2, got)
+	}
+	t.Logf("fix confirmed — client-go discovery client from rest.Config{CAData} "+
+		"trusts the cluster CA AND the served body is an APIResourceList with %d "+
+		"resources: %d bytes served", len(envelope.Resources), len(raw))
+}
+
+// TestDiscoveryDispatch_CoreGroupShape is the /api/<v> companion to F2 —
+// the core-group discovery shape is also served by the branch.
+func TestDiscoveryDispatch_CoreGroupShape(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// client-go's discovery client GETs LegacyPrefix("/api")+"/v1" for
+		// the core group.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[`+
+			`{"name":"namespaces","singularName":"namespace","namespaced":false,"kind":"Namespace","verbs":["get","list"]}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	caPEM := pemEncodeCert(srv.Certificate())
+	rc := &rest.Config{Host: srv.URL, BearerToken: "fake-sa-jwt", TLSClientConfig: rest.TLSClientConfig{CAData: caPEM}}
+	withDiscoverySARESTConfig(t, rc)
+
+	raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: "/api/v1"},
+	})
+	if err != nil {
+		t.Fatalf("core-group discovery dispatch failed: %v", err)
+	}
+	if !served {
+		t.Fatal("expected /api/v1 core-group discovery to be served by the branch")
+	}
+	if !strings.Contains(string(raw), "APIResourceList") {
+		t.Fatalf("served body is not an APIResourceList: %q", string(raw))
+	}
+}
+
+// TestDiscoveryDispatch_NonAPIServerPathFallsThrough is F3, behaviour-
+// neutral: a non-discovery (external / non-apiserver) path is NOT served
+// by the discovery branch.
+func TestDiscoveryDispatch_NonAPIServerPathFallsThrough(t *testing.T) {
+	// Seam swap guards against accidental SA-rc use — if the shape gate
+	// leaked, the dispatch would try to build a client and we'd notice.
+	withDiscoverySARESTConfig(t, &rest.Config{Host: "https://kubernetes.default.svc"})
+
+	raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: "https://example.com/external"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error for a non-apiserver path, got %v", err)
+	}
+	if served {
+		t.Fatal("F3: a non-apiserver path must NOT be served by the discovery branch")
+	}
+	if raw != nil {
+		t.Fatalf("expected nil bytes on fall-through, got %d bytes", len(raw))
+	}
+}
+
+// TestDiscoveryDispatch_ResourcePathNotRouted is F4, the LOAD-BEARING LEAK
+// GUARD. A RESOURCE path (≥3 segments after /apis/, or /api/v1/<resource>),
+// namespaced or cluster-scoped, GET-by-name or LIST, must NEVER be
+// classified as discovery / routed to the SA-serving discovery branch —
+// SA-serving a resource path would be a cross-user leak. This is what
+// code-enforces the §1 RBAC boundary.
+func TestDiscoveryDispatch_ResourcePathNotRouted(t *testing.T) {
+	// If the gate leaked, the dispatch would try to build a client against
+	// THIS rc; swapping it lets us assert served=false purely on the shape.
+	withDiscoverySARESTConfig(t, &rest.Config{Host: "https://kubernetes.default.svc"})
+
+	resourcePaths := []string{
+		"/apis/templates.krateo.io/v1/compositiondefinitions",                              // group LIST
+		"/apis/templates.krateo.io/v1/compositiondefinitions/foo",                          // group GET-by-name
+		"/apis/templates.krateo.io/v1/namespaces/krateo-system/compositiondefinitions",     // namespaced LIST
+		"/apis/templates.krateo.io/v1/namespaces/krateo-system/compositiondefinitions/foo", // namespaced GET-by-name
+		"/api/v1/namespaces",        // core LIST
+		"/api/v1/namespaces/krateo", // core GET-by-name
+		"/api/v1/pods",              // core cluster LIST
+		"/apis",                     // multi-group discovery index (not a single GV)
+		"/api",                      // core root (not a single GV)
+		"/apis/templates.krateo.io", // group version list (not a single GV)
+	}
+	for _, p := range resourcePaths {
+		// Predicate-level: ParseAPIServerDiscoveryPath must return false.
+		if gv, ok := cache.ParseAPIServerDiscoveryPath(p); ok {
+			t.Fatalf("F4 LEAK GUARD: ParseAPIServerDiscoveryPath(%q) returned ok=true "+
+				"(gv=%q) — a resource/non-single-GV path must NEVER be classified as "+
+				"discovery, else the SA-serve branch would leak it cross-user", p, gv)
+		}
+		// Dispatch-level: the branch must not serve it.
+		raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+			RequestInfo: httpcall.RequestInfo{Path: p},
+		})
+		if err != nil {
+			t.Fatalf("F4: unexpected error for resource path %q: %v", p, err)
+		}
+		if served {
+			t.Fatalf("F4 LEAK GUARD: resource/non-single-GV path %q was SERVED by the "+
+				"discovery branch — cross-user leak", p)
+		}
+		if raw != nil {
+			t.Fatalf("F4: expected nil bytes for non-routed path %q, got %d bytes", p, len(raw))
+		}
+	}
+
+	// And the discovery shapes themselves MUST be classified true (positive
+	// side of the boundary), so the guard isn't trivially passing.
+	for _, p := range []string{fixtureDiscoveryPath, "/api/v1", "/apis/apps/v1"} {
+		if _, ok := cache.ParseAPIServerDiscoveryPath(p); !ok {
+			t.Fatalf("F4 boundary: ParseAPIServerDiscoveryPath(%q) must classify the "+
+				"bare-discovery shape as ok=true", p)
+		}
+	}
+}
+
+// TestDiscoveryDispatch_NonGETNotServed is F5, the verb gate: a non-GET
+// (POST) bare-discovery-shaped path is NOT served by the discovery branch.
+func TestDiscoveryDispatch_NonGETNotServed(t *testing.T) {
+	withDiscoverySARESTConfig(t, &rest.Config{Host: "https://kubernetes.default.svc"})
+
+	raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{
+			Path: fixtureDiscoveryPath,
+			Verb: ptr.To(http.MethodPost),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error on the non-GET fall-through, got %v", err)
+	}
+	if served {
+		t.Fatal("F5: a non-GET bare-discovery-shaped path must NOT be served by the " +
+			"discovery branch")
+	}
+	if raw != nil {
+		t.Fatalf("expected nil bytes on the non-GET fall-through, got %d bytes", len(raw))
+	}
+}

--- a/internal/resolvers/restactions/api/mapdepth_gate_test.go
+++ b/internal/resolvers/restactions/api/mapdepth_gate_test.go
@@ -223,10 +223,11 @@ func TestDepthForLog_AC3_CommonPathTakesNoLock(t *testing.T) {
 
 // TestDepthForLog_AC6_AllFiveSitesGated — AC-6.
 //
-// Exactly 5 mapDepth call sites existed in resolve.go; all 5 are now
-// routed through depthForLog. This test greps resolve.go's source and
-// asserts: zero ungated `mapDepth(` CALL sites remain, and there are
-// exactly 5 depthForLog(r.ctx, ...) call sites.
+// All mapDepth call sites in resolve.go are routed through depthForLog.
+// This test greps resolve.go's source and asserts: zero ungated
+// `mapDepth(` CALL sites remain, and there are exactly 6 depthForLog(r.ctx,
+// ...) call sites (5 pre-Fix-A1 dispatch branches + the Fix A1 discovery
+// branch).
 //
 // Task #330 Commit 4: the 5 sites moved into (*resolveRun).dispatchOneCall,
 // where the OUTER context is r.ctx (the resolve-invariant field), so the
@@ -252,7 +253,7 @@ func TestDepthForLog_AC6_AllFiveSitesGated(t *testing.T) {
 			"every site must route through depthForLog", len(mapDepthCall))
 	}
 
-	// Exactly 5 depthForLog(r.ctx, ...) call sites — the outer-ctx form
+	// Exactly 6 depthForLog(r.ctx, ...) call sites — the outer-ctx form
 	// after the #330 dispatchOneCall extraction (the worker receives the
 	// resolve-invariant outer ctx as r.ctx; depthForLog must NOT get gctx).
 	//
@@ -260,14 +261,18 @@ func TestDepthForLog_AC6_AllFiveSitesGated(t *testing.T) {
 	// branch (one depthForLog site) was RETIRED (5→4), then the cache-off
 	// in-process resolve substitution added ONE site in the external branch
 	// (4→5, Diego Option (ii) — resolve:true is a transparent fallback that
-	// resolves cache-off too). The 5 gated sites are: apistage-content,
-	// informer, internal-rest-config, the cache-off in-process resolve, and
-	// the external fall-through. The cache-on in-process substitution rides
-	// the apistage/informer/internal-rest-config branches' existing success
-	// lines (no new site); only the cache-off external-branch substitution
-	// adds its own.
+	// resolves cache-off too).
+	//
+	// Fix A1 (2026-06-23, the bare-group-discovery x509 fix) added the
+	// discovery dispatch branch ahead of the external fall-through (5→6).
+	// The 6 gated sites are: apistage-content, informer, internal-rest-config,
+	// the discovery branch, the cache-off in-process resolve, and the external
+	// fall-through. The cache-on in-process substitution rides the
+	// apistage/informer/internal-rest-config branches' existing success lines
+	// (no new site); the discovery and cache-off external-branch substitutions
+	// each add their own.
 	calls := regexp.MustCompile(`depthForLog\(r\.ctx,`).FindAllString(codeOnly, -1)
-	if len(calls) != 5 {
-		t.Fatalf("AC-6 FAIL: found %d depthForLog(r.ctx, ...) call sites in resolve.go, want exactly 5", len(calls))
+	if len(calls) != 6 {
+		t.Fatalf("AC-6 FAIL: found %d depthForLog(r.ctx, ...) call sites in resolve.go, want exactly 6", len(calls))
 	}
 }

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -879,6 +879,76 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 		return nil
 	}
 
+	// Fix A1 — BARE group-discovery dispatch branch (CA-bearing SA
+	// transport). A composition-resources RA issues an api-step GET against
+	// a bare group-discovery URL /apis/<g>/<v> (no resource segment, no
+	// endpointRef) to enumerate a managed apiVersion's served resources.
+	// That 2-segment path parse-fails ParseAPIServerPathToDep, so it fell
+	// through every CA-bearing branch above to the external fetch, which
+	// builds a plumbing client from the per-user <user>-clientconfig TOKEN-
+	// auth Endpoint — plumbing's tlsConfigFor drops the cluster caData for a
+	// token-auth endpoint (HasCertAuth()-only CA install) → x509: certificate
+	// signed by unknown authority. TRACED:
+	// docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md. Same
+	// plumbing TLS defect internal_dispatch.go documents for the Phase-1 SA
+	// path (0.30.104).
+	//
+	// dispatchViaDiscovery serves the discovery SHAPE only (a resource path
+	// is NEVER routed here — ParseAPIServerDiscoveryPath returns false for
+	// ≥3-segment paths — so it keeps its per-user-token branch byte-
+	// unchanged; the SA-serve exemption is sound because group discovery is
+	// anonymous-readable and carries NO tenant data). The branch fires
+	// regardless of CACHE_ENABLED (the SA rc is the process-wide
+	// dynamic.ServiceAccountRESTConfig() singleton, present cache-on AND
+	// cache-off — AC5 transparent fallback) and BEFORE the external fetch,
+	// so the bare-discovery GET never reaches the broken plumbing TLS path.
+	//
+	// The served body is the marshalled *metav1.APIResourceList. It is fed
+	// through the SAME dictMu-protected handler chain (feedBytes) the other
+	// dispatch branches use — it is NOT a resolve:true RA/widget single-CR
+	// GET, so we do NOT run maybeResolveInProcess on it. A non-nil err is
+	// the REAL discovery error; like the internal-rest-config branch we do
+	// NOT fall through to the external fetch (that would re-hit the broken
+	// plumbing TLS path and mask the error behind a second x509 failure) —
+	// we surface it via recordItemError exactly as an httpcall.Do
+	// StatusFailure (ContinueOnError / ErrorKey honoured).
+	if raw, served, derr := dispatchViaDiscovery(gctx, call); served || derr != nil {
+		dispatch := "discovery"
+		if derr != nil {
+			r.log.Error("api call response failure", slog.String("name", id),
+				slog.String("host", call.Endpoint.ServerURL),
+				slog.String("path", call.Path),
+				slog.String("dispatch", "discovery"),
+				slog.String("error", derr.Error()))
+			var itemErr error
+			if !call.ContinueOnError {
+				itemErr = fmt.Errorf("api %s item %d failed: %w", id, i, derr)
+			}
+			r.recordItemError(dictMu, itemErrs, id, i, call.ErrorKey, derr.Error(), derr.Error(), itemErr)
+			dispatch = "discovery-error"
+		} else if ferr := feedBytes(raw); ferr != nil {
+			r.log.Error("discovery response handler failed",
+				slog.String("name", id),
+				slog.String("path", call.Path),
+				slog.String("dispatch", dispatch),
+				slog.String("error", ferr.Error()))
+			var itemErr error
+			if !call.ContinueOnError {
+				itemErr = fmt.Errorf("api %s item %d failed: %w", id, i, ferr)
+			}
+			r.recordItemError(dictMu, itemErrs, id, i, call.ErrorKey, ferr.Error(), ferr.Error(), itemErr)
+		}
+		depth := depthForLog(r.ctx, r.log, dictMu, dict)
+		r.log.Info("api successfully resolved",
+			slog.String("name", id),
+			slog.String("host", call.Endpoint.ServerURL),
+			slog.String("path", call.Path),
+			slog.Int("depth", depth),
+			slog.String("dispatch", dispatch),
+		)
+		return nil
+	}
+
 	// EXTERNAL branch (feat/restaction-yaml-response): the snowplow-owned
 	// fetch replaces plumbing's httpcall.Do. It transcribes request.Do
 	// MINUS the 406 JSON content-type gate, so a 2xx YAML body (e.g. a


### PR DESCRIPTION
## The defect (TRACED)

A RESTAction `spec.api[]` GET against a **bare group-discovery URL** `/apis/<group>/<version>` (no resource segment, no `endpointRef` — e.g. `/apis/templates.krateo.io/v1`, the `test-composition-resources-19` step-2 `discovery` iterator) failed:

```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The 2-segment path parse-fails `cache.ParseAPIServerPathToDep`, declining every CA-bearing dispatch branch → external fall-through builds a plumbing client from the per-user `<user>-clientconfig` **token-auth** Endpoint → plumbing's `tlsConfigFor` installs the cluster `caData` only inside the `HasCertAuth()` branch, so the CA is dropped and the apiserver cert is verified against the system root store. Same plumbing TLS defect `internal_dispatch.go` documents for the Phase-1 SA path (0.30.104) — here it bites a per-user request. Full trace: `docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md`.

## Fix A1

A dispatch branch keyed on the discovery **shape** (`cache.ParseAPIServerDiscoveryPath` — `/apis/<g>/<v>` or `/api/<v>`, no resource segment) inserted ahead of the external fall-through. Serves group discovery via client-go's discovery client (`ServerResourcesForGroupVersion`) on a **CA-bearing SA transport** sourced from `dynamic.ServiceAccountRESTConfig()` (the process-wide in-cluster SA `*rest.Config` singleton, present regardless of `CACHE_ENABLED` → cache-off transparent fallback). client-go installs the cluster CA correctly. Served body = the marshalled `APIResourceList`.

**RBAC boundary:** the SA-serve exemption is for the discovery **shape only**. Group discovery is anonymous-readable and carries no tenant data. A **resource path is never routed here** (`ParseAPIServerDiscoveryPath` returns false for ≥3-segment paths), so it keeps its existing per-user-token branch byte-unchanged — SA-serving a resource path would be a cross-user leak, and the segment-count shape predicate is what structurally prevents it.

## Acceptance criteria

- **AC1** branch fires only for the bare-discovery shape (GET + `/apis/<g>/<v>` no-resource OR `/api/<v>`).
- **AC2 (leak guard)** a resource path is never routed to the discovery branch — keeps its existing branch byte-unchanged.
- **AC3** served over the CA-bearing SA transport; body = `APIResourceList`.
- **AC4** all other paths' dispatch byte-identical.
- **AC5** cache-off: the branch still applies (transparent fallback via the process-wide SA singleton, not the context rc).
- **AC6** no special-cases — shape-keyed, never literal group/version/path.

## Falsifiers (httptest / in-process; mirror `internal_dispatch_tls_test.go`)

- **F1 negative** `TestPlumbingHttpcall_BareDiscoveryPath_DropsCA` — reproduces the live x509 via plumbing `httpcall.Do`.
- **F2 positive** `TestDiscoveryDispatch_TrustsClusterCA` — fix serves an `APIResourceList` (kind + non-empty resources) over a CA-bearing transport, no x509. + `_CoreGroupShape` (`/api/v1`).
- **F3** `_NonAPIServerPathFallsThrough` — external path not served.
- **F4 (leak guard)** `_ResourcePathNotRouted` — 10 resource/root/version-list paths predicate-false AND dispatch served=false; 3 discovery shapes predicate-true (non-vacuous).
- **F5** `_NonGETNotServed` — POST bare-discovery shape not served.
- `TestParseAPIServerDiscoveryPath` — 25-case predicate table.

RED-first proven: F1 confirms the bug is live; stubbing the predicate to decline flips F2 RED, restore → GREEN. `go build` + `go vet` clean; `internal/cache` + `internal/resolvers/restactions/api` packages `-race -count=1` clean; existing TLS suite + AC-6 gate (5→6) pass. No CRD/chart/env change.

**On-cluster falsifier owed at deploy:** a `/call` of the triggering RA returning 200 with no x509 in pod logs — the synthetic-CA httptest tests are necessary but not sufficient (per the file headers).

## Reviews

Dual review cleared pre-commit: **architect** (branch placement, structural no-shadowing proof, SA-transport/layering/concurrency, predicate RBAC boundary — all TRACED) and **PM** (every AC + F1–F5 incl. the F4 leak guard, independent RED-first re-run). Out of scope: B (RA-author portal-chart discovery-probe smell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1