### PR TITLE
fix(prewarm): bound informer-sync barrier (1b) + per-resolve logs INFO→Debug (2b)

### DIFF
--- a/internal/cache/phase1.go
+++ b/internal/cache/phase1.go
@@ -59,6 +59,7 @@ import (
 
 	"log/slog"
 
+	"github.com/krateoplatformops/plumbing/env"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientcache "k8s.io/client-go/tools/cache"
 )
@@ -318,9 +319,30 @@ func (rw *ResourceWatcher) RegisterMetaQuerySeeds() int {
 // at the start of the pass is synced AND nothing new appeared, hence
 // every informer is synced.
 //
-// It does NOT layer its own timeout — the caller (Phase1Warmup) owns the
-// deadline via ctx so the PHASE1_TIMEOUT_SECONDS budget is the single
-// source of truth and also bounds a pathological never-stabilizing loop.
+// BOUNDED EXIT POLICY (Fix 1b, task #43) — the outer ctx
+// (PHASE1_TIMEOUT_SECONDS) remains the absolute backstop, but the loop no
+// longer relies on it as the ONLY bound. Two UNIFORM env knobs (no
+// per-GVR/per-name branch — feedback_no_special_cases) bound the loop:
+//
+//   - PHASE1_SYNC_PASS_GRACE_SECONDS (default 45): each WaitForCacheSync
+//     pass runs under a per-pass CHILD ctx, not the outer 900s ctx. A
+//     single never-HasSynced informer can therefore only stall ONE pass
+//     for `passGrace`, not the whole budget.
+//   - PHASE1_SYNC_QUIESCENCE_SECONDS (default 10): once the registered set
+//     has been STABLE (count unchanged) for this window AND every informer
+//     that CAN sync has, the barrier returns "good enough" (nil error,
+//     readiness flips) even if a stuck informer never reached HasSynced.
+//     The stuck GVR set is named in the cache.phase1.sync_wait_good_enough
+//     structured log.
+//
+// "Good enough" is SAFE because a late- or never-syncing informer is
+// covered downstream: lazy register-on-navigation serves its first /call
+// via the apiserver fallthrough (informer-fallthrough-not-synced), and the
+// refresher converges its data into L1 as events land — readiness gates on
+// "substrate mostly warm + set stopped growing", not "every version-pinned
+// composition CRD finished its initial LIST". This extends the same
+// readiness-independent-of-cluster-shape invariant Ship 2 / 0.30.196 used
+// for the background cohort seed.
 //
 // INVARIANT the count-equality test depends on: the registered-informer
 // set is append-only during Phase 1 in practice — RemoveResourceType is
@@ -340,6 +362,18 @@ func (rw *ResourceWatcher) WaitAllInformersSynced(ctx context.Context) error {
 	}
 
 	start := time.Now()
+
+	// Fix 1b (task #43): uniform bounds, read once. Per-pass grace caps how
+	// long a single WaitForCacheSync pass can block on a slow/stuck informer
+	// (a child ctx, NOT the outer 900s budget). Quiescence is the
+	// set-stability window after which we accept "good enough".
+	passGrace := time.Duration(env.Int("PHASE1_SYNC_PASS_GRACE_SECONDS", 45)) * time.Second
+	quiescence := time.Duration(env.Int("PHASE1_SYNC_QUIESCENCE_SECONDS", 10)) * time.Second
+
+	// Set-stability tracking across passes (touched only in this goroutine).
+	lastCount := -1
+	lastChange := start
+
 	for pass := 1; ; pass++ {
 		if ctx.Err() != nil {
 			slog.Warn("cache.phase1.sync_wait_incomplete",
@@ -351,12 +385,15 @@ func (rw *ResourceWatcher) WaitAllInformersSynced(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		// Snapshot the informer set + count under the lock.
+		// Snapshot the informer set + count + GVRs under the lock so a
+		// post-pass !HasSynced check can name the stuck GVRs.
 		rw.mu.RLock()
 		countBefore := len(rw.informers)
 		syncs := make([]clientcache.InformerSynced, 0, countBefore)
-		for _, gi := range rw.informers {
+		gvrs := make([]schema.GroupVersionResource, 0, countBefore)
+		for gvr, gi := range rw.informers {
 			syncs = append(syncs, gi.Informer().HasSynced)
+			gvrs = append(gvrs, gvr)
 		}
 		rw.mu.RUnlock()
 
@@ -365,9 +402,23 @@ func (rw *ResourceWatcher) WaitAllInformersSynced(ctx context.Context) error {
 			return nil
 		}
 
-		// Wait for this snapshot's informers to sync (outside the lock,
-		// so concurrent registrations are not blocked).
-		if !clientcache.WaitForCacheSync(ctx.Done(), syncs...) {
+		// Track set-stability: a change resets the quiescence clock.
+		if countBefore != lastCount {
+			lastCount = countBefore
+			lastChange = time.Now()
+		}
+
+		// Wait for this snapshot's informers to sync under a PER-PASS child
+		// ctx (outside rw.mu, so concurrent registrations are not blocked).
+		// A single never-HasSynced informer can stall at most this one pass
+		// for `passGrace` — never the whole outer budget.
+		passCtx, cancel := context.WithTimeout(ctx, passGrace)
+		synced := clientcache.WaitForCacheSync(passCtx.Done(), syncs...)
+		cancel()
+
+		// The outer budget being exhausted is the hard backstop — surface it
+		// as the existing incomplete warning regardless of pass outcome.
+		if ctx.Err() != nil {
 			slog.Warn("cache.phase1.sync_wait_incomplete",
 				slog.String("subsystem", "cache"),
 				slog.Int("pass", pass),
@@ -375,19 +426,14 @@ func (rw *ResourceWatcher) WaitAllInformersSynced(ctx context.Context) error {
 				slog.Int64("waited_ms", time.Since(start).Milliseconds()),
 				slog.Any("err", ctx.Err()),
 			)
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return context.DeadlineExceeded
+			return ctx.Err()
 		}
 
-		// Re-snapshot: if the count is unchanged, NO informer was
-		// registered during the WaitForCacheSync pass — the barrier is
-		// genuinely complete. If it grew, a CRD-add (or a late resolver
-		// touch) landed mid-wait; loop and re-wait so the new informer
-		// is included.
 		countAfter := rw.RegisteredCount()
-		if countAfter == countBefore {
+		setStable := countAfter == countBefore
+
+		if synced && setStable {
+			// Happy path: every informer in a stable set synced.
 			slog.Info("cache.phase1.sync_wait_complete",
 				slog.String("subsystem", "cache"),
 				slog.Int("passes", pass),
@@ -396,12 +442,43 @@ func (rw *ResourceWatcher) WaitAllInformersSynced(ctx context.Context) error {
 			)
 			return nil
 		}
+
+		// Pass did NOT fully sync (or set still growing). If the registered
+		// set has been STABLE for the quiescence window, accept "good
+		// enough": the informers that can sync have, and the stuck ones are
+		// covered by lazy-register fallthrough + the refresher. Name the
+		// stuck GVRs so the operator can see exactly what was deferred.
+		if setStable && time.Since(lastChange) >= quiescence {
+			unsynced := make([]string, 0)
+			rw.mu.RLock()
+			for _, gvr := range gvrs {
+				if gi, ok := rw.informers[gvr]; ok && !gi.Informer().HasSynced() {
+					unsynced = append(unsynced, gvr.String())
+				}
+			}
+			rw.mu.RUnlock()
+			slog.Info("cache.phase1.sync_wait_good_enough",
+				slog.String("subsystem", "cache"),
+				slog.Int("passes", pass),
+				slog.Int("informer_count", countAfter),
+				slog.Int64("waited_ms", time.Since(start).Milliseconds()),
+				slog.Int64("set_stable_ms", time.Since(lastChange).Milliseconds()),
+				slog.Int("unsynced_count", len(unsynced)),
+				slog.Any("unsynced_gvrs", unsynced),
+				slog.String("reason", "registered set stable for the quiescence window; deferring still-unsynced informers to lazy-register fallthrough + refresher"),
+			)
+			return nil
+		}
+
+		// Set still changing OR not yet quiescent — re-snapshot and re-wait.
 		slog.Info("cache.phase1.sync_wait_repass",
 			slog.String("subsystem", "cache"),
 			slog.Int("pass", pass),
 			slog.Int("count_before", countBefore),
 			slog.Int("count_after", countAfter),
-			slog.String("reason", "informer registered mid-wait — re-snapshotting so the new informer is in the barrier"),
+			slog.Bool("pass_synced", synced),
+			slog.Int64("set_stable_ms", time.Since(lastChange).Milliseconds()),
+			slog.String("reason", "set still growing or not yet quiescent — re-snapshotting"),
 		)
 	}
 }

--- a/internal/cache/phase1_barrier_bound_test.go
+++ b/internal/cache/phase1_barrier_bound_test.go
@@ -1,0 +1,273 @@
+// phase1_barrier_bound_test.go — Fix 1b (task #43) falsifiers for the
+// BOUNDED WaitAllInformersSynced exit policy.
+//
+// The defect Fix 1b cures: the barrier blocked in WaitForCacheSync on the
+// OUTER PHASE1_TIMEOUT_SECONDS ctx, so a SINGLE never-HasSynced informer
+// held /readyz 503 for the full 900s budget (krateo-enterprise: observed
+// prewarm_complete.elapsed_ms = 900463 ms, == the 900s default to the ms).
+//
+// C2 (the discriminating control): with a deliberately-never-syncing
+// informer in the set, the barrier MUST return at ~ (passGrace +
+// quiescence), NOT at ~ PHASE1_TIMEOUT*1000 and NOT ∞. A single-snapshot /
+// outer-ctx-only implementation FAILS this — it would block on the outer
+// ctx for the whole budget. This is the test that would have caught the
+// 900s defect.
+//
+// C9 (-race): the per-pass child ctx + the set-stability last-change
+// timestamp + the post-pass unsynced-GVR snapshot all touch shared rw
+// state while late EnsureResourceType registrations land concurrently —
+// run under -race to prove no data race (feedback_shared_vs_copy_is_a_
+// concurrency_change).
+
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// stuckGVR is a composition-style GVR whose initial LIST always ERRORS —
+// modeling the krateo-enterprise `informer-fallthrough-not-synced`
+// informer whose initial LIST never succeeds (403/stall), so its Reflector
+// retries with backoff forever and HasSynced() stays false.
+//
+// NOTE on WHY error-not-block: the dynamicfake client serializes every
+// action across ALL informers under one process-wide `Fake` mutex
+// (client-go testing/fake.go Invokes holds c.Lock() for the whole reactor
+// body). A reactor that BLOCKS would hold that lock and starve the HEALTHY
+// informers' LISTs too — a test-harness artifact, not real behavior (in a
+// real cluster each informer has independent transport). Returning an
+// error releases the lock immediately, so the stuck informer never syncs
+// while the healthy ones sync normally — the fidelity the C2 control needs.
+func stuckGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "composition.krateo.io",
+		Version:  "v1",
+		Resource: "stuckthing",
+	}
+}
+
+// barrierBoundListKinds = the phase1 seeds (which sync normally) PLUS the
+// stuck GVR's List kind, so registering its informer does NOT panic the
+// fake client — the informer is created and starts, but its LIST errors.
+func barrierBoundListKinds() map[schema.GroupVersionResource]string {
+	m := phase1ListKinds()
+	m[stuckGVR()] = "StuckThingList"
+	return m
+}
+
+// stuckListReactor returns a LIST reactor that always errors (never holds
+// the shared Fake lock across a block), so the stuck GVR's informer never
+// reaches HasSynced while every other informer syncs normally.
+func stuckListReactor() k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: stuckGVR().Group, Resource: stuckGVR().Resource},
+			"", context.Canceled)
+	}
+}
+
+// TestWaitAllInformersSynced_GoodEnoughBoundsAStuckInformer is C2 — the
+// discriminating control. One informer never syncs; the rest do. The
+// barrier must return nil ("good enough") in O(passGrace + quiescence),
+// far below the outer PHASE1_TIMEOUT budget, naming the stuck GVR as
+// deferred to the lazy-register fallthrough.
+func TestWaitAllInformersSynced_GoodEnoughBoundsAStuckInformer(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	// Bounds: per-pass grace 3s comfortably exceeds the healthy fake
+	// informers' sync time (they LIST successfully and reach HasSynced
+	// independent of the erroring stuck informer); quiescence 1s. The
+	// OUTER budget is a deliberately LARGE 60s so a regression that blocks
+	// on the outer ctx (the pre-1b defect) lands at ~60s and trips the 15s
+	// ceiling below.
+	t.Setenv("PHASE1_SYNC_PASS_GRACE_SECONDS", "3")
+	t.Setenv("PHASE1_SYNC_QUIESCENCE_SECONDS", "1")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), barrierBoundListKinds())
+
+	// The stuck GVR's LIST always errors → its Reflector never reaches
+	// HasSynced, while the healthy seeds sync normally (the error reactor
+	// does not hold the shared Fake lock across a block — see stuckGVR doc).
+	dyn.PrependReactor("list", stuckGVR().Resource, stuckListReactor())
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	// Healthy seeds (sync normally) + the stuck informer.
+	rw.RegisterMetaQuerySeeds()
+	rw.EnsureResourceType(stuckGVR())
+
+	// OUTER budget = 60s backstop. If the barrier were still blocking on
+	// the outer ctx (the pre-1b defect), it would not return until 60s and
+	// trip the ceiling below.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := rw.WaitAllInformersSynced(ctx); err != nil {
+		t.Fatalf("barrier must return nil (good enough) with a stuck informer; got %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// DISCRIMINATING ceiling: ~ grace(1s)+quiescence(1s) plus pass/poll
+	// slack. A pre-1b (outer-ctx-only) implementation returns at ~60s and
+	// fails here. Generous 15s ceiling still proves O(tens of seconds),
+	// NOT O(PHASE1_TIMEOUT).
+	if elapsed > 15*time.Second {
+		t.Fatalf("barrier returned in %v — expected ~grace+quiescence (~2s), "+
+			"NOT the outer budget. The pre-1b defect (block on outer ctx) would "+
+			"land at ~60s.", elapsed)
+	}
+
+	// The stuck GVR must still be registered (deferred, not dropped) and
+	// must still be UNSYNCED — confirming the barrier returned "good
+	// enough" rather than waiting it out.
+	if !rw.IsRegistered(stuckGVR()) {
+		t.Fatalf("stuck GVR must remain registered (deferred to lazy-register fallthrough)")
+	}
+	if rw.IsSynced(stuckGVR()) {
+		t.Fatalf("test setup error: stuck GVR unexpectedly synced — the blocking LIST reactor did not engage")
+	}
+
+	// The healthy seeds MUST be synced (good-enough is not a free pass —
+	// every informer that CAN sync has).
+	for _, g := range cache.MetaQuerySeeds() {
+		if !rw.IsSynced(g) {
+			t.Fatalf("good-enough must still require every sync-able informer to be synced; %v is not", g)
+		}
+	}
+}
+
+// TestWaitAllInformersSynced_HappyPathUnchanged guards against a
+// regression where the new exit policy breaks the all-synced fast path:
+// with NO stuck informer the barrier must still return via the
+// sync_wait_complete path quickly.
+func TestWaitAllInformersSynced_HappyPathUnchanged(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("PHASE1_SYNC_PASS_GRACE_SECONDS", "5")
+	t.Setenv("PHASE1_SYNC_QUIESCENCE_SECONDS", "1")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), phase1ListKinds())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	rw.RegisterMetaQuerySeeds()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := rw.WaitAllInformersSynced(ctx); err != nil {
+		t.Fatalf("happy-path barrier must return nil; got %v", err)
+	}
+	// All informers sync in the fake client well under the 1s quiescence +
+	// a single grace pass — assert it returned promptly (no good-enough
+	// quiescence stall needed when everything is already synced).
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("happy path returned in %v — too slow; the all-synced fast path regressed", elapsed)
+	}
+	for _, g := range cache.MetaQuerySeeds() {
+		if !rw.IsSynced(g) {
+			t.Fatalf("happy path: %v must be synced at barrier return", g)
+		}
+	}
+}
+
+// TestWaitAllInformersSynced_RaceWithStuckAndLateRegistrations is C9 — the
+// -race falsifier. It combines the stuck informer (forcing the per-pass
+// child-ctx + good-enough path) with concurrent late EnsureResourceType
+// registrations (forcing the set-stability last-change-timestamp re-pass
+// path). Run with -race: the per-pass cancel, the lastChange touch, and
+// the post-pass unsynced-GVR snapshot all read/write shared rw state while
+// the late-register goroutine mutates rw.informers concurrently.
+func TestWaitAllInformersSynced_RaceWithStuckAndLateRegistrations(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("PHASE1_SYNC_PASS_GRACE_SECONDS", "1")
+	t.Setenv("PHASE1_SYNC_QUIESCENCE_SECONDS", "1")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), barrierBoundListKinds())
+
+	dyn.PrependReactor("list", stuckGVR().Resource, stuckListReactor())
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	rw.RegisterMetaQuerySeeds()
+	rw.EnsureResourceType(stuckGVR())
+
+	// Concurrently register late GVRs while the barrier runs — exercises
+	// the set-stability re-pass + lastChange touch against concurrent
+	// rw.informers mutation.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, g := range lateGVRs() {
+			rw.EnsureResourceType(g)
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	// OUTER budget = 60s backstop; the barrier must return on the
+	// grace/quiescence policy far below it even while registrations are
+	// still landing and one informer is permanently stuck.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := rw.WaitAllInformersSynced(ctx); err != nil {
+		t.Fatalf("barrier must return nil (good enough) under concurrent registration + stuck informer; got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("barrier returned in %v under concurrent registration — expected the bounded grace/quiescence policy, not the outer budget", elapsed)
+	}
+	wg.Wait()
+
+	// CONTRACT under good-enough: the barrier does NOT guarantee every
+	// late informer finished syncing (that is the whole point — it defers
+	// the still-syncing/stuck ones to lazy-register fallthrough + the
+	// refresher). What it DOES guarantee: it returned bounded, and every
+	// late GVR is at least REGISTERED (so the substrate exists for the
+	// fallthrough/refresher to converge). The permanently-stuck GVR must
+	// remain registered-but-unsynced.
+	for _, g := range lateGVRs() {
+		if !rw.IsRegistered(g) {
+			t.Fatalf("late GVR %v must be registered — test setup error", g)
+		}
+	}
+	if !rw.IsRegistered(stuckGVR()) {
+		t.Fatalf("stuck GVR must remain registered (deferred to lazy-register fallthrough)")
+	}
+	if rw.IsSynced(stuckGVR()) {
+		t.Fatalf("test setup error: stuck GVR unexpectedly synced")
+	}
+}

--- a/internal/resolvers/restactions/api/refilter.go
+++ b/internal/resolvers/restactions/api/refilter.go
@@ -518,7 +518,7 @@ func emitRefilterFalsifierFromHandler(ctx context.Context, log *slog.Logger, api
 	if u, err := xcontext.UserInfo(ctx); err == nil {
 		username = u.Username
 	}
-	log.Info("userAccessFilter",
+	log.Debug("userAccessFilter",
 		slog.String("subsystem", "uaf"),
 		slog.String("dispatch", "service_account"),
 		slog.String("user", username),
@@ -543,7 +543,7 @@ func emitRefilterFalsifier(log *slog.Logger, apiCall *templates.API, username st
 	if log == nil || apiCall == nil || apiCall.UserAccessFilter == nil {
 		return
 	}
-	log.Info("userAccessFilter",
+	log.Debug("userAccessFilter",
 		slog.String("subsystem", "uaf"),
 		slog.String("dispatch", "service_account"),
 		slog.String("user", username),

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -253,7 +253,7 @@ func newResolveRun(ctx context.Context, opts ResolveOptions, log *slog.Logger, u
 		}
 	}
 
-	log.Info("base dict for api resolver", slog.Any("dict", dict))
+	log.Debug("base dict for api resolver", slog.Any("dict", dict))
 
 	// Ship F1 (0.30.119): the content-keyed api-stage L1 is active
 	// whenever the resolved-output store is on (ApistageL1Enabled folded
@@ -767,7 +767,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 					}
 					// Ship #6 — see depthForLog (support.go).
 					depth := depthForLog(r.ctx, r.log, dictMu, dict)
-					r.log.Info("api successfully resolved",
+					r.log.Debug("api successfully resolved",
 						slog.String("name", id),
 						slog.String("host", call.Endpoint.ServerURL),
 						slog.String("path", call.Path),
@@ -794,7 +794,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 			dispatch := feedRawOrResolved(raw, "informer")
 			// Ship #6 — see depthForLog (support.go).
 			depth := depthForLog(r.ctx, r.log, dictMu, dict)
-			r.log.Info("api successfully resolved",
+			r.log.Debug("api successfully resolved",
 				slog.String("name", id),
 				slog.String("host", call.Endpoint.ServerURL),
 				slog.String("path", call.Path),
@@ -870,7 +870,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 		}
 		// Ship #6 — see depthForLog (support.go).
 		depth := depthForLog(r.ctx, r.log, dictMu, dict)
-		r.log.Info("api successfully resolved",
+		r.log.Debug("api successfully resolved",
 			slog.String("name", id),
 			slog.String("host", call.Endpoint.ServerURL),
 			slog.String("path", call.Path),
@@ -940,7 +940,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 			r.recordItemError(dictMu, itemErrs, id, i, call.ErrorKey, ferr.Error(), ferr.Error(), itemErr)
 		}
 		depth := depthForLog(r.ctx, r.log, dictMu, dict)
-		r.log.Info("api successfully resolved",
+		r.log.Debug("api successfully resolved",
 			slog.String("name", id),
 			slog.String("host", call.Endpoint.ServerURL),
 			slog.String("path", call.Path),
@@ -1009,7 +1009,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 			r.recordItemError(dictMu, itemErrs, id, i, call.ErrorKey, ferr.Error(), ferr.Error(), itemErr)
 		}
 		depth := depthForLog(r.ctx, r.log, dictMu, dict)
-		r.log.Info("api successfully resolved",
+		r.log.Debug("api successfully resolved",
 			slog.String("name", id),
 			slog.String("host", call.Endpoint.ServerURL),
 			slog.String("path", call.Path),
@@ -1111,7 +1111,7 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 	// read against concurrent jsonHandler writes. On the common
 	// (Info) path it does no work and takes no lock.
 	depth := depthForLog(r.ctx, r.log, dictMu, dict)
-	r.log.Info("api successfully resolved",
+	r.log.Debug("api successfully resolved",
 		slog.String("name", id),
 		slog.String("host", call.Endpoint.ServerURL),
 		slog.String("path", call.Path),

--- a/internal/resolvers/restactions/api/resolve_extraction_parity_test.go
+++ b/internal/resolvers/restactions/api/resolve_extraction_parity_test.go
@@ -433,10 +433,17 @@ func TestResolveExtractionParity_UserInfoErrEarlyExit(t *testing.T) {
 //
 // The assertion is a SUBSEQUENCE match on the load-bearing ordered events
 // (pagination → base dict → per-stage "api successfully resolved" ×2) rather
-// than an exhaustive full-log equality, because Debug-level events
+// than an exhaustive full-log equality, because the other events
 // (dep.recorded, "calling api", endpoint-resolved) are interleaved by the
 // concurrent worker and are not order-stable at parallelism>1. We pin
-// PARALLELISM=1 and assert the Info-level spine, which IS order-stable.
+// PARALLELISM=1 and assert the spine, which IS order-stable.
+//
+// Capture is at Debug level: Fix 2b (task #43) moved the steady-state
+// success lines "base dict for api resolver" and "api successfully resolved"
+// from Info→Debug (they fire per-resolve and dominated the prod log volume).
+// The spine itself — pagination → base dict → per-stage success ×2 — and its
+// ORDER are unchanged; only the emit LEVEL moved, so the order-preservation
+// invariant this test guards is asserted by capturing at Debug.
 func TestResolveExtractionParity_SlogEventOrder(t *testing.T) {
 	iterFailFastRetries(t)
 	t.Setenv("RESOLVER_ITER_PARALLELISM", "1")
@@ -458,7 +465,7 @@ func TestResolveExtractionParity_SlogEventOrder(t *testing.T) {
 		Filter:    ptr.To(".stage2"),
 	}
 
-	events := captureSlogEventsAt(t, slog.LevelInfo, func(ctx context.Context) {
+	events := captureSlogEventsAt(t, slog.LevelDebug, func(ctx context.Context) {
 		// ctx carries the capture logger; add UserInfo (so Resolve does NOT
 		// early-exit on the UserInfo guard) + the fixture endpoint.
 		ctx = xcontext.BuildContext(ctx, xcontext.WithUserInfo(jwtutil.UserInfo{Username: "parity-user"}))
@@ -471,7 +478,7 @@ func TestResolveExtractionParity_SlogEventOrder(t *testing.T) {
 		})
 	})
 
-	// The Info-level spine, in order:
+	// The resolve spine, in order:
 	//   "pagination options"           (P0)
 	//   "base dict for api resolver"   (P3)
 	//   "api successfully resolved"    (stage1)


### PR DESCRIPTION
## What

**Fix 1b — cure the 15-min `/readyz` 503 per pod boot on krateo-enterprise.** `WaitAllInformersSynced` (`internal/cache/phase1.go`) blocked in `WaitForCacheSync` on the outer 900s `PHASE1_TIMEOUT_SECONDS` ctx, so a SINGLE never-`HasSynced` informer held the full timeout. Observed `prewarm_complete.elapsed_ms = 900463` (== 900s to the ms); `MarkPhase1Done` fires only at barrier return, so that 900s is user-facing 503 downtime.

The barrier now:
- runs each `WaitForCacheSync` pass under a **per-pass child ctx** (`PHASE1_SYNC_PASS_GRACE_SECONDS`, default 45) — one stuck informer stalls one pass, not the whole budget;
- returns a new nil-error sentinel **`cache.phase1.sync_wait_good_enough`** once the registered informer set has been STABLE for `PHASE1_SYNC_QUIESCENCE_SECONDS` (default 10) AND every informer that CAN sync has — naming the still-unsynced GVR set in a structured field;
- keeps `PHASE1_TIMEOUT_SECONDS` as the absolute backstop (role unchanged).

Uniform loop-policy, **no per-GVR/per-name branch**. Still-unsynced informers are covered downstream by lazy register-on-navigation fallthrough + the refresher — the same readiness-independent-of-cluster-shape invariant Ship 2 / 0.30.196 relied on. No signature change; existing `sync_wait_repass/complete/incomplete` logs kept.

**Fix 2b — INFO→Debug on the 9 per-resolve / per-UAF success log sites** (`resolve.go` 6× "api successfully resolved" + the whole-dict "base dict for api resolver"; `refilter.go` 2× "userAccessFilter"). Pure log-level; prod default INFO drops the ~7,355 lines/sec dominator, `--debug` brings them back. Pairs with the chart `PRETTY_LOG=false` default.

## Falsifier-first (HARD GATE)
- **C1** baseline (krateo-enterprise 1.5.1): `prewarm_complete.elapsed_ms = 900463` == 900s timeout to the ms.
- **C2** discriminating control (`TestWaitAllInformersSynced_GoodEnoughBoundsAStuckInformer`): a deliberately never-syncing informer → barrier returns `sync_wait_good_enough waited_ms ≈ grace+quiescence`, naming exactly the stuck GVR — NOT 900000, NOT ∞. The test that would have caught the defect.
- **C9** (`TestWaitAllInformersSynced_RaceWithStuckAndLateRegistrations`): `-race` clean (per-pass child ctx + last-change timestamp + post-pass unsynced snapshot vs concurrent `EnsureResourceType`).
- Tests deterministic under `-race -count=1` (4/4); `go build` + `go vet ./...` clean.

## Reviews
Architect APPROVE (incl. Mode-B ruling: the 180s outer backstop bounds a perpetually-growing set; the churn-cap is a fast-follow, not a blocker). PM PASS-WITH-CONDITIONS (C1–C10, falsifier-first satisfied).

## Ship gate (POST-DEPLOY tester, C3–C6)
On the next boot with this image + the lockstep chart: pod logs `sync_wait_complete` OR `sync_wait_good_enough` with `waited_ms << PHASE1_TIMEOUT*1000`; `/readyz` first-200 − pod-start < 3 min; `kubectl logs --since=6s | wc -l` drops ~8× (Fix 2b + `PRETTY_LOG=false`); a `sync_wait_good_enough` `unsynced_gvrs` GVR serves via lazy-register fallthrough on first `/call`.

## Links
- Design: `docs/design-prewarm-warmup-code-cures-2026-06-26.md`
- RCA: `docs/rca-prewarm-15min-warmup-2026-06-26.md`
- Solidity map: `docs/architecture-solidity-hardening-2026-06-26.md` (1b enlarges the not-synced set → motivates the serve-requires-servable assertion riding into the same release)
- Lockstep chart PR: braghettos/krateo-snowplow-chart `fix/prewarm-barrier-knobs-1b`

**Parked — do NOT merge (Diego merges).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1