### PR TITLE
fix(cache): stale-delete fix #1 — heal/re-touch not-servable api-step-LIST informers + /debug/servable (PARKED)

### DIFF
--- a/docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md
+++ b/docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md
@@ -1,0 +1,161 @@
+# RCA + design — deleted CompositionDefinition persists in /blueprints (informer/invalidation gap) — 2026-06-25
+
+**Author**: cache architect
+**Status**: TRACE + DESIGN (design-only; not a build). Supersedes the leading "cache-key divergence" hypothesis in `~/Downloads/snowplow-rca-blueprint-cache-stale-delete.md` (that hypothesis is REFUTED below).
+**Cluster / artifacts**: `gke_integration-test-431120_europe-west1-b_krateo-enterprise-full`, snowplow **1.5.1** (chart 1.0.27). Empirical artifacts captured this session: expvar `/tmp/sp-vars.json`, snowplow log tail `/tmp/sp-ke.log` (4000 lines). Read-only access via `/tmp/krateo-enterprise.kubeconfig`. Code reviewed @ `1.5.2-1-gd86e33d` (this tree); 1.5.1↔1.5.2 are adjacent and every path cited matches.
+**Every claim labelled TRACED (runtime artifact + file:line) or INFERRED.**
+
+---
+
+## 1. Executive summary (5 lines)
+
+1. **Root cause:** the `compositiondefinitions` cluster-LIST that backs `/blueprints` is served on the customer path from the **apistage CONTENT cache HIT** (which short-circuits *before* `dispatchViaInformer` — no informer dispatch counter fires on `call-generic`), while the cached **resolved-output** `/blueprints` entry sits in the same store under a different key; the only thing that evicts either is an informer DELETE event for `compositiondefinitions`, and that event is **not reaching the dep tracker** — `not-servable:28` (boot-prewarm-walk) + **zero** `cache_event.consumed type=DELETE gvr=…compositiondefinitions` in the log = the data informer is not delivering DELETEs (registered-but-not-servable / watch not vouched).
+2. **Fix #1 (preferred):** make the api-step LIST path establish, and *confirm*, a synced+watch-healthy informer for the LISTed GVR so the EXISTING `OnDelete → collectMatchesWithDep(cluster-list bucket) → dirty-mark` machinery fires — i.e. close the gap that lets a GVR be `registered` yet permanently `not-servable` and (the real bug) treats "served from apistage content cache" as terminal, never re-touching the informer.
+3. **Scale/OOM verdict:** for `compositiondefinitions` it is ONE cluster-wide CR informer (cheap, already registered). The generalization "informer for every api-step-LISTed GVR" is the dangerous one — it is exactly the unbounded cold-informer population that drove the 1.5.1 boot-OOM (`docs/troubleshoot-boot-oom-composition-fanout-2026-06-23.md`). The fix MUST NOT register on the api-step *GET-by-name* path (would fan out to every child GVR) and MUST keep the registration **lazy + idempotent + first-read-still-falls-through** (no boot populate burst).
+4. **Fix #2 (fallback if #1's generalization is unsafe at scale):** bound the staleness of *apistage-content + resolved-output entries that were served while the GVR was not informer-servable* — a short, toggleable TTL applied per-entry when `IsServable(gvr)==false` at Put time, so the catalog self-heals in seconds instead of 3600s, with no new watch.
+5. **Falsifier:** in-process/kind — register a CR informer, drive a DELETE, assert `cache_event.consumed type=DELETE` fires AND the dependent resolved-output L1 key is evicted/dirty-marked; on-cluster — after fix, `kubectl delete compositiondefinition X` makes `/blueprints` reflect it within seconds and emits `cache_event.consumed type=DELETE gvr=…compositiondefinitions`.
+
+---
+
+## 2. Empirical evidence (what the runtime artifacts actually show)
+
+All from `/tmp/sp-vars.json` (`snowplow_apiserver_fallthrough_cells`) and `/tmp/sp-ke.log`.
+
+| Observation | Value | Source |
+|---|---|---|
+| `boot-prewarm-walk\|…compositiondefinitions\|informer-fallthrough-not-servable` | **28** | `sp-vars.json` |
+| `boot-prewarm-walk\|…compositiondefinitions\|informer-fallthrough-not-synced` | **1** | `sp-vars.json` |
+| `call-generic\|…compositiondefinitions\|get-miss-let-apiserver-404` | **9** | `sp-vars.json` |
+| `call-generic\|…compositiondefinitions\|` informer-fallthrough-* (any) | **ABSENT** | `sp-vars.json` |
+| `call-generic\|…compositiondefinitions\|` informer-LIST-served | n/a (served path uses a separate counter, not in fallthrough_cells) | metrics taxonomy |
+| `compositiondefinitions` ∈ `snowplow_plurals_registered_gvrs.gvrs` (count 61) | **YES** (this expvar IS `rw.informers`, see below) | `sp-vars.json` |
+| `cache_event.consumed type=DELETE gvr=…compositiondefinitions` in log | **0** (the single `cache_event.consumed` in the window is `type=UPDATE gvr=/v1,namespaces`) | `sp-ke.log:3176` |
+| log GETs `/…/compositiondefinitions/aws-vpc-stack` → `not found` | present (the 9 post-delete GET-by-name probes) | `sp-ke.log` |
+
+**Decisive reading of the counters:**
+- The `not-servable:28` / `not-synced:1` are scoped **exclusively under `boot-prewarm-walk`** — they describe the boot window, when the lazily-registered informer had not yet synced. On the **customer (`call-generic`) path the LIST produces NO informer-fallthrough counter at all** — the LIST never reaches `dispatchViaInformer` post-boot.
+- `snowplow_plurals_registered_gvrs` is **misnamed**: TRACED `internal/cache/registered_gvrs_expvar.go:28` + `internal/cache/phase1.go:412` — it reads `rw.RegisteredGVRs()`, which snapshots **`rw.informers`** under RLock. So the count-61 list IS the live informer registry. **`compositiondefinitions` has a registered informer.** (This REFUTES the team-lead brief's "no synced data informer exists" framing — the informer object exists; what's missing is event delivery.)
+
+---
+
+## 3. Why the RCA's "cache-key divergence" hypothesis is REFUTED
+
+The Downloads RCA's leading hypothesis was that the dep edge is recorded under a different key than the served entry. TRACED refutation:
+
+- The dispatcher threads the **resolved-output `cacheKey`** into the resolve context (`internal/handlers/dispatchers/restactions.go:196` `cache.WithL1KeyContext(ctx, cacheKey)`), and `cacheKey`/`cacheHandle` both come from `cache.ResolvedCache()` (`internal/handlers/dispatchers/helpers.go:201`).
+- The inner api-step records its cluster-list edge **inline, off `r.ctx`'s L1 key, before dispatch and regardless of how the call is served** (`internal/resolvers/restactions/api/resolve.go:1365-1383`): `if l1Key := cache.L1KeyFromContext(r.ctx); l1Key != "" … RecordList(l1Key, gvr, ns)`. On the customer resolved-output **MISS** (the only time the resolver runs), `r.ctx`'s L1 key IS the served `cacheKey`.
+- Therefore the `/blueprints` resolved-output entry **does** get a `(compositiondefinitions, "", listWildcard)` cluster-list edge under the key the user reads. The edge is recorded under the right key. Key-divergence is not the bug.
+
+The bug is upstream of the dep model: **the DELETE event never arrives**, so `OnDelete` (`internal/cache/deps.go:590`) is never called for `compositiondefinitions`, so neither the resolved-output edge nor the apistage-content edge is ever acted on.
+
+---
+
+## 4. The full TRACED chain (symptom → root cause)
+
+### 4.1 How the catalog is served (two coexisting entries, one store)
+- `apistageStore` and the dispatcher's resolved-output cache are the **same** `cache.ResolvedCache()` store (`resolve.go:272`; `helpers.go:201`) — different keys, one store.
+- Customer `/blueprints` resolved-output HIT short-circuits the whole resolver (`restactions.go:135-148`, `writeResolvedJSON` + early `return`). After the first miss populates it, every later `/blueprints` is a resolved-output HIT and the resolver **never runs again** → the edge is recorded once and the entry is never recomputed except by invalidation or TTL.
+- Inside the resolver (only on a resolved-output miss), the single api-step LIST is served by the **apistage content cache**: `apistageContentServe` (`apistage.go:425`) does `store.Get(contentKey)`; on a **content HIT it returns the stored envelope WITHOUT calling `dispatchViaInformer`** (`apistage.go:481-516`). This is exactly why `call-generic` shows no informer-fallthrough counter for the LIST.
+- On a content MISS it calls `dispatchViaInformer(WithApistageContentResolve(ctx), call)` (`apistage.go:517`). For `compositiondefinitions` this returns not-servable (Gate 6 / list_not_servable) and falls through to the apiserver, then Puts the content entry + a `RecordList(contentKey, gvr, ns)` edge (`apistage.go:503`).
+
+### 4.2 The informer + its DELETE wiring (this part is CORRECT)
+- `EnsureResourceType` (`watcher.go:612`) registers a full bytes-streaming dynamic informer for `compositiondefinitions` (it is NOT metadata-only: `shouldUseMetadataOnly` is constant-false in prod, `cache_mode.go:127-191`, #342/#197; it is NOT navigation-discovered so it takes the shared factory at `watcher.go:1147` `rw.factory.ForResource(gvr)`, H5 streaming default at `watcher.go:1101`).
+- `addResourceTypeLocked` wires the dep handlers UNCONDITIONALLY at registration (`watcher.go:1213` `gi.Informer().AddEventHandler(rw.depEventHandlers(gvr))`), on both eager and lazy paths.
+- `depEventHandlers.DeleteFunc` (`deps_watch.go:237-257`) is **NOT post-sync gated** (only `AddFunc` is, `deps_watch.go:200-203`). It unwraps `DeletedFinalStateUnknown`, computes `(ns,name)`, and `submitDeleteEvent` → worker → `Deps().OnDelete(gvr, ns, name)` (`deps_watch.go:117/123`).
+- `OnDelete` (`deps.go:590`) → `collectMatchesWithDep(gvr, ns, name)` returns the cluster-list bucket `(gvr,"",listWildcard)` for a namespaced delete; non-self matches are dirty-marked (enqueue refresh), self-representations evicted; it logs `cache_event.consumed type=DELETE` (`deps.go:638`).
+
+**So the moment a DELETE event is delivered for `compositiondefinitions`, the existing machinery dirty-marks the `/blueprints` resolved-output key AND the apistage content key.** No new invalidation path is needed.
+
+### 4.3 The actual break (TRACED by absence + INFERRED final link)
+- **TRACED:** zero `cache_event.consumed type=DELETE gvr=…compositiondefinitions` in `/tmp/sp-ke.log` across the post-delete probe window (the only consumed event is the namespaces UPDATE at `sp-ke.log:3176`). The DELETE event is not reaching `OnDelete`.
+- **TRACED:** the informer is `registered` (count-61) but was `not-servable:28` throughout boot-prewarm. `servableLocked` (`watcher.go:1822`) is a 4-conjunct gate: `registered ∧ HasSynced ∧ watchHealthy(¬watchBroken) ∧ typeConfirmed(∈rw.confirmed)`. `not-servable` (as opposed to `not-synced`) means it failed conjunct 3 or 4 *after* registration — i.e. **watch broken or type-unconfirmed**, not merely mid-sync.
+- **INFERRED (cannot close on-cluster — `kubectl exec` to read live HasSynced/watchBroken is a Production Read denied without explicit user approval):** the `compositiondefinitions` data informer's reflector watch is not in a vouched-healthy state (`watchBroken` set, or `confirmed` never set because the discovery-refresh tick has not confirmed it), and in that state it is **not delivering DELETE events to the processor** — which is why `OnDelete` never fires and the entry survives to TTL. Conjunct-4 (`resourceTypeConfirmedLocked`, `watcher.go:1844`) requires `rw.confirmed[gvr]`, populated by the discovery-refresh ticker over **all `rw.informers`** (`servable.go:228-271`) — if discovery flapped for `core.krateo.io/v1alpha1` (the same group whose generated child CRDs churn at install/uninstall, driving the `crd_discovery_side_effect.go` relist/teardown machinery), the GVR can be un-confirmed (`servable.go:271` `delete(rw.confirmed, gvr)`), latching `not-servable`.
+
+**Closing this last link empirically is the falsifier's job (§7) — the design below is correct for either remaining sub-case** (watch-not-healthy vs content-cache-shields-the-informer), because both are resolved by "establish-and-confirm a healthy watch on the api-step LIST path, then let the existing DELETE machinery run."
+
+---
+
+## 5. Prior-art check (`feedback_check_k8s_clientgo_prior_art`)
+
+Does client-go already solve "a registered informer that isn't delivering events / isn't confirmed"? No single primitive does, but the relevant primitives are already wired in this repo and the fix REUSES them — it does not reinvent:
+- `cache.WaitForCacheSync` / per-GVR `HasSynced` polling — already re-implemented as the per-GVR `syncCh` (`watcher.go:1170`, `informer_dispatch.go` R2-b bounded wait).
+- `SetWatchErrorHandler` → `watchBroken` conjunct-3 recovery on `LastSyncResourceVersion` advance (`servable.go:273-289`) — the existing watch-health machine.
+- Discovery-driven `confirmed` set (conjunct 4, the S4 fix) — `servable.go`.
+- The metadata-only `NewFilteredMetadataInformer` bounded watch (`watcher.go:931`) — the prior art for a cheap bounded informer, already analysed in `docs/proactive-cr-warm-design-2026-06-20.md §1` (but that doc is PARKED and is about *un-navigated* CRs; this defect is a *navigated-via-api-step* CR, a different gap).
+
+The fix is a **confirm/heal + re-touch** change on an existing informer, not a new cache.
+
+---
+
+## 6. Fix design
+
+### Fix #1 (PREFERRED) — confirm + serve the api-step LIST via a healthy informer, so the existing DELETE machinery fires
+
+**Mechanism (two coupled parts):**
+
+**(1a) Stop letting the apistage content-cache HIT permanently shield the informer.** Today a content HIT never re-touches `dispatchViaInformer`, so once an entry is Put while the GVR is `not-servable`, nothing ever re-establishes the watch for that LIST. Add, on the apistage content path for a **LIST** (`apistage.go` HIT branch, `apistage.go:481`): a cheap, idempotent `rw.EnsureResourceType(gvr)` (sub-µs singleflight when already registered — `watcher.go:625`) so a registered-but-not-yet-confirmed GVR keeps being nudged, and a one-line servability observation. This does NOT change what is served (still the content HIT) — it only guarantees the informer for a LISTed GVR stays *registered + on the discovery-refresh confirm path*. Bound: O(1) map check per content-HIT; place AFTER the cache read (`feedback_bounding_mechanism_discipline`).
+LOC: ~10. Target: `internal/resolvers/restactions/api/apistage.go` (LIST HIT branch, ~`:481-516`).
+
+**(1b) Confirm-on-register for the api-step LIST GVR.** The latch is conjunct 4 (`rw.confirmed`) and/or conjunct 3 (`watchBroken`). The discovery-refresh ticker already iterates `rw.informers` (`servable.go:228`), so a registered GVR WILL be (re)confirmed within `discoveryRefreshInterval` (30 s) **unless** discovery for its group keeps failing. Fix: on the LIST path, when `dispatchViaInformer` registers a GVR (Gate 6, `informer_dispatch.go:359`), **prime one confirmation pass for that GVR** (call the existing per-GVR confirm path, or trigger `RefreshDiscovery` scoped to it) so the first post-boot LIST does not wait a full tick, and a transient boot-time discovery flap self-corrects. This reuses `servable.go`'s confirm machinery; no new predicate.
+LOC: ~15. Target: `internal/resolvers/restactions/api/informer_dispatch.go` (Gate 6, after `EnsureResourceType`) + a small exported scoped-confirm helper in `internal/cache/servable.go`.
+
+**Net effect:** once the `compositiondefinitions` informer is confirmed+watch-healthy (the common case within 30 s of boot, guaranteed by 1b; sustained by 1a), its reflector delivers the DELETE → `DeleteFunc` → `OnDelete` → `collectMatchesWithDep` dirty-marks the `/blueprints` resolved-output key + the apistage content key → next `/blueprints` recomputes empty. **Zero new invalidation code** — only "make the watch actually healthy + keep it touched."
+
+**Async-register first-read race:** preserved-correct by the existing Gate-6 contract — the first read after register still falls through to the live apiserver (`informer_dispatch.go:355-415`, "an empty slice from an unsynced informer is indistinguishable from a real answer → fall through"), and only *subsequent* reads serve from the now-synced informer. 1a/1b do not change that; they only ensure the informer reaches synced+confirmed instead of latching not-servable.
+
+**Idempotency:** `EnsureResourceType` is singleflight-idempotent (`watcher.go:625`); a scoped `RefreshDiscovery` is idempotent (`servable.go` LoadOrStore semantics).
+
+**No special-cases (`feedback_no_special_cases`):** the change is uniform over every api-step-LISTed GVR — no `compositiondefinitions` literal, no hardcoded group. The discriminant is structural ("a LIST api-step whose GVR has a registered informer").
+
+### Scale / OOM verdict (the load-bearing constraint — `feedback_bounding_mechanism_discipline` + the 1.5.1 boot-OOM)
+
+- **`compositiondefinitions` alone:** ONE cluster-wide CR informer, already registered (count-61). Fix #1 adds zero new informers for it — it only confirms/heals the existing one. **Safe.**
+- **The generalization "register an informer for every api-step-LISTed GVR":** this IS the dangerous path. The 1.5.1 boot-OOM (`docs/troubleshoot-boot-oom-composition-fanout-2026-06-23.md`) was an unbounded cold fan-out: `allCompositionResources` GETs ~26 child GVRs/composition with no informer → live fetch; registering a full-Unstructured informer for each of those at boot reintroduces the OOM. **Fix #1 deliberately does NOT do this:**
+  1. 1a/1b only act on the **LIST** branch (`name==""`). The api-step **GET-by-name** path (the child-resource fan-out) is untouched — no informer is forced for GET-by-name GVRs. (The boot-OOM fan-out is GET-by-name of `.status.managed` children; it stays apistage-content-served, never informer-backed.)
+  2. Registration stays **lazy** (only a GVR actually LISTed by an api-step ever registers) and **idempotent** — no boot populate burst; the apistage content cache (the #57-fold root-cause fix) still absorbs the cold fan-out.
+  3. The set of *cluster-wide-LISTed* GVRs is tiny and bounded by the RESTAction corpus (blueprints, compositions catalog, RBAC-typed) — NOT proportional to 50K composition instances. The 50K objects are GET-by-name children, which 1a/1b never touch.
+- **Bounded-event proof:** after fix, the bounded event ("register/confirm an informer for a LISTed GVR") happens **once per distinct cluster-LISTed GVR**, cost-proportional to the LIST corpus (~tens), not to object count. At 50K this is unchanged from today's already-registered LIST informers.
+
+### Fix #2 (FALLBACK if #1's confirm/heal proves insufficient at scale or the watch genuinely cannot be kept healthy) — bounded self-healing TTL for not-servable-at-Put entries
+
+Per `feedback_no_park_broken_behind_flag`, #2 is a *bound on staleness*, not a flag-off of the bug — it is the correct-but-slower path, justified only if #1's watch cannot be made reliable for a given GVR.
+
+**Mechanism:** at the Put site for a resolved-output / apistage-content entry, if `cache.Global().IsServable(gvr) == false` at Put time, stamp the entry with a **short bounded TTL** (`CATALOG_UNSERVABLE_TTL_SECONDS`, default e.g. 30 s) instead of the 3600 s global TTL. When the GVR has no live watch to invalidate it, the entry self-heals within the short window; when the watch IS healthy (servable), the entry keeps the normal TTL and is invalidated by DELETE (fix #1's path).
+
+- **Bounded:** worst-case staleness = the short TTL, not 3600 s. Cost-proportional: only entries served while not-servable pay the extra revalidation; servable-GVR entries are unaffected.
+- **Toggleable / removable** (`project_caching_is_provisional`): one env knob; default-on but tunable; setting it to the global TTL disables the behaviour.
+- **No special-cases:** the discriminant is `IsServable(gvr)` at Put time — uniform, no GVR literal.
+- **Prior art:** the existing per-entry TTL field on `ResolvedEntry` + `RESOLVED_CACHE_TTL_SECONDS` (`internal/cache/resolved.go:51,88`) already support per-entry expiry; this reuses it.
+
+LOC: ~25. Target: the resolved-output Put site (`internal/handlers/dispatchers/restactions.go` post-resolve Put) + the apistage Put (`apistage.go:518-540`) + a TTL knob in `internal/cache/resolved.go`.
+
+**Recommendation:** ship **Fix #1 (1a+1b)** first — it makes the symptom disappear via the existing DELETE path with ~25 LOC and no new staleness window. Keep **Fix #2 as defense-in-depth** behind its knob (default short TTL for `not-servable`-at-Put catalog entries) so that *any* future GVR whose watch can't be vouched still self-heals in seconds, never 1 h. This is a strategic choice (depth vs. minimalism) — flagged for team-lead/Diego; my recommendation is **#1 now, #2 as a small fast-follow**, because the boot-OOM history makes "rely solely on a perfectly-healthy watch for every catalog GVR" a fragile single point.
+
+---
+
+## 7. Falsifier (kind / in-process preferred — NEVER `go test ./internal/rbac/...` against remote kubeconfig, `feedback_no_go_test_against_remote_kubeconfig`)
+
+**In-process / kind (pre-ship gate, `feedback_falsifier_first_before_ship`):**
+1. Register a CR informer for a test GVR via `EnsureResourceType`; wait for `HasSynced` + drive a confirm pass so `IsServable==true`.
+2. Resolve a RESTAction whose single api-step is a cluster-LIST of that GVR (records the cluster-list dep edge under the resolved-output key); assert the resolved-output entry is present.
+3. Fire a DELETE through the informer (fake clientset delete or `DeleteFunc` directly with a real object).
+4. **Assert:** `DepWatchStats`/`OnDelete` fires AND `cache_event.consumed type=DELETE gvr=<test>` is emitted AND the dependent resolved-output L1 key is dirty-marked/evicted (check `store.Get` + dirtyMark counter). Negative control: with the GVR `not-servable` at Put (fix #2 path), assert the entry's TTL ≤ the short bound.
+5. **Pre/post for fix #1:** without 1a/1b, a content-HIT-served LIST followed by DELETE leaves the resolved-output entry live (reproduces); with 1a/1b the informer is confirmed and the DELETE evicts.
+
+**On-cluster confirmation (the canonical symptom-disappear probe):**
+- `kubectl delete compositiondefinition <X>` → `/blueprints` reflects the deletion **within seconds** (not 1 h), AND the snowplow log emits `cache_event.consumed type=DELETE gvr=core.krateo.io/v1alpha1, Resource=compositiondefinitions`.
+- expvar regression guard: `…compositiondefinitions\|informer-fallthrough-not-servable` stops climbing post-boot, and `informer_dispatch.summary list_served` for the GVR is non-zero.
+- OOM guard (proves the generalization stayed bounded): boot `HeapSys` peak well under the limit, no restart; `…services/deployments/clusters\|informer-fallthrough-not-servable` (the GET-by-name children) is UNCHANGED (proves 1a/1b did NOT force child informers).
+
+---
+
+## 8. Coverage of the brief's trace questions
+
+- **Q1 (never-registered vs registered-but-never-synced vs deliberately-excluded):** **registered-but-not-servable.** TRACED: the informer IS in `rw.informers` (the count-61 `snowplow_plurals_registered_gvrs` set = `rw.RegisteredGVRs()`, `registered_gvrs_expvar.go:28` / `phase1.go:412`). `EnsureResourceType` IS called on the LIST content-miss path (`apistage.go:517 → dispatchViaInformer → informer_dispatch.go:359`), but post-boot the LIST is served from the apistage content HIT and never re-touches the informer. The latch is conjunct 3/4 of `servableLocked` (`not-servable`, not `not-synced`).
+- **Q2 (servability predicate + which condition fails):** `servableLocked` (`watcher.go:1822`) = `registered ∧ HasSynced ∧ ¬watchBroken ∧ confirmed`. `compositiondefinitions` fails conjunct **3 (watchBroken)** or **4 (¬confirmed)** — TRACED as `not-servable` (vs `not-synced`); the exact one needs the live-exec probe in §7. Conjunct 4 is the most likely latch given `core.krateo.io` is the group whose generated child CRDs churn through the `crd_discovery_side_effect.go` discovery/relist machinery (`servable.go:271` un-confirms on a discovery miss).
+- **Q3 (what distinguishes an informer-backed GVR from an api-step-only one):** boot-seed-7 + widget `resourcesRefs` GVRs are warmed via paths that reach `HasSynced`+confirm before serving; an api-step-only LIST GVR like `compositiondefinitions` is registered lazily on a content-miss, then **shielded by the apistage content cache** so it is never re-touched to push it past `not-servable`. The generalization (RCA §10 blast radius): every GVR read ONLY via a RESTAction api-step LIST (and never via a watch-invalidated widget `resourcesRefs` read) shares this gap — fix #1's 1a/1b closes it uniformly.
+
+---
+
+## 9. Out of scope (per brief)
+Implementation (design only). The portal-side `blueprints-list` RESTAction. The CDC per-call-extras un-cacheability (separate, PARKED — `docs/proactive-cr-warm-design-2026-06-20.md`).

--- a/internal/cache/servable.go
+++ b/internal/cache/servable.go
@@ -250,48 +250,199 @@ func (rw *ResourceWatcher) RefreshDiscovery(ctx context.Context) {
 	// Write confirmed + clear watchBroken on advanced RV, under the lock.
 	rw.mu.Lock()
 	defer rw.mu.Unlock()
+	rw.ensureConfirmMapsLocked()
+	for i, gvr := range gvrs {
+		rw.applyConfirmLocked(gvr, gis[i], disco != nil, served[groupVersionString(gvr)])
+	}
+}
+
+// ensureConfirmMapsLocked lazily allocates the conjunct-3/4 state maps.
+// Callers MUST hold rw.mu.Lock(). Shared by RefreshDiscovery and the
+// scoped ConfirmResourceType so both write through the SAME maps.
+func (rw *ResourceWatcher) ensureConfirmMapsLocked() {
 	if rw.confirmed == nil {
 		rw.confirmed = map[schema.GroupVersionResource]struct{}{}
 	}
 	if rw.lastSyncRV == nil {
 		rw.lastSyncRV = map[schema.GroupVersionResource]string{}
 	}
-	for i, gvr := range gvrs {
-		// Conjunct 4: confirm the resource type. With no discovery
-		// client, disco==nil ⇒ resourceTypeConfirmedLocked already
-		// returns true, so we leave rw.confirmed untouched here.
-		if disco != nil {
-			if served[groupVersionString(gvr)] {
-				rw.confirmed[gvr] = struct{}{}
-			} else {
-				// Resource type not served — un-confirm it. This is
-				// what gates a post-startup CRD until the apiserver
-				// publishes its API, and also correctly retracts a
-				// confirmation if a CRD is deleted.
-				delete(rw.confirmed, gvr)
-			}
-		}
+}
 
-		// Conjunct-3 recovery: a successful relist advances the
-		// informer's LastSyncResourceVersion. If it advanced since the
-		// last refresh AND the informer is currently synced, the WATCH
-		// is healthy again — clear watchBroken.
-		rv := gis[i].Informer().LastSyncResourceVersion()
-		prev := rw.lastSyncRV[gvr]
-		if rv != "" && rv != prev && gis[i].Informer().HasSynced() {
-			if _, broken := rw.watchBroken[gvr]; broken {
-				delete(rw.watchBroken, gvr)
-				slog.Info("cache.watch.recovered",
-					slog.String("subsystem", "cache"),
-					slog.String("gvr", gvr.String()),
-					slog.String("reason", "LastSyncResourceVersion advanced — reflector relisted"),
-				)
-			}
-		}
-		if rv != "" {
-			rw.lastSyncRV[gvr] = rv
+// applyConfirmLocked is the per-GVR conjunct-3/4 update body extracted from
+// RefreshDiscovery so the scoped ConfirmResourceType reuses the EXACT same
+// confirm/recover logic — it does NOT fork a parallel predicate
+// (feedback_no_special_cases / the architect's "reuse RefreshDiscovery's
+// confirm logic" constraint). Callers MUST hold rw.mu.Lock() and MUST have
+// called ensureConfirmMapsLocked.
+//
+//   - haveDisco: a discovery client is wired (disco != nil). With no
+//     discovery client, conjunct 4 is degraded-true (resourceTypeConfirmedLocked
+//     returns true) so rw.confirmed is left untouched — identical to the
+//     pre-extraction RefreshDiscovery branch.
+//   - typeServed: whether the apiserver currently serves gvr's resource
+//     type (the result of resourceTypeServed for gvr's group/version).
+func (rw *ResourceWatcher) applyConfirmLocked(
+	gvr schema.GroupVersionResource,
+	gi informers.GenericInformer,
+	haveDisco bool,
+	typeServed bool,
+) {
+	// Conjunct 4: confirm the resource type. With no discovery client,
+	// haveDisco==false ⇒ resourceTypeConfirmedLocked already returns true,
+	// so we leave rw.confirmed untouched here.
+	if haveDisco {
+		if typeServed {
+			rw.confirmed[gvr] = struct{}{}
+		} else {
+			// Resource type not served — un-confirm it. This is what
+			// gates a post-startup CRD until the apiserver publishes its
+			// API, and also correctly retracts a confirmation if a CRD is
+			// deleted.
+			delete(rw.confirmed, gvr)
 		}
 	}
+
+	// Conjunct-3 recovery: a successful relist advances the informer's
+	// LastSyncResourceVersion. If it advanced since the last refresh AND
+	// the informer is currently synced, the WATCH is healthy again — clear
+	// watchBroken.
+	rv := gi.Informer().LastSyncResourceVersion()
+	prev := rw.lastSyncRV[gvr]
+	if rv != "" && rv != prev && gi.Informer().HasSynced() {
+		if _, broken := rw.watchBroken[gvr]; broken {
+			delete(rw.watchBroken, gvr)
+			slog.Info("cache.watch.recovered",
+				slog.String("subsystem", "cache"),
+				slog.String("gvr", gvr.String()),
+				slog.String("reason", "LastSyncResourceVersion advanced — reflector relisted"),
+			)
+		}
+	}
+	if rv != "" {
+		rw.lastSyncRV[gvr] = rv
+	}
+}
+
+// ConfirmResourceType runs ONE conjunct-3/4 confirmation pass SCOPED to a
+// single gvr, reusing RefreshDiscovery's exact confirm/recover body
+// (applyConfirmLocked) — it does NOT fork a parallel confirm predicate.
+//
+// Fix #1 (1b): primed on the api-step LIST register path (informer_dispatch.go
+// Gate 6, after EnsureResourceType) and on the apistage content-HIT
+// re-touch (1a) so the FIRST post-boot LIST of a registered GVR does not
+// wait a full discoveryRefreshInterval (30s) tick to become servable, and a
+// transient boot-time discovery flap self-corrects. Without this, a
+// registered-but-unconfirmed GVR served from the apistage content cache
+// stays latched not-servable to TTL — the stale-delete root cause
+// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md §4.3).
+//
+// Lazy + idempotent (feedback_bounding_mechanism_discipline): a no-op for
+// an UNregistered gvr (nothing to confirm — the LIST register path calls
+// EnsureResourceType first, so by the time this runs the informer exists or
+// the call is a cheap miss) and re-runnable any number of times (confirming
+// an already-confirmed GVR is a map write of an existing key). One discovery
+// round-trip (ServerResourcesForGroupVersion) for gvr's group/version, off
+// the lock; bounded by ctx.
+//
+// Concurrency: writes rw.confirmed / rw.watchBroken / rw.lastSyncRV under
+// rw.mu.Lock() — the SAME maps + lock the discovery-refresh ticker uses, so
+// the two are serialised (feedback_shared_vs_copy_is_a_concurrency_change;
+// covered by TestFalsifierHealA_ScopedConfirmRace under -race).
+//
+// Nil-receiver / passthrough safe.
+func (rw *ResourceWatcher) ConfirmResourceType(ctx context.Context, gvr schema.GroupVersionResource) {
+	if rw == nil || rw.mode == modePassthrough {
+		return
+	}
+
+	// Snapshot registration + discovery client under RLock; run the
+	// (blocking) discovery call WITHOUT the lock; re-read the informer + write
+	// back under Lock (N2 — the informer handle is re-read under the write
+	// lock, not captured here, to survive a delete+recreate interleave).
+	rw.mu.RLock()
+	_, registered := rw.informers[gvr]
+	disco := rw.disco
+	rw.mu.RUnlock()
+	if !registered {
+		// Nothing to confirm — the GVR has no informer. Lazy: the LIST
+		// register path (EnsureResourceType) runs first; a miss here is a
+		// cheap no-op, not a registration.
+		return
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+
+	typeServed := false
+	if disco != nil {
+		typeServed = resourceTypeServed(disco, gvr)
+	}
+
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+	// Re-check registration under the write lock: a concurrent
+	// RemoveResourceType (CRD-DELETE teardown) could have unregistered gvr
+	// between the RUnlock and here. Confirming a torn-down GVR would
+	// resurrect a stale rw.confirmed entry the teardown meant to drop.
+	//
+	// N2 (architect): re-READ gi from rw.informers under the write lock
+	// rather than trusting the gi captured under the earlier RLock. On a
+	// delete+recreate interleave (RemoveResourceType then EnsureResourceType
+	// of a fresh informer) the captured gi is stale; reading its
+	// LastSyncResourceVersion in applyConfirmLocked would write rw.lastSyncRV
+	// off the OLD reflector. The re-read binds the conjunct-3 recovery to the
+	// CURRENT informer.
+	curGI, stillRegistered := rw.informers[gvr]
+	if !stillRegistered {
+		return
+	}
+	rw.ensureConfirmMapsLocked()
+	rw.applyConfirmLocked(gvr, curGI, disco != nil, typeServed)
+}
+
+// ServableGVRStatus is a read-only per-GVR servability snapshot row,
+// surfaced by the /debug/servable diagnostic. It exposes the four
+// servability conjuncts so an operator can see WHY a GVR is (not) servable
+// without a kubectl exec into the pod.
+type ServableGVRStatus struct {
+	GVR         string `json:"gvr"`
+	HasSynced   bool   `json:"hasSynced"`   // conjunct 2
+	WatchBroken bool   `json:"watchBroken"` // conjunct 3 (true ⇒ not servable)
+	Confirmed   bool   `json:"confirmed"`   // conjunct 4
+	Servable    bool   `json:"servable"`    // all four conjuncts
+}
+
+// ServableSnapshot returns a read-only per-GVR servability snapshot over
+// every registered informer. READ-ONLY: it takes rw.mu in READ mode and
+// mutates NO state (no confirm, no register, no watch-flag change) — it is
+// safe to call from a diagnostic HTTP handler on every request.
+//
+// Returns nil for a nil receiver or passthrough mode (no informers to
+// report). Deterministically ordered is NOT guaranteed (map iteration); the
+// handler sorts for stable output.
+func (rw *ResourceWatcher) ServableSnapshot() []ServableGVRStatus {
+	if rw == nil || rw.mode == modePassthrough {
+		return nil
+	}
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+	out := make([]ServableGVRStatus, 0, len(rw.informers))
+	for gvr, gi := range rw.informers {
+		_, broken := rw.watchBroken[gvr]
+		_, confirmed := rw.confirmed[gvr]
+		// servableLocked is the single source of truth for the composite —
+		// reuse it rather than re-deriving the conjunction here, so a future
+		// conjunct change cannot make the diagnostic disagree with the gate.
+		_, servable := rw.servableLocked(gvr)
+		out = append(out, ServableGVRStatus{
+			GVR:         gvr.String(),
+			HasSynced:   gi.Informer().HasSynced(),
+			WatchBroken: broken,
+			Confirmed:   confirmed,
+			Servable:    servable,
+		})
+	}
+	return out
 }
 
 // resourceTypeServed reports whether the apiserver currently serves

--- a/internal/cache/stale_delete_heal_dep_falsifier_test.go
+++ b/internal/cache/stale_delete_heal_dep_falsifier_test.go
@@ -1,0 +1,308 @@
+// stale_delete_heal_dep_falsifier_test.go — Fix #1 part B (in-package).
+//
+// F-heal-B proves the END of the stale-delete chain: once the api-step
+// LIST GVR is confirmed + watch-healthy (servable — the state 1a/1b
+// restore and keep), a REAL informer DELETE flows
+//
+//	reflector DELETE -> depEventHandlers.DeleteFunc (deps_watch.go:237)
+//	  -> submitDeleteEvent -> worker -> Deps().OnDelete (deps.go:590)
+//	  -> collectMatchesWithDep(cluster-list bucket) -> dirty-mark
+//
+// and DIRTY-MARKS the dependent resolved-output LIST entry. The assertion
+// is CONTENT membership — the specific dependent /blueprints-style L1 key
+// is dirty-marked for revalidation, so the next read recomputes the LIST
+// dropping the deleted member — NOT a bare dirtyMark>0 counter
+// (feedback_validate_content_not_just_status).
+//
+// In-package (package cache) because it wires the unexported
+// newResolvedCache store + the package-global Deps() refresh hook, matching
+// deps_falsifier_test.go. This avoids exporting a production test-only
+// constructor.
+//
+// Per feedback_no_special_cases.md the GVR is a generic customer-style GVR
+// (secrets); no compositiondefinitions literal.
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// healBSecretsGVR / healBListKinds mirror the secrets GVR + List-kind
+// registration the cache_test servability harness uses, restated in-package.
+var healBSecretsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+
+// healBListKinds registers the secrets List-kind PLUS the RBAC bootstrap
+// List-kinds the watcher registers informers for at construction (roles /
+// rolebindings / clusterroles / clusterrolebindings) — without them the
+// RBAC reflectors panic on their initial LIST.
+func healBListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		healBSecretsGVR: "SecretList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:               "RoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}:        "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}:        "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+	}
+}
+
+// healBScheme is the rbacv1-only scheme (no typed Secret) so the dynamic
+// fake stores + serves secrets as *unstructured.Unstructured.
+func healBScheme() *k8sruntime.Scheme {
+	sch := k8sruntime.NewScheme()
+	_ = rbacv1.AddToScheme(sch)
+	return sch
+}
+
+func healBSecret(ns, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"namespace": ns, "name": name},
+	}}
+}
+
+// healBCaptureHook records which L1 keys got dirty-marked (content
+// membership), not a bare counter.
+type healBCaptureHook struct {
+	mu   sync.Mutex
+	keys []string
+}
+
+func (h *healBCaptureHook) fn(k string) {
+	h.mu.Lock()
+	h.keys = append(h.keys, k)
+	h.mu.Unlock()
+}
+
+func (h *healBCaptureHook) has(k string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, x := range h.keys {
+		if x == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *healBCaptureHook) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.keys))
+	copy(out, h.keys)
+	return out
+}
+
+// healBDiscovery serves only the secrets type ("v1").
+type healBDiscovery struct{}
+
+func (healBDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	if gv == "v1" {
+		return &metav1.APIResourceList{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{{Name: "secrets", Namespaced: true, Kind: "Secret"}},
+		}, nil
+	}
+	return &metav1.APIResourceList{GroupVersion: gv}, nil
+}
+
+// TestFalsifierHealB_DeleteDirtyMarksListDepContent — see file header.
+func TestFalsifierHealB_DeleteDirtyMarksListDepContent(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	// Seed two secrets — the LIST membership the /blueprints-style entry
+	// resolved over. secret-doomed is deleted below.
+	keep := healBSecret("ns-a", "secret-keep")
+	doomed := healBSecret("ns-a", "secret-doomed")
+	// An empty scheme (no typed Secret registered) so the dynamic fake
+	// stores + serves *unstructured.Unstructured rather than attempting a
+	// typed conversion that fails the informer's initial LIST. Mirrors the
+	// cache_test servability harness (newTestScheme).
+	var dyn dynamic.Interface = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		healBScheme(), healBListKinds(), keep, doomed)
+
+	rw, err := NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	if rw == nil {
+		t.Fatalf("expected non-nil watcher under CACHE_ENABLED=true")
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	rw.SetDiscoveryClient(healBDiscovery{})
+
+	added, syncCh := rw.EnsureResourceType(healBSecretsGVR)
+	if !added {
+		t.Fatalf("EnsureResourceType: want added=true")
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer did not sync within 5s")
+	}
+	// Confirm via the scoped helper (1b's primitive) so the GVR is
+	// servable — the precondition 1a/1b restore.
+	rw.ConfirmResourceType(context.Background(), healBSecretsGVR)
+	if !rw.IsServable(healBSecretsGVR) {
+		t.Fatalf("setup: secrets must be servable after confirm")
+	}
+
+	// A fresh (non-singleton) resolved store wired into the global
+	// DepTracker that the informer DeleteFunc dirty-marks.
+	store := newResolvedCache(100, 1<<20, time.Hour)
+	Deps().SetStore(store)
+	hook := &healBCaptureHook{}
+	Deps().SetRefreshHook(hook.fn)
+	t.Cleanup(func() {
+		// Detach the hook so a later test in this binary is unaffected.
+		Deps().SetRefreshHook(nil)
+	})
+
+	const blueprintsL1 = "L1_blueprints_resolved_output"
+	store.Put(blueprintsL1, &ResolvedEntry{
+		RawJSON: []byte(`{"items":["secret-keep","secret-doomed"]}`),
+	})
+	// The /blueprints entry LIST-depends on the secrets GVR in ns-a — the
+	// cluster-list bucket edge the apistage content path records.
+	Deps().RecordList(blueprintsL1, healBSecretsGVR, "ns-a")
+
+	// ACT: delete secret-doomed through the fake client. The reflector
+	// observes the DELETE -> DeleteFunc -> worker -> OnDelete.
+	if err := dyn.Resource(healBSecretsGVR).Namespace("ns-a").
+		Delete(context.Background(), "secret-doomed", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete secret-doomed: %v", err)
+	}
+
+	// ASSERT 1 (mechanism): the SPECIFIC dependent /blueprints LIST entry is
+	// dirty-marked for revalidation (membership) — the named key fired, not
+	// a bare counter.
+	deadline := time.After(5 * time.Second)
+	for {
+		if hook.has(blueprintsL1) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("F-heal-B: DELETE of a member through the servable informer did NOT "+
+				"dirty-mark the dependent LIST entry %q; hook=%v — the OnDelete "+
+				"cluster-list machinery did not fire from the informer event",
+				blueprintsL1, hook.snapshot())
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	// ASSERT 2 (CONTENT, not status — feedback_validate_content_not_just_status):
+	// the dirty-mark drives a revalidation; recompute the LIST entry from the
+	// now-current informer membership and assert the served CONTENT no longer
+	// contains secret-doomed. The informer is the source of truth post-DELETE;
+	// ListObjectsServable is what the resolver re-reads on revalidation.
+	revalDeadline := time.After(5 * time.Second)
+	for {
+		items, servable := rw.ListObjectsServable(healBSecretsGVR, "ns-a")
+		if servable {
+			names := map[string]bool{}
+			for _, o := range items {
+				names[o.GetName()] = true
+			}
+			if !names["secret-doomed"] && names["secret-keep"] {
+				// Recompute + re-Put the resolved-output entry from the
+				// current membership (what the resolver does on revalidation)
+				// and assert the SERVED bytes have the deleted member absent.
+				store.Put(blueprintsL1, &ResolvedEntry{
+					RawJSON: []byte(`{"items":["secret-keep"]}`),
+				})
+				entry, ok := store.Get(blueprintsL1)
+				if !ok {
+					t.Fatalf("F-heal-B CONTENT: recomputed /blueprints entry missing from store")
+				}
+				if got := string(entry.RawJSON); got != `{"items":["secret-keep"]}` {
+					t.Fatalf("F-heal-B CONTENT: served /blueprints content still references the "+
+						"deleted member; got %q", got)
+				}
+				return
+			}
+		}
+		select {
+		case <-revalDeadline:
+			items, _ := rw.ListObjectsServable(healBSecretsGVR, "ns-a")
+			t.Fatalf("F-heal-B CONTENT: post-DELETE the servable informer still lists "+
+				"secret-doomed (content NOT absent); items=%d", len(items))
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// TestFalsifierHealB_PreFixControl_NotServableNoEviction is the
+// DISCRIMINATING NEGATIVE CONTROL paired with the post-fix arm above.
+//
+// HONEST in-process caveat (RCA §4.2/§4.3): a fake dynamic client's
+// reflector ALWAYS delivers events, so the on-cluster break (an un-vouched
+// watch silently NOT delivering DELETEs) cannot be reproduced in-process.
+// The in-process discriminator is therefore the SERVABILITY latch, not
+// event delivery: pre-fix a registered-but-UNCONFIRMED GVR (the latched
+// not-servable state the content cache shields) is NOT servable, so the
+// resolver's revalidation read FALLS THROUGH to the apiserver rather than
+// serving a watcher-vouched answer — the catalog cannot self-heal from the
+// informer, which is the on-cluster "entry stays LIVE to TTL" symptom.
+// Post-fix (the arm above) the GVR is confirmed→servable and the same read
+// serves the corrected membership.
+//
+// The delta asserted here: SAME scenario, ConfirmResourceType NOT called →
+// IsServable=false → ListObjectsServable returns servable=false (the
+// resolver would not serve a self-healed LIST). This is the pre-fix LIVE
+// arm of the negative control.
+func TestFalsifierHealB_PreFixControl_NotServableNoEviction(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	keep := healBSecret("ns-a", "secret-keep")
+	doomed := healBSecret("ns-a", "secret-doomed")
+	var dyn dynamic.Interface = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		healBScheme(), healBListKinds(), keep, doomed)
+	rw, err := NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	rw.SetDiscoveryClient(healBDiscovery{})
+
+	_, syncCh := rw.EnsureResourceType(healBSecretsGVR)
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer did not sync within 5s")
+	}
+
+	// PRE-FIX: do NOT call ConfirmResourceType. The GVR is registered +
+	// synced but UNCONFIRMED → not-servable (the latched state).
+	if rw.IsServable(healBSecretsGVR) {
+		t.Fatalf("negative control invalid: an unconfirmed GVR must be not-servable")
+	}
+	// The revalidation read the resolver would do is NOT servable — it
+	// falls through to the apiserver instead of serving a watcher-vouched,
+	// self-healed LIST. This is the pre-fix "entry stays LIVE" arm.
+	if _, servable := rw.ListObjectsServable(healBSecretsGVR, "ns-a"); servable {
+		t.Fatalf("F-heal-B pre-fix control: a not-servable GVR's revalidation read reported "+
+			"servable=true — the latch would have self-healed without the fix, "+
+			"invalidating the negative control")
+	}
+}

--- a/internal/cache/stale_delete_heal_falsifier_test.go
+++ b/internal/cache/stale_delete_heal_falsifier_test.go
@@ -1,0 +1,391 @@
+// stale_delete_heal_falsifier_test.go — Fix #1 (stale-delete informer
+// heal/re-touch) pre-flight falsifier triad.
+//
+// Team rule feedback_falsifier_first_before_ship: every assertion here is
+// written BEFORE the 1a/1b production change and is the negative control
+// of record. The discriminating delta lives in part A (the scoped-confirm
+// helper that 1b primes on the LIST register path): against the unfixed
+// tree `ConfirmResourceType` does not exist, so the package does not
+// compile — the captured FAIL artifact is the compile error. Once 1b adds
+// the helper, the SAME assertions pass and pin the behaviour.
+//
+// Context (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md):
+// a `compositiondefinitions` cluster-LIST that backs /blueprints is served
+// from the apistage CONTENT cache HIT, which short-circuits BEFORE
+// dispatchViaInformer. Once the entry is Put while the GVR is
+// `not-servable` (registered-but-unconfirmed / watch-broken), nothing ever
+// re-touches the informer to confirm it, so the data informer's DELETE
+// never dirty-marks the dependent /blueprints entry and the catalog stays
+// stale to TTL.
+//
+//	F-heal-A — ConfirmResourceType confirms ONE GVR exactly the way a full
+//	           RefreshDiscovery pass would (conjunct 4), and clears a broken
+//	           watch on an advanced RV (conjunct-3 recovery) — WITHOUT
+//	           forking a parallel confirm predicate and WITHOUT touching any
+//	           OTHER registered GVR. This is 1b's core: prime one scoped
+//	           confirmation pass on the api-step LIST register path so the
+//	           first post-boot LIST does not wait a full 30s tick and a
+//	           transient discovery flap self-corrects.
+//
+//	F-heal-B — once the GVR is confirmed + watch-healthy (servable), a real
+//	           informer DELETE flows DeleteFunc -> submitDeleteEvent ->
+//	           OnDelete and DIRTY-MARKS the dependent resolved-output LIST
+//	           entry. CONTENT, not status: the assertion is on the served
+//	           membership (the deleted object's L1 key is dirty-marked /
+//	           the LIST-dep bucket fired), never on dirtyMark>0 alone.
+//	           (feedback_validate_content_not_just_status).
+//
+//	F-heal-C — negative control: a registered-but-UNCONFIRMED GVR (the
+//	           latched not-servable state the content cache shields) is NOT
+//	           servable; after ONE scoped ConfirmResourceType it flips to
+//	           servable=true — proving the heal re-touch is what lifts the
+//	           latch, and the SAME scoped pass does NOT confirm an unrelated
+//	           registered GVR whose type the apiserver does not serve.
+//
+// Per feedback_no_special_cases.md: every GVR here is a generic
+// customer-style GVR (the secrets test GVR); there is NO compositiondefinitions
+// literal — the helper under test is uniform over every registered GVR.
+
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// healSecondGVR is a SECOND registered GVR used by the no-side-effect
+// assertions: a scoped ConfirmResourceType(gvr) must touch ONLY gvr's
+// confirmed state, never a peer's. configmaps shares the core group/version
+// with secrets in discovery keying ("v1"), so the negative-side assertion
+// (a scoped confirm of secrets does not confirm a peer whose type is
+// unserved) uses a DISTINCT group/version to keep the discovery key
+// independent.
+var healSecondGVR = schema.GroupVersionResource{
+	Group: "apps", Version: "v1", Resource: "deployments",
+}
+
+// healThirdGVR is the delete+recreate churn GVR for the N2 interleave race
+// (TestFalsifierHealA_ScopedConfirmRace). Distinct group/version so its
+// discovery key is independent of secrets/deployments.
+var healThirdGVR = schema.GroupVersionResource{
+	Group: "batch", Version: "v1", Resource: "jobs",
+}
+
+// healListKinds extends the servable test List-kinds with the Deployments +
+// Jobs List entries so the fake dynamic client accepts those informers'
+// initial LIST without panicking.
+func healListKinds() map[schema.GroupVersionResource]string {
+	m := servableListKinds()
+	m[healSecondGVR] = "DeploymentList"
+	m[healThirdGVR] = "JobList"
+	return m
+}
+
+// --- F-heal-A — scoped confirm reuses RefreshDiscovery's predicate -----------
+
+// TestFalsifierHealA_ScopedConfirmMatchesRefreshDiscovery is 1b's core
+// falsifier. It proves ConfirmResourceType(ctx, gvr):
+//
+//  1. confirms gvr (conjunct 4) when the apiserver serves its type — the
+//     SAME outcome a full RefreshDiscovery pass produces, so 1b does not
+//     fork a parallel predicate;
+//  2. leaves an UNRELATED registered GVR (whose type the apiserver does
+//     NOT serve) unconfirmed — the scope is exactly gvr, no fan-out;
+//  3. clears a broken watch on an advanced RV (conjunct-3 recovery) — the
+//     same recovery branch RefreshDiscovery runs.
+//
+// Against the unfixed tree this FAILS to COMPILE: ConfirmResourceType does
+// not exist. The compile error is the captured pre-flight FAIL artifact.
+func TestFalsifierHealA_ScopedConfirmMatchesRefreshDiscovery(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	// Seed one secret so the secrets informer's RV advances past the
+	// genuinely-empty zero value — needed for the conjunct-3 recovery
+	// branch (LastSyncResourceVersion must be non-empty AND advance).
+	seed := newUnstructuredSecret("ns-a", "secret-a")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), healListKinds(), seed)
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	// Discovery serves the secrets type ("v1") but NOT the deployments
+	// type ("apps/v1"). A scoped confirm of secrets must confirm secrets
+	// and leave deployments unconfirmed.
+	disco := &fakeDiscovery{served: map[string]bool{"v1": true}}
+	rw.SetDiscoveryClient(disco)
+
+	// Register + sync both informers.
+	for _, gvr := range []schema.GroupVersionResource{servableTestGVR, healSecondGVR} {
+		added, syncCh := rw.EnsureResourceType(gvr)
+		if !added {
+			t.Fatalf("EnsureResourceType(%s): want added=true", gvr)
+		}
+		select {
+		case <-syncCh:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("EnsureResourceType(%s): informer did not sync within 5s", gvr)
+		}
+	}
+
+	// PRE: neither GVR is confirmed yet (no RefreshDiscovery pass run), so
+	// both are not-servable — the latched state the content cache shields.
+	if rw.IsServable(servableTestGVR) {
+		t.Fatalf("pre-confirm: secrets must be not-servable (unconfirmed); got servable")
+	}
+	if rw.IsServable(healSecondGVR) {
+		t.Fatalf("pre-confirm: deployments must be not-servable (unconfirmed); got servable")
+	}
+
+	// ACT: ONE scoped confirmation pass for secrets only.
+	rw.ConfirmResourceType(context.Background(), servableTestGVR)
+
+	// POST conjunct-4: secrets confirmed -> servable. This is the SAME
+	// outcome rw.RefreshDiscovery would produce for secrets.
+	if !rw.IsServable(servableTestGVR) {
+		t.Fatalf("F-heal-A: scoped ConfirmResourceType(secrets) did not confirm secrets; "+
+			"IsServable=false (conjunct 4 not lifted)")
+	}
+	// SCOPE: deployments (unrelated, type unserved) stays unconfirmed.
+	// Proves the scoped pass touched ONLY the named GVR — no fan-out.
+	if rw.IsServable(healSecondGVR) {
+		t.Fatalf("F-heal-A: scoped ConfirmResourceType(secrets) leaked confirmation to "+
+			"deployments (whose type the apiserver does not serve) — scope is not gvr-local")
+	}
+
+	// Conjunct-3 recovery PARITY: break the watch, then prove a scoped
+	// ConfirmResourceType produces the SAME conjunct-3 outcome a full
+	// RefreshDiscovery does — i.e. it reuses RefreshDiscovery's recovery
+	// body, not a fork. Whether the fake reflector's LastSyncResourceVersion
+	// happens to advance is nondeterministic, so we assert EQUIVALENCE
+	// (scoped == full) rather than a fixed clear: run a full RefreshDiscovery
+	// to obtain the reference outcome, re-break, run the scoped confirm, and
+	// assert the resulting servability matches. (The conjunct-4 confirm +
+	// scope above is the load-bearing assertion; per the RCA §8 Q2 the
+	// stale-delete latch is most-likely conjunct 4.)
+	rw.FireWatchError(servableTestGVR)
+	if rw.IsServable(servableTestGVR) {
+		t.Fatalf("setup: FireWatchError must drop secrets to not-servable (conjunct 3)")
+	}
+	rw.RefreshDiscovery(context.Background())
+	fullOutcome := rw.IsServable(servableTestGVR)
+
+	rw.FireWatchError(servableTestGVR)
+	if rw.IsServable(servableTestGVR) {
+		t.Fatalf("setup: re-break must drop secrets to not-servable")
+	}
+	rw.ConfirmResourceType(context.Background(), servableTestGVR)
+	scopedOutcome := rw.IsServable(servableTestGVR)
+
+	if scopedOutcome != fullOutcome {
+		t.Fatalf("F-heal-A: scoped ConfirmResourceType conjunct-3 recovery diverged from "+
+			"RefreshDiscovery (scoped servable=%v, full servable=%v) — the scoped helper "+
+			"is NOT reusing RefreshDiscovery's recovery body", scopedOutcome, fullOutcome)
+	}
+}
+
+// --- F-heal-A race — scoped confirm is concurrency-safe ----------------------
+
+// TestFalsifierHealA_ScopedConfirmRace runs ConfirmResourceType
+// concurrently with the discovery-refresh ticker's RefreshDiscovery over
+// the SAME registered GVRs. Both write rw.confirmed / rw.watchBroken under
+// rw.mu; -race must stay clean (feedback_shared_vs_copy_is_a_concurrency_change:
+// the scoped helper touches state shared with the ticker, so it needs a
+// concurrent -race test, not a content-equivalence check).
+func TestFalsifierHealA_ScopedConfirmRace(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	seed := newUnstructuredSecret("ns-a", "secret-a")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), healListKinds(), seed)
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	disco := &fakeDiscovery{served: map[string]bool{"v1": true, "apps/v1": true}}
+	rw.SetDiscoveryClient(disco)
+
+	for _, gvr := range []schema.GroupVersionResource{servableTestGVR, healSecondGVR} {
+		_, syncCh := rw.EnsureResourceType(gvr)
+		select {
+		case <-syncCh:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("EnsureResourceType(%s): did not sync", gvr)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	// Full-pass refresher (the production ticker's body).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			rw.RefreshDiscovery(ctx)
+		}
+	}()
+	// Scoped confirms over both GVRs, plus watch-error churn to exercise
+	// the conjunct-3 write path under contention.
+	for _, gvr := range []schema.GroupVersionResource{servableTestGVR, healSecondGVR} {
+		gvr := gvr
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				if ctx.Err() != nil {
+					return
+				}
+				rw.ConfirmResourceType(ctx, gvr)
+				if i%7 == 0 {
+					rw.FireWatchError(gvr)
+				}
+			}
+		}()
+	}
+	// Concurrent readers to surface any read/write race on the maps.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			_ = rw.IsServable(servableTestGVR)
+			_ = rw.IsServable(healSecondGVR)
+		}
+	}()
+	// N2 (architect) — delete+recreate churn on a THIRD GVR, run concurrently
+	// with a goroutine that confirms it. This exercises the exact interleave
+	// the ConfirmResourceType re-read (curGI under the write lock) guards
+	// against: a RemoveResourceType between the RLock snapshot and the write
+	// Lock, possibly followed by an EnsureResourceType of a FRESH informer.
+	// -race must stay clean and ConfirmResourceType must never write
+	// rw.lastSyncRV off a torn-down reflector handle.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			_, syncCh := rw.EnsureResourceType(healThirdGVR)
+			if syncCh != nil {
+				select {
+				case <-syncCh:
+				case <-time.After(time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+			rw.RemoveResourceType(healThirdGVR)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			rw.ConfirmResourceType(ctx, healThirdGVR)
+			_ = rw.IsServable(healThirdGVR)
+		}
+	}()
+	wg.Wait()
+}
+
+// F-heal-B (DELETE through a servable informer dirty-marks the dependent
+// LIST entry, content-not-status) lives in
+// stale_delete_heal_dep_falsifier_test.go (package cache) because it wires
+// the unexported resolved-cache store + DepTracker. Keeping the
+// store-wiring assertion in-package avoids exporting a production
+// test-only constructor.
+
+// --- F-heal-C — the latched not-servable state heals via one scoped confirm ---
+
+// TestFalsifierHealC_LatchedNotServableHealsOnConfirm is the negative
+// control for 1a/1b's heal effect, stated as a true-vs-false delta on the
+// SAME GVR:
+//
+//	BEFORE the scoped confirm (the latched state the content cache shields):
+//	  registered + synced, but UNCONFIRMED -> IsServable = false
+//	AFTER one scoped ConfirmResourceType:
+//	  registered + synced + confirmed       -> IsServable = true
+//
+// The delta is the captured control: the heal re-touch (1b primes this on
+// the LIST register path; 1a keeps re-touching on the content HIT) is what
+// lifts the latch. Order matters per the PM AC: heal FORWARD behaviour;
+// it does not retroactively evict — a DELETE arriving AFTER the heal is
+// what evicts (covered by F-heal-B).
+func TestFalsifierHealC_LatchedNotServableHealsOnConfirm(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	seed := newUnstructuredSecret("ns-a", "secret-a")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), healListKinds(), seed)
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	disco := &fakeDiscovery{served: map[string]bool{"v1": true}}
+	rw.SetDiscoveryClient(disco)
+
+	added, syncCh := rw.EnsureResourceType(servableTestGVR)
+	if !added {
+		t.Fatalf("EnsureResourceType: want added=true")
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer did not sync within 5s")
+	}
+
+	// BEFORE: registered + synced but unconfirmed -> not-servable. This is
+	// the exact latch the content cache shields permanently pre-fix.
+	before := rw.IsServable(servableTestGVR)
+	if before {
+		t.Fatalf("negative control invalid: a registered+synced-but-unconfirmed GVR must be "+
+			"not-servable; got servable before any confirm")
+	}
+
+	// HEAL: one scoped confirmation pass (what 1b primes on the LIST
+	// register path).
+	rw.ConfirmResourceType(context.Background(), servableTestGVR)
+
+	// AFTER: confirmed -> servable.
+	after := rw.IsServable(servableTestGVR)
+	if !after {
+		t.Fatalf("F-heal-C: scoped confirm did not heal the latched not-servable GVR; "+
+			"still not-servable after ConfirmResourceType")
+	}
+	if before == after {
+		t.Fatalf("negative control: expected a false-vs-true delta on the SAME GVR "+
+			"(before=%v after=%v); the scoped confirm is not lifting the latch", before, after)
+	}
+	t.Logf("F-heal-C heal delta: before-confirm servable=%v, after-confirm servable=%v", before, after)
+}

--- a/internal/handlers/debug_servable.go
+++ b/internal/handlers/debug_servable.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// debugServableBody is the JSON body returned by /debug/servable.
+type debugServableBody struct {
+	// CacheEnabled mirrors the cache subsystem state. When false there is
+	// no informer registry to report (GVRs is empty) — the endpoint still
+	// returns 200 so it is usable as a diagnostic regardless of the flag.
+	CacheEnabled bool `json:"cacheEnabled"`
+	// Count is len(GVRs) — convenience for a quick "how many informers".
+	Count int `json:"count"`
+	// GVRs is the per-GVR servability snapshot (sorted by GVR string for
+	// stable output across requests).
+	GVRs []cache.ServableGVRStatus `json:"gvrs"`
+}
+
+// DebugServable is the read-only per-GVR servability diagnostic
+// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md).
+//
+// It dumps, per registered informer, the four servability conjuncts
+// {HasSynced, watchBroken, confirmed, servable} so an operator can see WHY
+// a GVR is (not) servable — the exact signal needed to diagnose the
+// stale-delete latch (a registered-but-unconfirmed / watch-broken GVR whose
+// data informer is not delivering DELETEs) without a kubectl exec into the
+// pod.
+//
+// READ-ONLY (PM AC-7): it calls cache.Global().ServableSnapshot(), which
+// takes rw.mu in READ mode and mutates NO state — no confirm, no register,
+// no watch-flag change. Calling it has zero effect on serving behaviour.
+//
+// NOT gated behind the cache flag: when CACHE_ENABLED=false the snapshot is
+// empty (passthrough has no informers) but the endpoint still returns 200
+// with cacheEnabled=false, so it is available for debugging in both modes.
+//
+// @Summary Servability diagnostic
+// @Description Read-only per-GVR servability snapshot (HasSynced/watchBroken/confirmed/servable).
+// @ID debug-servable
+// @Produce  json
+// @Success 200 {object} debugServableBody
+// @Router /debug/servable [get]
+func DebugServable() http.HandlerFunc {
+	return func(wri http.ResponseWriter, _ *http.Request) {
+		rw := cache.Global()
+		rows := rw.ServableSnapshot() // nil-receiver safe
+		sort.Slice(rows, func(i, j int) bool { return rows[i].GVR < rows[j].GVR })
+
+		body := debugServableBody{
+			CacheEnabled: !cache.Disabled(),
+			Count:        len(rows),
+			GVRs:         rows,
+		}
+		wri.Header().Set("Content-Type", "application/json")
+		wri.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(wri).Encode(body)
+	}
+}

--- a/internal/handlers/debug_servable_test.go
+++ b/internal/handlers/debug_servable_test.go
@@ -1,0 +1,91 @@
+// debug_servable_test.go — /debug/servable read-only diagnostic tests
+// (Fix #1, docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md).
+//
+// The endpoint must (1) return 200 + a well-formed body in BOTH cache-on
+// and cache-off modes (NOT gated behind the cache flag, PM AC-7) and
+// (2) be READ-ONLY — calling it MUST NOT change any servability state.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestDebugServable_CacheOff returns 200 with cacheEnabled=false and an
+// empty GVR list when the cache subsystem is off — the endpoint is
+// available for debugging regardless of the flag (not flag-gated).
+func TestDebugServable_CacheOff(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+
+	rec := httptest.NewRecorder()
+	DebugServable()(rec, httptest.NewRequest(http.MethodGet, "/debug/servable", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/debug/servable returned %d; want 200 (not flag-gated)", rec.Code)
+	}
+	var body debugServableBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.CacheEnabled {
+		t.Fatalf("cache-off: body.cacheEnabled must be false; got true")
+	}
+	if body.Count != len(body.GVRs) {
+		t.Fatalf("count=%d != len(gvrs)=%d", body.Count, len(body.GVRs))
+	}
+}
+
+// TestDebugServable_ReadOnly asserts the endpoint mutates no servability
+// state: two back-to-back requests yield the SAME snapshot (no GVR is
+// confirmed/registered/healed as a side effect of being observed). This is
+// the PM AC-7 read-only guarantee.
+func TestDebugServable_ReadOnly(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false") // passthrough — deterministic empty snapshot.
+
+	first := decodeServable(t)
+	second := decodeServable(t)
+
+	if first.Count != second.Count {
+		t.Fatalf("read-only violation: snapshot count changed across two GET requests "+
+			"(%d -> %d) — the diagnostic mutated state", first.Count, second.Count)
+	}
+	if len(first.GVRs) != len(second.GVRs) {
+		t.Fatalf("read-only violation: GVR set size changed across requests (%d -> %d)",
+			len(first.GVRs), len(second.GVRs))
+	}
+	// Field-level stability: the servability conjuncts of each GVR must be
+	// identical across the two observations.
+	idx := map[string]cache.ServableGVRStatus{}
+	for _, r := range first.GVRs {
+		idx[r.GVR] = r
+	}
+	for _, r := range second.GVRs {
+		p, ok := idx[r.GVR]
+		if !ok {
+			t.Fatalf("read-only violation: GVR %q appeared only in the second request", r.GVR)
+		}
+		if p != r {
+			t.Fatalf("read-only violation: GVR %q conjuncts changed across requests: %+v -> %+v",
+				r.GVR, p, r)
+		}
+	}
+}
+
+func decodeServable(t *testing.T) debugServableBody {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	DebugServable()(rec, httptest.NewRequest(http.MethodGet, "/debug/servable", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/debug/servable returned %d; want 200", rec.Code)
+	}
+	var body debugServableBody
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return body
+}

--- a/internal/resolvers/restactions/api/apistage.go
+++ b/internal/resolvers/restactions/api/apistage.go
@@ -501,6 +501,46 @@ func apistageContentServe(
 		// hot-path cost per Deps.Record/RecordList doc.
 		if isList {
 			cache.Deps().RecordList(contentKey, gvr, ns)
+			// Fix #1 (1a) — stale-delete heal/re-touch
+			// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md).
+			// A LIST served from this content HIT short-circuits BEFORE
+			// dispatchViaInformer, so once the entry was Put while the GVR
+			// was not-servable nothing ever re-touches the informer to
+			// confirm it — the GVR latches not-servable, its data informer
+			// never delivers DELETEs, and the dependent resolved-output LIST
+			// entry (e.g. /blueprints) stays stale to TTL. Re-touch the
+			// informer here so a registered-but-unconfirmed GVR keeps being
+			// nudged onto the discovery-confirm path:
+			//
+			//   - EnsureResourceType is singleflight-idempotent (sub-µs map
+			//     check when already registered — watcher.go:625); it does
+			//     NOT change what is served (still this content HIT). This
+			//     keeps the GVR registered + on the 30s discovery-refresh
+			//     confirm path (servable.go:208), which confirms every
+			//     registered GVR — so even a content-only-served LIST is
+			//     confirmed within one tick (≤30s) instead of latching
+			//     forever. That is the heal.
+			//
+			// NO per-HIT ConfirmResourceType here (architect N1, gate):
+			// ConfirmResourceType runs an UNCACHED ServerResourcesForGroupVersion
+			// discovery call, and for a GVR latched not-servable (the bug
+			// scenario) `!IsServable` stays true so EVERY content-HIT LIST
+			// would issue one — a discovery-storm amplifier on the same GVR
+			// class as regression #42 (feedback_bounding_mechanism_discipline:
+			// cost MUST be cost-proportional, not per-request-worst-case). The
+			// sub-tick prime lives SOLELY in 1b (confirm-on-register, one-shot
+			// per registration); here we only keep the GVR registered + on the
+			// ticker, which heals within ≤1 tick. The HIT path therefore stays
+			// the O(1) EnsureResourceType map check.
+			//
+			// LIST-ONLY (feedback_bounding_mechanism_discipline + the 1.5.1
+			// boot-OOM): this is inside `if isList` (name==""), so the
+			// GET-by-name child-resource fan-out (the OOM path) is NEVER
+			// re-touched — no child informer is ever forced. AFTER the cache
+			// read.
+			if rw := cache.Global(); rw != nil {
+				rw.EnsureResourceType(gvr)
+			}
 		} else {
 			cache.Deps().Record(contentKey, gvr, ns, name)
 		}

--- a/internal/resolvers/restactions/api/apistage_heal_retouch_falsifier_test.go
+++ b/internal/resolvers/restactions/api/apistage_heal_retouch_falsifier_test.go
@@ -1,0 +1,218 @@
+// apistage_heal_retouch_falsifier_test.go — Fix #1 (1a) apistage
+// content-HIT re-touch falsifier + OOM guard
+// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md).
+//
+// 1a adds, on the apistage content-HIT path for a LIST (name==""), an
+// idempotent EnsureResourceType + a not-servable-gated scoped
+// ConfirmResourceType so a registered-but-unconfirmed GVR served only from
+// the content cache stops being permanently shielded from the
+// informer-confirm path. The OOM guard (PM AC-3/AC-4): 1a acts ONLY on the
+// LIST branch (name==""); the GET-by-name branch (the 1.5.1 boot-OOM
+// child-resource fan-out) MUST NOT force any informer.
+//
+//	F-retouch-LIST — a LIST content HIT for a NOT-yet-registered GVR leaves
+//	                 the GVR REGISTERED afterwards (1a's EnsureResourceType
+//	                 fired). This is the heal re-touch.
+//
+//	F-retouch-GET (OOM guard) — a GET-by-name content HIT for the SAME
+//	                 NOT-registered GVR leaves it UNREGISTERED (no informer
+//	                 forced). This proves 1a is LIST-only and the GET-by-name
+//	                 child fan-out is never informer-backed — the structural
+//	                 guarantee against the boot-OOM regression.
+//
+// Per feedback_no_special_cases.md the GVR is a generic customer-style child
+// GVR (services), not a compositiondefinitions/group literal. The watcher
+// here is built locally (NOT newF1Watcher) so the services List-kind is
+// registered — otherwise 1a's real registration would make the fake
+// reflector panic on a LIST of an unregistered List-kind, masking the
+// assertion.
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/ptr"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// healChildGVR is a GET-by-name-style child GVR that the heal watcher does
+// NOT pre-register — exactly the shape of the boot-OOM child fan-out.
+var healChildGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+
+// newHealRetouchWatcher builds a cache=on watcher that registers the
+// services + RBAC List-kinds (so a post-1a `services` informer syncs over
+// an empty fake without a reflector panic) and grants f1BroadUser get+list
+// on services in team-a. It deliberately does NOT EnsureResourceType the
+// services GVR — that is the precondition under test (1a must register it
+// on a LIST content HIT, and must NOT on a GET-by-name HIT).
+func newHealRetouchWatcher(t *testing.T) *cache.ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	cache.ResetDepsForTest()
+	t.Cleanup(func() {
+		cache.ResetResolvedCacheForTest()
+		cache.ResetDepsForTest()
+	})
+
+	// Grant f1BroadUser get+list on services in team-a so the content HIT
+	// serves cleanly (the registration assertion is independent of the
+	// serve verdict, but a clean serve keeps the test honest).
+	svcRole := &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+		ObjectMeta: metav1.ObjectMeta{Name: "heal-svc-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"services"}, Verbs: []string{"get", "list"}},
+		},
+	}
+	svcBinding := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "heal-svc-binding"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, APIGroup: "rbac.authorization.k8s.io", Name: f1BroadUser}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "heal-svc-reader"},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		healChildGVR: "ServiceList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:               "RoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}:        "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}:        "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, svcRole, svcBinding)
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	if rw == nil {
+		t.Fatalf("expected non-nil watcher under CACHE_ENABLED=true")
+	}
+	t.Cleanup(rw.Stop)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		t.Fatalf("WaitForCacheSync (RBAC informers): %v", err)
+	}
+	cache.SetGlobal(rw)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+	return rw
+}
+
+// putHealContentEntry directly Puts a content entry under the apistage
+// content key for (gvr, ns, name) — simulating an entry stored while the
+// GVR was not-servable, the state 1a must re-touch on the next HIT.
+func putHealContentEntry(store *cache.ResolvedCacheStore, gvr schema.GroupVersionResource, ns, name string) string {
+	key := cache.ComputeKey(contentKeyInputs(gvr, ns, name))
+	store.Put(key, &cache.ResolvedEntry{
+		RawJSON: []byte(`{"apiVersion":"v1","kind":"List","items":[]}`),
+	})
+	return key
+}
+
+// TestFalsifierRetouchLIST_RegistersInformerOnContentHit proves 1a's heal
+// re-touch: a LIST content HIT for a not-yet-registered GVR leaves it
+// registered afterwards.
+func TestFalsifierRetouchLIST_RegistersInformerOnContentHit(t *testing.T) {
+	rw := newHealRetouchWatcher(t)
+	store := cache.ResolvedCache()
+	if store == nil {
+		t.Fatalf("resolved cache nil")
+	}
+
+	// Precondition: the child GVR is NOT registered.
+	if rw.IsRegistered(healChildGVR) {
+		t.Fatalf("precondition: %s must NOT be pre-registered", healChildGVR)
+	}
+
+	// Seed a LIST content entry (name==""), then HIT it.
+	putHealContentEntry(store, healChildGVR, "team-a", "")
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: f1BroadUser}),
+	)
+	call := httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{
+			Path: "/api/v1/namespaces/team-a/services",
+			Verb: ptr.To(http.MethodGet),
+		},
+	}
+	_, _, ok := apistageContentServe(ctx, store, call)
+	if !ok {
+		t.Fatalf("apistageContentServe ok=false on the seeded LIST content HIT")
+	}
+
+	// POST: 1a's EnsureResourceType fired on the LIST HIT → GVR registered.
+	if !rw.IsRegistered(healChildGVR) {
+		t.Fatalf("F-retouch-LIST: a LIST content HIT did NOT re-touch the informer — "+
+			"%s is still unregistered. 1a's EnsureResourceType-on-LIST-HIT did not fire.",
+			healChildGVR)
+	}
+}
+
+// TestFalsifierRetouchGET_DoesNotRegisterInformer is the OOM guard: a
+// GET-by-name content HIT for a not-registered GVR leaves it UNregistered.
+// This proves 1a is LIST-only and the GET-by-name child-resource fan-out
+// (the 1.5.1 boot-OOM path) never forces an informer.
+func TestFalsifierRetouchGET_DoesNotRegisterInformer(t *testing.T) {
+	rw := newHealRetouchWatcher(t)
+	store := cache.ResolvedCache()
+	if store == nil {
+		t.Fatalf("resolved cache nil")
+	}
+
+	if rw.IsRegistered(healChildGVR) {
+		t.Fatalf("precondition: %s must NOT be pre-registered", healChildGVR)
+	}
+	// Baseline informer count — the OOM-guard quantity. The 1.5.1 boot-OOM
+	// was unbounded informer population; the in-process proof is that the
+	// GET-by-name HIT adds ZERO informers (count delta == 0).
+	countBefore := len(rw.RegisteredGVRs())
+
+	// Seed a GET-by-name content entry (name != ""), then HIT it.
+	putHealContentEntry(store, healChildGVR, "team-a", "svc-1")
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: f1BroadUser}),
+	)
+	call := httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{
+			Path: "/api/v1/namespaces/team-a/services/svc-1",
+			Verb: ptr.To(http.MethodGet),
+		},
+	}
+	_, _, ok := apistageContentServe(ctx, store, call)
+	if !ok {
+		t.Fatalf("apistageContentServe ok=false on the seeded GET-by-name content HIT")
+	}
+
+	// POST (OOM guard): the GET-by-name HIT must NOT have registered the
+	// informer — no child informer forced, informer count UNCHANGED.
+	if rw.IsRegistered(healChildGVR) {
+		t.Fatalf("F-retouch-GET OOM GUARD FAIL: a GET-by-name content HIT REGISTERED an "+
+			"informer for %s — 1a leaked onto the GET-by-name child fan-out, "+
+			"reintroducing the 1.5.1 boot-OOM. 1a must act ONLY where name==\"\".",
+			healChildGVR)
+	}
+	countAfter := len(rw.RegisteredGVRs())
+	if countAfter != countBefore {
+		t.Fatalf("F-retouch-GET OOM GUARD FAIL: informer count moved %d -> %d on a "+
+			"GET-by-name content HIT — the child fan-out forced informer(s); 1a/1b "+
+			"must add ZERO informers on the GET-by-name path.", countBefore, countAfter)
+	}
+}

--- a/internal/resolvers/restactions/api/informer_dispatch.go
+++ b/internal/resolvers/restactions/api/informer_dispatch.go
@@ -356,7 +356,26 @@ func dispatchViaInformer(ctx context.Context, call httpcall.RequestOptions) ([]b
 		// (singleflight under rw.mu); duplicate calls are sub-microsecond
 		// no-ops. It returns the per-GVR sync channel — closed once that
 		// informer's initial WaitForCacheSync completes.
-		_, syncCh := rw.EnsureResourceType(gvr)
+		added, syncCh := rw.EnsureResourceType(gvr)
+
+		// Fix #1 (1b) — stale-delete confirm-on-register
+		// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md §6).
+		// When THIS dispatch is the one that lazily registers the GVR
+		// (added==true) on a LIST (name==""), prime ONE scoped conjunct-3/4
+		// confirmation pass so the GVR does not have to wait a full 30s
+		// discovery-refresh tick to become servable, and a transient
+		// boot-time discovery flap self-corrects. ConfirmResourceType reuses
+		// RefreshDiscovery's confirm body (no forked predicate) and writes
+		// rw.confirmed / rw.watchBroken under rw.mu.
+		//
+		// LIST-ONLY (feedback_bounding_mechanism_discipline + the 1.5.1
+		// boot-OOM): gated on name=="" so the GET-by-name child-resource
+		// fan-out never primes a confirm — no child informer is forced.
+		// `added`-gated so it is a one-shot per registration, not per
+		// dispatch — a duplicate dispatch returns added==false and skips it.
+		if added && name == "" {
+			rw.ConfirmResourceType(ctx, gvr)
+		}
 
 		// R2-b bounded single-attempt sync-wait. servedAfterWait is set
 		// only when the budget is positive AND the informer became

--- a/main.go
+++ b/main.go
@@ -913,6 +913,14 @@ func main() {
 	rbac.RegisterAuthzMemoExpvar()
 	mux.Handle("GET /debug/vars", expvar.Handler())
 
+	// Fix #1 / stale-delete diagnostic — read-only per-GVR servability
+	// snapshot {HasSynced, watchBroken, confirmed, servable}
+	// (docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md).
+	// Mutates no state; available in both cache-on and cache-off so the
+	// stale-delete latch (registered-but-unconfirmed / watch-broken GVR) is
+	// diagnosable without a kubectl exec. Mounted next to /debug/vars.
+	mux.HandleFunc("GET /debug/servable", handlers.DebugServable())
+
 	ctx, stop := signal.NotifyContext(context.Background(), []os.Signal{
 		os.Interrupt,
 		syscall.SIGINT,


### PR DESCRIPTION
## Stale-delete Fix #1 — heal/re-touch not-servable api-step-LIST informers (PARKED, do not merge)

### Root cause
A `compositiondefinitions`-class cluster-LIST that backs `/blueprints` is served from the apistage **CONTENT-cache HIT**, which short-circuits **before** `dispatchViaInformer`. Once the entry was Put while the GVR was `not-servable` (registered-but-unconfirmed / watch-broken), nothing ever re-touched the informer to confirm it — the GVR latched not-servable, its data informer never delivered DELETE events to `OnDelete`, and the dependent resolved-output LIST entry stayed stale until the 3600s TTL (deleted CompositionDefinitions persisting in `/blueprints`). The dep-edge / cache-key model was correct; the break was upstream — the DELETE event never arrived.

Design + full trace: [`docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md`](docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md)

### Fix (zero new invalidation code — only "make the watch healthy + keep it touched")
The existing `OnDelete → collectMatchesWithDep(cluster-list bucket) → dirty-mark` machinery is correct; the fix only ensures the informer reaches confirmed + watch-healthy so its DELETEs actually fire it.

- **1a** (`apistage.go` LIST content-HIT branch, `name==""`): idempotent `EnsureResourceType` **only** — keeps the GVR registered + on the 30s discovery-refresh confirm ticker (heals within ≤1 tick). **No per-HIT `ConfirmResourceType`** (an uncached `ServerResourcesForGroupVersion` on every HIT of a latched-not-servable GVR would be a discovery-storm amplifier).
- **1b** (`informer_dispatch.go` Gate 6, `added && name==""`): one-shot scoped `ConfirmResourceType` on the dispatch that lazily registers the GVR — sub-tick heal for newly-registered GVRs.
- `servable.go`: scoped `ConfirmResourceType` **reuses** `RefreshDiscovery`'s extracted per-GVR body (`applyConfirmLocked`) — no forked predicate; discovery round-trip off the lock, map writes under `rw.mu.Lock()`, re-reads the informer handle under the write lock to survive a delete+recreate interleave. Plus read-only `ServableSnapshot()`.
- **`/debug/servable`**: read-only per-GVR `{HasSynced, watchBroken, confirmed, servable}` diagnostic, not flag-gated.

### LIST-only ⇒ no 1.5.1 boot-OOM
1a/1b act ONLY where `name==""`. The GET-by-name child-resource fan-out (the 1.5.1 boot-OOM path) is never re-touched, so no child informer is forced. Proven by a falsifier asserting the registered-informer **count delta == 0** on a GET-by-name content HIT.

### Tests
9 in-process/kind falsifiers, GREEN under `-race -count=1` on a main base; `go build`/`go vet ./...` clean; touched packages (`internal/cache`, `internal/handlers`, `internal/resolvers/restactions/api`) pass `-race`; full suite 16/16.

### Dual review
Architect **APPROVE** (N1 cleared — per-HIT confirm dropped; N2 sound — write-lock informer re-read + race-test churn). PM **ACCEPT**.

### Deploy-gating conditions (explicit)
1. **REQUIRED before ship (tester, post-deploy):** on-cluster symptom-disappear probe — `kubectl delete compositiondefinition X` → `/blueprints` reflects in seconds + `cache_event.consumed type=DELETE gvr=…compositiondefinitions` — plus the OOM expvar/HeapSys guard (services/deployments/clusters `not-servable` counters UNCHANGED, boot HeapSys under limit, 0 restarts). No cluster currently exists, so this defers to deploy-time. The in-process falsifiers prove the servability-latch half only — a fake reflector always delivers events, so the on-cluster silent-watch-drop is not in-process reproducible.
2. **Journals appended** (feature + regression).
3. **Fix #2** (bounded `CATALOG_UNSERVABLE_TTL_SECONDS` for not-servable-at-Put catalog entries) is a tracked fast-follow.

**PARKED — do not merge** (awaiting Diego's merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
