### PR TITLE
fix(rbac): /rbac in-cluster-stage verb by path shape (collection→list, by-name→get)

### DIFF
--- a/docs/restaction-rbac-endpoint-design.md
+++ b/docs/restaction-rbac-endpoint-design.md
@@ -1,0 +1,264 @@
+# Snowplow `/rbac` endpoint — RESTAction→GVR inspect-only enumeration (REVISED design)
+
+Date: 2026-06-23
+Anchor: canonical `~/krateo/snowplow-cache/snowplow` @ `1.4.3-1-g4062db0`.
+Status: REVISED per PM gate (REVISE) + Diego auth ruling. Doc-only; no code in this pass.
+Supersedes the prior finalized design on exactly two premises (Corrections 1 and 2 below);
+everything else is carried forward verbatim (PM-blessed).
+
+> Note for §4 / §7.1 of the prior draft: the directive "omit the UAF stages from the
+> enumerated read-set" is **REVERSED** — UAF stages are **EMITTED** (with their verb).
+> See Correction 1.
+
+---
+
+## 0. Purpose
+
+core-provider needs to know, for a given RESTAction, the full set of
+`(group, resource, verb)` tuples that resolving it will read — so it can pre-generate
+the RBAC (Roles/RoleBindings) a user needs *before* the first `/call`. `/rbac` enumerates
+that read-set from the RA's `api[]` stages **without dispatching** (no apiserver reads of
+the referenced data, no per-user creds required) and returns a canonical, deduped,
+sorted list.
+
+---
+
+## 1. Prior-art check (k8s / client-go)
+
+- `SelfSubjectRulesReview` (authorization/v1) enumerates what *a caller* may do, not what a
+  *RESTAction* will read — wrong axis. We need the RA's static read-set, derived from the
+  blueprint, before any binding exists.
+- `RESTMapper` / discovery (`discoveryClientFor`, discovery_dispatch.go:114) maps
+  group/version → resource plurals; we **reuse** it (already in-process). It does not, on its
+  own, walk an RA's `api[]` + `dependsOn` graph — that walk is snowplow-specific.
+- No client-go primitive walks a snowplow RA blueprint. So the *enumeration* is new; every
+  *primitive it calls* is existing snowplow code (§3). Nothing reinvented.
+
+---
+
+## 2. Root-axis facts (all TRACED against the anchor)
+
+| Fact | Where | Status |
+|---|---|---|
+| HTTP-stage `self.verb` is CEL-bound to GET/HEAD (case-insensitive) | `apis/templates/v1/core.go:30` | TRACED |
+| `self.userAccessFilter.verb` is **only** CEL-required non-empty — NOT member-bound | `apis/templates/v1/core.go:32` | TRACED |
+| `UserAccessFilterSpec.Verb` is a **free-form lower-case string** ("get, list, watch, etc.") | `apis/templates/v1/core.go:139-141` | TRACED |
+| refilter passes `Verb: uaf.Verb` **verbatim** into `EvaluateRBAC` | `internal/resolvers/restactions/api/refilter.go:257-267` (line 260) | TRACED |
+| `/call` mounts on `middleware.UserConfig(*signKey, *authnNS)` | `main.go:813-814` | TRACED |
+| `UserConfig` = JWT-validate (authn) + load `<user>-clientconfig` Endpoint into ctx | `internal/handlers/middleware/userconfig.go:151,229-233` | TRACED |
+| `/refreshes` mounts WITHOUT `RegisterScopedRoute` (zero apiserver reads → outside read-path-scoped invariant) | `main.go:825,831-833` | TRACED |
+| `RegisterScopedRoute` is what enrolls a route in the per-user apiserver-read scope invariant | `internal/cache/fallthrough_middleware.go:142-158` | TRACED |
+| Enumeration primitives all exist in-process | topologicalSort `sort.go:9`; ParseAPIServerPathToDep `internal/cache/inventory.go:251`; discoveryClientFor `discovery_dispatch.go:114`; createRequestOptions `setup.go:28`; `ServiceAccountRESTConfig` `internal/dynamic/sa_client.go:158` | TRACED |
+
+---
+
+## 3. Reuse map — KEPT UNCHANGED (PM-blessed)
+
+The enumeration body is unchanged from the prior finalized design:
+
+- **No-dispatch path-eval**: `createRequestOptions(ctx, log, in, dict)` (`setup.go:28`) resolves a
+  stage's `path` from the (possibly empty) dict WITHOUT issuing the HTTP/apiserver call —
+  use it to materialize each stage's concrete path, then classify.
+- **Path → GVR**: `ParseAPIServerPathToDep(path)` (`inventory.go:251`) yields
+  `(gvr, namespace, name, ok)` for an in-cluster apiserver-shaped path.
+- **Discovery**: `discoveryClientFor(rc)` (`discovery_dispatch.go:114`) on
+  `ServiceAccountRESTConfig()` (`sa_client.go:158`) resolves bare `/apis/<g>/<v>` discovery-shaped
+  stages to their resource plural set — **SA discovery, dispatch-free**.
+- **Dependency order**: `topologicalSort(items)` (`sort.go:9`) — **corrected location** (prior
+  draft mis-cited `resolve.go:1480`). Used to evaluate `dependsOn` edges in order so a
+  stage's path that templates off an upstream stage's (empty-dict) output is still walkable.
+- **dependsOn cutoff**: empty-dict eval + parser rejection — a path that cannot be
+  materialized from the empty dict (because it genuinely needs upstream *data*, not just
+  shape) is reported, not silently dropped.
+- **Permissive default**, **fail-loud non-200 enumeration**, **canonical dedupe/sort**: unchanged.
+- **Zero dispatch-path modification**: `/rbac` is a read-only sibling endpoint; it does not
+  touch `Resolve`, the dispatcher, or the refilter.
+
+The ~280-LOC sketch is carried forward **minus the ServiceAuth middleware** (see Correction 2):
+`serviceauth.go` is **dropped**; `/rbac` mounts on the existing `UserConfig`.
+
+---
+
+## 4. Correction 1 — UAF stages are EMITTED (with their verb); they are NOT omitted
+
+### Root cause of the prior error (TRACED)
+The prior draft asserted "CRD CEL restricts `userAccessFilter.verb` to get/head/list, so a
+verb-less response is provably safe, and UAF stages can be omitted from the read-set." That is
+**FALSE**:
+- `core.go:30` bounds **`self.verb`** — the *HTTP stage method* — to GET/HEAD.
+- `core.go:32` only requires **`self.userAccessFilter.verb != ''`** (non-empty); it does **not**
+  constrain it to any member set.
+- `core.go:139-141`: `UserAccessFilterSpec.Verb` is a free-form lower-case string
+  ("get, list, watch, etc.").
+- `refilter.go:260`: the refilter calls `EvaluateRBAC(Verb: uaf.Verb, …)` **verbatim**.
+
+So `uaf.Verb` can be `watch`, `deletecollection`, or anything else. A verb-less `/rbac`
+response paired with a consumer that grants only a fixed `{get,list,watch}` read-set would
+**UNDER-GRANT** any UAF stage whose verb falls outside that set → silent under-read at first
+`/call`. The "CEL guarantees it" claim is **struck entirely**.
+
+### Fix — emit `uaf.Verb` on UAF rows (PM-preferred)
+A UAF stage contributes a read-set row carrying its **own** verb so the consumer grants
+exactly that verb. The verb the SA-dispatch+refilter actually checks is `uaf.Verb`
+(refilter.go:260) on `(uaf.Group, resource∈resolveUAFResources)` — that is precisely what
+the user must hold, so that is precisely what we emit.
+
+### Response shape (build-ready)
+
+```json
+{
+  "restaction": { "name": "compositions-get-ns-and-crd", "namespace": "krateo-system" },
+  "readSet": [
+    { "group": "",                         "resource": "namespaces",     "verb": "get" },
+    { "group": "apiextensions.k8s.io",     "resource": "customresourcedefinitions", "verb": "list" },
+    { "group": "composition.krateo.io",    "resource": "fireworksapps",  "verb": "watch" }
+  ],
+  "unresolved": [
+    { "stage": "detail", "reason": "path templates off upstream stage data; not materializable from empty dict" }
+  ]
+}
+```
+
+Field rules (the digest/dedupe key is the full triple, so this stays stable):
+
+- **`verb` is ALWAYS present** on every row. This is the deliberate, documented divergence
+  from chart-inspector byte-parity, and it is the entire correctness point of Correction 1.
+- **Non-UAF rows** (plain in-cluster stages, classified via `ParseAPIServerPathToDep`)
+  carry the verb dictated by the path SHAPE: a **COLLECTION** read
+  (`.../resource`, no object name) → **`"list"`**; a **BY-NAME** read
+  (`.../resource/<name>`) → **`"get"`**. ✅ **FIXED** (2026-06-25, #44 verb bug):
+  the prior draft asserted a *constant* `"get"` on the (mistaken) rationale that
+  "`core.go:30` bounds the HTTP-stage method to GET/HEAD, so `get` is exact". That
+  conflated the HTTP *method* with the RBAC *verb*: the apiserver authorizes a
+  collection GET under the **`list`** verb, so a constant `get` UNDER-GRANTED every
+  collection stage (the dominant catalog shape, e.g. the `/blueprints`
+  `compositiondefinitions` LIST) and 403'd the real LIST at `/call`. The fix
+  (`inspect.go` `inspectInClusterStage`) captures the object `name` from
+  `ParseAPIServerPathToDep` and emits `verb := "list"; if name != "" { verb = "get" }`.
+  Resource granularity is unchanged — `Resource.Name` stays `""` (a resource-level
+  grant, per §3.2); only the verb reflects the read shape.
+- **UAF rows** carry **`uaf.Verb`** verbatim (the value at `core.go:141`, passed at
+  refilter.go:260). For a `resourcesFrom` UAF the row fans out to one row per discovered
+  plural (each with the same `uaf.Verb` and `uaf.Group`), matching the OR-semantics loop at
+  refilter.go:254-285.
+
+> Prior-draft note: a "verb-less response with chart-inspector byte-parity" is **abandoned**.
+> Byte-parity on the *non-UAF* subset is preserved only at the (group, resource) level;
+> the always-present `verb` field is an additive, documented field on the snowplow response.
+> The consumer (core-provider) keys on the triple.
+
+### Dedupe / sort (unchanged mechanism, now over the triple)
+Canonical-dedupe and -sort operate on `(group, resource, verb)` lexicographically. Two stages
+that read the same resource under different verbs (e.g. an HTTP-GET stage on `namespaces` and
+a UAF `watch` on `namespaces`) yield **two** distinct rows — correct, because the user needs
+both verbs granted.
+
+### Falsifier (PM-required)
+Construct an RA with a UAF stage whose `uaf.Verb` ∉ {get,list,watch} — e.g.
+`userAccessFilter: { verb: deletecollection, group: "", resource: namespaces }` (admission
+accepts it: `core.go:32` only checks non-empty + XOR). Call `/rbac`. **PASS** iff the
+`readSet` contains exactly `{ "group": "", "resource": "namespaces", "verb": "deletecollection" }`.
+A verb-less or omitted row = FAIL (the under-grant the prior design would have produced).
+
+---
+
+## 5. Correction 2 — `/rbac` REUSES the existing `UserConfig` auth (no new ServiceAuth)
+
+### Root cause of the prior error
+The prior draft invented a dedicated-key `ServiceAuth` middleware (`serviceauth.go`) on the
+premise that core-provider arrives **unauthenticated**. Diego confirms that premise is FALSE:
+**core-provider already presents the standard `/call` auth** (a JWT + a `<user>-clientconfig`).
+So no new middleware and no new signing key.
+
+### Fix — mount `/rbac` on `middleware.UserConfig(*signKey, *authnNS)`
+Identical to `/call` (`main.go:813-814`). Concretely, mount in the same block:
+
+```go
+// GET /rbac — RESTAction read-set enumeration for core-provider RBAC pre-gen.
+// Authenticated with the SAME JWT+clientconfig as /call (middleware.UserConfig).
+// DELIBERATELY NOT cache.RegisterScopedRoute'd: like /refreshes (main.go:831-833),
+// it issues ZERO per-user apiserver reads — enumeration runs under SA discovery —
+// so it sits outside the read-path-scoped invariant (fallthrough_middleware.go:142).
+mux.Handle("GET /rbac", chain.Append(
+    middleware.UserConfig(*signKey, *authnNS)).
+    Then(handlers.RBAC( /* deps: SA rest.Config + RA lookup */ )))
+```
+
+### The load-bearing framing: authentication ≠ the caller's RBAC permissions (TRACED)
+This is the point to get exactly right:
+
+- `UserConfig` does two things (userconfig.go): (a) **validate the JWT** → `userInfo`
+  (`:151`); (b) **load `<user>-clientconfig`** Endpoint into ctx via `WithUserConfig`
+  (`:229-233`). (a) is authentication. (b) is the per-user dispatch *capability*.
+- `/rbac` consumes **(a) only** for the authn gate. It does **NOT** use (b): the enumeration
+  reads nothing through the caller's clientconfig — discovery runs under
+  `ServiceAccountRESTConfig()` (`sa_client.go:158`). Loading the clientconfig is **harmless**:
+  core-provider has one, and `/rbac` simply never dispatches with it.
+- Therefore `/rbac` needs **NONE of the caller's RBAC permissions** → the read-set can be
+  generated **before** the first resolve / before any binding exists. This is the whole reason
+  the endpoint exists, and it survives the auth-reuse: requiring a JWT for *authentication* is
+  orthogonal to needing the caller's *permissions*.
+- Loading the clientconfig is a Secret read served from the informer cache
+  (`api.FromInformerSecret`, userconfig.go:169) — **not** a per-user apiserver RBAC read.
+  This is why `/rbac` stays correctly **un-`RegisterScopedRoute`'d** (mirrors `/refreshes`,
+  whose comment at main.go:824-826 states the same "zero apiserver reads → outside the
+  invariant" rationale).
+
+### Privileged-oracle tradeoff (addressed, not over-engineered)
+With `UserConfig`, **any** authenticated caller (any holder of a valid JWT + clientconfig) can
+call `/rbac` and learn a RESTAction's GVR read-set. That is **read-only metadata** about a
+blueprint; it confers no access — the actual privilege (writing RBAC) lives in core-provider,
+not in `/rbac`. The data leaked is "which GVRs does RA X read", which is already discoverable
+by anyone who can `GET` the RESTAction CR. **Accepted tradeoff; default is plain `UserConfig`
+per Diego.**
+
+**OPTIONAL hardening (offered, not default):** if `/rbac` should be restricted to
+core-provider specifically, the minimal add is a caller-identity/group check inside
+`handlers.RBAC` — gate on the core-provider SA's group (`system:serviceaccounts:<ns>` or its
+specific SA username from `userInfo`, already in ctx from `WithUserInfo`). ~5 LOC, no new
+middleware. Recommendation: **ship plain `UserConfig`** (Diego's ruling); add the group check
+later only if a concrete need to restrict the oracle appears.
+
+---
+
+## 6. LOC bound & file:line targets
+
+- `internal/handlers/rbac.go` (**new**, ~180 LOC): `func RBAC(...) http.Handler` — load RA by
+  name/ns, walk `api[]` in `topologicalSort` order, classify each stage
+  (`createRequestOptions` → `ParseAPIServerPathToDep` for in-cluster GET; `discoveryClientFor`
+  on SA RC for bare discovery paths; UAF branch reads `uaf.Group`/`uaf.Verb`/resource-set),
+  dedupe+sort the triples, marshal §4 shape, fail-loud on non-200 discovery.
+- `main.go` (~5 LOC at the §5 mount site, adjacent to main.go:818): mount `GET /rbac` on
+  `UserConfig`; **do not** `RegisterScopedRoute`.
+- **Dropped vs prior draft**: `serviceauth.go` (entire file) — not created.
+- Net: ~280 LOC → ~185 LOC after dropping the middleware.
+
+---
+
+## 7. Falsifiers (consolidated; PM re-gate checklist)
+
+1. **UAF verb emit (§4):** RA with UAF `verb: deletecollection` on `namespaces` →
+   `/rbac` readSet contains `{group:"", resource:"namespaces", verb:"deletecollection"}`.
+   Verb-less/omitted = FAIL.
+2. **Non-UAF verb:** plain in-cluster GET stage on `/api/v1/namespaces` → row
+   `{group:"", resource:"namespaces", verb:"get"}`.
+3. **resourcesFrom fan-out:** UAF with `resourcesFrom` yielding 3 plurals → 3 rows, each
+   carrying `uaf.Verb` + `uaf.Group`.
+4. **Auth reuse (§5):** a request with the **same** JWT+clientconfig that succeeds on `/call`
+   succeeds on `/rbac`; a request with no/invalid Authorization header → 401 (UserConfig
+   `:135-158`). No new key needed.
+5. **Dispatch-free / before-resolve:** `/rbac` returns a correct read-set when the caller holds
+   **zero** RBAC on the enumerated GVRs (enumeration under SA discovery; the caller's
+   clientconfig is loaded but never used for the reads).
+6. **Not scoped:** `AssertReadPathsScoped` / `requiredScopedRoutes`
+   (`fallthrough_assert.go`) startup assertion still passes with `/rbac` mounted and
+   un-registered (mirrors `/refreshes`).
+
+---
+
+## 8. Strategic choice surfaced (one)
+
+**Oracle restriction** (§5): default `UserConfig` (any authenticated caller) vs optional
+core-provider-group check. **Recommendation: default `UserConfig`** per Diego — the leak is
+read-only blueprint metadata already obtainable via `GET` on the RA CR; add the group check
+only on a concrete need. Everything else in this design is non-strategic and TRACED.

--- a/internal/resolvers/restactions/api/inspect.go
+++ b/internal/resolvers/restactions/api/inspect.go
@@ -218,16 +218,29 @@ func inspectInClusterStage(rc *rest.Config, stage *templates.API, dict map[strin
 		path := opt.Path
 
 		// Resource path → GVR (the dominant case).
-		if gvr, ns, _, ok := cache.ParseAPIServerPathToDep(path); ok {
+		if gvr, ns, name, ok := cache.ParseAPIServerPathToDep(path); ok {
 			if err := validateGVR(rc, gvr); err != nil {
 				return nil, fmt.Errorf("discovery validation failed for %s: %w", gvr.String(), err)
+			}
+			// The RBAC verb is determined by the path SHAPE, not a constant:
+			// a COLLECTION read (`.../resource`, no object name) is authorized
+			// as `list`; a BY-NAME read (`.../resource/<name>`) as `get`. The
+			// HTTP-stage method is CEL-bound to GET/HEAD (core.go:30), but the
+			// apiserver authorizes a collection GET under the `list` verb — so
+			// the prior constant `get` UNDER-GRANTED every collection stage and
+			// 403'd the real LIST at /call (#44 verb bug, design §4). Resource
+			// granularity is unchanged (Name stays "" — a resource-level grant,
+			// per design §3.2); only the verb reflects the read shape.
+			verb := "list"
+			if name != "" {
+				verb = "get"
 			}
 			rows = append(rows, Resource{
 				Group:     gvr.Group,
 				Version:   gvr.Version,
 				Resource:  gvr.Resource,
 				Namespace: ns,
-				Verb:      "get",
+				Verb:      verb,
 			})
 			continue
 		}

--- a/internal/resolvers/restactions/api/inspect_test.go
+++ b/internal/resolvers/restactions/api/inspect_test.go
@@ -167,9 +167,12 @@ func TestInspect_UAFVerbVerbatim_FreeFormVerb(t *testing.T) {
 	}
 }
 
-// Falsifier #2 — a non-UAF in-cluster GET stage emits verb "get" (core.go:30
-// bounds the HTTP-stage verb to GET/HEAD; HEAD requires the same get RBAC verb).
-func TestInspect_NonUAFStage_VerbGet(t *testing.T) {
+// Falsifier #2 — a non-UAF in-cluster COLLECTION stage emits verb "list".
+// The HTTP-stage method is CEL-bound to GET/HEAD (core.go:30), but a
+// collection read (`.../pods`, no object name) is authorized by the apiserver
+// under the `list` verb, not `get` (#44 verb fix, design §4). The prior
+// constant `get` here UNDER-GRANTED the collection read.
+func TestInspect_NonUAFStage_CollectionVerbList(t *testing.T) {
 	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
 
 	ra := &templates.RESTAction{
@@ -186,9 +189,9 @@ func TestInspect_NonUAFStage_VerbGet(t *testing.T) {
 	if len(unresolved) != 0 {
 		t.Fatalf("expected zero unresolved, got %+v", unresolved)
 	}
-	row, ok := findRow(rows, "", "pods", "get")
+	row, ok := findRow(rows, "", "pods", "list")
 	if !ok {
-		t.Fatalf("FALSIFIER #2 FAIL: non-UAF GET stage must emit verb=get for pods; got %+v", rows)
+		t.Fatalf("FALSIFIER #2 FAIL: non-UAF COLLECTION stage must emit verb=list for pods; got %+v", rows)
 	}
 	if row.Namespace != "krateo-system" {
 		t.Fatalf("expected namespace krateo-system on the namespaced pods row, got %q", row.Namespace)
@@ -198,8 +201,9 @@ func TestInspect_NonUAFStage_VerbGet(t *testing.T) {
 // DEFECT 2 falsifier — an extras-driven dependsOn.iterator stage expands to one
 // RequestOptions per iterator element (createRequestOptions/jqutil.ForEach). The
 // inspect pass MUST classify EVERY opt, not just opts[0]: a per-namespace pods
-// GET iterating [ns-a, ns-b] must emit a pods row for EACH namespace. Before the
-// fix (only opts[0] inspected) the ns-b row was silently dropped = under-grant.
+// COLLECTION iterating [ns-a, ns-b] must emit a pods row for EACH namespace.
+// Before the fix (only opts[0] inspected) the ns-b row was silently dropped =
+// under-grant. Each collection row carries verb=list (#44 verb fix).
 func TestInspect_ExtrasIteratorStage_EmitsRowPerNamespace(t *testing.T) {
 	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
 
@@ -233,13 +237,13 @@ func TestInspect_ExtrasIteratorStage_EmitsRowPerNamespace(t *testing.T) {
 	for _, ns := range []string{"ns-a", "ns-b"} {
 		found := false
 		for _, r := range rows {
-			if r.Resource == "pods" && r.Verb == "get" && r.Namespace == ns {
+			if r.Resource == "pods" && r.Verb == "list" && r.Namespace == ns {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Fatalf("DEFECT 2 FAIL: extras-iterator stage must emit a pods/get row for "+
+			t.Fatalf("DEFECT 2 FAIL: extras-iterator stage must emit a pods/list row for "+
 				"namespace %q — inspecting only opts[0] would drop it (under-grant). got rows=%+v", ns, rows)
 		}
 	}
@@ -359,8 +363,9 @@ func TestInspect_EndpointRefStage_Omitted(t *testing.T) {
 	if _, ok := findRow(rows, "", "external", "get"); ok {
 		t.Fatalf("endpointRef stage leaked an in-cluster row: %+v", rows)
 	}
-	if _, ok := findRow(rows, "", "pods", "get"); !ok {
-		t.Fatalf("the in-cluster pods stage should still emit; got %+v", rows)
+	// /api/v1/pods is a cluster-scoped COLLECTION → verb=list (#44 verb fix).
+	if _, ok := findRow(rows, "", "pods", "list"); !ok {
+		t.Fatalf("the in-cluster pods collection stage should still emit (verb=list); got %+v", rows)
 	}
 	if len(rows) != 1 {
 		t.Fatalf("expected exactly 1 row (pods); got %d: %+v", len(rows), rows)
@@ -492,15 +497,17 @@ func TestInspect_DedupeAndSort(t *testing.T) {
 	if len(unresolved) != 0 {
 		t.Fatalf("expected zero unresolved, got %+v", unresolved)
 	}
-	// namespaces/get appears once (deduped), namespaces/watch once, deployments/get once.
-	if _, ok := findRow(rows, "", "namespaces", "get"); !ok {
-		t.Fatalf("missing namespaces/get; got %+v", rows)
+	// namespaces/list appears once (the two collection GET stages dedupe),
+	// namespaces/watch once (UAF, distinct verb), deployments/list once.
+	// (#44 verb fix: collection reads carry verb=list, not get.)
+	if _, ok := findRow(rows, "", "namespaces", "list"); !ok {
+		t.Fatalf("missing namespaces/list; got %+v", rows)
 	}
 	if _, ok := findRow(rows, "", "namespaces", "watch"); !ok {
 		t.Fatalf("missing namespaces/watch (different verb, must stay distinct); got %+v", rows)
 	}
-	if _, ok := findRow(rows, "apps", "deployments", "get"); !ok {
-		t.Fatalf("missing apps/deployments/get; got %+v", rows)
+	if _, ok := findRow(rows, "apps", "deployments", "list"); !ok {
+		t.Fatalf("missing apps/deployments/list; got %+v", rows)
 	}
 	if len(rows) != 3 {
 		t.Fatalf("expected exactly 3 rows after dedupe, got %d: %+v", len(rows), rows)

--- a/internal/resolvers/restactions/api/inspect_verb_falsifier_test.go
+++ b/internal/resolvers/restactions/api/inspect_verb_falsifier_test.go
@@ -1,0 +1,178 @@
+// inspect_verb_falsifier_test.go — /rbac in-cluster-stage verb fix
+// (docs/restaction-rbac-endpoint-design.md §4).
+//
+// THE BUG (#44 shipped it unfixed): inspectInClusterStage emitted a CONSTANT
+// Verb:"get" for every non-UAF in-cluster stage, on the (wrong) rationale
+// that "core.go:30 bounds the HTTP-stage method to GET/HEAD, so get is exact".
+// But the RBAC verb for a COLLECTION GET (`GET /apis/g/v/resource`, no object
+// name) is `list`, NOT `get` — the apiserver authorizes a collection read as
+// the `list` verb. So a RESTAction whose in-cluster stage is a collection LIST
+// (the dominant catalog shape, e.g. `/apis/.../compositiondefinitions`) was
+// granted `get` on that resource, which 403s a real LIST at /call → the
+// core-provider under-grants and the catalog read fails.
+//
+// THE FIX: capture the object name from ParseAPIServerPathToDep and emit
+// `verb := "list"; if name != "" { verb = "get" }`. A by-name GET
+// (`.../pods/my-pod`) stays `get`; a collection GET becomes `list`. UAF stages
+// (which emit uaf.Verb verbatim) are untouched.
+//
+// Falsifier-FIRST (feedback_falsifier_first_before_ship): this test is written
+// BEFORE the inspect.go change. The collection-LIST assertion FAILS against the
+// unfixed tree (it emits `get`); the by-name + UAF assertions pass either way
+// (negative controls that pin the fix does NOT over-reach). Kind/in-process
+// only — NEVER remote go test (feedback_no_go_test_against_remote_kubeconfig).
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+)
+
+// TestInspect_CollectionStage_VerbList is the DISCRIMINATING falsifier: a
+// non-UAF in-cluster stage whose path is a COLLECTION (no trailing object
+// name) must emit verb=list. Pre-fix this FAILS (constant get). The
+// group/version/resource/namespace of the row are asserted unchanged — only
+// the verb flips.
+func TestInspect_CollectionStage_VerbList(t *testing.T) {
+	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
+
+	ra := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{
+				// Cluster-scoped collection LIST — no object name. namespaces is
+				// cluster-scoped (namespaced:false) and served by the fake
+				// discovery, so validateGVR passes. This is the dominant catalog
+				// shape (/blueprints-class).
+				{Name: "ns-list", Path: "/api/v1/namespaces"},
+			},
+		},
+	}
+	rows, unresolved, err := InspectReadSet(context.Background(), ra, nil)
+	if err != nil {
+		t.Fatalf("InspectReadSet errored: %v", err)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("expected zero unresolved, got %+v", unresolved)
+	}
+
+	row, ok := findRow(rows, "", "namespaces", "list")
+	if !ok {
+		t.Fatalf("VERB FALSIFIER FAIL: a COLLECTION in-cluster stage "+
+			"(/api/v1/namespaces, no object name) must emit verb=list — the apiserver "+
+			"authorizes a collection read as `list`, so the prior constant `get` "+
+			"UNDER-GRANTS and 403s the real LIST at /call. got rows=%+v", rows)
+	}
+	// The rest of the row is unchanged (group/version/resource present; the
+	// cluster-scoped collection has empty namespace). Only the verb flipped.
+	if row.Group != "" || row.Resource != "namespaces" {
+		t.Fatalf("verb fix must not alter group/resource; got %+v", row)
+	}
+	if row.Namespace != "" {
+		t.Fatalf("cluster-scoped collection must have empty namespace; got %q", row.Namespace)
+	}
+	// And there must be NO stray `get` row for the same resource (the fix
+	// REPLACES the verb, it does not add a second row).
+	if _, dupGet := findRow(rows, "", "namespaces", "get"); dupGet {
+		t.Fatalf("verb fix must REPLACE get with list, not emit both; got %+v", rows)
+	}
+}
+
+// TestInspect_NamespacedCollectionStage_VerbList — the namespaced collection
+// form (`/api/v1/namespaces/<ns>/pods`, no object name) must also be `list`,
+// with the namespace preserved on the row.
+func TestInspect_NamespacedCollectionStage_VerbList(t *testing.T) {
+	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
+
+	ra := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{
+				{Name: "pods", Path: "/api/v1/namespaces/krateo-system/pods"},
+			},
+		},
+	}
+	rows, _, err := InspectReadSet(context.Background(), ra, nil)
+	if err != nil {
+		t.Fatalf("InspectReadSet errored: %v", err)
+	}
+	row, ok := findRow(rows, "", "pods", "list")
+	if !ok {
+		t.Fatalf("VERB FALSIFIER FAIL: namespaced COLLECTION stage "+
+			"(/api/v1/namespaces/krateo-system/pods, no object name) must emit verb=list; got %+v", rows)
+	}
+	if row.Namespace != "krateo-system" {
+		t.Fatalf("namespace must be preserved on the list row; got %q", row.Namespace)
+	}
+}
+
+// TestInspect_GetByNameStage_VerbGet is the NEGATIVE CONTROL: a by-name GET
+// (path ending in an object name) must STILL emit verb=get — the fix must not
+// over-reach and turn legitimate by-name reads into list. Passes both pre- and
+// post-fix; pins the discriminant.
+func TestInspect_GetByNameStage_VerbGet(t *testing.T) {
+	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
+
+	ra := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{
+				// Object name present → GET-by-name → verb=get.
+				{Name: "one-pod", Path: "/api/v1/namespaces/krateo-system/pods/my-pod"},
+			},
+		},
+	}
+	rows, _, err := InspectReadSet(context.Background(), ra, nil)
+	if err != nil {
+		t.Fatalf("InspectReadSet errored: %v", err)
+	}
+	row, ok := findRow(rows, "", "pods", "get")
+	if !ok {
+		t.Fatalf("VERB FALSIFIER FAIL: a GET-by-name stage "+
+			"(/api/v1/namespaces/krateo-system/pods/my-pod) must STILL emit verb=get; got %+v", rows)
+	}
+	if row.Namespace != "krateo-system" {
+		t.Fatalf("namespace must be preserved on the get row; got %q", row.Namespace)
+	}
+	// No stray list row for the by-name read.
+	if _, dupList := findRow(rows, "", "pods", "list"); dupList {
+		t.Fatalf("a by-name GET must NOT emit a list row; got %+v", rows)
+	}
+}
+
+// TestInspect_UAFVerb_UntouchedByVerbFix is the negative control for the UAF
+// path: the fix touches ONLY inspectInClusterStage; a UAF stage still emits
+// uaf.Verb verbatim (here a free-form verb on a collection path that, were it a
+// plain in-cluster stage, would now be `list`). Proves the verb fix did not
+// leak into inspectUAFStage.
+func TestInspect_UAFVerb_UntouchedByVerbFix(t *testing.T) {
+	withInspectSARESTConfig(t, fakeDiscoveryServer(t))
+
+	ra := &templates.RESTAction{
+		Spec: templates.RESTActionSpec{
+			API: []*templates.API{
+				{
+					Name: "ns",
+					Path: "/api/v1/namespaces", // collection path, but UAF-classified
+					UserAccessFilter: &templates.UserAccessFilterSpec{
+						Verb:     "deletecollection",
+						Group:    "",
+						Resource: "namespaces",
+					},
+				},
+			},
+		},
+	}
+	rows, _, err := InspectReadSet(context.Background(), ra, nil)
+	if err != nil {
+		t.Fatalf("InspectReadSet errored: %v", err)
+	}
+	if _, ok := findRow(rows, "", "namespaces", "deletecollection"); !ok {
+		t.Fatalf("UAF row must emit uaf.Verb verbatim (deletecollection), untouched by the "+
+			"in-cluster verb fix; got %+v", rows)
+	}
+	// The UAF path must NOT have been rewritten to list/get by the fix.
+	if _, leakedList := findRow(rows, "", "namespaces", "list"); leakedList {
+		t.Fatalf("verb fix leaked into the UAF path (emitted list); got %+v", rows)
+	}
+}


### PR DESCRIPTION
## /rbac in-cluster-stage verb fix — collection→list, by-name→get

### Root cause (#44)
The `/rbac` inspect endpoint shipped with `inspectInClusterStage` discarding the parsed object name and hardcoding `Verb:"get"` for every non-UAF in-cluster stage. This conflated the HTTP **method** (GET, CEL-bound by `core.go:30`) with the RBAC **verb**: the apiserver authorizes a **collection** read (`.../resource`, no object name) under the `list` verb, not `get`. So a collection-LIST stage — the dominant catalog shape (e.g. the `/blueprints` `compositiondefinitions` LIST) — was enumerated as `get`, the core-provider granted only `get`, and the real LIST **403'd at `/call`** (silent under-grant).

### Fix
`inspect.go` `inspectInClusterStage` captures the object `name` from `ParseAPIServerPathToDep` and emits the verb by path shape:
```go
verb := "list"
if name != "" { verb = "get" }
```
Resource granularity is unchanged — `Resource.Name` stays `""` (a resource-level grant per design §3.2); only the verb reflects the read shape. UAF stages are untouched (still emit `uaf.Verb` verbatim).

### Tests
Discriminating falsifier (`inspect_verb_falsifier_test.go`, kind/in-process): collection→`list` (RED pre-fix / GREEN post-fix), namespaced-collection→`list`, GET-by-name→`get` (negative control), UAF verb untouched (negative control), replace-not-add. Four existing bug-encoding assertions updated to the corrected `list` expectation. `go build`/`go vet ./...` clean; full `internal/resolvers/restactions/api` package green under `-race`.

### Design doc
`docs/restaction-rbac-endpoint-design.md` §4 corrected: the constant-`get` field rule → list/get-by-name rule, with a ✅ FIXED marker.

### Intentional readSet change (not a baseline regression)
This **intentionally** changes the readSet for LIST-stage RAs (`get`→`list`) → the core-provider digest for those RAs changes → a **one-time re-reconcile**. That is the correct fix (the old `get` 403s a real LIST), NOT a byte-identical-baseline regression.

### Dual review
Architect **APPROVE** + PM **ACCEPT**.

### Deploy-gating (tester, post-deploy)
A previously-403'ing collection-LIST RA returns **200 with correct RBAC-scoped CONTENT** after the core-provider re-reconcile (the #44 symptom-disappear, not just digest-changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
