### PR TITLE
fix(cache): publish refresh on cold-fill Put when a subscriber is armed — closes #61 TTL-evict residual (#62)

### DIFF
--- a/internal/handlers/dispatchers/refresh_publish.go
+++ b/internal/handlers/dispatchers/refresh_publish.go
@@ -1,0 +1,51 @@
+// refresh_publish.go — #62: publish a live-refresh signal on a genuine
+// COLD-dispatch Put when (and only when) a /refreshes connection is armed for
+// that key.
+//
+// Why (the #61 TTL-evict residual, RCA §C-2 / backlog #62): #61 made a
+// dep-change dirty-mark the armed top-level key so the REFRESHER re-resolves
+// it and PublishRefreshes. But if the armed key was TTL-EVICTED before the
+// resource churned, its dep edges were removed (RemoveL1Key) → the dep-change
+// matches nothing → the refresher never re-resolves it → no PublishRefresh →
+// that cycle's delivery is missed. The frontend re-arms on the next /call,
+// which COLD-fills the key (a genuine Put here, dep edges re-recorded) — but
+// that cold Put historically did NOT publish (PublishRefresh fires only on the
+// refresher path, resolve_populate.go). So a viewer whose key cold-filled
+// after an eviction sees one stale frame until the NEXT churn. This closes
+// that gap: announce the cold-fill to any already-armed subscriber.
+//
+// SCOPE IS THE SAFETY BOUNDARY (C62-4 placement + class scope): call this
+// ONLY from the genuine-Put else-if of restactions.go + widgets.go — AFTER the
+// Put + dep-Record, NEVER on the stage-error / external-skip / declined
+// branches (no Put there → publishing would signal a non-event). Do NOT call
+// it for widgetContent (the one class ComputeKey does NOT fold BindingUID into
+// — resolved.go:669 — so a publish on its shared key could cross-deliver to a
+// differently-authorized viewer) or apistage (never armed — dead surface).
+//
+// Cost-proportional + leak-safe by construction: HasRefreshSubscriber is an
+// O(1) RLock map read; when no connection is armed for the key it returns
+// false and we never publish (counters stay flat). When armed, PublishRefresh
+// fans out ONLY to subscribers whose armed set contains this exact key — and
+// the key is the per-identity DeriveSubscriptionKey (BindingUID folded in for
+// identity-bearing classes), so the cold-filler's key matches only a
+// subscriber armed under the SAME identity. Both HasRefreshSubscriber and
+// PublishRefresh take the hub RLock, so this is safe under concurrent
+// Subscribe/unsubscribe (no deliver-after-unsub: PublishRefresh re-checks the
+// armed set under the lock).
+package dispatchers
+
+import "github.com/krateoplatformops/snowplow/internal/cache"
+
+// publishIfSubscribed announces a genuine cold-dispatch Put of l1Key to any
+// already-armed /refreshes subscriber, and is a no-op when none is armed
+// (cost-proportional) or when the SSE layer / cache is off (both nil-safe via
+// the broadcaster). l1Key MUST be the just-Put genuine cache key (the
+// per-identity DeriveSubscriptionKey-equivalent the serve path stamps).
+func publishIfSubscribed(l1Key string) {
+	if l1Key == "" {
+		return
+	}
+	if cache.HasRefreshSubscriber(l1Key) {
+		cache.PublishRefresh(l1Key)
+	}
+}

--- a/internal/handlers/dispatchers/refresh_publish_falsifier_test.go
+++ b/internal/handlers/dispatchers/refresh_publish_falsifier_test.go
@@ -1,0 +1,193 @@
+// refresh_publish_falsifier_test.go — #62: publishIfSubscribed (cold-dispatch
+// Put announces to an already-armed /refreshes subscriber) falsifiers.
+//
+// publishIfSubscribed is the ~6-LOC helper called from the genuine-Put else-if
+// of restactions.go + widgets.go AFTER Put+dep-Record. These arms exercise it
+// against REAL per-identity keys (DeriveSubscriptionKey, the same seam the
+// serve path stamps), reusing the two-distinct-BindingUID RBAC harness from
+// refresh_isolation_falsifier_test.go (buildTwoUserRBACWatcher / ctxAs /
+// compositionsCoords).
+//
+//   C62-1 (cross-user leak, HARD): userA cold-fills its key → userB (armed for
+//          B's DISTINCT-BindingUID key) receives NOTHING + B's delivered count
+//          is unchanged. The RBAC isolation proof made real for the cold-Put
+//          path: publishIfSubscribed(keyA) can only fan to a subscriber armed
+//          for keyA.
+//   C62-2 (RED→GREEN, HARD): an evicted key, a subscriber armed for it, then a
+//          cold-fill Put → delivered. RED if the cold Put does NOT publish
+//          (the pre-#62 behaviour: PublishRefresh fired only on the refresher
+//          path); GREEN after publishIfSubscribed. Asserts refreshDeliveredTotal
+//          +1 AND the subscriber channel receives the key.
+//   C62-3 (cost-proportional): NO armed subscriber → publishIfSubscribed is a
+//          no-op, all broadcaster counters stay FLAT (HasRefreshSubscriber
+//          false → no PublishRefresh).
+//   C62-5 (-race): concurrent cold-fill publishIfSubscribed + Subscribe/unsub
+//          on the same key — no data race, no deliver-after-unsub (both
+//          HasRefreshSubscriber and PublishRefresh take the hub RLock).
+package dispatchers
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// C62-2 — the RED→GREEN sufficiency arm. RED pre-fix (cold Put doesn't
+// publish), GREEN post-fix.
+func TestFalsifier62_ColdFillPublishesToArmedSubscriber(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0")
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	coords := compositionsCoords()
+	keyA, ok := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	if !ok || keyA == "" {
+		t.Fatalf("derive keyA failed (ok=%v key=%q)", ok, keyA)
+	}
+
+	// The viewer re-armed after its key was TTL-evicted (the #61 residual
+	// scenario): an armed subscriber whose L1 entry is currently cold.
+	ch, unsub := cache.SubscribeRefresh(map[string]struct{}{keyA: {}})
+	defer unsub()
+
+	_, deliveredBefore, _, _ := cache.RefreshBroadcasterCounters()
+
+	// The cold-dispatch Put fires this (restactions.go / widgets.go genuine-Put
+	// else-if). Pre-#62 the cold Put did NOT publish → this would be a no-op →
+	// the subscriber starves until the next churn.
+	publishIfSubscribed(keyA)
+
+	select {
+	case got := <-ch:
+		if got != keyA {
+			t.Fatalf("C62-2: subscriber received %q, want the armed key %q", got, keyA)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("C62-2 RED: armed subscriber received NOTHING within 2s after the cold-fill Put — " +
+			"publishIfSubscribed did not announce the cold-fill (pre-#62 behaviour: cold Put never published).")
+	}
+
+	_, deliveredAfter, _, _ := cache.RefreshBroadcasterCounters()
+	if deliveredAfter != deliveredBefore+1 {
+		t.Fatalf("C62-2: refreshDeliveredTotal = %d, want %d", deliveredAfter, deliveredBefore+1)
+	}
+}
+
+// C62-1 — the cross-user leak arm. userA's cold-fill must NOT deliver to userB
+// (distinct BindingUID → distinct key). The RBAC isolation proof for the
+// cold-Put path.
+func TestFalsifier62_ColdFillNoCrossUserLeak(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0")
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	coords := compositionsCoords()
+	keyA, okA := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	keyB, okB := DeriveSubscriptionKey(ctxAs("userB"), coords)
+	if !okA || !okB || keyA == keyB {
+		t.Fatalf("setup: keys not distinct (keyA=%q keyB=%q okA=%v okB=%v)", keyA, keyB, okA, okB)
+	}
+
+	// userB arms ONLY its own (distinct-BindingUID) key.
+	chB, unsubB := cache.SubscribeRefresh(map[string]struct{}{keyB: {}})
+	defer unsubB()
+
+	_, deliveredBefore, _, _ := cache.RefreshBroadcasterCounters()
+
+	// userA's request cold-fills userA's key (the cold-Put path stamps keyA).
+	publishIfSubscribed(keyA)
+
+	// userB must receive NOTHING — keyA != keyB.
+	select {
+	case leaked := <-chB:
+		t.Fatalf("C62-1 LEAK: userB received %q from userA's cold-fill — cross-user signal leak on the cold-Put path", leaked)
+	case <-time.After(300 * time.Millisecond):
+		// correct — no leak
+	}
+
+	// And nothing was delivered at all (keyA had no armed subscriber here).
+	_, deliveredAfter, _, _ := cache.RefreshBroadcasterCounters()
+	if deliveredAfter != deliveredBefore {
+		t.Fatalf("C62-1: delivered moved (%d→%d) — userA's cold-fill delivered to a sub it must not have",
+			deliveredBefore, deliveredAfter)
+	}
+}
+
+// C62-3 — cost-proportional: no armed subscriber → publishIfSubscribed is a
+// pure no-op (HasRefreshSubscriber false → no PublishRefresh → counters flat).
+func TestFalsifier62_NoSubscriberNoPublish(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0")
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	coords := compositionsCoords()
+	keyA, ok := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	if !ok || keyA == "" {
+		t.Fatalf("derive keyA failed")
+	}
+
+	pubBefore, delBefore, dropBefore, coalBefore := cache.RefreshBroadcasterCounters()
+
+	// No SubscribeRefresh — nobody armed for keyA. The vast majority of cold
+	// fills (no live viewer on that exact widget) hit this path.
+	publishIfSubscribed(keyA)
+
+	pubAfter, delAfter, dropAfter, coalAfter := cache.RefreshBroadcasterCounters()
+	if pubAfter != pubBefore || delAfter != delBefore || dropAfter != dropBefore || coalAfter != coalBefore {
+		t.Fatalf("C62-3: counters moved with NO armed subscriber "+
+			"(pub %d→%d, del %d→%d, drop %d→%d, coal %d→%d) — publishIfSubscribed published when it should have no-op'd",
+			pubBefore, pubAfter, delBefore, delAfter, dropBefore, dropAfter, coalBefore, coalAfter)
+	}
+}
+
+// C62-5 — concurrent cold-fill + subscribe/unsub on the same key. -race must
+// be clean; no deliver-after-unsub panic. (Both HasRefreshSubscriber and
+// PublishRefresh take the hub RLock; unsub does not close the channel.)
+func TestFalsifier62_ConcurrentColdFillAndSubscribe(t *testing.T) {
+	buildTwoUserRBACWatcher(t)
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	t.Setenv("REFRESH_COALESCE_WINDOW_MS", "0")
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	coords := compositionsCoords()
+	keyA, ok := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	if !ok || keyA == "" {
+		t.Fatalf("derive keyA failed")
+	}
+
+	var wg sync.WaitGroup
+	// Churn of cold-fills.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			publishIfSubscribed(keyA)
+		}()
+	}
+	// Concurrent arm/disarm churn on the same key.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, unsub := cache.SubscribeRefresh(map[string]struct{}{keyA: {}})
+			// Drain opportunistically so a delivery never blocks the producer.
+			select {
+			case <-ch:
+			default:
+			}
+			unsub()
+		}()
+	}
+	wg.Wait()
+	// Reaching here under -race with no panic IS the assertion (deliver-after-
+	// unsub / concurrent-map-access would fail the race detector or panic).
+}

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -302,6 +302,14 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		// edge whose DELETE/UPDATE events the watcher never wires.
 		ensureWatcherInformerForGVR(got.GVR)
 		cache.Deps().Record(cacheKey, got.GVR, got.Unstructured.GetNamespace(), got.Unstructured.GetName())
+
+		// #62: GENUINE cold-dispatch Put (this else-if guarantees a real
+		// Put + dep-Record — never the stage-error / external-skip declines
+		// above). If a /refreshes connection is already armed for this key
+		// (it re-armed after a TTL-eviction, and this cold-fill replaces the
+		// evicted entry), announce the fill so the viewer's frame goes fresh
+		// now instead of waiting for the next churn. No-op when unarmed.
+		publishIfSubscribed(cacheKey)
 	}
 
 	log.Info("RESTAction successfully resolved",

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -331,6 +331,16 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		// refs filtered out per Revision 14). Edge type 3 (inner K8s
 		// calls inside the RestAction) is OUT OF SCOPE at this tag.
 		recordWidgetDeps(log, cacheKey, got.GVR, res)
+
+		// #62: GENUINE cold-dispatch Put (this else-if guarantees a real
+		// Put + dep-Record — never the stage-error / external-skip declines
+		// above). If a /refreshes connection is already armed for this key
+		// (it re-armed after a TTL-eviction, and this cold-fill replaces the
+		// evicted entry), announce the fill so the viewer's frame goes fresh
+		// now instead of waiting for the next churn. No-op when unarmed.
+		// SCOPE: widgets only — NOT widgetContent (shared key w/o BindingUID
+		// fold → cross-deliver risk) per refresh_publish.go.
+		publishIfSubscribed(cacheKey)
 	}
 
 	log.Info("Widget successfully resolved",


### PR DESCRIPTION
Evicted armed key → dep edge gone → refresher skips → cold-fill on next GET never published. Fix: publishIfSubscribed(key) after the genuine Put+dep-Record at restactions.go + widgets.go ONLY (identity-bearing classes; widgetContent/apistage excluded — the safety boundary). RBAC cross-deliver proof: identity-bearing keys fold BindingUID → A's cold-Put key ≠ B's armed key. Dual-gate GREEN (arch soundness PASS + PM ACCEPT, fresh-cache 3× hostile-env, cross-user leak arm proven). Closes the #61 TTL-evict residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)