### PR TITLE
feat(prewarm): aggregate seed-footprint bound + assert at the shared per-unit primitives (#46)

### DIFF
--- a/internal/cache/fallthrough_meter_expvar.go
+++ b/internal/cache/fallthrough_meter_expvar.go
@@ -62,8 +62,9 @@ func registerFallthroughExpvar() {
 			// check= label here (Ship D: read_paths_scoped; hardening #1:
 			// serve_requires_servable).
 			return map[string]uint64{
-				"read_paths_scoped":       assertionViolationsTotal.Load(),
-				"serve_requires_servable": serveRequiresServableViolations.Load(),
+				"read_paths_scoped":        assertionViolationsTotal.Load(),
+				"serve_requires_servable":  serveRequiresServableViolations.Load(),
+				"seed_aggregate_footprint": seedUnitFootprintViolations.Load(),
 			}
 		}))
 		expvar.Publish("snowplow_apiserver_fallthrough_cells", expvar.Func(func() any {

--- a/internal/cache/seed_assert.go
+++ b/internal/cache/seed_assert.go
@@ -1,0 +1,97 @@
+// seed_assert.go — #46 Piece A: the prewarm seed per-unit aggregate-footprint
+// assertion (solidity hardening, the #23 boot-OOM class).
+//
+// THE INVARIANT: no single prewarm seed unit (one (target, layer) resolve —
+// e.g. a seedRAFullListForWidget UNPAGINATED full-list materialization) may
+// allocate more than the configured seed-footprint budget. The #23 OOM was
+// the legacy errgroup running GOMAXPROCS such units CONCURRENTLY (ΣN ≈ 8 GiB);
+// the engine path is serial today, so its present-day risk is a SINGLE
+// oversized unit — exactly what this assertion catches. Piece B's semaphore
+// is the aggregate bound for the (reachable, engine=false back-out) concurrent
+// path; this assertion is the per-unit guard that fires on BOTH postures.
+//
+// APPARATUS: mirrors serve_assert.go's TestMode/prod asymmetry + the
+// snowplow_assertion_violations_total expvar map (fallthrough_meter_expvar.go),
+// check="seed_aggregate_footprint":
+//
+//   - env.TestMode()==true  → panic. A test whose seed unit blows the budget
+//     fails loud (a real regression — an unbounded/unpaginated materialization
+//     slipped in).
+//   - env.TestMode()==false → ERROR log + seedUnitFootprintViolations.Add(1).
+//     The seed unit still completed (we sample AFTER it resolved); the
+//     violation is alertable. We do NOT abort the seed — best-effort warmth,
+//     never a boot-fail (feedback_no_park_broken_behind_flag: this is an
+//     OBSERVABILITY assert, the BOUND is Piece B's semaphore which blocks).
+//
+// Cost-proportional + seed-scoped: sampled once per seed unit, AFTER the unit
+// resolved, on the seed goroutine only — never on the customer /call path
+// (feedback_bounding_mechanism_discipline). The HeapInuse delta is captured at
+// the call site (prewarm_engine_boot.go seedOneTarget); this helper only
+// evaluates the breach so the threshold logic + counter live next to the
+// sibling serve-assert.
+package cache
+
+import (
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/krateoplatformops/plumbing/env"
+)
+
+// seedUnitFootprintViolations is the production-mode counter bumped when a
+// single prewarm seed unit's measured HeapInuse delta exceeded the seed
+// footprint budget. Exposed via snowplow_assertion_violations_total under
+// check="seed_aggregate_footprint".
+var seedUnitFootprintViolations atomic.Uint64
+
+// SeedUnitFootprintViolations returns the cumulative count of seed-unit
+// footprint-budget violations observed in production mode. Exported for the
+// falsifier gate.
+func SeedUnitFootprintViolations() uint64 {
+	return seedUnitFootprintViolations.Load()
+}
+
+// ResetSeedUnitFootprintViolationsForTest zeroes the counter (test-only).
+func ResetSeedUnitFootprintViolationsForTest() {
+	seedUnitFootprintViolations.Store(0)
+}
+
+// AssertSeedUnitFootprint evaluates the per-unit seed-footprint invariant for
+// one resolved seed unit. deltaBytes is the measured HeapInuse delta the
+// caller sampled around the unit's resolve; budgetBytes is the configured
+// SEED_FOOTPRINT_BUDGET_BYTES. label is a short seed-unit descriptor for the
+// log (kind + target — never a per-name special-case).
+//
+// budgetBytes <= 0 disables the assertion (returns true, no-op) — the
+// transparent-fallback posture when the budget is unset.
+//
+// Returns true when within budget (the common path). On breach:
+//   - test mode → panic (loud; an oversized/unpaginated unit is a regression).
+//   - prod mode → count + ERROR log + return false (the unit already resolved;
+//     this is observability, the seed proceeds — Piece B's semaphore is the
+//     mechanism that actually blocks/serializes).
+func AssertSeedUnitFootprint(label string, deltaBytes, budgetBytes uint64) bool {
+	if budgetBytes == 0 || deltaBytes <= budgetBytes {
+		return true
+	}
+
+	if env.TestMode() {
+		panic("cache.AssertSeedUnitFootprint: a single prewarm seed unit exceeded the seed footprint budget" +
+			" (label=" + label + ") — a seed unit MUST stay within SEED_FOOTPRINT_BUDGET_BYTES;" +
+			" an unbounded/unpaginated materialization (e.g. seedRAFullListForWidget full-list)" +
+			" is the #23 boot-OOM class")
+	}
+
+	seedUnitFootprintViolations.Add(1)
+	slog.Error("cache.seed_aggregate_footprint.violation",
+		slog.String("subsystem", "cache"),
+		slog.String("check", "seed_aggregate_footprint"),
+		slog.String("seed_unit", label),
+		slog.Uint64("delta_bytes", deltaBytes),
+		slog.Uint64("budget_bytes", budgetBytes),
+		slog.String("hint", "a single prewarm seed unit's HeapInuse delta exceeded SEED_FOOTPRINT_BUDGET_BYTES "+
+			"— an oversized/unpaginated materialization; the seed proceeds (best-effort warmth) but this is "+
+			"the #23 boot-OOM-class signal, alertable. Piece B's semaphore is the blocking bound."),
+	)
+	return false
+}

--- a/internal/cache/seed_assert_falsifier_test.go
+++ b/internal/cache/seed_assert_falsifier_test.go
@@ -1,0 +1,38 @@
+// seed_assert_falsifier_test.go — #46 Piece A cache-side falsifiers for
+// AssertSeedUnitFootprint (the per-unit seed-footprint invariant).
+package cache
+
+import "testing"
+
+// B2 — test mode PANICS on an oversized unit (loud-fail; an
+// unbounded/unpaginated unit slipping in is a regression).
+func TestSeedAssert_TestModePanicsOnBreach(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+	ResetSeedUnitFootprintViolationsForTest()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("B2: AssertSeedUnitFootprint did NOT panic in test mode on an over-budget unit")
+		}
+	}()
+	// 5000 > 1000 budget → panic in test mode.
+	AssertSeedUnitFootprint("unit/oversized", 5000, 1000)
+}
+
+// Within budget in test mode must NOT panic.
+func TestSeedAssert_TestModeWithinBudgetNoPanic(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+	ResetSeedUnitFootprintViolationsForTest()
+	if ok := AssertSeedUnitFootprint("unit/small", 500, 1000); !ok {
+		t.Fatal("within-budget unit reported a violation in test mode")
+	}
+}
+
+// budget==0 disables the assert even in test mode (transparent).
+func TestSeedAssert_DisabledNoPanicTestMode(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+	ResetSeedUnitFootprintViolationsForTest()
+	if ok := AssertSeedUnitFootprint("unit/huge", 1<<40, 0); !ok {
+		t.Fatal("budget==0 should disable the assert (no panic, within budget)")
+	}
+}

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -520,6 +520,12 @@ func runPIPSeed(ctx context.Context, h *contentPrewarmHarvester, nh *navWidgetHa
 			// FOREGROUND (still gates phase1Done) but per-cohort
 			// failures no longer FAIL-CLOSE the whole pod.
 			pipBindingSetSeedResolvesTotal.Add(1)
+			// #46: NO bound wrap here — the footprint bound lives in the SHARED
+			// primitives seedOneWidget/seedOneRestaction (which this errgroup's
+			// seedCohortFn funnels through), so the aggregate is bounded at the
+			// shared mechanism, NOT per-caller. The errgroup's SetLimit
+			// (GOMAXPROCS) is the OUTER semaphore; Piece-B's is INNER (in the
+			// primitive) — strict outer→inner ordering, deadlock-free.
 			if err := seedCohortFn(gctx, cohort, restactionRefs, widgetEntries, saEP, saRC, authnNS); err != nil {
 				// #158 — classify the failure instead of blanket-labelling
 				// it "expected RBAC." pipBindingSetSeedFailuresTotal is kept
@@ -968,6 +974,18 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 		return nil
 	}
 
+	// #46: bound this seed unit's footprint (semaphore admission + per-unit
+	// HeapInuse assert), AFTER the identity short-circuit so the customer
+	// /call path is untouched. seedOneRestaction is a SHARED primitive — both
+	// the engine (serial) and legacy errgroup (concurrent) seed paths funnel
+	// here, so this one bracket bounds BOTH aggregates. Transparent when
+	// SEED_FOOTPRINT_BUDGET_BYTES==0.
+	seedRelease, seedErr := enterSeedUnit(ctx, "restaction/"+ref.Namespace+"/"+ref.Name)
+	if seedErr != nil {
+		return seedErr // ctx cancelled while blocked on the bound
+	}
+	defer seedRelease()
+
 	scheme := k8sruntime.NewScheme()
 	if err := apis.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("add apis to scheme: %w", err)
@@ -1121,6 +1139,18 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 		// seedOneRestaction.
 		return nil
 	}
+
+	// #46: bound this seed unit's footprint (semaphore admission + per-unit
+	// HeapInuse assert), AFTER the identity short-circuit so the customer
+	// /call path is untouched. seedOneWidget is a SHARED primitive — both the
+	// engine (serial) and legacy errgroup (concurrent) seed paths funnel here,
+	// so this one bracket bounds BOTH aggregates. Transparent when
+	// SEED_FOOTPRINT_BUDGET_BYTES==0.
+	seedRelease, seedErr := enterSeedUnit(ctx, "widget/"+e.W.GetNamespace()+"/"+e.W.GetName())
+	if seedErr != nil {
+		return seedErr // ctx cancelled while blocked on the bound
+	}
+	defer seedRelease()
 
 	// DeepCopy the widget CR — widgets.Resolve mutates its In object
 	// (sets status.widgetData etc.). The harvester already DeepCopied

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -466,6 +466,13 @@ func seedScopeYielding(ctx context.Context,
 		cctx, cancel := context.WithTimeout(ctx, pipCohortTimeout)
 		defer cancel()
 		cohortCtx := withCohortSeedContext(cctx, c, saEP, saRC)
+		// #46: the footprint bound (semaphore admission + per-unit HeapInuse
+		// assert) lives in the SHARED primitives seedOneWidget/seedOneRestaction
+		// (after their identity short-circuit), NOT here — both the engine
+		// (this) and the legacy errgroup path funnel through those primitives,
+		// so bounding the shared mechanism covers both with ONE insertion
+		// (feedback_no_special_cases). seedOneTarget stays a thin timeout+yield
+		// wrapper.
 		return do(cohortCtx)
 	}
 

--- a/internal/handlers/dispatchers/seed_bound.go
+++ b/internal/handlers/dispatchers/seed_bound.go
@@ -1,0 +1,248 @@
+// seed_bound.go — #46 Piece B: the prewarm-seed aggregate-footprint bound +
+// the Piece-A per-unit footprint sample, applied at the seed-unit choke point.
+//
+// THE #23 OOM CLASS: a prewarm seed unit (one (target, layer) resolve) can
+// materialize a multi-hundred-MB UNPAGINATED full-list envelope
+// (seedRAFullListForWidget). Running many such units CONCURRENTLY (the legacy
+// runPIPSeed errgroup at GOMAXPROCS) summed to the ~8 GiB #23 boot OOM. The
+// engine path (seedScopeYielding) is SERIAL today, so its present risk is a
+// single oversized unit; the legacy errgroup path — reachable via the
+// PREWARM_ENGINE_ENABLED=false back-out lever — is the live concurrent
+// aggregate. Both are wrapped here (C46-2: bound the path that runs AND the
+// reachable back-out path).
+//
+// TWO mechanisms, ONE wrapper (boundSeedUnit):
+//   - Piece B (the BOUND): a process-wide semaphore.Weighted sized by
+//     SEED_FOOTPRINT_BUDGET_BYTES. Each unit Acquires its estimated weight
+//     before resolving and Releases after. Excess BLOCKS (never drops → the
+//     seed still completes, just serialized under memory pressure). On the
+//     serial engine path this is a no-op admission gate (one unit at a time);
+//     on the concurrent errgroup path it caps the aggregate in-flight
+//     footprint. Disabled (no-op) when the budget is 0.
+//   - Piece A (the ASSERT): sample HeapInuse delta around the resolve and call
+//     cache.AssertSeedUnitFootprint — panics in test / logs+counts in prod
+//     when a SINGLE unit exceeds the budget (the oversized-unit signal that
+//     fires on both postures).
+//
+// C46-1 (EMPIRICAL estUnitBytes, NOT a design-time constant — the 1.5.1 180×
+// lesson): the per-unit Acquire weight is calibrated from the FIRST unit's
+// MEASURED HeapInuse delta (one-shot), then reused. Before calibration (and as
+// the conservative fallback) the weight is SEED_EST_UNIT_BYTES_FALLBACK, which
+// MUST be conservative-HIGH (over-reserve, never under) so we never admit more
+// aggregate than the budget on the strength of a too-small guess.
+//
+// SEED-SCOPED (customer /call UNTOUCHED): boundSeedUnit is called ONLY from the
+// seed choke points (seedOneTarget engine + the legacy errgroup closure), both
+// AFTER the per-binding identity short-circuit. The customer dispatcher never
+// routes here (feedback_bounding_mechanism_discipline: after the cache-hit,
+// seed-scoped, cost-proportional).
+package dispatchers
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// envSeedFootprintBudgetBytes caps the aggregate in-flight prewarm-seed
+	// HeapInuse. 0 (default) DISABLES the bound + the per-unit assert — the
+	// transparent posture (project_caching_is_provisional: cleanly
+	// removable). Operators set it from the empirical per-entry cost × safety
+	// (feedback_capacity_caps_empirical_per_entry_cost).
+	envSeedFootprintBudgetBytes = "SEED_FOOTPRINT_BUDGET_BYTES"
+
+	// envSeedEstUnitBytesFallback is the CONSERVATIVE-HIGH per-unit weight
+	// used before the one-shot empirical calibration lands (and when
+	// calibration is somehow unavailable). Over-reserve by design: a too-high
+	// fallback serializes a bit more aggressively (safe); a too-low one would
+	// admit too much aggregate (the 1.5.1 180× under-estimate failure mode).
+	// 256 MiB ≈ a large unpaginated full-list unit; never larger than the
+	// whole budget would allow (clamped at use).
+	envSeedEstUnitBytesFallback        = "SEED_EST_UNIT_BYTES_FALLBACK"
+	defaultSeedEstUnitBytesFallback    = 256 * 1024 * 1024 // 256 MiB, conservative-high
+)
+
+var (
+	// seedBoundOnce lazily builds the semaphore from the budget on first use
+	// (env is populated before any seed runs). A plain mutex-guarded
+	// double-check (NOT sync.Once) so resetSeedBoundForTest can rebuild it.
+	seedBoundMu      sync.Mutex
+	seedBoundSem     *semaphore.Weighted
+	seedBoundBudget  int64
+	seedBoundBuilt   bool
+
+	// estUnitBytes is the calibrated per-unit Acquire weight. Starts at the
+	// conservative-high fallback; replaced ONCE by the first unit's measured
+	// HeapInuse delta (C46-1). Guarded by estUnitMu.
+	estUnitMu       sync.Mutex
+	estUnitBytes    int64
+	estUnitCalibrated bool
+)
+
+// seedBudgetBytes reads SEED_FOOTPRINT_BUDGET_BYTES (0 = disabled).
+func seedBudgetBytes() int64 {
+	return int64(env.Int(envSeedFootprintBudgetBytes, 0))
+}
+
+// seedEstUnitFallback reads the conservative-high fallback per-unit weight.
+func seedEstUnitFallback() int64 {
+	return int64(env.Int(envSeedEstUnitBytesFallback, defaultSeedEstUnitBytesFallback))
+}
+
+// seedBound lazily builds (once) the process-wide seed semaphore from the
+// budget, returning (sem, budget). Returns (nil, 0) when the budget is 0
+// (disabled → boundSeedUnit is a transparent pass-through).
+func seedBound() (*semaphore.Weighted, int64) {
+	seedBoundMu.Lock()
+	defer seedBoundMu.Unlock()
+	if !seedBoundBuilt {
+		seedBoundBudget = seedBudgetBytes()
+		if seedBoundBudget > 0 {
+			seedBoundSem = semaphore.NewWeighted(seedBoundBudget)
+		}
+		seedBoundBuilt = true
+	}
+	return seedBoundSem, seedBoundBudget
+}
+
+// currentEstUnit returns the current per-unit Acquire weight, clamped to the
+// budget (a single Acquire can never exceed the semaphore capacity, else it
+// would deadlock forever). Uses the calibrated value once available, else the
+// conservative-high fallback.
+func currentEstUnit(budget int64) int64 {
+	estUnitMu.Lock()
+	est := estUnitBytes
+	calibrated := estUnitCalibrated
+	estUnitMu.Unlock()
+	if !calibrated || est <= 0 {
+		est = seedEstUnitFallback()
+	}
+	if budget > 0 && est > budget {
+		est = budget // clamp: one unit may use up to the whole budget, never more
+	}
+	if est < 1 {
+		est = 1
+	}
+	return est
+}
+
+// calibrateEstUnit records the first unit's MEASURED HeapInuse delta as the
+// empirical per-unit weight (C46-1, one-shot). Subsequent units reuse it.
+// A measured delta of 0 (GC ran mid-unit, or a static no-op unit) is ignored
+// so we don't calibrate to an unrealistically small weight.
+func calibrateEstUnit(measuredDelta int64) {
+	if measuredDelta <= 0 {
+		return
+	}
+	estUnitMu.Lock()
+	if !estUnitCalibrated {
+		estUnitBytes = measuredDelta
+		estUnitCalibrated = true
+	}
+	estUnitMu.Unlock()
+}
+
+// heapInuse samples the current HeapInuse. ReadMemStats stops the world
+// briefly; called at most twice per seed unit on the seed goroutine — never
+// on the customer path.
+func heapInuse() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapInuse
+}
+
+// calibratedEstUnitForTest returns (estUnitBytes, calibrated) so the
+// granularity-discriminating falsifier can assert calibration landed in a
+// per-UNIT band (not N× a whole cohort). Test-only.
+func calibratedEstUnitForTest() (int64, bool) {
+	estUnitMu.Lock()
+	defer estUnitMu.Unlock()
+	return estUnitBytes, estUnitCalibrated
+}
+
+// enterSeedUnit is the seed-unit footprint bound, applied as a lifecycle
+// bracket at the SHARED seed primitives (seedOneWidget / seedOneRestaction),
+// AFTER their identity short-circuit. Both the engine (serial) and the legacy
+// errgroup (concurrent) paths funnel through those primitives, so bracketing
+// there bounds BOTH aggregates with one insertion (feedback_no_special_cases —
+// bound the shared mechanism, not each caller).
+//
+// Usage at each primitive, right after `if handle==nil || key=="" { return }`:
+//
+//	release, err := enterSeedUnit(ctx, "widget/"+ns+"/"+name)
+//	if err != nil { return err }   // ctx cancelled while blocked on the bound
+//	defer release()
+//
+// label is a short seed-unit descriptor (kind + identity) for the assert log —
+// never a per-name special-case (feedback_no_special_cases).
+//
+// When the budget is 0 it is a transparent pass-through: Acquire is skipped and
+// release() is a no-op (no semaphore, no assert). Otherwise: Acquire(estUnit)
+// [blocks if the aggregate in-flight weight would exceed the budget] + sample
+// HeapInuse on entry; release() samples HeapInuse again, asserts the delta is
+// within budget, calibrates estUnit (one-shot), and Releases the weight.
+//
+// The Acquire weight is clamped to the budget (currentEstUnit) so a single unit
+// larger than the whole budget runs ALONE rather than blocking forever — the
+// guaranteed-progress / "bounded event still happens" property. Nesting is
+// deadlock-free: the legacy errgroup SetLimit(GOMAXPROCS) is the OUTER
+// semaphore (acquired at g.Go spawn), this is INNER (acquired in the
+// primitive) — strict outer→inner, no lock-order inversion.
+func enterSeedUnit(ctx context.Context, label string) (release func(), err error) {
+	sem, budget := seedBound()
+	if sem == nil || budget == 0 {
+		return func() {}, nil // disabled — transparent pass-through.
+	}
+
+	est := currentEstUnit(budget)
+	if aerr := sem.Acquire(ctx, est); aerr != nil {
+		// ctx cancelled/expired while blocked on the bound — propagate (the
+		// seed unit is abandoned for this run; the seed yields).
+		return nil, aerr
+	}
+
+	before := heapInuse()
+	return func() {
+		after := heapInuse()
+		// HeapInuse can shrink across a GC mid-unit; treat a negative delta as
+		// 0 (no measurable growth — a static/no-op unit).
+		var delta int64
+		if after > before {
+			delta = int64(after - before)
+		}
+		calibrateEstUnit(delta)
+		cache.AssertSeedUnitFootprint(label, uint64(delta), uint64(budget))
+		sem.Release(est)
+	}, nil
+}
+
+// boundSeedUnit is the closure form of enterSeedUnit, kept for the falsifier
+// tests (the shared-primitive call sites use enterSeedUnit's bracket form
+// directly because their resolve+Put bodies are long).
+func boundSeedUnit(ctx context.Context, label string, do func() error) error {
+	release, err := enterSeedUnit(ctx, label)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return do()
+}
+
+// resetSeedBoundForTest rebuilds the lazy semaphore + clears the calibration
+// so a falsifier can drive a fresh budget via t.Setenv. Test-only.
+func resetSeedBoundForTest() {
+	seedBoundMu.Lock()
+	seedBoundBuilt = false
+	seedBoundSem = nil
+	seedBoundBudget = 0
+	seedBoundMu.Unlock()
+	estUnitMu.Lock()
+	estUnitBytes = 0
+	estUnitCalibrated = false
+	estUnitMu.Unlock()
+}

--- a/internal/handlers/dispatchers/seed_bound_falsifier_test.go
+++ b/internal/handlers/dispatchers/seed_bound_falsifier_test.go
@@ -1,0 +1,354 @@
+// seed_bound_falsifier_test.go — #46 Piece A + Piece B falsifiers (hermetic).
+//
+// The 50K SCALE falsifier (C46-3: peak HeapInuse under budget WITH the bound /
+// scales-toward-#23 WITHOUT, on the engine=false concurrent posture; per-unit
+// assert trips on an oversized unit on the engine=true serial posture; seed
+// COMPLETES not drops; CONTENT check warm rows non-empty + RBAC-correct) is
+// the cache-tester's bench harness. These hermetic arms prove the bound +
+// assert MECHANISM in-process so the 50K run validates behaviour, not basic
+// correctness:
+//
+//   B1 — Piece A assert TRIPS in prod (counts) when a unit's measured delta
+//        exceeds the budget; does NOT trip within budget. The discriminating
+//        oversized-unit guard.
+//   B2 — Piece A assert PANICS in test mode on breach (loud-fail; an
+//        unbounded/unpaginated unit slipping in is a regression).
+//   B3 — Piece B semaphore SERIALIZES concurrent units beyond the budget (the
+//        aggregate bound on the legacy/engine=false concurrent path): with a
+//        budget that admits only one unit's weight at a time, two concurrent
+//        boundSeedUnit calls never overlap. The original #46 mechanism.
+//   B4 — disabled (SEED_FOOTPRINT_BUDGET_BYTES==0) is a transparent
+//        pass-through: do() runs, no Acquire, no assert, counter flat.
+//   B5 — seed COMPLETES (blocks, never drops): every wrapped unit's do() runs
+//        even under a tight budget (excess blocks then proceeds).
+//   B6 — -race: concurrent boundSeedUnit churn under a tight budget, clean.
+package dispatchers
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// B1 — Piece A assert trips in prod on an oversized delta; clean within budget.
+// (Prod mode: AssertSeedUnitFootprint counts + returns false, never panics.)
+func TestFalsifier46_PerUnitAssertTripsOnOversized(t *testing.T) {
+	// NOT test mode for this arm — we want the prod count path, not panic.
+	// (env.TestMode keys off a separate env; this package's tests run with it
+	// unset by default. Assert the prod-count branch directly.)
+	cache.ResetSeedUnitFootprintViolationsForTest()
+
+	const budget = 1000
+
+	// Within budget → no violation.
+	if ok := cache.AssertSeedUnitFootprint("unit/small", 500, budget); !ok {
+		t.Fatalf("within-budget unit (500<=1000) reported a violation")
+	}
+	if v := cache.SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("within-budget unit bumped the violation counter: %d", v)
+	}
+
+	// Over budget → violation counted, returns false.
+	if ok := cache.AssertSeedUnitFootprint("unit/oversized", 5000, budget); ok {
+		t.Fatalf("oversized unit (5000>1000) reported WITHIN budget")
+	}
+	if v := cache.SeedUnitFootprintViolations(); v != 1 {
+		t.Fatalf("oversized unit did not bump the violation counter exactly once: %d", v)
+	}
+
+	// budget==0 disables the assert (transparent).
+	cache.ResetSeedUnitFootprintViolationsForTest()
+	if ok := cache.AssertSeedUnitFootprint("unit/huge", 1<<40, 0); !ok {
+		t.Fatalf("budget==0 should disable the assert (always within budget)")
+	}
+	if v := cache.SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("budget==0 bumped the violation counter: %d", v)
+	}
+}
+
+// B3 — Piece B semaphore serializes concurrent units beyond budget. With a
+// budget that fits exactly ONE unit's weight, two concurrent boundSeedUnit
+// calls must NOT overlap (the second blocks until the first Releases).
+func TestFalsifier46_SemaphoreSerializesBeyondBudget(t *testing.T) {
+	// Budget == one unit's fallback weight → at most one unit in flight.
+	// Use a small explicit budget + a fallback that equals it so estUnit==budget.
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "1024")
+	t.Setenv("SEED_EST_UNIT_BYTES_FALLBACK", "1024")
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+
+	var inFlight atomic.Int32
+	var maxObserved atomic.Int32
+	started := make(chan struct{}, 2)
+
+	unit := func() error {
+		n := inFlight.Add(1)
+		for {
+			old := maxObserved.Load()
+			if n <= old || maxObserved.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		started <- struct{}{}
+		time.Sleep(80 * time.Millisecond) // hold the weight so overlap would show
+		inFlight.Add(-1)
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = boundSeedUnit(context.Background(), "unit", unit)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxObserved.Load(); got != 1 {
+		t.Fatalf("B3: max concurrent in-flight units = %d, want 1 — the budget admits only one unit's weight, "+
+			"so the semaphore must serialize them (aggregate bound not enforced)", got)
+	}
+}
+
+// B4 — disabled (budget==0) is a transparent pass-through.
+func TestFalsifier46_DisabledIsTransparent(t *testing.T) {
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "0")
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+	cache.ResetSeedUnitFootprintViolationsForTest()
+
+	ran := false
+	err := boundSeedUnit(context.Background(), "unit", func() error {
+		ran = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("disabled pass-through returned err: %v", err)
+	}
+	if !ran {
+		t.Fatalf("disabled pass-through did NOT run do()")
+	}
+	// No assert fires when disabled (budget 0 → AssertSeedUnitFootprint no-op,
+	// and boundSeedUnit returns before sampling anyway).
+	if v := cache.SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("disabled path bumped the violation counter: %d", v)
+	}
+}
+
+// B5 — seed COMPLETES (blocks, never drops): every unit's do() runs even under
+// a tight budget that forces serialization.
+func TestFalsifier46_TightBudgetAllUnitsComplete(t *testing.T) {
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "1024")
+	t.Setenv("SEED_EST_UNIT_BYTES_FALLBACK", "1024")
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+
+	const n = 20
+	var ran atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = boundSeedUnit(context.Background(), "unit", func() error {
+				ran.Add(1)
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	if got := ran.Load(); got != n {
+		t.Fatalf("B5: %d/%d units ran — a tight budget must BLOCK (serialize) excess, never DROP", got, n)
+	}
+}
+
+// B6 — -race: concurrent boundSeedUnit churn under a tight budget.
+func TestFalsifier46_ConcurrentBoundRace(t *testing.T) {
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "4096")
+	t.Setenv("SEED_EST_UNIT_BYTES_FALLBACK", "1024")
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = boundSeedUnit(context.Background(), "unit", func() error {
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	// Clean -race + no deadlock IS the assertion.
+}
+
+// B7 — THE GRANULARITY DISCRIMINATOR (feedback_falsifier_shape_must_discriminate):
+// K>1 cohorts × M>1 units, asserting on the REAL semaphore weight the bracket
+// reserves (currentEstUnit) and the REAL effective concurrency — NOT a test-side
+// counter decoupled from the semaphore (that decoupling is exactly how B3's K=2/M=1
+// shape masked the @15cff6b per-cohort defect).
+//
+// The load-bearing assertions, both keyed off the actual Acquire weight:
+//   (a) EFFECTIVE CONCURRENCY: with the budget sized to fit floor(budget/estUnit)
+//       UNITS, the max number of bracket bodies running simultaneously must equal
+//       that per-UNIT count. Under a per-COHORT acquire (estUnit inflated to a whole
+//       cohort, then budget-clamped) the semaphore admits only ONE body at a time —
+//       observed concurrency collapses to 1, FAILING this assertion.
+//   (b) PER-UNIT WEIGHT: currentEstUnit(budget) must stay in the per-UNIT band
+//       (< a cohort). A per-cohort granularity inflates it to ≈ M× (clamped to
+//       budget) — caught directly.
+// The RED control below (run by the dev pre-freeze, documented in the artifact)
+// multiplies the acquire weight ×M to simulate @15cff6b and confirms BOTH (a) and (b)
+// flip to FAIL.
+func TestFalsifier46_GranularityDiscriminator_PerUnitNotPerCohort(t *testing.T) {
+	const (
+		M = 8 // units per cohort (M>1)
+		K = 4 // concurrent cohorts (K>1) → K*M = 32 units
+		// budget fits exactly 4 per-UNIT weights in flight; a whole cohort
+		// (M units) would NOT fit → the discriminator.
+		budgetUnits = 4
+	)
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "4194304")  // 4 MiB
+	t.Setenv("SEED_EST_UNIT_BYTES_FALLBACK", "1048576") // 1 MiB per UNIT (conservative-high)
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+	cache.ResetSeedUnitFootprintViolationsForTest()
+
+	// The REAL per-unit weight the bracket reserves (no real allocation → calibration
+	// stays at the fallback, which is the per-unit cost). This is what the semaphore
+	// actually Acquires — assert on IT, not a decoupled counter.
+	_, budget := seedBound()
+	estUnit := currentEstUnit(budget)
+
+	// (b) PER-UNIT WEIGHT band: estUnit must fit the budget as a UNIT, and a whole
+	// cohort (M×estUnit) must NOT — else the test can't discriminate.
+	if estUnit > budget {
+		t.Fatalf("B7(b) setup: estUnit %d > budget %d — a single unit must fit", estUnit, budget)
+	}
+	if M*estUnit <= budget {
+		t.Fatalf("B7(b) setup: a cohort (%d×%d=%d) must EXCEED budget %d to discriminate per-unit vs per-cohort",
+			M, estUnit, M*estUnit, budget)
+	}
+	wantConcurrency := int(budget / estUnit) // == budgetUnits (4)
+	if wantConcurrency != budgetUnits {
+		t.Fatalf("B7 setup: expected %d concurrent units, got %d (budget/estUnit)", budgetUnits, wantConcurrency)
+	}
+
+	// (a) EFFECTIVE CONCURRENCY through the REAL bracket. Track how many bracket
+	// bodies are simultaneously past Acquire — driven purely by the semaphore.
+	var inFlight atomic.Int32
+	var maxConc atomic.Int32
+	runUnit := func() {
+		release, err := enterSeedUnit(context.Background(), "unit")
+		if err != nil {
+			t.Errorf("enterSeedUnit: %v", err)
+			return
+		}
+		n := inFlight.Add(1)
+		for {
+			old := maxConc.Load()
+			if n <= old || maxConc.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(40 * time.Millisecond) // hold the slot so true overlap is observable
+		inFlight.Add(-1)
+		release()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < K*M; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runUnit()
+		}()
+	}
+	wg.Wait()
+
+	// The semaphore must admit exactly budget/estUnit UNITS simultaneously (ΣN-units
+	// bound). Under a per-COHORT acquire the inflated+clamped weight would pin this to
+	// 1 — this assertion FAILS for the @15cff6b granularity.
+	if got := int(maxConc.Load()); got != wantConcurrency {
+		t.Fatalf("B7(a) GRANULARITY: max concurrent units = %d, want %d (= budget %d / estUnit %d). "+
+			"A value of 1 means the acquire weight is per-COHORT (inflated+clamped), the @15cff6b defect; "+
+			"the bound must be PER-UNIT so floor(budget/unit) units run at once = ΣN-units aggregate cap.",
+			got, wantConcurrency, budget, estUnit)
+	}
+
+	// (b) the per-unit weight band, asserted directly on the real acquire weight.
+	if estUnit >= M*1<<20 {
+		t.Fatalf("B7(b) WEIGHT: estUnit %d is in the per-COHORT band (>= M units) — granularity defect", estUnit)
+	}
+}
+
+// B8 — C46-4(a) CALIBRATION-BAND discriminator: drive units that each allocate a
+// KNOWN, retained per-unit footprint through the per-unit bracket, and assert
+// calibrateEstUnit lands in a PER-UNIT band — tight enough that a per-COHORT
+// calibration (M× a unit, which the @15cff6b g.Go-cohort placement would have
+// measured) FAILS the band. This is the half of C46-4 that keys on what
+// calibrate MEASURES (B7 keys on effective concurrency); together they pin the
+// granularity from both the weight and the concurrency side.
+//
+// The per-cohort RED control is structural, not a proxy: the @15cff6b defect
+// wrapped seedCohort (M units' summed allocation inside ONE enterSeedUnit), so
+// the FIRST measured delta = M units. Asserting `calibrated < perUnitCeil`
+// (perUnitCeil < M×unit) FAILS for that placement and PASSES for the
+// shared-primitive (one-unit) placement.
+func TestFalsifier46_CalibrationLandsInPerUnitBand(t *testing.T) {
+	const (
+		M          = 8
+		perUnitMiB = 4
+		// budget generous so the bracket never blocks; we're testing calibration.
+		budgetMiB = 256
+	)
+	t.Setenv("SEED_FOOTPRINT_BUDGET_BYTES", "268435456")  // 256 MiB
+	t.Setenv("SEED_EST_UNIT_BYTES_FALLBACK", "268435456") // high fallback so calibration (not fallback) is what we read
+	resetSeedBoundForTest()
+	t.Cleanup(resetSeedBoundForTest)
+	cache.ResetSeedUnitFootprintViolationsForTest()
+
+	// One unit: allocate + RETAIN ~perUnitMiB so the HeapInuse delta the bracket
+	// samples reflects ONE unit's real footprint (calibration is one-shot off the
+	// first unit).
+	var sink [][]byte
+	runUnit := func() {
+		release, err := enterSeedUnit(context.Background(), "unit")
+		if err != nil {
+			t.Errorf("enterSeedUnit: %v", err)
+			return
+		}
+		// Retain the allocation across the release() sample so the delta is real.
+		buf := make([]byte, perUnitMiB*(1<<20))
+		for i := range buf {
+			buf[i] = byte(i) // touch pages so they're resident (HeapInuse, not just reserved)
+		}
+		sink = append(sink, buf)
+		release()
+	}
+
+	// Drive a few units sequentially (calibration pins on the first non-zero delta).
+	for i := 0; i < M; i++ {
+		runUnit()
+	}
+	runtime.KeepAlive(sink)
+
+	est, calibrated := calibratedEstUnitForTest()
+	if !calibrated {
+		t.Skip("B8: calibration did not latch (GC ran across every first-unit sample) — non-deterministic on this host; B7 covers the concurrency side")
+	}
+	// PER-UNIT band: the calibrated weight must be < a whole cohort (M units). A
+	// per-cohort placement (@15cff6b) would have calibrated ≈ M×, FAILING this.
+	perUnitCeil := int64(M) * perUnitMiB * (1 << 20) / 2 // half a cohort — generous per-unit ceiling
+	if est >= perUnitCeil {
+		t.Fatalf("B8 C46-4(a): calibrated estUnit %d B >= per-unit ceiling %d B — calibration measured a "+
+			"PER-COHORT footprint (the @15cff6b g.Go-cohort placement), not one unit", est, perUnitCeil)
+	}
+}


### PR DESCRIPTION
Bounds the prewarm seed fanout's aggregate memory so seeding can't OOM (#23 ΣN-units shape) — gates enabling prewarm-seeding (#42). Piece A: per-unit HeapInuse assert (seed_assert.go). Piece B: semaphore.Weighted at the shared per-unit primitives seedOneWidget+seedOneRestaction (after the identity short-circuit), empirical estUnit calibration clamped≤budget, blocks-not-drops. DEFAULT-OFF (SEED_FOOTPRINT_BUDGET_BYTES==0 → transparent). Dual-gate GREEN: arch placement PASS (shared-primitive, both per-path wraps deleted, seed-scoped) + PM ACCEPT (B7 concurrency + B8 calibration-band discriminators RED-proven on per-cohort, C46-5 grep zero customer-path callers, not-1.5.1). 50K bench arm = tester, post-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)