### PR TITLE
fix(cache): R1 Layer 1 — refresh-context content-bypass cures the apistage content-shield

### DIFF
--- a/internal/cache/crd_schema_relist_test.go
+++ b/internal/cache/crd_schema_relist_test.go
@@ -42,8 +42,8 @@ type dirtyRecorder struct {
 }
 
 func newDirtyRecorder() *dirtyRecorder { return &dirtyRecorder{keys: map[string]int{}} }
-func (r *dirtyRecorder) hook() func(string) {
-	return func(k string) { r.mu.Lock(); r.keys[k]++; r.mu.Unlock() }
+func (r *dirtyRecorder) hook() func(string, schema.GroupVersionResource) {
+	return func(k string, _ schema.GroupVersionResource) { r.mu.Lock(); r.keys[k]++; r.mu.Unlock() }
 }
 func (r *dirtyRecorder) marked(k string) bool {
 	r.mu.Lock()

--- a/internal/cache/deps.go
+++ b/internal/cache/deps.go
@@ -268,6 +268,49 @@ func ApistagePrewarmFromContext(ctx context.Context) bool {
 	return v
 }
 
+// ctxKeyRefreshTriggerGVRType is the typed context key for the R1 Layer 1
+// refresh-trigger-GVR marker.
+type ctxKeyRefreshTriggerGVRType struct{}
+
+var ctxKeyRefreshTriggerGVR = ctxKeyRefreshTriggerGVRType{}
+
+// WithRefreshTriggerGVR returns a child context carrying the GVR whose
+// dirty-mark TRIGGERED this refresher re-resolve (R1 Layer 1). It is set
+// ONLY by the refresher's re-resolve entry point (resolve_populate.go),
+// NEVER on a request-path /call — so a marked ctx is structurally proof
+// that this resolve is a refresher re-resolve driven by a specific GVR
+// event.
+//
+// THE INVARIANT it establishes: during a refresher re-resolve triggered by
+// GVR X, apistageContentServe must NOT serve a stale content HIT for a
+// content entry whose OWN dep GVR == X — it must re-dispatch that unit
+// fresh, so the whole-RA re-resolve consumes the FRESH input rather than a
+// sibling stage's stale content snapshot (the content-shield defect, R1
+// §3). The comparison is dep-edge equality (entry's GVR == trigger GVR),
+// UNIFORM across every GVR — no per-resource/path special-case
+// (feedback_no_special_cases). The request path never carries the marker,
+// so apistageContentServe's HIT branch is byte-identical for real /call.
+//
+// A nil ctx is returned unchanged.
+func WithRefreshTriggerGVR(ctx context.Context, gvr schema.GroupVersionResource) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyRefreshTriggerGVR, gvr)
+}
+
+// RefreshTriggerGVRFromContext returns the trigger GVR set by
+// WithRefreshTriggerGVR and true, or a zero GVR and false when the ctx is
+// not a refresher re-resolve (every request-path /call). apistageContentServe
+// consults it to decide a forced-miss on dep-edge equality.
+func RefreshTriggerGVRFromContext(ctx context.Context) (schema.GroupVersionResource, bool) {
+	if ctx == nil {
+		return schema.GroupVersionResource{}, false
+	}
+	v, ok := ctx.Value(ctxKeyRefreshTriggerGVR).(schema.GroupVersionResource)
+	return v, ok
+}
+
 // Dependency env knobs.
 const (
 	envDepsMaxRecords = "DEPS_MAX_RECORDS"
@@ -349,9 +392,12 @@ type DepTracker struct {
 	store   *ResolvedCacheStore
 
 	// enqueueFn is the refresher hook OnUpdate calls. Wired by
-	// SetRefreshHook; nil-safe (OnUpdate becomes a no-op).
+	// SetRefreshHook; nil-safe (OnUpdate becomes a no-op). R1 Layer 1: the
+	// hook now also receives the GVR whose event triggered the dirty-mark,
+	// so the refresher can carry it to the re-resolve (WithRefreshTriggerGVR)
+	// for the dep-edge-equality forced-miss.
 	enqueueMu sync.RWMutex
-	enqueueFn func(l1Key string)
+	enqueueFn func(l1Key string, triggerGVR schema.GroupVersionResource)
 }
 
 // depsInstance is the singleton — lazily initialised on first call to
@@ -401,10 +447,13 @@ func (d *DepTracker) SetStore(s *ResolvedCacheStore) {
 // SetRefreshHook wires the refresher enqueue function. Safe to call
 // multiple times; later calls replace the earlier wiring.
 //
-// The hook is called with an L1 key string for each dependent entry
-// matched by OnUpdate. The refresher is responsible for dedup, ordering,
-// and the actual re-resolve.
-func (d *DepTracker) SetRefreshHook(fn func(l1Key string)) {
+// The hook is called with an L1 key string + the GVR whose event matched
+// this dependent entry (R1 Layer 1 — the trigger GVR), for each dependent
+// entry matched by OnUpdate/OnAdd/OnDelete. The refresher is responsible
+// for dedup, ordering, and the actual re-resolve, and carries the trigger
+// GVR to the re-resolve so apistageContentServe can force-miss a content
+// entry keyed on that same GVR.
+func (d *DepTracker) SetRefreshHook(fn func(l1Key string, triggerGVR schema.GroupVersionResource)) {
 	d.enqueueMu.Lock()
 	d.enqueueFn = fn
 	d.enqueueMu.Unlock()
@@ -536,7 +585,7 @@ func (d *DepTracker) onChange(eventType string, gvr schema.GroupVersionResource,
 	marked := 0
 	for l1Key := range matched {
 		if enqueue != nil {
-			enqueue(l1Key)
+			enqueue(l1Key, gvr)
 		}
 		marked++
 	}
@@ -618,7 +667,7 @@ func (d *DepTracker) OnDelete(gvr schema.GroupVersionResource, namespace, name s
 		}
 		// Bucket 2 (LIST-dep) or bucket 3 (dependent-GET-dep) → dirty-mark.
 		if enqueue != nil {
-			enqueue(l1Key)
+			enqueue(l1Key, gvr)
 		}
 		dirtyMarked++
 	}
@@ -762,7 +811,7 @@ func (d *DepTracker) dirtyMarkResourceType(eventType string, gvr schema.GroupVer
 	marked := 0
 	for l1Key := range matched {
 		if enqueue != nil {
-			enqueue(l1Key)
+			enqueue(l1Key, gvr)
 		}
 		marked++
 	}

--- a/internal/cache/deps_falsifier_test.go
+++ b/internal/cache/deps_falsifier_test.go
@@ -45,8 +45,8 @@ type captureHook struct {
 	keys []string
 }
 
-func (h *captureHook) fn() func(string) {
-	return func(k string) {
+func (h *captureHook) fn() func(string, schema.GroupVersionResource) {
+	return func(k string, _ schema.GroupVersionResource) {
 		h.mu.Lock()
 		h.keys = append(h.keys, k)
 		h.mu.Unlock()

--- a/internal/cache/deps_test.go
+++ b/internal/cache/deps_test.go
@@ -158,7 +158,7 @@ func TestDeps_OnDelete_DirtyMarksDependentGet(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	got := d.OnDelete(gvr, "ns", "dependency")
 	if got != 0 {
@@ -215,7 +215,7 @@ func TestDeps_OnUpdate_EnqueuesAndDoesNotEvict(t *testing.T) {
 
 	var enqueued []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(l1Key string) {
+	d.SetRefreshHook(func(l1Key string, _ schema.GroupVersionResource) {
 		mu.Lock()
 		enqueued = append(enqueued, l1Key)
 		mu.Unlock()
@@ -430,7 +430,7 @@ func TestDeps_ConcurrentRecordAndDelete_RaceFree(t *testing.T) {
 
 	// Updaters: OnUpdate sweeps the other half. No real hook needed —
 	// we just exercise the lookup path.
-	d.SetRefreshHook(func(_ string) {})
+	d.SetRefreshHook(func(_ string, _ schema.GroupVersionResource) {})
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -511,7 +511,7 @@ func TestRecordingInnerCallDep_ListScope(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	// OnDelete for ANY object of that GVR in ns dirty-marks via list-scope.
 	got := d.OnDelete(gvr, "bench-ns-02", "bench-app-02-XX")
@@ -566,7 +566,7 @@ func TestRecordingInnerCallDep_ExactObject(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	// DELETE the named object — neither widget is its self-representation,
 	// so both are dirty-marked (exact-GET-dep + list-dep).
@@ -646,7 +646,7 @@ func TestIteratorEmitsPerNamespaceEdges(t *testing.T) {
 	// away, so the entry is stale-while-revalidate, not evicted).
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	got := d.OnDelete(iterGVR, "bench-ns-25", "bench-app-XX")
 	if got != 0 {
@@ -681,7 +681,7 @@ func TestOnDelete_DirtyMarksViaListScope(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	evicted := d.OnDelete(gvr, "bench-ns-02", "bench-app-02-06")
 	if evicted != 0 {
@@ -720,7 +720,7 @@ func TestDeps_OnResourceTypeAvailable_DirtyMarksListDeps(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	got := d.OnResourceTypeAvailable(gvr)
 	if got != 2 {
@@ -755,7 +755,7 @@ func TestDeps_OnResourceTypeAvailable_NoMatchIsNoOp(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	if got := d.OnResourceTypeAvailable(gvr); got != 0 {
 		t.Fatalf("OnResourceTypeAvailable marked %d, want 0 (no matching LIST-dep)", got)
@@ -799,7 +799,7 @@ func TestDeps_OnResourceTypeRemoved_DirtyMarksListAndGetDeps(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	got := d.OnResourceTypeRemoved(gvr)
 	if got != 3 {
@@ -833,7 +833,7 @@ func TestDeps_OnResourceTypeRemoved_NoMatchIsNoOp(t *testing.T) {
 
 	var marked []string
 	var mu sync.Mutex
-	d.SetRefreshHook(func(k string) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { mu.Lock(); marked = append(marked, k); mu.Unlock() })
 
 	if got := d.OnResourceTypeRemoved(gvr); got != 0 {
 		t.Fatalf("OnResourceTypeRemoved marked %d, want 0 (no matching dep)", got)

--- a/internal/cache/deps_watch_test.go
+++ b/internal/cache/deps_watch_test.go
@@ -62,7 +62,7 @@ func TestACR1b_AddPreSyncDropped(t *testing.T) {
 	d := Deps()
 	d.RecordList(adminL1, gvr, "bench-ns-01")
 	marked := 0
-	d.SetRefreshHook(func(string) { marked++ })
+	d.SetRefreshHook(func(string, schema.GroupVersionResource) { marked++ })
 
 	// Fire an ADD-equivalent through the real handler closure.
 	handlers.AddFunc(unstructuredObj(gvr, "bench-ns-01", "new-obj"))
@@ -98,7 +98,7 @@ func TestACR1a_AddPostSyncDirtyMarksListDep(t *testing.T) {
 	d := Deps()
 	d.RecordList(adminL1, gvr, "bench-ns-07")
 	var marked []string
-	d.SetRefreshHook(func(k string) { marked = append(marked, k) })
+	d.SetRefreshHook(func(k string, _ schema.GroupVersionResource) { marked = append(marked, k) })
 
 	handlers.AddFunc(unstructuredObj(gvr, "bench-ns-07", "fresh-obj"))
 
@@ -129,7 +129,7 @@ func TestACO14_NilSyncChDrops(t *testing.T) {
 	d := Deps()
 	d.RecordList(adminL1, gvr, "bench-ns-01")
 	marked := 0
-	d.SetRefreshHook(func(string) { marked++ })
+	d.SetRefreshHook(func(string, schema.GroupVersionResource) { marked++ })
 
 	// Two ADDs — the WARN must fire at most once, both must drop.
 	handlers.AddFunc(unstructuredObj(gvr, "bench-ns-01", "a"))

--- a/internal/cache/refresher.go
+++ b/internal/cache/refresher.go
@@ -43,6 +43,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -244,6 +245,21 @@ type refresher struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]RefreshFunc
 
+	// triggerGVRByKey carries the GVR whose dirty-mark enqueued each key
+	// (R1 Layer 1). The SetRefreshHook callback stores key→trigger-GVR
+	// before the queue.Add; processNext loads+deletes it at dequeue and
+	// stamps WithRefreshTriggerGVR on the re-resolve ctx so
+	// apistageContentServe force-misses a content entry keyed on that GVR.
+	// A key present in the queue but ABSENT here (e.g. a self-enqueue, or
+	// a value overwritten by a later dirty-mark before dequeue) simply
+	// carries no trigger GVR — the re-resolve then behaves exactly as
+	// pre-R1 (no forced miss). Last-write-wins on concurrent re-marks of
+	// the same key is acceptable: any of the dirtying GVRs is a valid
+	// force-miss target, and the rate-floor/dedup already collapses the
+	// re-marks to one re-resolve. sync.Map: write-on-enqueue,
+	// delete-on-dequeue, bounded by the in-flight key set.
+	triggerGVRByKey sync.Map
+
 	// Falsifier counters (atomic).
 	enqueueTotal        atomic.Uint64
 	completedTotal      atomic.Uint64
@@ -406,7 +422,14 @@ func StartRefresher(ctx context.Context) {
 		// branch); the memo holds the entry, so we MUST consult the memo
 		// directly, not the L1 store. The invalidator is non-blocking
 		// (drop-on-full) so this never delays the refresher enqueue path.
-		Deps().SetRefreshHook(func(l1Key string) {
+		Deps().SetRefreshHook(func(l1Key string, triggerGVR schema.GroupVersionResource) {
+			// R1 Layer 1 — record the GVR whose dirty-mark enqueued this key
+			// BEFORE the queue.Add, so processNext can stamp it on the
+			// re-resolve ctx (dep-edge-equality force-miss). Last-write-wins
+			// on concurrent re-marks (any dirtying GVR is a valid target);
+			// an empty (zero) GVR is still stored — RefreshTriggerGVRFromContext
+			// only matches a non-empty equality so a zero never force-misses.
+			r.triggerGVRByKey.Store(l1Key, triggerGVR)
 			// Path 3.2 / 0.30.218 — two-tier dispatch. If the key is a
 			// registered cluster_list cell, route it to the
 			// HIGH-PRIORITY tier; otherwise the normal tier. The
@@ -761,7 +784,21 @@ func (r *refresher) processNext(ctx context.Context) bool {
 		}
 	}
 
-	if err := r.processOne(ctx, key, entry, ok); err != nil {
+	// R1 Layer 1 — stamp the trigger GVR (recorded at enqueue by the
+	// SetRefreshHook callback) onto the re-resolve ctx, so
+	// apistageContentServe force-misses a content entry keyed on that GVR
+	// during this whole-RA re-resolve. Load-and-delete: the entry is
+	// consumed exactly once per dispatch; a key with no recorded GVR (self-
+	// enqueue) carries none and the re-resolve is pre-R1-identical. Done
+	// here (not in the floored-defer branch above) so the GVR survives a
+	// floor deferral and is consumed at the eventual real dispatch.
+	rctx := ctx
+	if v, present := r.triggerGVRByKey.LoadAndDelete(key); present {
+		if tg, isGVR := v.(schema.GroupVersionResource); isGVR && !tg.Empty() {
+			rctx = WithRefreshTriggerGVR(ctx, tg)
+		}
+	}
+	if err := r.processOne(rctx, key, entry, ok); err != nil {
 		r.failedTotal.Add(1)
 		// Poison-pill bound (Part A). NumRequeues is how many times this
 		// exact key has already been AddRateLimited. Once it exceeds the

--- a/internal/cache/stale_delete_heal_dep_falsifier_test.go
+++ b/internal/cache/stale_delete_heal_dep_falsifier_test.go
@@ -80,7 +80,7 @@ type healBCaptureHook struct {
 	keys []string
 }
 
-func (h *healBCaptureHook) fn(k string) {
+func (h *healBCaptureHook) fn(k string, _ schema.GroupVersionResource) {
 	h.mu.Lock()
 	h.keys = append(h.keys, k)
 	h.mu.Unlock()

--- a/internal/handlers/dispatchers/gvr_discovered_integration_test.go
+++ b/internal/handlers/dispatchers/gvr_discovered_integration_test.go
@@ -349,7 +349,7 @@ func TestGVRDiscoveredIntegration_DepRecordedThenAddFiresConsumed(t *testing.T) 
 	// against a separate engine instance, but the global deps tracker
 	// is process-wide).
 	var enqueueCount atomic.Int64
-	stub := func(key string) {
+	stub := func(key string, _ schema.GroupVersionResource) {
 		if key == l1Key {
 			enqueueCount.Add(1)
 		}
@@ -441,7 +441,7 @@ func TestGVRDiscoveredIntegration_AdminPerBindingCellsExceedPreExistingClusterLi
 
 	// Install a counter to track WHICH cells are dirty-marked.
 	dirtyMarked := map[string]int{}
-	deps.SetRefreshHook(func(key string) {
+	deps.SetRefreshHook(func(key string, _ schema.GroupVersionResource) {
 		dirtyMarked[key]++
 	})
 	defer deps.SetRefreshHook(nil)

--- a/internal/resolvers/restactions/api/apistage.go
+++ b/internal/resolvers/restactions/api/apistage.go
@@ -478,7 +478,26 @@ func apistageContentServe(
 	var parsed parsedListEnvelope
 	var haveParsed bool
 	var entryRef *cache.ResolvedEntry
-	if entry, hit := store.Get(contentKey); hit && entry != nil {
+	// R1 Layer 1 — refresh-context content-bypass (force a MISS on a content
+	// HIT whose OWN dep GVR is the GVR that TRIGGERED this refresher
+	// re-resolve). Without it, a whole-RA refresh re-resolve serves this
+	// stage from its STORED content bytes (the HIT branch below short-
+	// circuits the fresh fetch — the content-shield, R1 §3), so the
+	// re-resolve consumes a stale sibling snapshot and re-stores a degraded
+	// result. forceContentMiss is true ONLY when:
+	//   - ctx carries a refresh trigger GVR (WithRefreshTriggerGVR, set ONLY
+	//     by the refresher's re-resolve entry point — NEVER a request-path
+	//     /call, so the HIT branch is byte-identical for real traffic), AND
+	//   - that trigger GVR == this content unit's own GVR (dep-edge
+	//     equality — UNIFORM, no per-resource/path special-case,
+	//     feedback_no_special_cases).
+	// On a forced miss we fall through to the MISS branch, which re-dispatches
+	// fresh + re-Puts, so the whole-RA re-resolve reads the FRESH input.
+	forceContentMiss := false
+	if tg, ok := cache.RefreshTriggerGVRFromContext(ctx); ok && tg == gvr {
+		forceContentMiss = true
+	}
+	if entry, hit := store.Get(contentKey); hit && entry != nil && !forceContentMiss {
 		hitObserved = true // Ship 0.30.193 C3 — observed cache hit.
 		envelope = entry.RawJSON
 		entryRef = entry

--- a/internal/resolvers/restactions/api/apistage_dep_record_test.go
+++ b/internal/resolvers/restactions/api/apistage_dep_record_test.go
@@ -40,17 +40,18 @@ import (
 	"github.com/krateoplatformops/plumbing/ptr"
 	httpcall "github.com/krateoplatformops/plumbing/http/request"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // depRecordCapturedHook returns a SetRefreshHook closure that captures
 // every enqueued L1 key, plus a snapshot function. Concurrency-safe so
 // the test can run under -race.
-func depRecordCapturedHook() (hook func(string), snapshot func() []string) {
+func depRecordCapturedHook() (hook func(string, schema.GroupVersionResource), snapshot func() []string) {
 	var (
 		mu      sync.Mutex
 		entries []string
 	)
-	hook = func(k string) {
+	hook = func(k string, _ schema.GroupVersionResource) {
 		mu.Lock()
 		entries = append(entries, k)
 		mu.Unlock()

--- a/internal/resolvers/restactions/api/apistage_refresh_bypass_falsifier_test.go
+++ b/internal/resolvers/restactions/api/apistage_refresh_bypass_falsifier_test.go
@@ -1,0 +1,263 @@
+// apistage_refresh_bypass_falsifier_test.go — R1 Layer 1 hermetic falsifier
+// for the refresh-context content-bypass (the content-shield cure).
+//
+// THE DEFECT (R1 §3, the content-shield): during a refresher whole-RA
+// re-resolve triggered by GVR X, the RA's getComposition-style content stage
+// is served from its OWN apistage-content HIT — the STORED (possibly stale)
+// bytes — instead of being re-dispatched fresh. So the re-resolve consumes a
+// stale sibling snapshot and re-stores a degraded result.
+//
+// THE FIX (R1 Layer 1, Option A): apistageContentServe force-MISSES a content
+// HIT whose own dep GVR == the refresh TRIGGER GVR (WithRefreshTriggerGVR on
+// the refresh ctx), so the whole-RA re-resolve reads the FRESH input. UNIFORM
+// dep-edge equality — no per-resource/path special-case.
+//
+// DISCRIMINATING ARMS:
+//   - RED (the defect, structurally still present on the REQUEST path): a
+//     content HIT served WITHOUT the refresh marker returns the STALE stored
+//     shape — asserted POSITIVELY (the collapsed 1-element snapshot), per
+//     pm-warmup's F-3 condition (fails for the content-shield reason, not
+//     merely "≠ fresh"). This is ALSO the negative control proving the
+//     request path keeps stale-while-revalidate (no force-miss off-refresh).
+//   - GREEN (the cure): the SAME HIT served WITH WithRefreshTriggerGVR(==gvr)
+//     force-misses → re-dispatches fresh → returns the FRESH 2-element shape.
+//   - NEGATIVE (F-4 dep-edge equality, not "any refresh"): WITH a refresh
+//     marker for a DIFFERENT GVR, the HIT is still served stale (the bypass
+//     fires ONLY on dep-edge equality, never blanket-on-refresh — the
+//     0.30.185 amplification guard).
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/ptr"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// r1FsaGVR is a generic composition-style GET-by-name content GVR (the
+// getComposition shape). Customer-style — no carve-out (feedback_no_special_cases).
+var r1FsaGVR = schema.GroupVersionResource{
+	Group:    "composition.krateo.io",
+	Version:  "v1",
+	Resource: "fullstackapps",
+}
+
+const (
+	r1Ns   = "demo-system"
+	r1Name = "fsa-y2"
+	r1User = "r1-broad-user"
+)
+
+// r1StaleManagedCount / r1FreshManagedCount model the 1→26 transition: the
+// stored content entry is the STALE 1-managed snapshot; the live informer
+// holds the FRESH object with 2 managed (a smaller-but-distinct count keeps
+// the test fast; the shape is what matters).
+const (
+	r1StaleManaged = 1
+	r1FreshManaged = 2
+)
+
+// newR1RefreshBypassWatcher builds a cache-on watcher whose fake client holds
+// the FRESH fsa-y2 object (so a forced-miss re-dispatch GET-by-name returns
+// fresh) and grants r1User get on fullstackapps in demo-system.
+func newR1RefreshBypassWatcher(t *testing.T) *cache.ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	cache.ResetDepsForTest()
+	t.Cleanup(func() {
+		cache.ResetResolvedCacheForTest()
+		cache.ResetDepsForTest()
+	})
+
+	role := &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+		ObjectMeta: metav1.ObjectMeta{Name: "r1-fsa-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"composition.krateo.io"}, Resources: []string{"fullstackapps"}, Verbs: []string{"get", "list"}},
+		},
+	}
+	binding := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: r1Ns, Name: "r1-fsa-binding"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, APIGroup: "rbac.authorization.k8s.io", Name: r1User}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "r1-fsa-reader"},
+	}
+
+	// The FRESH live object (2 managed) — what a forced-miss re-dispatch reads.
+	freshFSA := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "composition.krateo.io/v1",
+		"kind":       "FullStackApp",
+		"metadata":   map[string]any{"namespace": r1Ns, "name": r1Name},
+		"status":     map[string]any{"managed": r1ManagedList(r1FreshManaged)},
+	}}
+
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		r1FsaGVR: "FullStackAppList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:               "RoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}:        "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}:        "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, role, binding, freshFSA)
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(rw.Stop)
+
+	// Register + sync the fsa informer so a forced-miss GET-by-name is servable
+	// and returns the fresh object.
+	rw.EnsureResourceType(r1FsaGVR)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	cache.SetGlobal(rw)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+	return rw
+}
+
+func r1ManagedList(n int) []any {
+	out := make([]any, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, map[string]any{"name": "child", "kind": "ConfigMap"})
+	}
+	return out
+}
+
+// putR1StaleContentEntry seeds the apistage GET-by-name content entry with the
+// STALE 1-managed snapshot — the content-shield's stored bytes.
+func putR1StaleContentEntry(store *cache.ResolvedCacheStore) string {
+	key := cache.ComputeKey(contentKeyInputs(r1FsaGVR, r1Ns, r1Name))
+	stale := map[string]any{
+		"apiVersion": "composition.krateo.io/v1",
+		"kind":       "FullStackApp",
+		"metadata":   map[string]any{"namespace": r1Ns, "name": r1Name},
+		"status":     map[string]any{"managed": r1ManagedList(r1StaleManaged)},
+	}
+	raw, _ := json.Marshal(stale)
+	store.Put(key, &cache.ResolvedEntry{
+		RawJSON: raw,
+		Inputs:  ptrTo(contentKeyInputs(r1FsaGVR, r1Ns, r1Name)),
+	})
+	return key
+}
+
+// managedCountOf extracts .status.managed length from an apistageContentServe
+// value. For a GET-by-name the gate returns the DECODED envelope (a
+// map[string]any via json.Unmarshal, apistage.go gateContentEnvelope:290) —
+// NOT raw bytes. Handle both shapes defensively.
+func managedCountOf(t *testing.T, v any) int {
+	t.Helper()
+	var obj map[string]any
+	switch typed := v.(type) {
+	case map[string]any:
+		obj = typed
+	case []byte:
+		if err := json.Unmarshal(typed, &obj); err != nil {
+			t.Fatalf("unmarshal served bytes: %v (raw=%s)", err, typed)
+		}
+	default:
+		t.Fatalf("served value is %T, want map[string]any or []byte", v)
+	}
+	status, _ := obj["status"].(map[string]any)
+	managed, _ := status["managed"].([]any)
+	return len(managed)
+}
+
+func r1GetCall() httpcall.RequestOptions {
+	return httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{
+			Path: "/apis/composition.krateo.io/v1/namespaces/" + r1Ns + "/fullstackapps/" + r1Name,
+			Verb: ptr.To(http.MethodGet),
+		},
+	}
+}
+
+func r1Ctx() context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: r1User}),
+	)
+}
+
+// TestFalsifierR1_RefreshTriggerForcesMissOfStaleContent is the discriminating
+// 3-arm falsifier.
+func TestFalsifierR1_RefreshTriggerForcesMissOfStaleContent(t *testing.T) {
+	_ = newR1RefreshBypassWatcher(t) // installs the cache.Global watcher + fresh fsa object
+	store := cache.ResolvedCache()
+	if store == nil {
+		t.Fatalf("resolved cache nil")
+	}
+
+	// --- RED arm + negative control: REQUEST path (no refresh marker) serves
+	// the STALE content HIT. Asserted POSITIVELY: the served value is the
+	// 1-managed collapsed snapshot (the content-shield, F-3 condition).
+	putR1StaleContentEntry(store)
+	v, served, ok := apistageContentServe(r1Ctx(), store, r1GetCall())
+	if !ok || !served {
+		t.Fatalf("request-path content HIT must serve (ok=%v served=%v)", ok, served)
+	}
+	if got := managedCountOf(t, v); got != r1StaleManaged {
+		t.Fatalf("RED arm: request-path HIT must serve the STALE %d-managed snapshot "+
+			"(stale-while-revalidate on the request path); got %d managed", r1StaleManaged, got)
+	}
+
+	// --- NEGATIVE control: refresh marker for a DIFFERENT GVR must NOT
+	// force-miss (dep-edge inequality) — still serves stale.
+	otherGVR := schema.GroupVersionResource{Group: "x.io", Version: "v1", Resource: "others"}
+	vNeg, servedNeg, okNeg := apistageContentServe(
+		cache.WithRefreshTriggerGVR(r1Ctx(), otherGVR), store, r1GetCall())
+	if !okNeg || !servedNeg {
+		t.Fatalf("different-GVR refresh HIT must still serve (ok=%v served=%v)", okNeg, servedNeg)
+	}
+	if got := managedCountOf(t, vNeg); got != r1StaleManaged {
+		t.Fatalf("NEGATIVE control: a refresh triggered by a DIFFERENT GVR must NOT force-miss "+
+			"(F-4 dep-edge equality, not blanket-on-refresh); want stale %d, got %d",
+			r1StaleManaged, got)
+	}
+
+	// --- GREEN arm: refresh marker for THE SAME GVR force-misses → fresh.
+	vFresh, servedFresh, okFresh := apistageContentServe(
+		cache.WithRefreshTriggerGVR(r1Ctx(), r1FsaGVR), store, r1GetCall())
+	if !okFresh || !servedFresh {
+		t.Fatalf("same-GVR refresh re-dispatch must serve fresh (ok=%v served=%v)", okFresh, servedFresh)
+	}
+	if got := managedCountOf(t, vFresh); got != r1FreshManaged {
+		t.Fatalf("GREEN arm: a refresh triggered by the entry's OWN GVR must FORCE-MISS and "+
+			"re-dispatch FRESH (%d managed from the live informer), NOT serve the stale "+
+			"content HIT; got %d managed — the content-shield bypass did not fire",
+			r1FreshManaged, got)
+	}
+
+	// And the forced miss RE-STORED the fresh content: a subsequent
+	// request-path HIT now serves fresh (the re-resolve corrected the cell).
+	vAfter, _, okAfter := apistageContentServe(r1Ctx(), store, r1GetCall())
+	if !okAfter {
+		t.Fatalf("post-bypass request-path HIT must serve")
+	}
+	if got := managedCountOf(t, vAfter); got != r1FreshManaged {
+		t.Fatalf("after the forced miss re-Put the fresh content, the request-path HIT must "+
+			"serve fresh %d; got %d", r1FreshManaged, got)
+	}
+}


### PR DESCRIPTION
## What
Cure the apistage **content-shield** stale-replay (R1 §3, the headline R1 fix). During a refresher whole-RA re-resolve triggered by GVR X, the RA's `getComposition`-style content stage was served from its OWN apistage-content HIT (stored bytes) instead of being re-dispatched fresh — so the re-resolve consumed a stale sibling snapshot and re-stored a degraded result (the `fsa-y2` `allCompositionResources` 1→26 collapse to a single cluster-scoped `/api/v1/configmaps`).

Design: `docs/design-r1-allcompositionresources-invalidation-2026-06-26.md` §4/§5. RCA: `docs/rca-allcompositionresources-listshape-2026-06-26.md`.

## Fix — Option A (refresh-path trigger-GVR threading)
Rejected the content-entry-stale-flag alternative (would break the ratified stale-while-revalidate model). Thread the dirty-mark trigger GVR through to the re-resolve:
- `deps.go`: `WithRefreshTriggerGVR`/`RefreshTriggerGVRFromContext` ctx-marker; `enqueueFn`/`SetRefreshHook` carry the trigger GVR; the 3 enqueue sites pass their `gvr`.
- `refresher.go`: `triggerGVRByKey sync.Map` records key→GVR **before** enqueue (store-before-enqueue, race-clean per arch); `processNext` `LoadAndDelete`s once-per-dispatch (`:798`) and stamps the ctx (survives a floor-defer).
- `apistage.go:481` HIT branch: force a MISS when `RefreshTriggerGVRFromContext(ctx) == this call's gvr` (**uniform dep-edge equality, F-4 — no resource/path literal**), falling to the existing MISS branch (re-dispatch fresh + re-Put).

**Refresh-path-ONLY containment:** the marker is set ONLY on the refresher re-resolve path, NEVER a request-path `/call` — so the HIT branch is byte-identical for real traffic (stale-while-revalidate preserved; the negative control proves it).

## Known corner (documented, no silent cap)
`triggerGVRByKey` is last-write-wins. If one l1Key depends on GVR-A AND GVR-B and both change in one coalesced cycle, only the last-written GVR's content stages force-miss that cycle. The other GVR's freshness still arrives via (i) its OWN content-entry enqueue+force-miss (each content entry has its own dep edge) and (ii) the key's next re-resolve → self-heals within one extra cycle; strictly better than pre-R1 (force-missed nothing); **#36 `CATALOG_UNSERVABLE_TTL` is the floor.** Escalation if telemetry ever shows a residual window: option (b) queue-item-carries-a-GVR-set. Arch ruled the side-map ships as-is.

## Falsifier (hermetic, real dynamics — `apistage_refresh_bypass_falsifier_test.go`)
- **RED / negative-control:** request-path HIT (no marker) serves the STALE collapsed snapshot — positively asserted (stale-while-revalidate preserved off-refresh).
- **GREEN:** same-GVR trigger → force-miss → fresh + the re-Put corrects the cell.
- **NEGATIVE-2:** DIFFERENT-GVR trigger does NOT force-miss (F-4 dep-edge precision / the 0.30.185 amplification guard).
- RED→GREEN proven by neutering the force-miss (GREEN fails with the content-shield signature) then restoring.

## Reviews
arch-listshape PASS (all checks incl. the side-map ruled race-clean + the multi-GVR corner non-issue). pm-warmup ACCEPT (3 arms + structural refresh-path-only containment, endorsed the side-map as stronger containment than the gated design).

## Tests
cache / api / dispatchers all `-race` clean; `go build` + `go vet ./...` clean.

## Topology
Targets **1.5.6**, parallel to #57 (Go) + chart #42. The content-shield/refresh-coherence regression-journal row lands with this. **Parked — do NOT merge (Diego merges).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1