### PR TITLE
fix(cache): /refreshes zero-delivery — dep edge on status-resolved displayed refs (#61)

### DIFF
--- a/internal/handlers/debug_refreshes.go
+++ b/internal/handlers/debug_refreshes.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// debugRefreshesBody is the JSON body returned by /debug/refreshes.
+//
+// AGGREGATE-ONLY (#61, C-3): process-wide totals + the live subscriber count.
+// It DELIBERATELY exposes NO per-subscription-key or per-identity breakdown —
+// a per-key dump would be a cross-user signal (which keys are armed reveals
+// which widgets/resources a connected user is watching). The four counters +
+// the connection count are identity-free and safe to expose at operator level.
+type debugRefreshesBody struct {
+	// SSEEnabled mirrors the live-refresh SSE layer toggle. When false the
+	// broadcaster hub is nil and the counters never move; the endpoint still
+	// returns 200 so it is usable as a diagnostic regardless of the flag.
+	SSEEnabled bool `json:"sseEnabled"`
+	// Subscribers is the current number of live /refreshes connections.
+	Subscribers int `json:"subscribers"`
+	// Published counts PublishRefresh calls that fanned out (post-coalesce).
+	Published uint64 `json:"published"`
+	// Delivered counts individual (key -> subscriber) sends that succeeded.
+	// This is THE signal for verifying live-refresh delivery: >0 for an armed
+	// key under churn means the #61 zero-delivery defect is cured.
+	Delivered uint64 `json:"delivered"`
+	// Dropped counts (key -> subscriber) sends dropped because the consumer's
+	// buffer was full (degrades to the frontend 5s throttle, never stale).
+	Dropped uint64 `json:"dropped"`
+	// Coalesced counts emits suppressed by the per-key coalesce window.
+	Coalesced uint64 `json:"coalesced"`
+}
+
+// DebugRefreshes is the read-only aggregate refresh-broadcaster diagnostic
+// (docs/rca-refreshes-zero-delivery-2026-06-26.md §5). It is the on-cluster
+// instrument the RCA flagged as the #1 missing diagnostic: previously there
+// was no way to observe whether PublishRefresh was firing / delivering without
+// a kubectl exec + log grep.
+//
+// READ-ONLY: it calls cache.RefreshBroadcasterCounters() (atomic loads) +
+// cache.RefreshSubscriberCount() (RLock, no mutation) + cache.RefreshSSEEnabled()
+// — zero effect on serving or delivery behaviour.
+//
+// NOT gated behind the cache flag: when the SSE layer is disabled the counters
+// are all zero and subscribers=0, but the endpoint still returns 200 with
+// sseEnabled=false, so it is available for debugging in both modes.
+//
+// @Summary Refresh-broadcaster diagnostic
+// @Description Read-only AGGREGATE refresh-broadcaster counters (published/delivered/dropped/coalesced + subscriber count). No per-key/identity enumeration.
+// @ID debug-refreshes
+// @Produce  json
+// @Success 200 {object} debugRefreshesBody
+// @Router /debug/refreshes [get]
+func DebugRefreshes() http.HandlerFunc {
+	return func(wri http.ResponseWriter, _ *http.Request) {
+		published, delivered, dropped, coalesced := cache.RefreshBroadcasterCounters()
+		body := debugRefreshesBody{
+			SSEEnabled:  cache.RefreshSSEEnabled(),
+			Subscribers: cache.RefreshSubscriberCount(),
+			Published:   published,
+			Delivered:   delivered,
+			Dropped:     dropped,
+			Coalesced:   coalesced,
+		}
+		wri.Header().Set("Content-Type", "application/json")
+		wri.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(wri).Encode(body)
+	}
+}

--- a/internal/handlers/dispatchers/deps_extract.go
+++ b/internal/handlers/dispatchers/deps_extract.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/krateoplatformops/plumbing/maps"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -200,39 +201,95 @@ type resourceRefLite struct {
 	Name       string
 }
 
-// extractResourcesRefs reads spec.resourcesRefs.items[] off the widget
-// object and returns the lite triples.
+// extractResourcesRefs reads the UNION of the widget's
+// status.resourcesRefs.items[] (the resolved, request-extras-driven
+// displayed refs the resolver writes — see resolve.go status
+// SetNestedField + the extractResourcesRefsItems precedent at
+// phase1_walk.go:1567) AND spec.resourcesRefs.items[] (any
+// author-declared static refs) and returns the lite triples.
+//
+// (#61, 1.5.8) Decoding the status `path` is LOAD-BEARING: a composition-
+// DETAIL widget resolves its displayed target into status with an EMPTY
+// spec. A spec-only read — OR a naive status FIELD read (the items have no
+// such fields) — recorded NO dep edge on the displayed resource → the
+// armed top-level L1 key was never dirty-marked on its reconcile →
+// /refreshes delivered zero events (broken 1.5.5–1.5.7). The union (not a
+// flip to status-only) preserves genuinely-static spec refs (resolve.go
+// guards the status write with len(results)>0, so an unresolved widget is
+// spec-only).
 func extractResourcesRefs(w *unstructured.Unstructured) []resourceRefLite {
 	if w == nil {
 		return nil
 	}
-	arr, ok, err := maps.NestedSlice(w.Object, "spec", "resourcesRefs", "items")
-	if !ok || err != nil {
-		return nil
-	}
-	out := make([]resourceRefLite, 0, len(arr))
-	for _, raw := range arr {
-		m, ok := raw.(map[string]any)
-		if !ok {
-			continue
+	out := make([]resourceRefLite, 0, 8)
+	seen := map[resourceRefLite]struct{}{}
+	appendUnique := func(r resourceRefLite) {
+		if _, dup := seen[r]; dup {
+			return
 		}
-		r := resourceRefLite{}
-		if v, ok := m["id"].(string); ok {
-			r.ID = v
-		}
-		if v, ok := m["apiVersion"].(string); ok {
-			r.APIVersion = v
-		}
-		if v, ok := m["resource"].(string); ok {
-			r.Resource = v
-		}
-		if v, ok := m["namespace"].(string); ok {
-			r.Namespace = v
-		}
-		if v, ok := m["name"].(string); ok {
-			r.Name = v
-		}
+		seen[r] = struct{}{}
 		out = append(out, r)
+	}
+
+	// (a) status items: PATH-DECODED (ResourceRefResult has no inline gvr
+	// fields; the displayed target is encoded in path as /call?resource=…).
+	if arr, ok, err := maps.NestedSlice(w.Object, "status", "resourcesRefs", "items"); ok && err == nil {
+		for _, raw := range arr {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			pathStr, _ := m["path"].(string)
+			if pathStr == "" {
+				continue
+			}
+			ref, ok := objects.ParseCallPathToObjectRef(pathStr)
+			if !ok {
+				// External link / non-/call path / missing resource|apiVersion.
+				continue
+			}
+			r := resourceRefLite{
+				APIVersion: ref.APIVersion,
+				Resource:   ref.Resource,
+				Namespace:  ref.Namespace,
+				Name:       ref.Name,
+			}
+			if id, ok := m["id"].(string); ok {
+				r.ID = id
+			}
+			appendUnique(r)
+		}
+	}
+
+	// (b) spec items: FIELD-READ (static author refs carry inline fields).
+	if arr, ok, err := maps.NestedSlice(w.Object, "spec", "resourcesRefs", "items"); ok && err == nil {
+		for _, raw := range arr {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			r := resourceRefLite{}
+			if v, ok := m["id"].(string); ok {
+				r.ID = v
+			}
+			if v, ok := m["apiVersion"].(string); ok {
+				r.APIVersion = v
+			}
+			if v, ok := m["resource"].(string); ok {
+				r.Resource = v
+			}
+			if v, ok := m["namespace"].(string); ok {
+				r.Namespace = v
+			}
+			if v, ok := m["name"].(string); ok {
+				r.Name = v
+			}
+			appendUnique(r)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/handlers/dispatchers/deps_refresh_delivery_falsifier_test.go
+++ b/internal/handlers/dispatchers/deps_refresh_delivery_falsifier_test.go
@@ -1,0 +1,232 @@
+// deps_refresh_delivery_falsifier_test.go — #61 (1.5.8) the /refreshes
+// zero-delivery falsifier set.
+//
+// RCA: docs/rca-refreshes-zero-delivery-2026-06-26.md. A composition-DETAIL
+// widget resolves its displayed target into status.resourcesRefs.items[] with
+// an EMPTY spec.resourcesRefs. extractResourcesRefs USED to read only `spec`
+// → recordWidgetDeps recorded NO dep edge on the displayed resource → when
+// that resource reconciled, OnUpdate dirty-marked only the intermediate
+// apistage cells, NEVER the top-level armed L1 key → PublishRefresh never
+// fired for it → the armed /refreshes subscriber received zero `event:
+// refresh`. Broken 1.5.5–1.5.7. The fix (deps_extract.go) reads the UNION of
+// status.resourcesRefs ∪ spec.resourcesRefs.
+//
+// THREE arms (RCA §5):
+//   - ARM A (key-equality golden) — REGRESSION GUARD, green pre+post. Lives in
+//     handlers/refreshes_test.go + dispatchers/refresh_isolation_falsifier_test.go
+//     (DeriveSubscriptionKey == the serve key, byte-identical per class). The
+//     keys were never the bug; that existing golden pins the equality contract
+//     that was previously untested. NOT re-duplicated here.
+//   - ARM B (TestFalsifier61_StatusRefDepCoverage) — the discriminating
+//     dep-coverage falsifier: status ref R, EMPTY spec → recordWidgetDeps →
+//     OnUpdate(R) dirty-marks the widget key. RED pre-fix (spec-only read →
+//     no dep on R → key NOT marked), GREEN post-fix.
+//   - C-1 (TestFalsifier61_EndToEndDelivery) — the REQUIRED sufficiency arm:
+//     seed the widget L1 entry, recordWidgetDeps from a status-bearing res,
+//     arm SubscribeRefresh for the key, OnUpdate(R) through the REAL refresh
+//     hook, assert refreshDeliveredTotal +1 AND the subscriber channel
+//     receives the key. Proves dirty-mark → enqueue → (refresher terminal
+//     PublishRefresh) → delivery END-TO-END.
+//
+// Hermetic: no apiserver, no kubeconfig. The one MODELED link in C-1 is the
+// refresher's re-resolve→Put→PublishRefresh terminal step: rather than spin
+// the async refresher worker + a real resolve closure (non-hermetic, pulls the
+// whole resolver), the test wires the dep tracker's REAL refresh hook
+// (Deps().SetRefreshHook, the exact seam refresher.go:425 wires) to call
+// cache.PublishRefresh(l1Key) — which is verbatim what resolve_populate.go:328
+// does after the refresher's Put. So the chain under test is the real
+// OnUpdate→dirty-mark→enqueueFn→PublishRefresh→subscriber path; only the
+// re-resolve compute between enqueue and publish is elided (it cannot change
+// WHICH key publishes).
+
+package dispatchers
+
+import (
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// detailWidgetForTest builds a composition-DETAIL widget in the post-resolve
+// shape: the displayed target (awsvpcstacks/demo-vpc) lives ONLY in
+// status.resourcesRefs.items[] (the resolver writes it there from the request
+// extras); spec.resourcesRefs is EMPTY (the templated-detail shape). This is
+// the exact shape that recorded zero dep edges pre-fix.
+func detailWidgetForTest() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata": map[string]any{
+			"name":      "detail-panel-1",
+			"namespace": "demo-ns",
+		},
+		// EMPTY spec.resourcesRefs — the displayed target is request-driven,
+		// not author-declared. (No apiRef either: isolate edge type 1.)
+		"spec": map[string]any{},
+		// The resolved displayed ref lives in STATUS as a ResourceRefResult:
+		// {id, path, verb, allowed}. The gvr/ns/name are encoded ONLY in the
+		// /call `path` query string — there are NO inline apiVersion/resource/
+		// namespace/name fields. This is the trap: a naive status FIELD read
+		// finds empty strings; only objects.ParseCallPathToObjectRef on `path`
+		// recovers the displayed target.
+		"status": map[string]any{
+			"resourcesRefs": map[string]any{
+				"items": []any{
+					map[string]any{
+						"id":      "displayed-1",
+						"path":    "/call?resource=awsvpcstacks&apiVersion=composition.krateo.io%2Fv1&namespace=demo-system&name=demo-vpc",
+						"verb":    "GET",
+						"allowed": true,
+					},
+				},
+			},
+		},
+	}}
+}
+
+// displayedResource is the (gvr, ns, name) the detail widget DISPLAYS — the
+// resource whose reconcile must dirty-mark the widget key.
+var (
+	displayedGVR  = schema.GroupVersionResource{Group: "composition.krateo.io", Version: "v1", Resource: "awsvpcstacks"}
+	displayedNS   = "demo-system"
+	displayedName = "demo-vpc"
+
+	detailWidgetGVR = schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
+)
+
+// TestFalsifier61_StatusRefDepCoverage — ARM B. The discriminating
+// dep-coverage falsifier. RED before the deps_extract union fix (spec-only
+// read finds no displayed ref → no dep edge → OnUpdate marks 0), GREEN after
+// (union reads status → dep edge on demo-vpc → OnUpdate marks the widget key).
+func TestFalsifier61_StatusRefDepCoverage(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetDepsForTest()
+
+	l1Key := "L1_detail_demo_vpc"
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, detailWidgetForTest())
+
+	// The widget key MUST depend on the DISPLAYED resource (status ref).
+	matched := cache.Deps().CollectMatchesForTest(displayedGVR, displayedNS, displayedName)
+	if _, ok := matched[l1Key]; !ok {
+		t.Fatalf("ARM B RED: widget key %q records NO dep edge on the DISPLAYED resource %s/%s/%s "+
+			"(status.resourcesRefs ref). extractResourcesRefs must read status ∪ spec, not spec-only. matched=%v",
+			l1Key, displayedGVR, displayedNS, displayedName, matched)
+	}
+
+	// And a real OnUpdate on that resource must dirty-mark (return marked>=1
+	// including our key).
+	marked := cache.Deps().OnUpdate(displayedGVR, displayedNS, displayedName)
+	if marked < 1 {
+		t.Fatalf("ARM B RED: OnUpdate(%s/%s/%s) dirty-marked %d keys — the widget key was never enqueued; "+
+			"PublishRefresh can never fire for it.", displayedGVR, displayedNS, displayedName, marked)
+	}
+}
+
+// TestFalsifier61_StaticSpecRefStillRecorded — UNION guard (C-0): a
+// genuinely-static spec.resourcesRefs ref MUST still be recorded after the fix
+// (the union must not be a status-only flip that drops static refs).
+func TestFalsifier61_StaticSpecRefStillRecorded(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetDepsForTest()
+
+	staticGVR := schema.GroupVersionResource{Group: "composition.krateo.io", Version: "v1", Resource: "compositions"}
+	w := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata":   map[string]any{"name": "static-panel", "namespace": "demo-ns"},
+		"spec": map[string]any{
+			"resourcesRefs": map[string]any{
+				"items": []any{
+					map[string]any{
+						"id":         "static-1",
+						"apiVersion": "composition.krateo.io/v1",
+						"resource":   "compositions",
+						"namespace":  "bench-ns-01",
+						"name":       "static-app-01",
+					},
+				},
+			},
+		},
+		// Empty status — the static-only widget shape.
+		"status": map[string]any{},
+	}}
+
+	l1Key := "L1_static_panel"
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, w)
+
+	matched := cache.Deps().CollectMatchesForTest(staticGVR, "bench-ns-01", "static-app-01")
+	if _, ok := matched[l1Key]; !ok {
+		t.Fatalf("UNION GUARD: the union DROPPED a static spec.resourcesRefs ref %s/bench-ns-01/static-app-01 "+
+			"(the fix must be status∪spec, NOT a flip to status-only). matched=%v", staticGVR, matched)
+	}
+}
+
+// TestFalsifier61_EndToEndDelivery — C-1 (HARD, REQUIRED). Proves the full
+// sufficiency chain: recordWidgetDeps(status ref) → SubscribeRefresh(armed
+// key) → OnUpdate(R) → [real refresh hook = the resolve_populate.go:328
+// PublishRefresh terminal] → the armed subscriber RECEIVES the key AND
+// refreshDeliveredTotal increments. RED pre-fix (no dep edge → OnUpdate marks
+// 0 → hook never called → no publish → subscriber gets nothing → delivered
+// stays flat).
+func TestFalsifier61_EndToEndDelivery(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	// HERMETIC TO THE ENV: do NOT rely on the REFRESH_SSE_ENABLED default —
+	// RefreshSSEEnabled() is `env != "false"`, so a runner whose shell has
+	// REFRESH_SSE_ENABLED set to anything-but-true makes ResetRefreshBroadcasterForTest
+	// re-read it disabled -> the hub is nil -> SubscribeRefresh returns a CLOSED
+	// channel -> zero delivery -> a green-here/red-on-another-env split on a HARD
+	// gate. Hard-set it BEFORE the reset so the reset picks up the enabled hub.
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	cache.ResetDepsForTest()
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	l1Key := "L1_detail_demo_vpc_e2e"
+
+	// Wire the REAL dep-tracker refresh hook to the REAL terminal publish
+	// (verbatim resolve_populate.go:328: cache.PublishRefresh(key) after a
+	// successful refresher re-resolve+Put). The re-resolve compute between
+	// enqueue and publish is elided — it cannot change WHICH key publishes.
+	cache.Deps().SetRefreshHook(func(key string, _ schema.GroupVersionResource) {
+		cache.PublishRefresh(key)
+	})
+
+	// Record the dep edges from the resolved detail widget (status-bearing).
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, detailWidgetForTest())
+
+	// Arm a /refreshes subscriber for the widget key (the seam
+	// handlers.Refreshes uses after re-deriving the key under the connection
+	// identity).
+	ch, unsub := cache.SubscribeRefresh(map[string]struct{}{l1Key: {}})
+	defer unsub()
+
+	_, deliveredBefore, _, _ := cache.RefreshBroadcasterCounters()
+
+	// The displayed resource reconciles (18×/min in production).
+	cache.Deps().OnUpdate(displayedGVR, displayedNS, displayedName)
+
+	// The armed subscriber must receive the key.
+	select {
+	case got := <-ch:
+		if got != l1Key {
+			t.Fatalf("C-1: subscriber received key %q, want the armed widget key %q", got, l1Key)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("C-1 RED: /refreshes subscriber received NOTHING within 2s after the displayed resource "+
+			"reconciled — the dep-change never reached PublishRefresh for the armed key (zero-delivery).")
+	}
+
+	_, deliveredAfter, _, _ := cache.RefreshBroadcasterCounters()
+	if deliveredAfter != deliveredBefore+1 {
+		t.Fatalf("C-1: refreshDeliveredTotal = %d, want %d (exactly one (key→subscriber) delivery)",
+			deliveredAfter, deliveredBefore+1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -959,6 +959,15 @@ func main() {
 	// /debug/servable (docs/design-r1-allcompositionresources-invalidation-2026-06-26.md §6).
 	mux.HandleFunc("GET /debug/apistage", handlers.DebugApistage())
 
+	// #61 diagnostic — read-only AGGREGATE-ONLY refresh-broadcaster counters
+	// (published/delivered/dropped/coalesced + subscriber count), the
+	// on-cluster instrument for verifying live-refresh delivery
+	// (refreshDeliveredTotal>0 for an armed key under churn) without a kubectl
+	// exec. NO per-subscription-key/identity enumeration — totals only (a
+	// per-key dump would be a cross-user signal). Mounted next to
+	// /debug/servable + /debug/apistage (docs/rca-refreshes-zero-delivery-2026-06-26.md §5).
+	mux.HandleFunc("GET /debug/refreshes", handlers.DebugRefreshes())
+
 	ctx, stop := signal.NotifyContext(context.Background(), []os.Signal{
 		os.Interrupt,
 		syscall.SIGINT,


### PR DESCRIPTION
Composition-detail widgets resolve displayed target into status.resourcesRefs (empty spec) → top-level widget key recorded no dep → never dirty-marked → PublishRefresh never fired → zero event:refresh (broken 1.5.5-1.5.7). Fix: union status (path-decoded) ∪ spec. +/debug/refreshes (aggregate-only). Dual-gate GREEN (arch PASS + PM ACCEPT 3× hostile-env frozen ref). TTL-evict residual → #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)