### PR TITLE
feat(cache): R1 Phase 1 — /debug/apistage metadata diagnostic + bounded CATALOG_UNSERVABLE_TTL backstop

### DIFF
--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -50,6 +51,20 @@ const (
 	envResolvedCacheMaxBytes     = "RESOLVED_CACHE_MAX_BYTES"
 	envResolvedCacheTTLSeconds   = "RESOLVED_CACHE_TTL_SECONDS"
 	envResolvedCacheSummaryEvery = "RESOLVED_CACHE_SUMMARY_EVERY_SECONDS"
+
+	// envCatalogUnservableTTLSeconds is the R1 Layer 2 (#36) bounded
+	// staleness backstop. When > 0, an apistage entry stored while its
+	// underlying GVR informer is NOT servable (registered-but-not-synced /
+	// watch-broken / unconfirmed) gets this SHORT per-entry TTL instead of
+	// the standard RESOLVED_CACHE_TTL_SECONDS, so a degraded / not-fully-
+	// resolved catalog entry self-corrects within the bound EVEN IF a
+	// dirty-mark / refresh-ordering gap is ever missed. This is a
+	// bounded-staleness floor, NOT a flag-park: the dirty-mark + refresher
+	// remain the primary invalidation; this is the safety net that caps the
+	// worst case. Default 0 = DISABLED (the per-entry override is purely
+	// additive; with it unset, entries use the standard TTL exactly as
+	// before). Operators set it via the chart value.
+	envCatalogUnservableTTLSeconds = "CATALOG_UNSERVABLE_TTL_SECONDS"
 
 	// envResolvedCacheMaxResidentBytes is the Ship 4a (0.30.198) byte
 	// budget for the PINNED resident region — the eviction-protected cells
@@ -238,6 +253,17 @@ type ResolvedEntry struct {
 	// before Put; Put reads it under mu to decide resident vs transient
 	// accounting.
 	Pinned bool
+
+	// TTLOverride — R1 Layer 2 (#36) bounded-staleness backstop. When > 0,
+	// THIS entry expires after TTLOverride instead of the store's standard
+	// ttl. Set to the short CATALOG_UNSERVABLE_TTL_SECONDS when an apistage
+	// entry is stored while its GVR informer is not servable, so a degraded
+	// catalog entry self-evicts within the bound even if a dirty-mark is
+	// missed. Zero means "use the store's standard ttl" (the default for
+	// every healthy entry) — purely additive. Read in Get's TTL check;
+	// also folded into the metadata ttl-remaining projection. Set before
+	// Put; not mutated after.
+	TTLOverride time.Duration
 }
 
 // ResolvedKeyInputs is the canonical key-input bundle. The exact set
@@ -723,6 +749,20 @@ func canonicaliseExtras(m map[string]any) ([]byte, error) {
 	return out, nil
 }
 
+// effectiveTTLLocked returns the TTL governing this entry's expiry: the
+// per-entry TTLOverride when positive (R1 Layer 2 #36 bounded-staleness
+// backstop), else the store's standard ttl. Callers MUST hold c.mu.
+func (c *ResolvedCacheStore) effectiveTTLLocked(entry *ResolvedEntry) time.Duration {
+	if entry != nil && entry.TTLOverride > 0 {
+		// Honour the shorter of the two so the backstop can only TIGHTEN the
+		// bound, never extend an entry past the store's standard ttl.
+		if c.ttl <= 0 || entry.TTLOverride < c.ttl {
+			return entry.TTLOverride
+		}
+	}
+	return c.ttl
+}
+
 // Get returns the cached entry for key, or (nil, false). A TTL-expired
 // entry is treated as a miss and is dropped during the same call so
 // memory pressure is bounded. Increments hit/miss counters atomically.
@@ -739,7 +779,12 @@ func (c *ResolvedCacheStore) Get(key string) (*ResolvedEntry, bool) {
 		return nil, false
 	}
 	item := el.Value.(*lruItem)
-	if c.ttl > 0 && time.Since(item.entry.CreatedAt) > c.ttl {
+	// R1 Layer 2 (#36): a per-entry TTLOverride (the short
+	// CATALOG_UNSERVABLE_TTL_SECONDS set on entries stored while their GVR
+	// was not servable) takes precedence over the store's standard ttl, so a
+	// degraded catalog entry self-evicts within the bound. Zero override =
+	// the standard ttl (every healthy entry).
+	if eff := c.effectiveTTLLocked(item.entry); eff > 0 && time.Since(item.entry.CreatedAt) > eff {
 		c.removeElementLocked(el)
 		c.evictTTLTotal.Add(1)
 		c.missTotal.Add(1)
@@ -999,6 +1044,125 @@ func (c *ResolvedCacheStore) Stats() ResolvedCacheStats {
 		ResidentPinTotal:        c.residentPinTotal.Load(),
 		ResidentDemoteTotal:     c.residentDemoteTotal.Load(),
 	}
+}
+
+// ResolvedEntryMeta is the METADATA-ONLY projection of one cached
+// resolved-output entry, returned by RangeMetadata for the /debug/apistage
+// diagnostic (R1 design §6 Mode 1).
+//
+// STRUCTURAL LEAK GUARD (PM F-2): this struct contains ONLY scalar metadata
+// — class, key hash, GVR coordinates, age/TTL, and the LENGTH of the body.
+// It deliberately has NO []byte, NO []*unstructured.Unstructured, and NO
+// map field, so it is STRUCTURALLY INCAPABLE of carrying RawJSON, the parsed
+// Items, or the Extras key-inputs. Resolved output is per-identity
+// RBAC-sensitive; a content dump would be a cross-user leak. The leak guard
+// is the type itself (and RangeMetadata's field-by-field copy), not a
+// comment — see TestRangeMetadata_StructurallyCannotLeakContent.
+type ResolvedEntryMeta struct {
+	CacheEntryClass string `json:"cacheEntryClass"`
+	// KeyHash is the opaque ComputeKey string (a hash) — not reversible to
+	// inputs, safe to expose.
+	KeyHash string `json:"keyHash"`
+	// Path is a derived apiserver-style path from the GVR coordinates
+	// (group/version/resource[/namespaces/ns][/name]) — built from the key
+	// inputs, NOT from any resolved body.
+	Path      string `json:"path"`
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Resource  string `json:"resource"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	// Stage is the apistage per-stage discriminator (itself a hash of the
+	// stage id + filter + dependsOn-output) — opaque, not content.
+	Stage       string `json:"stage,omitempty"`
+	AgeSeconds  int64  `json:"ageSeconds"`
+	TTLRemainingSeconds int64 `json:"ttlRemainingSeconds"`
+	Pinned      bool   `json:"pinned"`
+	// ItemsCount is the LENGTH of the pre-parsed LIST envelope (0 when not a
+	// parsed-list apistage entry). A count only — never the items themselves.
+	ItemsCount int `json:"itemsCount"`
+	// RawJSONBytes is the LENGTH of the encoded body (for size diagnostics) —
+	// never the body.
+	RawJSONBytes int `json:"rawJSONBytes"`
+}
+
+// RangeMetadata walks every live cached entry under c.mu (read-consistent
+// snapshot semantics: the lock is held for the whole walk) and invokes fn
+// with the METADATA-ONLY projection of each. Iteration stops early if fn
+// returns false. Returns immediately on a nil receiver.
+//
+// STRUCTURAL LEAK GUARD (PM F-2): fn receives a ResolvedEntryMeta, which by
+// construction cannot carry RawJSON / Items / Extras (see the type doc). This
+// method reads those fields ONLY to compute scalar projections (len(), an age
+// duration, a path string from the GVR) — it never copies a body, a parsed
+// item, or the extras map into the emitted value. A future field added to
+// ResolvedEntryMeta that could carry content would break
+// TestRangeMetadata_StructurallyCannotLeakContent.
+func (c *ResolvedCacheStore) RangeMetadata(fn func(ResolvedEntryMeta) bool) {
+	if c == nil {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for el := c.order.Front(); el != nil; el = el.Next() {
+		item := el.Value.(*lruItem)
+		entry := item.entry
+		meta := ResolvedEntryMeta{
+			KeyHash:      item.key,
+			AgeSeconds:   int64(now.Sub(entry.CreatedAt).Seconds()),
+			Pinned:       entry.Pinned,
+			ItemsCount:   len(entry.Items),
+			RawJSONBytes: len(entry.RawJSON),
+		}
+		if eff := c.effectiveTTLLocked(entry); eff > 0 {
+			rem := eff - now.Sub(entry.CreatedAt)
+			if rem < 0 {
+				rem = 0
+			}
+			meta.TTLRemainingSeconds = int64(rem.Seconds())
+		}
+		if in := entry.Inputs; in != nil {
+			meta.CacheEntryClass = in.CacheEntryClass
+			meta.Group = in.Group
+			meta.Version = in.Version
+			meta.Resource = in.Resource
+			meta.Namespace = in.Namespace
+			meta.Name = in.Name
+			meta.Stage = in.Stage
+			meta.Path = metaPathFromCoords(in.Group, in.Version, in.Resource, in.Namespace, in.Name)
+		}
+		if !fn(meta) {
+			return
+		}
+	}
+}
+
+// metaPathFromCoords builds an apiserver-style path string from GVR
+// coordinates for the /debug metadata projection. Pure string composition
+// from the key inputs — touches no resolved body.
+func metaPathFromCoords(group, version, resource, namespace, name string) string {
+	var b strings.Builder
+	if group == "" {
+		b.WriteString("/api/")
+		b.WriteString(version)
+	} else {
+		b.WriteString("/apis/")
+		b.WriteString(group)
+		b.WriteString("/")
+		b.WriteString(version)
+	}
+	if namespace != "" {
+		b.WriteString("/namespaces/")
+		b.WriteString(namespace)
+	}
+	b.WriteString("/")
+	b.WriteString(resource)
+	if name != "" {
+		b.WriteString("/")
+		b.WriteString(name)
+	}
+	return b.String()
 }
 
 // ApistageEvictPressure is the Ship E (0.30.116) O6 budget signal: the
@@ -1322,6 +1486,20 @@ func intFromEnv(key string, def int) int {
 		return def
 	}
 	return n
+}
+
+// CatalogUnservableTTL returns the configured R1 Layer 2 (#36) bounded-
+// staleness backstop duration, or 0 when DISABLED (the default — the env
+// var unset/0/invalid). When > 0, an apistage entry stored while its GVR is
+// not servable should carry this as ResolvedEntry.TTLOverride. Read at Put
+// time (cheap os.Getenv + Atoi); kept here next to the resolved-cache TTL
+// knobs since it governs per-entry expiry in this store.
+func CatalogUnservableTTL() time.Duration {
+	s := intFromEnv(envCatalogUnservableTTLSeconds, 0)
+	if s <= 0 {
+		return 0
+	}
+	return time.Duration(s) * time.Second
 }
 
 func int64FromEnv(key string, def int64) int64 {

--- a/internal/cache/resolved_catalog_ttl_test.go
+++ b/internal/cache/resolved_catalog_ttl_test.go
@@ -1,0 +1,119 @@
+// resolved_catalog_ttl_test.go — R1 Layer 2 (#36) falsifiers for the
+// bounded CATALOG_UNSERVABLE_TTL_SECONDS backstop.
+//
+// The invariant: an entry stamped with a short per-entry TTLOverride
+// (set when its GVR was not servable at Put time) MUST self-evict within
+// that bound even when the store's standard ttl is long — the
+// bounded-staleness floor that caps a missed dirty-mark. A healthy entry
+// (no override) keeps the standard ttl. The override can only TIGHTEN the
+// bound, never extend past the standard ttl.
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTTLOverride_ShortBackstopEvictsBeforeStandardTTL is the discriminating
+// control: the store ttl is a long 1h, but the entry carries a 1s override
+// → after the override window the entry is a MISS, while a sibling without
+// an override is still a HIT.
+func TestTTLOverride_ShortBackstopEvictsBeforeStandardTTL(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour) // standard ttl = 1h
+
+	// Degraded entry: stored "while not servable" → short 1s override,
+	// CreatedAt backdated 2s so it is already past the override but FAR
+	// inside the 1h standard ttl.
+	c.Put("k-degraded", &ResolvedEntry{
+		RawJSON:     []byte(`{}`),
+		CreatedAt:   time.Now().Add(-2 * time.Second),
+		TTLOverride: 1 * time.Second,
+	})
+	// Healthy entry: no override, same backdate → governed by the 1h ttl.
+	c.Put("k-healthy", &ResolvedEntry{
+		RawJSON:   []byte(`{}`),
+		CreatedAt: time.Now().Add(-2 * time.Second),
+	})
+
+	if _, ok := c.Get("k-degraded"); ok {
+		t.Fatalf("backstop FAIL: the degraded entry (1s override, age 2s) must be evicted as a MISS, "+
+			"not served — the bounded-staleness floor did not fire")
+	}
+	if _, ok := c.Get("k-healthy"); !ok {
+		t.Fatalf("the healthy entry (no override, age 2s, 1h ttl) must still be a HIT — the override "+
+			"must not affect entries that don't carry it")
+	}
+}
+
+// TestTTLOverride_HonouredWithinWindow: a degraded entry is still a HIT
+// inside its override window (the backstop bounds staleness, it does not
+// evict eagerly).
+func TestTTLOverride_HonouredWithinWindow(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour)
+	c.Put("k", &ResolvedEntry{
+		RawJSON:     []byte(`{}`),
+		CreatedAt:   time.Now(), // fresh
+		TTLOverride: 1 * time.Hour,
+	})
+	if _, ok := c.Get("k"); !ok {
+		t.Fatalf("a fresh entry within its override window must be a HIT")
+	}
+}
+
+// TestEffectiveTTL_OverrideOnlyTightens: the override can only shorten the
+// bound — an override LONGER than the store ttl must not extend the entry's
+// life past the standard ttl.
+func TestEffectiveTTL_OverrideOnlyTightens(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour) // standard 1h
+
+	// Override of 10h (longer than the 1h standard) on an entry aged 2h:
+	// the entry is past the 1h standard ttl, so effectiveTTL must clamp to
+	// the standard ttl and evict it — the override must NOT keep it alive.
+	c.Put("k", &ResolvedEntry{
+		RawJSON:     []byte(`{}`),
+		CreatedAt:   time.Now().Add(-2 * time.Hour),
+		TTLOverride: 10 * time.Hour,
+	})
+	if _, ok := c.Get("k"); ok {
+		t.Fatalf("an override LONGER than the standard ttl must not extend life past it — "+
+			"the entry aged 2h (>1h standard) must be evicted")
+	}
+
+	// Unit-level: effectiveTTLLocked returns the SHORTER of the two.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	got := c.effectiveTTLLocked(&ResolvedEntry{TTLOverride: 10 * time.Hour})
+	if got != time.Hour {
+		t.Fatalf("effectiveTTL with a longer override = %v, want the standard 1h (override only tightens)", got)
+	}
+	got = c.effectiveTTLLocked(&ResolvedEntry{TTLOverride: 30 * time.Second})
+	if got != 30*time.Second {
+		t.Fatalf("effectiveTTL with a shorter override = %v, want 30s", got)
+	}
+	got = c.effectiveTTLLocked(&ResolvedEntry{}) // no override
+	if got != time.Hour {
+		t.Fatalf("effectiveTTL with no override = %v, want the standard 1h", got)
+	}
+}
+
+// TestCatalogUnservableTTL_DisabledByDefault: the env accessor returns 0
+// (disabled) unless set, so the override is purely additive.
+func TestCatalogUnservableTTL_DisabledByDefault(t *testing.T) {
+	t.Setenv("CATALOG_UNSERVABLE_TTL_SECONDS", "")
+	if d := CatalogUnservableTTL(); d != 0 {
+		t.Fatalf("CatalogUnservableTTL unset must be 0 (disabled); got %v", d)
+	}
+	t.Setenv("CATALOG_UNSERVABLE_TTL_SECONDS", "0")
+	if d := CatalogUnservableTTL(); d != 0 {
+		t.Fatalf("CatalogUnservableTTL=0 must be 0 (disabled); got %v", d)
+	}
+	t.Setenv("CATALOG_UNSERVABLE_TTL_SECONDS", "45")
+	if d := CatalogUnservableTTL(); d != 45*time.Second {
+		t.Fatalf("CatalogUnservableTTL=45 must be 45s; got %v", d)
+	}
+	t.Setenv("CATALOG_UNSERVABLE_TTL_SECONDS", "garbage")
+	if d := CatalogUnservableTTL(); d != 0 {
+		t.Fatalf("CatalogUnservableTTL invalid must be 0 (disabled); got %v", d)
+	}
+}

--- a/internal/cache/resolved_metadata_test.go
+++ b/internal/cache/resolved_metadata_test.go
@@ -1,0 +1,157 @@
+// resolved_metadata_test.go — R1 §6 Mode 1 + PM F-2 falsifiers for the
+// metadata-only /debug/apistage projection.
+//
+// F-2 (PM condition): a STRUCTURAL leak-guard TEST proving RangeMetadata
+// cannot return resolved content — not just a comment. Two arms:
+//
+//   - STRUCTURAL: reflect over every field of ResolvedEntryMeta and assert
+//     NONE is a content-bearing type (no []byte, no slice-of-pointer/struct,
+//     no map, no unstructured). A future field that could carry RawJSON /
+//     Items / Extras fails the test at the TYPE level, before any handler
+//     ever runs. This is the load-bearing guard.
+//   - BEHAVIORAL: Put an entry whose RawJSON + Items + Extras carry a unique
+//     sentinel, run RangeMetadata, JSON-encode the emitted metadata, and
+//     assert the sentinel NEVER appears — while the metadata coordinates
+//     (class/gvr/path/age/counts) ARE correct.
+
+package cache
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TestRangeMetadata_StructurallyCannotLeakContent is the F-2 STRUCTURAL
+// guard: ResolvedEntryMeta must contain only scalar metadata fields. Any
+// field whose type could carry a resolved body (a byte slice, a slice of
+// objects/pointers, a map, or an unstructured) is a leak vector and fails
+// here — at the type level, independent of RangeMetadata's body.
+func TestRangeMetadata_StructurallyCannotLeakContent(t *testing.T) {
+	mt := reflect.TypeOf(ResolvedEntryMeta{})
+	for i := 0; i < mt.NumField(); i++ {
+		f := mt.Field(i)
+		switch f.Type.Kind() {
+		case reflect.String, reflect.Bool,
+			reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			// Scalar — safe. (Note: a []byte would be Kind()==Slice, caught below;
+			// a lone Uint8 field is a harmless scalar, not a body.)
+		default:
+			t.Fatalf("F-2 STRUCTURAL leak: ResolvedEntryMeta.%s has type %s (kind %s) — "+
+				"only scalar metadata fields are allowed; a slice/map/pointer/struct field "+
+				"could carry resolved content (RawJSON/Items/Extras) and is a cross-user leak vector",
+				f.Name, f.Type, f.Type.Kind())
+		}
+	}
+}
+
+// TestRangeMetadata_BehaviorallyEmitsNoBody is the F-2 BEHAVIORAL guard: a
+// populated entry's body never reaches the emitted metadata, and the
+// metadata coordinates are correct.
+func TestRangeMetadata_BehaviorallyEmitsNoBody(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour)
+
+	const sentinel = "SECRET-DO-NOT-LEAK-7f3a9"
+	// RawJSON, a parsed Item, and an Extras value all carry the sentinel.
+	entry := &ResolvedEntry{
+		RawJSON: []byte(`{"secretField":"` + sentinel + `","items":[1,2,3]}`),
+		Items: []*unstructured.Unstructured{
+			{Object: map[string]any{"metadata": map[string]any{"name": sentinel}}},
+			{Object: map[string]any{"metadata": map[string]any{"name": "two"}}},
+		},
+		ItemsAPIVersion: "v1",
+		ItemsKind:       "ConfigMapList",
+		Inputs: &ResolvedKeyInputs{
+			CacheEntryClass: CacheEntryClassApistage,
+			Group:           "",
+			Version:         "v1",
+			Resource:        "configmaps",
+			Namespace:       "",
+			Name:            "",
+			Stage:           "stage-hash-abc",
+			Extras:          map[string]any{"compositionId": sentinel},
+		},
+	}
+	c.Put("opaque-key-1", entry)
+
+	var got []ResolvedEntryMeta
+	c.RangeMetadata(func(m ResolvedEntryMeta) bool {
+		got = append(got, m)
+		return true
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 metadata row, got %d", len(got))
+	}
+	m := got[0]
+
+	// Coordinates are correct (the diagnostic must be useful).
+	if m.CacheEntryClass != CacheEntryClassApistage {
+		t.Errorf("class = %q, want apistage", m.CacheEntryClass)
+	}
+	if m.Resource != "configmaps" || m.Version != "v1" {
+		t.Errorf("gvr coords wrong: %+v", m)
+	}
+	if m.Path != "/api/v1/configmaps" {
+		t.Errorf("path = %q, want /api/v1/configmaps", m.Path)
+	}
+	if m.Stage != "stage-hash-abc" {
+		t.Errorf("stage = %q, want the opaque stage hash", m.Stage)
+	}
+	if m.ItemsCount != 2 {
+		t.Errorf("itemsCount = %d, want 2 (the LENGTH, not the items)", m.ItemsCount)
+	}
+	if m.RawJSONBytes != len(entry.RawJSON) {
+		t.Errorf("rawJSONBytes = %d, want %d (the LENGTH, not the body)", m.RawJSONBytes, len(entry.RawJSON))
+	}
+
+	// THE GUARD: the fully-serialized metadata must NOT contain the sentinel
+	// from RawJSON, Items, or Extras anywhere.
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if strings.Contains(string(blob), sentinel) {
+		t.Fatalf("F-2 BEHAVIORAL leak: the sentinel %q (from RawJSON/Items/Extras) appeared in the "+
+			"emitted metadata JSON: %s", sentinel, blob)
+	}
+}
+
+// TestRangeMetadata_AgeAndTTL covers the age/ttl-remaining projection used
+// to spot a stale entry (the R1 verification signal: after a composition
+// update the entry's age resets).
+func TestRangeMetadata_AgeAndTTL(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour)
+	old := &ResolvedEntry{
+		RawJSON:   []byte(`{}`),
+		CreatedAt: time.Now().Add(-10 * time.Minute),
+		Inputs:    &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassApistage, Version: "v1", Resource: "configmaps"},
+	}
+	c.Put("k-old", old)
+
+	var m ResolvedEntryMeta
+	c.RangeMetadata(func(x ResolvedEntryMeta) bool { m = x; return false })
+
+	if m.AgeSeconds < 590 || m.AgeSeconds > 610 {
+		t.Errorf("ageSeconds = %d, want ~600 (10 min)", m.AgeSeconds)
+	}
+	// ttl 1h - age 10min ≈ 3000s remaining.
+	if m.TTLRemainingSeconds < 2980 || m.TTLRemainingSeconds > 3020 {
+		t.Errorf("ttlRemainingSeconds = %d, want ~3000", m.TTLRemainingSeconds)
+	}
+}
+
+// TestRangeMetadata_NilReceiver is the cache-off path: a nil store is a
+// no-op (the handler reports cacheEnabled=false, zero entries).
+func TestRangeMetadata_NilReceiver(t *testing.T) {
+	var c *ResolvedCacheStore
+	called := false
+	c.RangeMetadata(func(ResolvedEntryMeta) bool { called = true; return true })
+	if called {
+		t.Fatalf("nil-receiver RangeMetadata must not invoke fn")
+	}
+}

--- a/internal/handlers/debug_apistage.go
+++ b/internal/handlers/debug_apistage.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// debugApistageBody is the JSON body returned by /debug/apistage.
+type debugApistageBody struct {
+	// CacheEnabled mirrors the resolved-output cache state. When the
+	// resolved cache is off there are no entries to report (Entries is
+	// empty) — the endpoint still returns 200 so it is usable as a
+	// diagnostic regardless of the flag.
+	CacheEnabled bool `json:"cacheEnabled"`
+	// Count is len(Entries) — convenience for a quick "how many entries".
+	Count int `json:"count"`
+	// Entries is the per-entry METADATA snapshot (sorted by key hash for
+	// stable output across requests).
+	Entries []cache.ResolvedEntryMeta `json:"entries"`
+}
+
+// DebugApistage is the read-only resolved-output-cache entry diagnostic
+// (R1 design §6 Mode 1, docs/design-r1-allcompositionresources-invalidation-2026-06-26.md).
+//
+// It dumps, per cached resolved-output entry, METADATA ONLY:
+// class / key-hash / GVR coordinates / derived path / stage hash / age /
+// ttl-remaining / pinned / items_count / rawjson_bytes — the signal needed
+// to diagnose a degraded apistage entry (e.g. an `allCompositionResources`
+// entry whose `path` is `/api/v1/configmaps` with an `itemsCount` reflecting
+// the cluster-wide LIST, or a stale `getComposition` entry with a large
+// `ageSeconds`) without a kubectl exec into the pod, and to VERIFY R1 (after
+// a composition update, `ageSeconds` resets + the path/items_count reflect
+// the 26 by-name fan-out).
+//
+// STRUCTURAL LEAK GUARD (PM F-2): resolved output is per-identity
+// RBAC-sensitive; a content dump would be a cross-user leak. This handler
+// returns cache.ResolvedEntryMeta values produced by RangeMetadata, a type
+// that is STRUCTURALLY INCAPABLE of carrying RawJSON / parsed Items / the
+// Extras key-inputs (no []byte, no slice-of-object, no map field). The guard
+// is the type, not this comment — see
+// TestRangeMetadata_StructurallyCannotLeakContent.
+//
+// READ-ONLY: RangeMetadata takes the store mutex in a read-walk and mutates
+// NO state — no Put, no evict, no LRU touch. Calling it has zero effect on
+// serving behaviour.
+//
+// NOT gated behind the cache flag: when the resolved cache is off the
+// snapshot is empty but the endpoint still returns 200 with
+// cacheEnabled=false, so it is available for debugging in both modes.
+// Mounted next to /debug/servable and /debug/vars (operator-level, NOT the
+// per-user /call surface).
+//
+// @Summary Resolved-cache entry metadata diagnostic
+// @Description Read-only metadata-only snapshot of resolved-output cache entries (class/path/gvr/age/ttl/items_count). Never returns resolved bodies.
+// @ID debug-apistage
+// @Produce  json
+// @Success 200 {object} debugApistageBody
+// @Router /debug/apistage [get]
+func DebugApistage() http.HandlerFunc {
+	return func(wri http.ResponseWriter, _ *http.Request) {
+		store := cache.ResolvedCache() // nil when the resolved cache is off
+		var rows []cache.ResolvedEntryMeta
+		// RangeMetadata is nil-receiver safe; guard anyway for clarity.
+		if store != nil {
+			store.RangeMetadata(func(m cache.ResolvedEntryMeta) bool {
+				rows = append(rows, m)
+				return true
+			})
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].KeyHash < rows[j].KeyHash })
+
+		body := debugApistageBody{
+			CacheEnabled: store != nil,
+			Count:        len(rows),
+			Entries:      rows,
+		}
+		wri.Header().Set("Content-Type", "application/json")
+		wri.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(wri).Encode(body)
+	}
+}

--- a/internal/resolvers/restactions/api/apistage.go
+++ b/internal/resolvers/restactions/api/apistage.go
@@ -565,6 +565,18 @@ func apistageContentServe(
 			RawJSON: dispatched,
 			Inputs:  ptrTo(contentKeyInputs(gvr, ns, name)),
 		}
+		// R1 Layer 2 (#36): bounded-staleness backstop. If this content
+		// entry is being stored while its GVR informer is NOT servable
+		// (registered-but-not-synced / watch-broken / unconfirmed — e.g. the
+		// core.krateo.io discovery flap that re-latches not-servable), it may
+		// be a degraded / not-fully-resolved snapshot. Stamp the short
+		// CATALOG_UNSERVABLE_TTL_SECONDS so it self-evicts within the bound
+		// even if a dirty-mark / refresh-ordering gap is missed. Uniform
+		// over every GVR (no path/resource special-case — feedback_no_special_cases);
+		// disabled (TTLOverride stays 0 → standard TTL) when the env is unset.
+		if ttl := cache.CatalogUnservableTTL(); ttl > 0 && !cache.Global().IsServable(gvr) {
+			newEntry.TTLOverride = ttl
+		}
 		// R3: parse the LIST envelope ONCE and attach the items to the
 		// entry, so every future content-Get-hit gates without a
 		// re-unmarshal. A malformed envelope (parseOK=false) stores

--- a/internal/resolvers/restactions/api/cluster_list.go
+++ b/internal/resolvers/restactions/api/cluster_list.go
@@ -421,6 +421,15 @@ func populateClusterListCellSync(
 		ItemsAPIVersion: parsed.apiVersion,
 		ItemsKind:       parsed.kind,
 	}
+	// R1 Layer 2 (#36) bounded-staleness backstop — same uniform predicate
+	// as the apistage content Put (apistage.go): a catalog entry materialised
+	// while its GVR informer is NOT servable gets the short
+	// CATALOG_UNSERVABLE_TTL_SECONDS so a degraded cluster_list snapshot
+	// self-evicts within the bound. UNIFORM, no path/resource special-case
+	// (feedback_no_special_cases); disabled (override stays 0) when unset.
+	if ttl := cache.CatalogUnservableTTL(); ttl > 0 && !cache.Global().IsServable(gvr) {
+		newEntry.TTLOverride = ttl
+	}
 	defensiveParseMs := materialiseElapsed.Milliseconds()
 
 	putStart := time.Now()

--- a/main.go
+++ b/main.go
@@ -950,6 +950,15 @@ func main() {
 	// diagnosable without a kubectl exec. Mounted next to /debug/vars.
 	mux.HandleFunc("GET /debug/servable", handlers.DebugServable())
 
+	// R1 diagnostic — read-only METADATA-ONLY snapshot of resolved-output
+	// cache entries (class/path/gvr/age/ttl/items_count), for diagnosing a
+	// degraded apistage entry (stale getComposition / cluster-scoped
+	// allCompositionResources) without a kubectl exec. NEVER returns
+	// resolved bodies (per-identity RBAC-sensitive) — the structural leak
+	// guard is cache.ResolvedEntryMeta's type shape. Mounted next to
+	// /debug/servable (docs/design-r1-allcompositionresources-invalidation-2026-06-26.md §6).
+	mux.HandleFunc("GET /debug/apistage", handlers.DebugApistage())
+
 	ctx, stop := signal.NotifyContext(context.Background(), []os.Signal{
 		os.Interrupt,
 		syscall.SIGINT,


### PR DESCRIPTION
## What
R1 convergence-hardening **Phase 1** (target 1.5.6), two additive + **default-off** pieces. Layer 1 (the refresh-context content-bypass) is NOT in this PR — it waits on the attach-point ruling. Design: `docs/design-r1-allcompositionresources-invalidation-2026-06-26.md` §6 (Mode 1) + §4 (Layer 2).

### Phase 1a — `/debug/apistage` METADATA-ONLY entry dump (#50)
- `resolved.go`: `ResolvedEntryMeta` (scalar-only projection) + `RangeMetadata(fn)` under `c.mu`, emitting class/keyHash/path/gvr/ns/name/stage/age/ttlRemaining/pinned/itemsCount/rawJSONBytes — **never** RawJSON/Items/Extras.
- `debug_apistage.go`: read-only handler modelled on `debug_servable.go`; nil-safe when the resolved cache is off (200, `cacheEnabled:false`). Registered at `GET /debug/apistage` next to `/debug/servable` (operator-level).
- **F-2 leak guard** (`resolved_metadata_test.go`): STRUCTURAL — reflect over every `ResolvedEntryMeta` field, fail if any is a slice/map/pointer/struct (content-bearing) → the guard is the TYPE; + BEHAVIORAL — a sentinel in RawJSON+Items+Extras never appears in the emitted metadata.

### Phase 1b — Layer 2 bounded `CATALOG_UNSERVABLE_TTL_SECONDS` (#36, #51, #52)
- `resolved.go`: env `CATALOG_UNSERVABLE_TTL_SECONDS` (default 0 = DISABLED) + `CatalogUnservableTTL()`; per-entry `ResolvedEntry.TTLOverride`; `effectiveTTLLocked` (override only TIGHTENS, never extends past the standard ttl); `Get` + `RangeMetadata` honour it.
- `apistage.go` + `cluster_list.go` (#52) catalog Put sites: stamp the short `TTLOverride` when the GVR is not servable at Put time — UNIFORM, no path/resource special-case. A degraded catalog entry self-evicts within the bound even if a dirty-mark is missed.

## Behaviour-neutral until the chart sets the env
Go default is 0, so this PR ships **nothing observable** until the lockstep chart sets `CATALOG_UNSERVABLE_TTL_SECONDS` (held separately on the warmup-churn verdict). `/debug/apistage` is additive operator diagnostic.

## Reviews
arch-listshape SOUNDNESS PASS (leak structurally closed; tighten-only proven; Put-site uniform+nil-safe; warmup-churn UNFOUNDED — Put only after a servable dispatch, fires only on a narrow post-dispatch flip = cost-proportional). PM-ACCEPT (F-2 sufficient; #51 self-evict/tighten/F-4 confirmed; ran both test files -race green).

## Tests
8 new tests GREEN under `-race -count=1`; full cache pkg `-race` ok; api pkg `-race` ok; `go build` + `go vet ./...` clean.

## Topology
Independent of the parked 1.5.5 set (#54/#55/#56/#41); targets **1.5.6**. **Parked — do NOT merge (Diego merges).** Lockstep chart value for `CATALOG_UNSERVABLE_TTL_SECONDS` ships in a separate chart PR once the churn verdict clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1