### PR TITLE
feat(otel): additive, default-OFF OpenTelemetry traces + metrics + log-correlation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,14 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.4
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0
+	go.opentelemetry.io/otel v1.33.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.33.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0
+	go.opentelemetry.io/otel/metric v1.33.0
+	go.opentelemetry.io/otel/sdk v1.33.0
+	go.opentelemetry.io/otel/sdk/metric v1.33.0
+	go.opentelemetry.io/otel/trace v1.33.0
 	golang.org/x/sync v0.20.0
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
@@ -30,12 +38,15 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/color v1.18.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
@@ -47,6 +58,7 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -71,8 +83,9 @@ require (
 	github.com/swaggo/files v0.0.0-20220610200504-28940afbdbfe // indirect
 	github.com/vladimirvivien/gexe v0.4.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.opentelemetry.io/otel v1.33.0 // indirect
-	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
@@ -85,6 +98,7 @@ require (
 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
+	google.golang.org/grpc v1.68.1 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -87,7 +88,6 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 h1:TmHmbvxPmaegwhDubVz0lICL0J5Ka2vwTzhoePEXsGE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKAPIS5qsmQDqZna/PgVt4rWtI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -204,14 +204,20 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 h1:yd02MEj
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0/go.mod h1:umTcuxiv1n/s/S6/c2AT/g2CQ7u5C59sHDNmfSwgz7Q=
 go.opentelemetry.io/otel v1.33.0 h1:/FerN9bax5LoK51X/sI0SVYrjSE0/yUL7DpxW4K3FWw=
 go.opentelemetry.io/otel v1.33.0/go.mod h1:SUUkR6csvUQl+yjReHu5uM3EtVV7MBm5FHKRlNx4I8I=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.33.0 h1:bSjzTvsXZbLSWU8hnZXcKmEVaJjjnandxD0PxThhVU8=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.33.0/go.mod h1:aj2rilHL8WjXY1I5V+ra+z8FELtk681deydgYT8ikxU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 h1:Vh5HayB/0HHfOQA7Ctx69E/Y/DcQSMPpKANYVMQ7fBA=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 h1:5pojmb1U1AogINhN3SurB+zm/nIcusopeBNp42f45QM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0/go.mod h1:57gTHJSE5S1tqg+EKsLPlTWhpHMsWlVmer+LA926XiA=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0 h1:wpMfgF8E1rkrT1Z6meFh1NDtownE9Ii3n3X2GJYjsaU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0/go.mod h1:wAy0T/dUbs468uOlkT31xjvqQgEVXv58BRFWEgn5v/0=
 go.opentelemetry.io/otel/metric v1.33.0 h1:r+JOocAyeRVXD8lZpjdQjzMadVZp2M4WmQ+5WtEnklQ=
 go.opentelemetry.io/otel/metric v1.33.0/go.mod h1:L9+Fyctbp6HFTddIxClbQkjtubW6O9QS3Ann/M82u6M=
 go.opentelemetry.io/otel/sdk v1.33.0 h1:iax7M131HuAm9QkZotNHEfstof92xM+N8sr3uHXc2IM=
 go.opentelemetry.io/otel/sdk v1.33.0/go.mod h1:A1Q5oi7/9XaMlIWzPSxLRWOI8nG3FnzHJNbiENQuihM=
+go.opentelemetry.io/otel/sdk/metric v1.33.0 h1:Gs5VK9/WUJhNXZgn8MR6ITatvAmKeIuCtNbsP3JkNqU=
+go.opentelemetry.io/otel/sdk/metric v1.33.0/go.mod h1:dL5ykHZmm1B1nVRk9dDjChwDmt81MjVp3gLkQRwKf/Q=
 go.opentelemetry.io/otel/trace v1.33.0 h1:cCJuF7LRjUFso9LPnEAHJDB2pqzp+hbO8eu1qqW2d/s=
 go.opentelemetry.io/otel/trace v1.33.0/go.mod h1:uIcdVUZMpTAmz0tI1z04GoVSezK37CbGV4fr1f2nBck=
 go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1jgeg=

--- a/internal/cache/prewarm_complete_metric.go
+++ b/internal/cache/prewarm_complete_metric.go
@@ -126,3 +126,20 @@ func registerPrewarmCompleteMetric() {
 func RegisterPrewarmCompleteMetricForTest() {
 	registerPrewarmCompleteMetric()
 }
+
+// PrewarmCompleteSnapshot returns (done, elapsedMs) mirroring the
+// snowplow_prewarm_complete expvar value: done is 1 after the Phase1Done
+// flip (0 before), elapsedMs is the process-start->done wall-clock in ms
+// (-1 until the flip). Exported so the OTel metrics mirror
+// (internal/metrics) can observe the same boundary as /debug/vars without
+// reaching into private cache state.
+func PrewarmCompleteSnapshot() (done int64, elapsedMs int64) {
+	done, elapsedMs = 0, -1
+	if IsPhase1Done() {
+		done = 1
+		if n := phase1DoneNanos.Load(); n > 0 {
+			elapsedMs = (n - prewarmProcessStartNanos) / int64(time.Millisecond)
+		}
+	}
+	return done, elapsedMs
+}

--- a/internal/handlers/dispatchers/per_call_log.go
+++ b/internal/handlers/dispatchers/per_call_log.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // perCallState carries the per-/call timing + observability state that
@@ -50,7 +51,7 @@ func beginPerCall(r *http.Request, handler string) (*perCallState, func()) {
 		if ui, err := xcontext.UserInfo(ctx); err == nil {
 			user = ui.Username
 		}
-		slog.InfoContext(ctx, "dispatcher.call.complete",
+		attrs := []any{
 			slog.String("handler", handler),
 			slog.String("path", st.path),
 			slog.String("method", st.method),
@@ -58,6 +59,22 @@ func beginPerCall(r *http.Request, handler string) (*perCallState, func()) {
 			slog.String("l1_hit", st.l1Hit),
 			slog.String("gvr", st.gvr),
 			slog.Int64("total_ms", time.Since(st.start).Milliseconds()),
-		)
+		}
+		// OTel log-correlation (ADDITIVE + default-OFF). When tracing is
+		// enabled, an OTel server span is active on ctx (otelhttp wrap in
+		// main.go), so attach its W3C trace_id/span_id to this
+		// otel_logs-bound record for trace<->log correlation in ClickHouse.
+		// When tracing is disabled SpanContextFromContext returns an invalid
+		// span context, so these fields are simply omitted and the record is
+		// byte-identical to the pre-OTel emission. This does NOT touch the
+		// shortid X-Krateo-TraceId correlation id, which lives on a separate
+		// header/status field and is unaffected here.
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			attrs = append(attrs,
+				slog.String("trace_id", sc.TraceID().String()),
+				slog.String("span_id", sc.SpanID().String()),
+			)
+		}
+		slog.InfoContext(ctx, "dispatcher.call.complete", attrs...)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,288 @@
+// Package metrics mirrors snowplow's existing expvar counters/gauges onto
+// an OpenTelemetry OTLP/HTTP MeterProvider so they can be scraped by the
+// OTel collector alongside traces.
+//
+// ADDITIVE + GATED (load-bearing): the expvar surface at /debug/vars is
+// UNTOUCHED — these OTLP instruments are a parallel export of the SAME
+// underlying counters, read through the same exported accessors the expvar
+// closures use. The whole pipeline is gated by OTEL_METRICS_ENABLED
+// (default false). When the gate is off, Setup registers NOTHING (no
+// MeterProvider, no exporter, no instruments) and returns a no-op
+// shutdown, so the off-path is byte-identical to the pre-OTel binary.
+//
+// All instruments are OBSERVABLE (async): a single registered callback
+// reads the live counter snapshots at collection time. This matches the
+// expvar.Func "computed-on-read" semantics exactly and adds zero cost to
+// the hot path — the callback only runs when the collector reads, and only
+// when metrics are enabled.
+package metrics
+
+import (
+	"context"
+
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/rbac"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+const (
+	// EnvMetricsEnabled gates the entire OTLP metrics pipeline. Default
+	// false.
+	EnvMetricsEnabled = "OTEL_METRICS_ENABLED"
+
+	// EnvOTLPEndpoint is the OTLP/HTTP collector endpoint, shared with the
+	// trace pipeline via the standard OTEL_EXPORTER_OTLP_ENDPOINT contract.
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	serviceName = "snowplow"
+	meterName   = "github.com/krateoplatformops/snowplow"
+)
+
+// ShutdownFunc flushes and stops the metrics pipeline. Always non-nil; a
+// no-op when metrics were not enabled.
+type ShutdownFunc func(context.Context) error
+
+// Setup wires the OTLP/HTTP metric exporter + a periodic-reader
+// MeterProvider when OTEL_METRICS_ENABLED is true, registers it as the
+// global MeterProvider, and registers the observable instruments that
+// mirror snowplow's expvar counters.
+//
+// No-op (registers nothing) when the gate is off.
+func Setup(ctx context.Context, build string) (ShutdownFunc, error) {
+	noop := func(context.Context) error { return nil }
+
+	if !env.Bool(EnvMetricsEnabled, false) {
+		return noop, nil
+	}
+
+	opts := []otlpmetrichttp.Option{}
+	if ep := env.String(EnvOTLPEndpoint, ""); ep != "" {
+		opts = append(opts, otlpmetrichttp.WithEndpointURL(ep))
+	}
+
+	exp, err := otlpmetrichttp.New(ctx, opts...)
+	if err != nil {
+		return noop, err
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(build),
+		),
+	)
+	if err != nil && res == nil {
+		res = resource.Default()
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	if err := registerInstruments(mp.Meter(meterName)); err != nil {
+		// Best-effort: shut the provider down so we don't leak the reader
+		// goroutine, then surface the error.
+		_ = mp.Shutdown(ctx)
+		return noop, err
+	}
+
+	return mp.Shutdown, nil
+}
+
+// registerInstruments declares every observable instrument and a single
+// callback that reads the live counter snapshots. Instrument names mirror
+// the expvar keys (with the conventional `_total` suffix on monotonic
+// counters) so dashboards can correlate the two surfaces.
+func registerInstruments(m metric.Meter) error {
+	// --- cache: apiserver fallthrough + assertion violations ---
+	fallthroughTotal, err := m.Int64ObservableCounter(
+		"snowplow_apiserver_fallthrough_total",
+		metric.WithDescription("Cumulative apiserver fall-throughs (cache miss path)."),
+	)
+	if err != nil {
+		return err
+	}
+	assertionViolations, err := m.Int64ObservableCounter(
+		"snowplow_assertion_violations_total",
+		metric.WithDescription("Cumulative read-path-scoped assertion violations."),
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- cache: RBAC snapshot publish sequence ---
+	rbacPublishSeq, err := m.Int64ObservableCounter(
+		"snowplow_rbac_publish_seq",
+		metric.WithDescription("RBAC snapshot publish sequence number."),
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- cache: CRD discovery bridge counters (one gauge, keyed by stat) ---
+	crdDiscovery, err := m.Int64ObservableCounter(
+		"snowplow_crd_discovery",
+		metric.WithDescription("CRD-discovery bridge counters, labelled by stat."),
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- cache: registered GVR count ---
+	registeredGVRs, err := m.Int64ObservableGauge(
+		"snowplow_plurals_registered_gvrs",
+		metric.WithDescription("Number of GVRs with a registered informer."),
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- cache: prewarm completion boundary ---
+	prewarmDone, err := m.Int64ObservableGauge(
+		"snowplow_prewarm_complete",
+		metric.WithDescription("1 once Phase1Done has flipped, else 0."),
+	)
+	if err != nil {
+		return err
+	}
+	prewarmElapsed, err := m.Int64ObservableGauge(
+		"snowplow_prewarm_complete_elapsed_ms",
+		metric.WithDescription("Process-start to Phase1Done wall-clock (ms); -1 until flip."),
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- cache: live-refresh broadcaster ---
+	refreshPublished, err := m.Int64ObservableCounter("snowplow_refresh_broadcaster_published_total",
+		metric.WithDescription("Live-refresh signals published."))
+	if err != nil {
+		return err
+	}
+	refreshDelivered, err := m.Int64ObservableCounter("snowplow_refresh_broadcaster_delivered_total",
+		metric.WithDescription("Live-refresh signals delivered to subscribers."))
+	if err != nil {
+		return err
+	}
+	refreshDropped, err := m.Int64ObservableCounter("snowplow_refresh_broadcaster_dropped_total",
+		metric.WithDescription("Live-refresh signals dropped (slow consumer)."))
+	if err != nil {
+		return err
+	}
+	refreshCoalesced, err := m.Int64ObservableCounter("snowplow_refresh_broadcaster_coalesced_total",
+		metric.WithDescription("Live-refresh signals coalesced."))
+	if err != nil {
+		return err
+	}
+	refreshSubscribers, err := m.Int64ObservableGauge("snowplow_refresh_broadcaster_subscribers",
+		metric.WithDescription("Current live-refresh subscriber count."))
+	if err != nil {
+		return err
+	}
+
+	// --- rbac: snapshot authz memo ---
+	memoHits, err := m.Int64ObservableCounter("snowplow_authz_memo_hits",
+		metric.WithDescription("Snapshot authz memo hits."))
+	if err != nil {
+		return err
+	}
+	memoMisses, err := m.Int64ObservableCounter("snowplow_authz_memo_misses",
+		metric.WithDescription("Snapshot authz memo misses."))
+	if err != nil {
+		return err
+	}
+	memoSwaps, err := m.Int64ObservableCounter("snowplow_authz_memo_swaps",
+		metric.WithDescription("Snapshot authz memo generation swaps."))
+	if err != nil {
+		return err
+	}
+	memoRefused, err := m.Int64ObservableCounter("snowplow_authz_memo_refused",
+		metric.WithDescription("Snapshot authz memo cap-breach refused inserts."))
+	if err != nil {
+		return err
+	}
+	memoDenyUncached, err := m.Int64ObservableCounter("snowplow_authz_memo_deny_uncached_total",
+		metric.WithDescription("Deny verdicts not cached by the memo."))
+	if err != nil {
+		return err
+	}
+	memoEntries, err := m.Int64ObservableGauge("snowplow_authz_memo_entries",
+		metric.WithDescription("Live entry count of the current memo shard."))
+	if err != nil {
+		return err
+	}
+
+	// Single callback reading every snapshot at collection time.
+	_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		o.ObserveInt64(fallthroughTotal, int64(cache.FallthroughTotal()))
+		o.ObserveInt64(assertionViolations, int64(cache.AssertionViolationsTotal()),
+			metric.WithAttributes(attribute.String("check", "read_paths_scoped")))
+		o.ObserveInt64(rbacPublishSeq, int64(cache.RBACGen()))
+
+		s := cache.CRDDiscoveryStatsSnapshot()
+		for stat, v := range map[string]uint64{
+			"events_enqueued":      s.EventsEnqueued,
+			"events_dropped":       s.EventsDropped,
+			"events_processed":     s.EventsProcessed,
+			"discovery_invoked":    s.DiscoveryInvoked,
+			"discovery_skipped_ng": s.DiscoverySkippedNG,
+			"deletes_processed":    s.DeletesProcessed,
+			"delete_skipped_ng":    s.DeleteSkippedNG,
+			"panics_recovered":     s.PanicsRecovered,
+			"schema_relists_fired": s.SchemaRelistsFired,
+			"schema_unchanged":     s.SchemaUnchanged,
+		} {
+			o.ObserveInt64(crdDiscovery, int64(v),
+				metric.WithAttributes(attribute.String("stat", stat)))
+		}
+
+		o.ObserveInt64(registeredGVRs, registeredGVRCount())
+
+		done, elapsed := cache.PrewarmCompleteSnapshot()
+		o.ObserveInt64(prewarmDone, done)
+		o.ObserveInt64(prewarmElapsed, elapsed)
+
+		published, delivered, dropped, coalesced := cache.RefreshBroadcasterCounters()
+		o.ObserveInt64(refreshPublished, int64(published))
+		o.ObserveInt64(refreshDelivered, int64(delivered))
+		o.ObserveInt64(refreshDropped, int64(dropped))
+		o.ObserveInt64(refreshCoalesced, int64(coalesced))
+		o.ObserveInt64(refreshSubscribers, int64(cache.RefreshSubscriberCount()))
+
+		hits, misses, swaps, refused, denyUncached, entries := rbac.AuthzMemoSnapshot()
+		o.ObserveInt64(memoHits, int64(hits))
+		o.ObserveInt64(memoMisses, int64(misses))
+		o.ObserveInt64(memoSwaps, int64(swaps))
+		o.ObserveInt64(memoRefused, int64(refused))
+		o.ObserveInt64(memoDenyUncached, int64(denyUncached))
+		o.ObserveInt64(memoEntries, int64(entries))
+		return nil
+	},
+		fallthroughTotal, assertionViolations, rbacPublishSeq, crdDiscovery,
+		registeredGVRs, prewarmDone, prewarmElapsed,
+		refreshPublished, refreshDelivered, refreshDropped, refreshCoalesced, refreshSubscribers,
+		memoHits, memoMisses, memoSwaps, memoRefused, memoDenyUncached, memoEntries,
+	)
+	return err
+}
+
+// registeredGVRCount returns the number of GVRs with a registered informer,
+// mirroring the `count` field of snowplow_plurals_registered_gvrs. Returns
+// 0 when the global watcher is nil (cache off / not wired).
+func registeredGVRCount() int64 {
+	rw := cache.Global()
+	if rw == nil {
+		return 0
+	}
+	return int64(len(rw.RegisteredGVRs()))
+}

--- a/internal/rbac/snapshot_authz_memo.go
+++ b/internal/rbac/snapshot_authz_memo.go
@@ -229,6 +229,17 @@ func AuthzMemoDenyUncachedForTest() uint64 {
 	return authzMemoDenyUncached.Load()
 }
 
+// AuthzMemoSnapshot returns the live snapshot-authz memo counters
+// (hits, misses, swaps, refused, denyUncached, entries) mirroring the
+// snowplow_authz_memo_* expvar keys. Exported (unlike AuthzMemoStatsForTest,
+// which is test-only and resettable) so the OTel metrics mirror
+// (internal/metrics) can observe the same values as /debug/vars in
+// production.
+func AuthzMemoSnapshot() (hits, misses, swaps, refused, denyUncached uint64, entries int) {
+	return authzMemoHits.Load(), authzMemoMisses.Load(), authzMemoSwaps.Load(),
+		authzMemoRefused.Load(), authzMemoDenyUncached.Load(), authzMemoEntriesForExpvar()
+}
+
 // authzMemoExpvarFuncs is consumed by RegisterAuthzMemoExpvar; kept here
 // so the counters' wiring stays adjacent to their definitions.
 func authzMemoExpvarFuncs() map[string]expvar.Func {

--- a/internal/resolvers/restactions/api/external_fetch.go
+++ b/internal/resolvers/restactions/api/external_fetch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/krateoplatformops/plumbing/http/response"
 	"github.com/krateoplatformops/plumbing/http/util"
 	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/tracing"
 	"sigs.k8s.io/yaml"
 )
 
@@ -128,6 +129,17 @@ func httpFetchAllowingNonJSON(ctx context.Context, opts httpcall.RequestOptions)
 		werr := fmt.Errorf("unable to create HTTP Client for endpoint: %w", err)
 		return response.New(http.StatusInternalServerError, werr), nil, "", werr
 	}
+
+	// OTel outbound instrumentation (ADDITIVE + default-OFF). When
+	// OTEL_TRACES_ENABLED is true, wrap the client transport so this
+	// external GET to authn / api-steps emits a client span and injects a
+	// W3C `traceparent` (the request already carries ctx via
+	// NewRequestWithContext above, so the active server span is the
+	// parent). When tracing is disabled WrapTransport returns the transport
+	// unchanged, so this branch is a no-op and the outbound path stays
+	// byte-identical. The existing shortid X-Krateo-TraceId header set
+	// above is UNTOUCHED — both correlation ids ride the same request.
+	cli.Transport = tracing.WrapTransport(cli.Transport)
 
 	// REUSED verbatim: retry wrapper.
 	retryCli := util.NewRetryClient(cli)

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,139 @@
+// Package tracing wires snowplow's OpenTelemetry trace pipeline.
+//
+// COEXISTENCE CONTRACT (load-bearing): this package is ADDITIVE and must
+// not interfere with the existing observability surfaces. Specifically:
+//
+//   - The shortid `X-Krateo-TraceId` correlation id (plumbing
+//     xcontext.TraceId, surfaced as status.traceId, set as an outbound
+//     header, and consumed by /refreshes) is UNTOUCHED. OTel spans carry a
+//     separate W3C `traceparent`; the two coexist on the same request.
+//
+//   - The stdout -> otel-daemonset filelog -> ClickHouse `otel_logs` log
+//     pipeline (slog JSON to os.Stdout) is UNTOUCHED. OTel adds
+//     trace_id/span_id ATTRIBUTES to those log records for correlation but
+//     does not reroute or replace the pipeline.
+//
+// GATING: Setup is a no-op unless OTEL_TRACES_ENABLED is true. When the
+// flag is unset/false, Setup registers NOTHING — no TracerProvider, no
+// propagator, no exporter — so the global otel.GetTracerProvider() stays
+// the no-op default and every instrumentation site (otelhttp handler,
+// otelhttp transport, span lookups) degrades to a zero-cost no-op. The
+// off-path is therefore byte-identical to the pre-OTel binary.
+package tracing
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/env"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+const (
+	// EnvTracesEnabled gates the entire trace pipeline. Default false.
+	EnvTracesEnabled = "OTEL_TRACES_ENABLED"
+
+	// EnvOTLPEndpoint is the OTLP/HTTP collector endpoint
+	// (e.g. "otel-collector.krateo-system.svc:4318"). Consumed by the
+	// standard OTEL_EXPORTER_OTLP_ENDPOINT env contract via
+	// otlptracehttp's WithEndpointURL/env auto-config.
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	// serviceName is the resource service.name reported for every span.
+	serviceName = "snowplow"
+)
+
+// ShutdownFunc flushes and stops the trace pipeline. Always non-nil so the
+// caller can `defer shutdown(ctx)` unconditionally; it is a no-op when
+// tracing was not enabled.
+type ShutdownFunc func(context.Context) error
+
+// Setup wires the OTLP/HTTP trace exporter and a batch TracerProvider when
+// OTEL_TRACES_ENABLED is true, registers it as the global TracerProvider,
+// and installs the composite W3C TraceContext + Baggage propagator.
+//
+// When the gate is off it returns a no-op ShutdownFunc and registers
+// nothing (off-path byte-identical guarantee).
+//
+// build is the snowplow build string (main.build), recorded as the
+// service.version resource attribute.
+func Setup(ctx context.Context, build string) (ShutdownFunc, error) {
+	noop := func(context.Context) error { return nil }
+
+	if !env.Bool(EnvTracesEnabled, false) {
+		return noop, nil
+	}
+
+	// otlptracehttp reads OTEL_EXPORTER_OTLP_ENDPOINT (and the standard
+	// OTLP env vars: headers, protocol, insecure) from the environment by
+	// default, so the endpoint is configured via the env contract without
+	// a hard-coded address. WithEndpointURL is applied explicitly when the
+	// var is set so a bare host:port or a full URL both resolve.
+	opts := []otlptracehttp.Option{}
+	if ep := env.String(EnvOTLPEndpoint, ""); ep != "" {
+		opts = append(opts, otlptracehttp.WithEndpointURL(ep))
+	}
+
+	exp, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return noop, err
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(build),
+		),
+	)
+	if err != nil {
+		// resource.New can return a partial resource + a non-fatal merge
+		// error (e.g. schema-url skew); use whatever resource we got.
+		if res == nil {
+			res = resource.Default()
+		}
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp,
+			sdktrace.WithBatchTimeout(5*time.Second),
+		),
+		sdktrace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return tp.Shutdown, nil
+}
+
+// Enabled reports whether OTEL_TRACES_ENABLED is true. Instrumentation
+// sites outside main (e.g. the outbound external-fetch transport) consult
+// this so they only wrap when the trace pipeline is actually wired —
+// keeping the off-path byte-identical.
+func Enabled() bool {
+	return env.Bool(EnvTracesEnabled, false)
+}
+
+// WrapTransport wraps rt with otelhttp.NewTransport when tracing is
+// enabled, so an outbound request created with a span-carrying context
+// gets a client span and an injected W3C traceparent (via the global
+// propagator). When tracing is disabled it returns rt unchanged — the
+// outbound path is then byte-identical to the pre-OTel client. A nil rt is
+// returned as-is (callers default to http.DefaultTransport downstream).
+func WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	if !Enabled() || rt == nil {
+		return rt
+	}
+	return otelhttp.NewTransport(rt)
+}

--- a/main.go
+++ b/main.go
@@ -34,11 +34,15 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/handlers"
 	"github.com/krateoplatformops/snowplow/internal/handlers/dispatchers"
 	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
+	"github.com/krateoplatformops/snowplow/internal/metrics"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
 	crdschema "github.com/krateoplatformops/snowplow/internal/resolvers/crds/schema"
 	restactionsapi "github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
 	jqsupport "github.com/krateoplatformops/snowplow/internal/support/jq"
+	"github.com/krateoplatformops/snowplow/internal/tracing"
 	httpSwagger "github.com/swaggo/http-swagger"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -153,6 +157,28 @@ func main() {
 	if *debugOn {
 		log.Debug("environment variables", slog.Any("env", os.Environ()))
 	}
+
+	// OTel observability (ADDITIVE + default-OFF). Both Setup calls are
+	// no-ops unless OTEL_TRACES_ENABLED / OTEL_METRICS_ENABLED are true; in
+	// the off-path they register nothing (no TracerProvider/MeterProvider,
+	// no propagator, no exporter), so the global providers stay no-op and
+	// every instrumentation site degrades to zero cost. This does NOT touch
+	// the shortid X-Krateo-TraceId correlation id, the stdout->otel_logs log
+	// pipeline, or the use.TraceId()/use.Logger() chain below — OTel
+	// coexists with all three. The deferred shutdowns flush the batch
+	// span/metric pipelines on graceful exit; they are no-ops when disabled.
+	otelCtx := context.Background()
+	traceShutdown, err := tracing.Setup(otelCtx, build)
+	if err != nil {
+		log.Error("otel tracing setup failed", slog.Any("err", err))
+	}
+	defer func() { _ = traceShutdown(context.Background()) }()
+
+	metricShutdown, err := metrics.Setup(otelCtx, build)
+	if err != nil {
+		log.Error("otel metrics setup failed", slog.Any("err", err))
+	}
+	defer func() { _ = metricShutdown(context.Background()) }()
 
 	chain := use.NewChain(
 		use.TraceId(),
@@ -923,6 +949,30 @@ func main() {
 	}...)
 	defer stop()
 
+	// OTel HTTP server instrumentation (default-OFF gated). otelhttp wraps
+	// the mux to create a server span per request and EXTRACT inbound W3C
+	// traceparent/baggage (the global propagator installed by
+	// tracing.Setup). When tracing is disabled the global TracerProvider is
+	// the no-op default, so otelhttp.NewHandler produces no spans and adds
+	// negligible overhead — the off-path stays effectively byte-identical.
+	//
+	// The wrap sits INSIDE use.CORS so CORS remains OUTERMOST and answers
+	// the OPTIONS preflight before otelhttp ever runs (otelhttp would
+	// otherwise span the preflight; CORS must own it). WithFilter skips
+	// span creation for the high-frequency health/readiness/debug probes.
+	var rootHandler http.Handler = otelhttp.NewHandler(mux, serviceName,
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			return r.Method + " " + r.URL.Path
+		}),
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			switch r.URL.Path {
+			case "/health", "/readyz":
+				return false
+			}
+			return !strings.HasPrefix(r.URL.Path, "/debug/")
+		}),
+	)
+
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%d", *port),
 		Handler: use.CORS(cors.Options{
@@ -934,11 +984,17 @@ func main() {
 				"Content-Type",
 				"X-Auth-Code",
 				"X-Krateo-TraceId",
+				// W3C trace-context + baggage headers — REQUIRED so the
+				// browser frontend can propagate traceparent/tracestate/
+				// baggage into snowplow (cross-repo CORS dependency).
+				"traceparent",
+				"tracestate",
+				"baggage",
 			},
 			ExposedHeaders:   []string{"Link", "X-Snowplow-Refresh-Key"},
 			AllowCredentials: true,
 			MaxAge:           300, // Maximum value not ignored by any of major browsers
-		})(mux),
+		})(rootHandler),
 		ReadTimeout:  10 * time.Second, // read is fast; unchanged (#351/C2)
 		WriteTimeout: writeTimeout,     // 300s — clears cache-OFF heavy path (#351/C2)
 		IdleTimeout:  30 * time.Second, // keep-alive; unchanged (#351/C2)


### PR DESCRIPTION
## Summary

Implements full OpenTelemetry observability adherence in the **snowplow** Go service: distributed **traces**, **metrics** (OTLP mirror of the existing expvar surface), and **slog log-correlation**. The OTel trace SDK was already present in deps but deliberately unwired — this wires it.

Everything is **ADDITIVE** and **gated default-OFF**. The off-path is byte-identical: when the gates are unset/false, `Setup` registers **nothing** (no TracerProvider/MeterProvider, no propagator, no exporters), so the global providers stay no-op and every instrumentation site (otelhttp handler, otelhttp transport, span lookups) degrades to a zero-cost no-op.

## Coexistence with the existing pipeline (load-bearing — unchanged)

- The shortid **`X-Krateo-TraceId`** correlation id is **UNTOUCHED**: `status.traceId`, the outbound header, and `/refreshes` all keep working. OTel's W3C `traceparent` rides **alongside** it on the same request — the two correlation ids coexist.
- The stdout → otel-daemonset filelog → ClickHouse **`otel_logs`** log pipeline is **UNTOUCHED**. OTel only **ADDS** `trace_id`/`span_id` attributes to the `dispatcher.call.complete` record for trace↔log correlation; it does not reroute or replace the pipeline.
- The expvar surface at `/debug/vars` is **kept** — OTLP metrics are a parallel export of the same counters.

## Changes

**Traces** — `internal/tracing/tracing.go` (new)
- `Setup(ctx, build)` gated by `OTEL_TRACES_ENABLED`. When on: OTLP/HTTP exporter (`otlptracehttp`) to `OTEL_EXPORTER_OTLP_ENDPOINT`, batch `TracerProvider` (resource `service.name=snowplow` / `service.version=build`), global `otel.SetTracerProvider`, composite `TraceContext`+`Baggage` propagator.
- `Enabled()` / `WrapTransport()` helpers so off-site instrumentation only wraps when the pipeline is wired.

**Traces** — `main.go`
- Calls `tracing.Setup` + `metrics.Setup` right after `slog.SetDefault`, with deferred shutdowns (no-ops when disabled).
- Wraps the mux with `otelhttp.NewHandler(mux, "snowplow", WithSpanNameFormatter, WithFilter)` **INSIDE** the `use.CORS(...)` wrap so **CORS stays outermost** and answers the OPTIONS preflight before otelhttp runs. The filter skips `/health`, `/readyz`, `/debug/*`.
- `use.NewChain(use.TraceId(), use.Logger(log))` kept as-is.
- Adds `traceparent`, `tracestate`, `baggage` to CORS `AllowedHeaders`.

**Traces (outbound)** — `internal/resolvers/restactions/api/external_fetch.go`
- After `httpcall.HTTPClientForEndpoint`, wraps `cli.Transport` with `otelhttp.NewTransport(...)` (gated). The request already carries `ctx` via `NewRequestWithContext`, so the active server span is the parent and `traceparent` is injected. Existing `X-Krateo-TraceId` header preserved.

**Log-correlation** — `internal/handlers/dispatchers/per_call_log.go`
- Adds `trace_id`/`span_id` from `trace.SpanContextFromContext(ctx)` to `dispatcher.call.complete` when the span context is valid. Shortid untouched.

**Metrics** — `internal/metrics/metrics.go` (new)
- `Setup(ctx, build)` gated by `OTEL_METRICS_ENABLED`. OTLP/HTTP `MeterProvider` (periodic reader) mirrors the existing expvar counters/gauges as **observable** instruments via a single collection-time callback (matches expvar.Func computed-on-read semantics; zero hot-path cost). Mirrors: `snowplow_apiserver_fallthrough_total`, `snowplow_assertion_violations_total`, `snowplow_rbac_publish_seq`, `snowplow_crd_discovery` (labelled by `stat`), `snowplow_plurals_registered_gvrs`, `snowplow_prewarm_complete` (+`_elapsed_ms`), `snowplow_refresh_broadcaster_*`, `snowplow_authz_memo_*`.
- Two small exported accessors added next to their expvar registrations to avoid cross-package private reach: `cache.PrewarmCompleteSnapshot()`, `rbac.AuthzMemoSnapshot()`.

**go.mod**
- Promoted `go.opentelemetry.io/otel`, `.../sdk`, `.../trace`, `.../metric` to direct; added `.../sdk/metric`, `.../exporters/otlp/otlptrace/otlptracehttp` (**pinned v1.33.0** to match otel core in go.sum — version-skew is a common build break), `.../exporters/otlp/otlpmetric/otlpmetrichttp`, `contrib/.../otelhttp v0.58.0`. `go mod tidy` run.

## Env contract

| Var | Default | Effect |
|---|---|---|
| `OTEL_TRACES_ENABLED` | `false` | Enables the trace pipeline (otelhttp server + outbound spans, propagator). |
| `OTEL_METRICS_ENABLED` | `false` | Enables the OTLP metrics mirror. |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP/HTTP collector endpoint, shared by both pipelines (also honours the standard OTLP env vars). |

## Known coverage gap

The generic plumbing `httpcall.Do` outbound path is **not instrumentable** (plumbing is unforkable, no transport seam). Only the snowplow-owned `external_fetch.go` outbound path is wrapped. Documented here, not fixed.

## Cross-repo dependency (CORS)

Browser → snowplow trace propagation requires the `traceparent`/`tracestate`/`baggage` request headers, which are now in snowplow's CORS `AllowedHeaders`. The **frontend** must actually emit those headers for browser-originated spans to chain; this PR only opens the server side.

## Verification

`go build ./...` and `go vet ./...` pass. Tests green for all touched packages (cache, rbac, dispatchers, restactions/api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)