### PR TITLE
feat(prewarm): proactive composition-page L1 seed — RBAC-reachable RA enumeration (Option A)

### DIFF
--- a/internal/cache/proactive_ra_seed.go
+++ b/internal/cache/proactive_ra_seed.go
@@ -1,0 +1,116 @@
+// proactive_ra_seed.go — the RBAC-reachable RESTAction enumeration
+// source for the prewarm-engine boot seed (Option A).
+//
+// PROBLEM. The boot seed source (prewarm_engine_boot.go:258) drains the
+// nav-walk content harvester (contentPrewarmHarvester). The harvester
+// only records the spec.apiRef RESTActions of widgets the walk actually
+// REACHES — the nav-tree roots and their resolvable children. The
+// per-composition click-through detail widgets (and their
+// `composition-resources`-style RESTActions) are NEVER walked at boot:
+// the frontend reaches them only on a user navigation into a composition
+// detail page. So those RESTActions are never seeded — every first
+// composition-detail /call is a cold resolve.
+//
+// SOURCE (Option A — ALL RBAC-reachable RESTActions). The seed-targeting
+// source is purely RBAC-derived, with NO resource/name/path literal
+// (feedback_no_special_cases): the set of RESTActions some published RBAC
+// binding grants `get` on, intersected with the RESTAction CRs that
+// actually exist in the cluster (read from the BOOT-anchored RESTActions
+// informer — restActionGVR is a MetaQuerySeeds boot anchor, phase1.go,
+// so NO new informer is registered).
+//
+// WHY THE INTERSECTION IS CLEAN. RBAC on `restactions` is resource-level
+// (group/resource), never per-object-name — rulesGrantGetList
+// (bindings_by_gvr.go) skips resourceNames-scoped rules entirely. So the
+// reachable set is binary: if ANY binding grants get on restactions, the
+// whole existing RESTAction CR set is reachable by that binding's
+// subjects; if NO binding does, the set is empty. The PER-RA → per-binding
+// scoping for the actual seed is NOT done here — it is done downstream by
+// the existing seed loop (seedScopeYielding → restActionTargetGVR →
+// EnumeratePrewarmTargetsForGVR on each RA's TARGET GVR). This function
+// only widens WHICH RESTAction refs the seed loop iterates; it does not
+// change the per-binding cell-key scoping (which stays per the RA's own
+// userAccessFilter target GVR).
+//
+// Option B (filter to a compositions GVR) was REJECTED at the gate as a
+// special-case smell. This source is the full RBAC-reachable RESTAction
+// set — no GVR/resource filter.
+
+package cache
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// RestActionRef is a namespace/name pointer to a RESTAction CR. The
+// caller (the dispatcher prewarm-engine seed) builds the
+// templatesv1.ObjectReference from it (the GVR is fixed — restActionGVR —
+// so only ns/name need cross the package boundary). Kept package-local in
+// SHAPE (no apis/templates import in the cache package).
+type RestActionRef struct {
+	Namespace string
+	Name      string
+}
+
+// RBACReachableRestActionRefs returns the namespace/name refs of every
+// RESTAction CR that is RBAC-reachable for a `get` — i.e. the intersection
+// of (a) "some published binding grants get on restactions" and (b) the
+// RESTAction CRs resident in the boot-anchored RESTActions informer.
+//
+// EMPTY RETURN (nil) when:
+//   - rw is nil / passthrough, OR
+//   - the BindingsByGVR index reports NO binding granting get on
+//     restactions (EnumeratePrewarmTargetsForGVR empty) — nothing is
+//     RBAC-reachable, so the seed is a no-op and serving is transparent
+//     (F-6), OR
+//   - the RESTActions informer holds no items.
+//
+// This is SEED-TARGETING only (per the bindings_by_gvr.go AUTHZ-BOUNDARY
+// note): over-inclusion = wasted seed (benign); the per-request authz
+// boundary is unchanged (EvaluateRBAC at /call time). The refs are read
+// via meta.Accessor (ns/name only) — the full RESTAction JSON is NOT
+// decoded here.
+func RBACReachableRestActionRefs(rw *ResourceWatcher) []RestActionRef {
+	if rw == nil || rw.mode == modePassthrough {
+		return nil
+	}
+
+	// (a) RBAC gate — is `get restactions` granted by ANY published
+	// binding? Reuse the per-binding enumerator (the same one the seed
+	// loop uses for per-RA target scoping). We only need the YES/NO here;
+	// the per-binding scoping happens downstream per the RA's TARGET GVR.
+	if len(EnumeratePrewarmTargetsForGVR(restActionGVR, "get")) == 0 {
+		return nil
+	}
+
+	// (b) the RESTAction CRs resident in the boot-anchored informer.
+	// indexerList reads the registered informer's indexer directly — no
+	// new informer, no full-object decode (meta.Accessor reads the
+	// embedded ObjectMeta of each store value: *bytesObject or
+	// *unstructured.Unstructured).
+	items := indexerList(rw, restActionGVR)
+	if len(items) == 0 {
+		return nil
+	}
+
+	out := make([]RestActionRef, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, it := range items {
+		acc, err := meta.Accessor(it)
+		if err != nil {
+			continue
+		}
+		ns := acc.GetNamespace()
+		name := acc.GetName()
+		if name == "" {
+			continue
+		}
+		key := ns + "/" + name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, RestActionRef{Namespace: ns, Name: name})
+	}
+	return out
+}

--- a/internal/cache/proactive_ra_seed_test.go
+++ b/internal/cache/proactive_ra_seed_test.go
@@ -1,0 +1,160 @@
+// proactive_ra_seed_test.go — falsifiers for the cache-side RBAC-reachable
+// RESTAction enumeration source (Option A). Package cache so it can reach
+// the unexported index build + informer-seed helpers + the
+// PublishRBACSnapshotForTest seam. NON-DESTRUCTIVE — synthetic in-process
+// snapshots + a fake dynamic client; never touches the rbac package's
+// destructive TestMain. Safe under `go test ./internal/cache/...`.
+
+package cache
+
+import (
+	"sort"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// seedRestActionItem adds an unstructured RESTAction CR (ns/name only —
+// the enumerator reads ns/name via meta.Accessor) to the boot-anchored
+// RESTActions informer indexer.
+func seedRestActionItem(t *testing.T, rw *ResourceWatcher, ns, name string) {
+	t.Helper()
+	rw.mu.RLock()
+	gi, ok := rw.informers[restActionGVR]
+	rw.mu.RUnlock()
+	if !ok {
+		t.Fatalf("precondition: restActionGVR informer not registered")
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": restActionGVR.Group + "/" + restActionGVR.Version,
+		"kind":       "RESTAction",
+		"metadata":   map[string]any{"namespace": ns, "name": name},
+	}}
+	if err := gi.Informer().GetIndexer().Add(u); err != nil {
+		t.Fatalf("seed RESTAction %s/%s: %v", ns, name, err)
+	}
+}
+
+func refKeys(refs []RestActionRef) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Namespace+"/"+r.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestProactiveRASeed_F_intersection — the airtight cache-side falsifier.
+// When SOME published binding grants get on restactions, the enumerator
+// returns ALL RESTAction CRs resident in the boot informer (Option A:
+// resource-level RBAC → the whole RA set is reachable by that binding's
+// subjects). De-dup is by {ns,name}.
+func TestProactiveRASeed_F_intersection(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	ResetBindingsByGVRIndexForTest()
+
+	// A binding granting get/list on restactions (templates.krateo.io).
+	crb, cr := crbRuleUID("ra-reader", "uid-ra-reader",
+		rbacv1.Subject{Kind: "User", Name: "alice"},
+		getListRules(restActionGVR.Group, restActionGVR.Resource))
+	snap := buildSnap([]*rbacv1.ClusterRoleBinding{crb}, []*rbacv1.ClusterRole{cr})
+	PublishRBACSnapshotForTest(snap)
+
+	// Index must be built over a navigated set INCLUDING restActionGVR so
+	// the get-restactions binding is enrolled.
+	if n := BuildBindingsByGVRIndex([]schema.GroupVersionResource{restActionGVR}); n != 1 {
+		t.Fatalf("expected 1 binding enrolled, got %d", n)
+	}
+	// Precondition: the gate the enumerator reads is non-empty.
+	if got := EnumeratePrewarmTargetsForGVR(restActionGVR, "get"); len(got) != 1 {
+		t.Fatalf("precondition: expected 1 get-restactions target, got %d", len(got))
+	}
+
+	rw := newSyntheticRemoveWatcher(t, restActionGVR)
+	t.Cleanup(func() { rw.Stop() })
+	rw.EnsureResourceType(restActionGVR)
+
+	// Seed three composition-detail-style RESTActions (the per-composition
+	// RAs the nav walk never reaches). One duplicate add to prove dedup.
+	seedRestActionItem(t, rw, "comp-a", "composition-resources")
+	seedRestActionItem(t, rw, "comp-b", "composition-resources")
+	seedRestActionItem(t, rw, "krateo-system", "sidebar-nav-menu")
+	seedRestActionItem(t, rw, "comp-a", "composition-resources") // dup
+
+	got := refKeys(RBACReachableRestActionRefs(rw))
+	want := []string{"comp-a/composition-resources", "comp-b/composition-resources", "krateo-system/sidebar-nav-menu"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d reachable refs, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ref[%d]: want %q got %q (full: %v)", i, want[i], got[i], got)
+		}
+	}
+}
+
+// TestProactiveRASeed_F6_transparent_no_binding — F-6 cache layer. When NO
+// binding grants get on restactions, the enumerator returns nil EVEN IF
+// RA CRs exist (the RBAC gate fails closed → nothing reachable → the seed
+// source is unchanged → serving is transparent). This is the RBAC-leak
+// guard: we never seed under identities that cannot authorise the GVR.
+func TestProactiveRASeed_F6_transparent_no_binding(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	ResetBindingsByGVRIndexForTest()
+
+	// A binding granting ONLY compositions — NOT restactions.
+	crb, cr := crbRuleUID("comp-reader", "uid-comp-reader",
+		rbacv1.Subject{Kind: "Group", Name: "devs"},
+		getListRules("composition.krateo.io", "compositions"))
+	snap := buildSnap([]*rbacv1.ClusterRoleBinding{crb}, []*rbacv1.ClusterRole{cr})
+	PublishRBACSnapshotForTest(snap)
+	BuildBindingsByGVRIndex([]schema.GroupVersionResource{restActionGVR, gr("composition.krateo.io", "compositions")})
+
+	if got := EnumeratePrewarmTargetsForGVR(restActionGVR, "get"); len(got) != 0 {
+		t.Fatalf("precondition: expected 0 get-restactions targets, got %d", len(got))
+	}
+
+	rw := newSyntheticRemoveWatcher(t, restActionGVR)
+	t.Cleanup(func() { rw.Stop() })
+	rw.EnsureResourceType(restActionGVR)
+	seedRestActionItem(t, rw, "comp-a", "composition-resources")
+
+	if got := RBACReachableRestActionRefs(rw); got != nil {
+		t.Fatalf("F-6 FAIL: expected nil (no binding grants get-restactions), got %v", refKeys(got))
+	}
+}
+
+// TestProactiveRASeed_F6_transparent_empty_informer — F-6 cache layer.
+// Even with a get-restactions binding, an EMPTY RESTActions informer
+// yields nil (nothing to seed) — the seed source is unchanged.
+func TestProactiveRASeed_F6_transparent_empty_informer(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	ResetBindingsByGVRIndexForTest()
+
+	crb, cr := crbRuleUID("ra-reader", "uid-ra-reader",
+		rbacv1.Subject{Kind: "User", Name: "alice"},
+		getListRules(restActionGVR.Group, restActionGVR.Resource))
+	snap := buildSnap([]*rbacv1.ClusterRoleBinding{crb}, []*rbacv1.ClusterRole{cr})
+	PublishRBACSnapshotForTest(snap)
+	BuildBindingsByGVRIndex([]schema.GroupVersionResource{restActionGVR})
+
+	rw := newSyntheticRemoveWatcher(t, restActionGVR)
+	t.Cleanup(func() { rw.Stop() })
+	rw.EnsureResourceType(restActionGVR)
+	// No items seeded.
+
+	if got := RBACReachableRestActionRefs(rw); got != nil {
+		t.Fatalf("expected nil (empty informer), got %v", refKeys(got))
+	}
+}
+
+// TestProactiveRASeed_F6_nil_passthrough — F-6 cache layer. A nil watcher
+// is a no-op (defensive — the dispatcher always passes a live rw, but the
+// helper must be safe).
+func TestProactiveRASeed_F6_nil_passthrough(t *testing.T) {
+	if got := RBACReachableRestActionRefs(nil); got != nil {
+		t.Fatalf("expected nil for nil watcher, got %v", refKeys(got))
+	}
+}

--- a/internal/handlers/dispatchers/prewarm_engine.go
+++ b/internal/handlers/dispatchers/prewarm_engine.go
@@ -82,6 +82,27 @@ func PrewarmEngineEnabled() bool {
 	return env.String(envPrewarmEngineEnabled, "false") == "true"
 }
 
+// envProactiveRASeedEnabled is the opt-in for the proactive
+// composition-page RESTAction seed source (Option A). When ON, the engine
+// boot seed UNIONS the RBAC-reachable RESTAction refs
+// (cache.RBACReachableRestActionRefs) into the nav-walk harvester snapshot
+// so the per-composition click-through detail RESTActions (never reached
+// by the nav walk) get warmed at boot. Default false: flag-off the seed
+// source is byte-identical to the harvester-only snapshot (F-6 — the
+// served content is unchanged; this flag only widens WHICH refs the seed
+// loop iterates, never the per-request authz boundary).
+//
+// It rides the engine gate: it is a no-op unless PrewarmEnabled()
+// (implicit-on-cache, #57) AND the engine boot seed runs
+// (PrewarmEngineEnabled()). The legacy runPIPSeed path does NOT consult it.
+const envProactiveRASeedEnabled = "PROACTIVE_RA_SEED_ENABLED"
+
+// ProactiveRASeedEnabled reports whether the proactive RESTAction seed
+// source is opted in. Defaults false (opt-in).
+func ProactiveRASeedEnabled() bool {
+	return env.String(envProactiveRASeedEnabled, "false") == "true"
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Customer-priority signal. Every customer /call dispatch brackets its
 // work with these. The engine yields while the counter is > 0.

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -187,6 +187,40 @@ func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps) error {
 		return nil
 	}
 
+	// LATENT HAZARD (gate build-obligation #1). This engine boot seed runs
+	// the SERIAL single-worker loop (seedScopeYielding — a plain for-loop
+	// with one restactions.Resolve in flight at a time, yielding to
+	// customers via engineYieldCheckpoint). That serial shape is what
+	// memory-bounds the seed: warm-peak is bounded by a SINGLE resolve's
+	// weight, NOT a concurrent fan-out, so it CANNOT reproduce the
+	// concurrent-fan-out OOM that (a)/#46 fixed.
+	//
+	// BUT: the DEAD errgroup seed path (runPIPSeed, phase1_pip_seed.go —
+	// GOMAXPROCS-bounded g.SetLimit(runtime.GOMAXPROCS(0)) concurrent
+	// cohort fan-out) RE-ACTIVATES if PREWARM_ENGINE_ENABLED=false
+	// (phase1_walk.go:409 picks runPIPSeed when the engine is off). That
+	// concurrent seed BYPASSES the (a) process-wide weighted memory budget
+	// (which is on the CUSTOMER resolve entry, not the legacy seed loop) →
+	// it can re-OOM on the seed. The proactive RA union here WIDENS the
+	// seed source, so a fallback to the concurrent path would fan out over
+	// MORE refs.
+	//
+	// GUARD: production MUST keep PREWARM_ENGINE_ENABLED=true (the helm
+	// overlay sets it true — main-chart-reconciliation). F-3 asserts the
+	// production-on posture. Deleting the dead errgroup path is a separate
+	// BACKLOG item (NOT this ship).
+	if !PrewarmEngineEnabled() {
+		// Defensive: rePrewarmBoot is only reached when the engine path is
+		// selected (phase1_walk.go:482), so this branch should be
+		// unreachable in production. Emit loudly if it ever fires.
+		log.Warn("prewarm.engine.boot.hazard_engine_disabled_but_boot_reached",
+			slog.String("subsystem", "cache"),
+			slog.String("effect", "rePrewarmBoot reached with PREWARM_ENGINE_ENABLED=false — the concurrent "+
+				"runPIPSeed errgroup path (which BYPASSES the (a) memory budget) may also be active; "+
+				"this is the documented latent re-OOM hazard — keep the engine enabled"),
+		)
+	}
+
 	// ── (1) RE-WALK the nav roots AFTER the sync barrier. A FRESH walker
 	// per root (new visited map — reusing the boot pass's visited would
 	// short-circuit every child and descend nothing). The SAME walk() so
@@ -257,6 +291,19 @@ func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps) error {
 	// ── (4) SEED per cohort with PER-TARGET-GVR scoping.
 	restactionRefs := deps.harvester.snapshot()
 	widgetEntries := deps.navHarv.snapshot()
+
+	// Proactive composition-page RESTAction seed (Option A) — UNION the
+	// RBAC-reachable RESTAction refs into the harvester snapshot so the
+	// per-composition click-through detail RESTActions (never reached by
+	// the nav walk — the harvester gap) are warmed at boot. Default-OFF
+	// (PROACTIVE_RA_SEED_ENABLED); flag-off the union is a no-op and the
+	// snapshot is harvester-only (F-6 transparent). The added refs flow
+	// through the SAME seedScopeYielding loop — each ref is scoped to its
+	// own per-binding targets via restActionTargetGVR + per-RA target GVR,
+	// so the per-binding cell-key sharing invariant is unchanged.
+	if ProactiveRASeedEnabled() {
+		restactionRefs = unionProactiveRARefs(restactionRefs, deps.rw, log)
+	}
 
 	log.Info("prewarm.engine.boot.rewalk_complete",
 		slog.String("subsystem", "cache"),
@@ -481,6 +528,82 @@ func seedScopeYielding(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+// unionProactiveRARefs unions the RBAC-reachable RESTAction refs
+// (cache.RBACReachableRestActionRefs — Option A: the RESTAction CRs some
+// published binding grants `get` on, intersected with the boot-anchored
+// RESTActions informer) into the nav-walk harvester snapshot, deduped by
+// {ns,name} EXACTLY as the harvester dedups (phase1_content_prewarm.go).
+//
+// The proactive refs carry the SAME fixed RESTAction GVR coordinates the
+// harvester writes (restActionGVR group/version/resource), so the
+// downstream seedScopeYielding loop + objects.Get treat them identically.
+//
+// SEED-TARGETING ONLY (no special-case): the source is purely
+// RBAC-derived (zero resource/name/path literal). Over-inclusion = wasted
+// seed (benign); the per-request authz boundary is unchanged.
+func unionProactiveRARefs(harvested []templatesv1.ObjectReference,
+	rw *cache.ResourceWatcher, log *slog.Logger) []templatesv1.ObjectReference {
+
+	proactive := cache.RBACReachableRestActionRefs(rw)
+	if len(proactive) == 0 {
+		log.Info("prewarm.engine.boot.proactive_ra_seed",
+			slog.String("subsystem", "cache"),
+			slog.Int("harvested", len(harvested)),
+			slog.Int("proactive_reachable", 0),
+			slog.Int("added", 0),
+			slog.String("note", "no RBAC-reachable RESTAction refs (no binding grants get on restactions, or informer empty) — seed source unchanged"),
+		)
+		return harvested
+	}
+
+	out := unionRefsForTest(harvested, proactive)
+
+	log.Info("prewarm.engine.boot.proactive_ra_seed",
+		slog.String("subsystem", "cache"),
+		slog.Int("harvested", len(harvested)),
+		slog.Int("proactive_reachable", len(proactive)),
+		slog.Int("added", len(out)-len(harvested)),
+		slog.String("note", "RBAC-reachable RESTAction refs unioned into the boot seed source (Option A); the per-composition detail RESTActions the nav walk never reaches are now seeded"),
+	)
+	return out
+}
+
+// unionRefsForTest is the pure dedup core of unionProactiveRARefs — it
+// appends the proactive refs (built as RESTAction ObjectReferences with the
+// fixed GVR coordinates the harvester uses) onto the harvested slice, deduped
+// by {ns,name} EXACTLY as the harvester dedups
+// (phase1_content_prewarm.go). RBAC-source-independent so a falsifier can
+// exercise the dedup without a live cluster. Named *ForTest because the
+// falsifier is its only direct external caller; production reaches it through
+// unionProactiveRARefs.
+func unionRefsForTest(harvested []templatesv1.ObjectReference,
+	proactive []cache.RestActionRef) []templatesv1.ObjectReference {
+
+	seen := make(map[string]struct{}, len(harvested)+len(proactive))
+	out := make([]templatesv1.ObjectReference, 0, len(harvested)+len(proactive))
+	for _, r := range harvested {
+		key := r.Namespace + "/" + r.Name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, r)
+	}
+	for _, p := range proactive {
+		key := p.Namespace + "/" + p.Name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, templatesv1.ObjectReference{
+			Reference:  templatesv1.Reference{Name: p.Name, Namespace: p.Namespace},
+			APIVersion: restActionGVR.Group + "/" + restActionGVR.Version,
+			Resource:   restActionGVR.Resource,
+		})
+	}
+	return out
 }
 
 // restActionTargetGVR derives the GVR a RESTAction LISTs from its

--- a/internal/handlers/dispatchers/proactive_ra_seed_falsifier_test.go
+++ b/internal/handlers/dispatchers/proactive_ra_seed_falsifier_test.go
@@ -1,0 +1,208 @@
+// proactive_ra_seed_falsifier_test.go — in-process falsifiers for the
+// proactive composition-page RESTAction seed (Option A). Package
+// dispatchers. NON-DESTRUCTIVE — pure key/handle assertions over the
+// resolved-output L1 singleton + the union helper; no live ResourceWatcher,
+// no apiserver, no rbac TestMain. Safe under `go test
+// ./internal/handlers/dispatchers/...`.
+//
+// FALSIFIER MAP (see the ship brief):
+//   - F-1 cross-ref same-cell: a proactively-unioned RA ref Put under its
+//     dispatcher key is HIT — byte-identical RawJSON — under the SAME key a
+//     harvested ref of the same RA would produce. Proves the union does not
+//     perturb the seed/serve cell.
+//   - F-2 ComputeKey parity: the dispatcher key for a proactive ref =={binding,
+//     RA, extras_len:0, page:-1}== the key for the equivalent harvested ref
+//     (the union builds the byte-identical ObjectReference the harvester does).
+//   - F-6 transparency: PROACTIVE_RA_SEED_ENABLED defaults OFF; the union with
+//     an empty proactive set returns the harvested slice UNCHANGED (object
+//     identity), so the seed source — and served content — is unchanged.
+//   - union dedup: a proactive ref colliding by {ns,name} with a harvested ref
+//     is NOT duplicated (matches the harvester's own {ns,name} dedup).
+//   - F-3 guard: the latent-hazard guard — PrewarmEngineEnabled() defaults to
+//     the documented opt-in posture and ProactiveRASeedEnabled() defaults OFF;
+//     the production posture (engine ON) is the contract the on-cluster F-3
+//     pprof probe asserts.
+
+package dispatchers
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+)
+
+// raRef builds the ObjectReference the nav-walk harvester produces for a
+// RESTAction (phase1_content_prewarm.go:162-169) — the SHAPE the union must
+// reproduce for a proactive ref so the downstream key computation is identical.
+func raRef(ns, name string) templatesv1.ObjectReference {
+	return templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: name, Namespace: ns},
+		APIVersion: restActionGVR.Group + "/" + restActionGVR.Version,
+		Resource:   restActionGVR.Resource,
+	}
+}
+
+// TestProactiveRASeed_F2_DispatchKeyParity — F-2. The dispatcher cache key
+// for a PROACTIVELY-unioned RA ref is byte-identical to the key for the
+// harvested ref of the same RA, at the restactions seed tuple {ns, name,
+// extras=nil, page:-1, perPage:-1}. seedOneRestaction computes the key via
+// dispatchCacheLookupKey("restactions", g,v,r, ns,name, -1,-1, nil) — the
+// SAME call restactions.go:117 makes — so identical refs ⇒ identical keys.
+func TestProactiveRASeed_F2_DispatchKeyParity(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const ns, name = "comp-a", "composition-resources"
+
+	g, v, r := restActionGVR.Group, restActionGVR.Version, restActionGVR.Resource
+
+	// Harvested ref (the existing source) vs the union's proactive ref. The
+	// union builds the proactive ref via unionRefsForTest — the SAME path
+	// production uses — so they must be byte-identical for the same RA.
+	harvested := raRef(ns, name)
+	unioned := unionRefsForTest(nil, []cache.RestActionRef{{Namespace: ns, Name: name}})
+	if len(unioned) != 1 {
+		t.Fatalf("expected 1 unioned ref, got %d", len(unioned))
+	}
+	proactive := unioned[0]
+
+	keyH, handleH, _ := dispatchCacheLookupKey(ctx, "restactions",
+		g, v, r, harvested.Namespace, harvested.Name, -1, -1, nil)
+	keyP, handleP, _ := dispatchCacheLookupKey(ctx, "restactions",
+		g, v, r, proactive.Namespace, proactive.Name, -1, -1, nil)
+
+	if handleH == nil || handleP == nil {
+		t.Fatalf("expected live restactions L1 handles (H=%v P=%v)", handleH, handleP)
+	}
+	if keyH == "" || keyP == "" {
+		t.Fatalf("expected non-empty keys (H=%q P=%q)", keyH, keyP)
+	}
+	if keyH != keyP {
+		t.Fatalf("F-2 FAILED: proactive-ref key %q != harvested-ref key %q — the proactively "+
+			"seeded RA would MISS the cell the dispatcher serves from", keyP, keyH)
+	}
+}
+
+// TestProactiveRASeed_F1_SeedServeHit — F-1. Put a RESTAction body under the
+// SEED key computed for a proactive ref; Get under the SERVE key the
+// dispatcher computes for the SAME RA → HIT, byte-identical RawJSON. Proves
+// the proactively-seeded cell is the cell the customer /call reads.
+func TestProactiveRASeed_F1_SeedServeHit(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const ns, name = "comp-b", "composition-resources"
+	g, v, r := restActionGVR.Group, restActionGVR.Version, restActionGVR.Resource
+
+	// SEED side — the key seedOneRestaction would compute for the proactive ref.
+	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "restactions",
+		g, v, r, ns, name, -1, -1, nil)
+	if seedHandle == nil || seedKey == "" {
+		t.Fatal("expected a live seed handle + key")
+	}
+	body := []byte(`{"status":{"items":[{"name":"comp-b-resource"}]}}`)
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: body, Inputs: seedInputs})
+
+	// SERVE side — the dispatcher's key for the same RA tuple (same identity).
+	serveKey, serveHandle, _ := dispatchCacheLookupKey(ctx, "restactions",
+		g, v, r, ns, name, -1, -1, nil)
+	if serveHandle == nil || serveKey == "" {
+		t.Fatal("expected a live serve handle + key")
+	}
+	if seedKey != serveKey {
+		t.Fatalf("F-1 FAILED: seed key %q != serve key %q", seedKey, serveKey)
+	}
+	got, hit := serveHandle.Get(serveKey)
+	if !hit {
+		t.Fatal("F-1 FAILED: serve-key lookup MISSED the proactively-seeded cell")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("F-1 FAILED: served wrong body: got %q want %q", got.RawJSON, body)
+	}
+}
+
+// TestProactiveRASeed_F6_FlagDefaultsOff — F-6. The proactive seed is opt-in;
+// flag-off it must be inert (no env set).
+func TestProactiveRASeed_F6_FlagDefaultsOff(t *testing.T) {
+	if ProactiveRASeedEnabled() {
+		t.Fatal("F-6 FAILED: PROACTIVE_RA_SEED_ENABLED must default OFF")
+	}
+}
+
+// TestProactiveRASeed_F6_EmptyProactiveUnchanged — F-6. The union with an
+// empty proactive set (nil rw degrades RBACReachableRestActionRefs to nil)
+// returns the harvested slice UNCHANGED — same length, same contents — so the
+// seed source is byte-identical to harvester-only (transparent).
+func TestProactiveRASeed_F6_EmptyProactiveUnchanged(t *testing.T) {
+	harvested := []templatesv1.ObjectReference{
+		raRef("krateo-system", "sidebar-nav-menu"),
+		raRef("demo-system", "panel-list"),
+	}
+	got := unionProactiveRARefs(harvested, nil, slog.Default())
+	if len(got) != len(harvested) {
+		t.Fatalf("F-6 FAILED: empty-proactive union changed the seed source length: got %d want %d",
+			len(got), len(harvested))
+	}
+	for i := range harvested {
+		if got[i].Namespace != harvested[i].Namespace || got[i].Name != harvested[i].Name {
+			t.Fatalf("F-6 FAILED: empty-proactive union perturbed ref[%d]: got %s/%s want %s/%s",
+				i, got[i].Namespace, got[i].Name, harvested[i].Namespace, harvested[i].Name)
+		}
+	}
+}
+
+// TestProactiveRASeed_UnionDedup — the union dedups proactive refs that collide
+// by {ns,name} with a harvested ref (matches the harvester's own dedup key).
+// Driven via unionRefsForTest (the pure dedup core, RBAC-source-independent) so
+// it needs no live cluster.
+func TestProactiveRASeed_UnionDedup(t *testing.T) {
+	harvested := []templatesv1.ObjectReference{
+		raRef("krateo-system", "sidebar-nav-menu"),
+		raRef("comp-a", "composition-resources"),
+	}
+	proactive := []cache.RestActionRef{
+		{Namespace: "comp-a", Name: "composition-resources"}, // dup of harvested[1]
+		{Namespace: "comp-b", Name: "composition-resources"}, // new
+		{Namespace: "comp-b", Name: "composition-resources"}, // dup of itself
+	}
+	got := unionRefsForTest(harvested, proactive)
+	// Expect: 2 harvested + 1 genuinely-new proactive = 3.
+	if len(got) != 3 {
+		t.Fatalf("union dedup FAILED: got %d refs, want 3: %+v", len(got), got)
+	}
+	seen := map[string]int{}
+	for _, r := range got {
+		seen[r.Namespace+"/"+r.Name]++
+	}
+	for k, c := range seen {
+		if c != 1 {
+			t.Fatalf("union dedup FAILED: %q appears %d times", k, c)
+		}
+	}
+	if seen["comp-b/composition-resources"] != 1 {
+		t.Fatal("union dedup FAILED: the genuinely-new proactive ref was dropped")
+	}
+}
+
+// TestProactiveRASeed_F3_EngineGuardDefaults — F-3 (in-process portion of the
+// latent-hazard guard). The proactive seed rides the engine path; the
+// PRODUCTION posture (asserted by the on-cluster F-3 pprof probe) is engine
+// ON. Here we assert the Go-default opt-in posture for BOTH flags so the
+// hazard guard's preconditions are documented and stable:
+//   - ProactiveRASeedEnabled() defaults OFF (no auto-on).
+//   - PrewarmEngineEnabled() defaults OFF in code; production flips it ON via
+//     the helm overlay (main-chart-reconciliation). The dead errgroup
+//     runPIPSeed re-OOM hazard is gated on PREWARM_ENGINE_ENABLED=false, which
+//     production must never set.
+func TestProactiveRASeed_F3_EngineGuardDefaults(t *testing.T) {
+	if ProactiveRASeedEnabled() {
+		t.Fatal("F-3 FAILED: PROACTIVE_RA_SEED_ENABLED must default OFF")
+	}
+	// Production posture: engine ON. Assert the flag is readable + ON when set
+	// (the production contract the hazard guard depends on).
+	t.Setenv(envPrewarmEngineEnabled, "true")
+	if !PrewarmEngineEnabled() {
+		t.Fatal("F-3 FAILED: PREWARM_ENGINE_ENABLED=true (production posture) not honoured — " +
+			"the engine path would not run and the dead errgroup runPIPSeed re-OOM hazard re-activates")
+	}
+}


### PR DESCRIPTION
## What & why

The engine boot seed source drains **only** the nav-walk content harvester, which records the `apiRef` RESTActions of widgets the walk **reaches**. The per-composition click-through detail RESTActions (`composition-resources`-style) are never walked at boot, so every first composition-detail `/call` is a cold resolve.

**Option A** unions the RBAC-reachable RESTAction refs into the boot seed source so those RAs warm at boot. The reachable set is the intersection of (a) "some published binding grants `get` on restactions" and (b) the RESTAction CRs resident in the **boot-anchored** RESTActions informer (`restActionGVR` is a `MetaQuerySeeds` boot anchor — **no new informer**).

### Attribution (kept distinct — the 0.30.144 lesson)
This is a **PERF OPTIMIZATION**, separate from the (a)/#46 OOM regression fix. It has a known race window: the serial engine loop + customer yields means an SPA composition-burst can beat seed convergence (first burst-paint may still cold-resolve). It is **not** a regression fix — `project_regression_journal.md` untouched.

## Mechanism
- `cache.RBACReachableRestActionRefs(rw)` — the RBAC gate (`EnumeratePrewarmTargetsForGVR(restActionGVR,"get")`) ∩ the informer's RA CRs (ns/name via `meta.Accessor`, no full decode). Returns nil (transparent) when no binding grants get-restactions or the informer is empty. Resource-level RBAC (`rulesGrantGetList` skips `resourceNames`) makes reachability **binary** — no per-name special-case.
- `PROACTIVE_RA_SEED_ENABLED` (**default OFF**), riding the engine gate (`PrewarmEnabled` & `PrewarmEngineEnabled`).
- `unionProactiveRARefs` unions the refs into `restactionRefs` at the boot seed, deduped by `{ns,name}` exactly as the harvester. Each added ref flows through the **unchanged** `seedScopeYielding`/`seedOneRestaction` loop — per-binding cell-key scoping (via the RA's target GVR) unchanged, byte-identical `RawJSON` via the same `restactions.Resolve`.

## Latent hazard (logged + guarded)
The dead errgroup `runPIPSeed` path (GOMAXPROCS-bounded concurrent fan-out) re-activates if `PREWARM_ENGINE_ENABLED=false`, **bypassing the (a) memory budget** → re-OOM, over a now-wider seed source. `rePrewarmBoot` emits a loud Warn if reached with the engine disabled. Deleting the dead errgroup path is a separate backlog item.

## Falsifiers (in-process, green under `-race -count=1`)
- **F-1** seed/serve cell hit, byte-identical `RawJSON`.
- **F-2** dispatch-key parity (proactive ref == harvested ref at `{restactions, ns,name, extras=nil, page:-1, perPage:-1}`).
- **F-6** transparency — default-off, no-binding fail-closed (RBAC-leak guard), empty informer, nil watcher, empty-proactive union unchanged.
- union dedup; **F-3** engine-guard defaults.
- Full `internal/cache` + `internal/handlers/dispatchers` suites green under `-race`; `go build` + `go vet` clean.

On-cluster **F-3/F-4/F-5/F-7** deferred to deploy-validation (tracked: #27 — F-4 must capture a narrow-RBAC cyberjoker `composition-resources` /call asserting `extras_len:0` + `l1_hit`).

## Reviews
- **PM gate:** APPROVED (3 build obligations met, falsifiers captured-not-imagined, invariants verified).
- **Architect:** SIGN-OFF (all 5 review foci TRACED-sound; no changes requested).

## Scope
No CRD change. `PROACTIVE_RA_SEED_ENABLED` (default-off) noted for `braghettos/snowplow-chart` at release lockstep — **not** this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1