### PR TITLE
fix(cache): /refreshes subscription key must fold the widget's inline-extras union (#64)

### DIFF
--- a/internal/handlers/dispatchers/refresh_isolation_falsifier_test.go
+++ b/internal/handlers/dispatchers/refresh_isolation_falsifier_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,13 +59,25 @@ func buildTwoUserRBACWatcher(t *testing.T) {
 	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
 	scheme := runtime.NewScheme()
 	_ = rbacv1.AddToScheme(scheme)
+	compGVR := schema.GroupVersionResource{Group: "composition.krateo.io", Version: "v1alpha1", Resource: "compositions"}
+	panelGVR := schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
 	listKinds := map[schema.GroupVersionResource]string{
 		crbGVR: "ClusterRoleBindingList",
 		crGVR:  "ClusterRoleList",
 		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
 		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		compGVR:  "CompositionList",
+		panelGVR: "PanelList",
 	}
-	compRule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"composition.krateo.io"}, Resources: []string{"compositions"}}}
+	// #64: grant compositions AND panels get/list — both classWidgets and
+	// widgetContent coords (compositionsCoords + the WidgetContentSharedShell
+	// panels coord) now fetch their CR via subscriptionKeyExtras→objects.Get
+	// (RBAC-gated under the connection identity). Without the panels grant the
+	// widgetContent fetch fail-closes (C64-1) and the shared-shell test can't arm.
+	compRule := []rbacv1.PolicyRule{
+		{Verbs: []string{"get", "list"}, APIGroups: []string{"composition.krateo.io"}, Resources: []string{"compositions"}},
+		{Verbs: []string{"get", "list"}, APIGroups: []string{"widgets.templates.krateo.io"}, Resources: []string{"panels"}},
+	}
 	mkCR := func(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 		return &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}, Rules: rules}
 	}
@@ -81,6 +94,27 @@ func buildTwoUserRBACWatcher(t *testing.T) {
 		// the per-binding cell identity (BindingUID) differs per user.
 		mkCRB("a-bind", "uid-A", "comp-reader", rbacv1.Subject{Kind: "User", Name: "userA"}),
 		mkCRB("b-bind", "uid-B", "comp-reader", rbacv1.Subject{Kind: "User", Name: "userB"}),
+		// #64: the compositionsCoords() class is classWidgets, which now (post-#64)
+		// fetches the widget CR via subscriptionKeyExtras→objects.Get to fold the
+		// inline-extras union. Seed the compositions CR (no inline extras → the
+		// union == request-only, so the distinct-BindingUID key invariant is
+		// unchanged) so the fetch succeeds and the test exercises the real arming
+		// path rather than fail-closed-skipping (C64-1).
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "composition.krateo.io/v1alpha1",
+			"kind":       "Composition",
+			"metadata":   map[string]any{"name": "demo-1", "namespace": "team-a"},
+			"spec":       map[string]any{},
+		}},
+		// #64: the WidgetContentSharedShell panels coord (dashboard-piechart/
+		// krateo-system) — no inline extras → union==request-only, shared-shell
+		// key invariant unchanged.
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1",
+			"kind":       "Panel",
+			"metadata":   map[string]any{"name": "dashboard-piechart", "namespace": "krateo-system"},
+			"spec":       map[string]any{},
+		}},
 	}
 
 	wctx, wcancel := context.WithCancel(context.Background())
@@ -97,6 +131,12 @@ func buildTwoUserRBACWatcher(t *testing.T) {
 		wcancel()
 		t.Fatalf("WaitForCacheSync: %v", err)
 	}
+	// #64: make the compositions GVR servable so objects.Get serves the seeded
+	// CR from the informer (subscriptionKeyExtras' read), not an apiserver
+	// fallthrough.
+	_, _ = rw.EnsureResourceType(compGVR)
+	_, _ = rw.EnsureResourceType(panelGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
 	cache.RebuildRBACSnapshotForTest(rw)
 	prev := cache.Global()
 	cache.SetGlobal(rw)

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -35,7 +35,11 @@ package dispatchers
 import (
 	"context"
 
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // classRestActions / classWidgets are the two entry-class values that have
@@ -83,6 +87,57 @@ type SubscriptionCoordinates struct {
 // is rbac.EvaluateRBAC, which reads the in-process RBAC snapshot (the same
 // snapshot /call consults) — never the apiserver. So /refreshes stays off
 // the apiserver path end to end.
+// subscriptionKeyExtras returns the SAME extras union the EMIT path folds into
+// a widget's cache key — the inline author-declared blocks UNIONed with the
+// request extras — so the subscription key the server arms is byte-identical to
+// the key the resolver Puts + PublishRefreshes (#64).
+//
+// THE BUG IT FIXES: the emit key folds unionForKey(spec.apiRef.extras,
+// spec.resourcesRefsTemplateExtras, requestExtras) (helpers.go:275 +
+// widgets.GetApiRefExtras/GetResourcesRefsExtras), but DeriveSubscriptionKey
+// historically folded ONLY coords.Extras (the request half). A
+// composition-DETAIL widget with inline extras therefore derived a DIFFERENT
+// key on the subscription side than the cell publishes → zero delivery. The
+// frontend CANNOT supply the inline blocks (they are server-side CR fields it
+// never sees), so the union MUST be reconstructed server-side from the widget
+// CR — exactly as the emit path does.
+//
+// MECHANISM REUSE (C64-2, no re-impl): the inline getters
+// widgets.GetApiRefExtras / GetResourcesRefsExtras + the in-package unionForKey
+// are the EXACT functions the emit path uses, so the fold is identical by
+// construction.
+//
+// FAIL-CLOSED (C64-1): objects.Get failing (NotFound / RBAC-denied / nil) →
+// (nil, false). The caller SKIPS the coordinate — it does NOT arm a
+// request-only key (which would never match the emit key for an inline-extras
+// widget, re-introducing the bug) and does NOT fall back. A connection can
+// only arm a key whose widget CR its own identity can GET — the same
+// forgery-proof posture as the BindingUID derivation (the objects.Get carries
+// the connection ctx's identity + RBAC).
+//
+// COST (C64-6): objects.Get is informer-served under cache-on (get.go
+// useInformer→IsServable) — an in-memory read at SUBSCRIBE time (≤ the armed
+// coord count, bounded ≤512), never per-event, never the apiserver.
+func subscriptionKeyExtras(ctx context.Context, c SubscriptionCoordinates) (map[string]any, bool) {
+	got := objects.Get(ctx, templatesv1.ObjectReference{
+		Reference: templatesv1.Reference{
+			Name:      c.Name,
+			Namespace: c.Namespace,
+		},
+		APIVersion: schema.GroupVersion{Group: c.Group, Version: c.Version}.String(),
+		Resource:   c.Resource,
+	})
+	if got.Err != nil || got.Unstructured == nil {
+		// Fail-closed: skip the coord (no request-only fallback).
+		return nil, false
+	}
+	return unionForKey(
+		widgets.GetApiRefExtras(got.Unstructured.Object),
+		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
+		c.Extras,
+	), true
+}
+
 func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) (string, bool) {
 	switch coords.Class {
 	case cache.CacheEntryClassWidgetContent:
@@ -90,21 +145,51 @@ func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) 
 		// (nobody owns it); the per-user gating is re-applied at serve time
 		// (gateWidgetEnvelope). Arming it reveals only "the shared envelope
 		// changed" — not subject-specific information (design §5.2 caveat).
+		//
+		// #64: a widgetContent cell is a widget — its emit key folds the inline
+		// extras union, so the subscription key MUST too. Reconstruct the union
+		// from the widget CR (fail-closed-skip if it can't be GET) and pass it
+		// in place of the request-only coords.Extras.
+		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
+		if !ok {
+			return "", false
+		}
 		key, handle, _ := dispatchWidgetContentKey(ctx,
 			coords.Group, coords.Version, coords.Resource,
-			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
+		if handle == nil || key == "" {
+			return "", false
+		}
+		return key, true
+
+	case classWidgets:
+		// Identity-bound widget. #64: same inline-extras union as widgetContent
+		// — the emit key (widgets.go genuine-Put) folds unionForKey(inline,
+		// request); the subscription key must fold the identical union or the
+		// armed key never matches the published one for an inline-extras widget.
+		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
+		if !ok {
+			return "", false
+		}
+		key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
 		if handle == nil || key == "" {
 			return "", false
 		}
 		return key, true
 
 	case classRestActions,
-		classWidgets,
 		cache.CacheEntryClassApistage,
 		cache.CacheEntryClassRAFullList:
 		// Identity-bound: dispatchCacheLookupKey folds the BindingUID derived
 		// from ctx's identity. A foreign coordinate set yields the caller's
 		// own BindingUID -> a key the foreign cell never publishes to.
+		//
+		// #64: these classes carry NO inline-extras blocks (they are not
+		// widgets — a RESTAction/apistage/raFullList cell's emit key folds only
+		// the request extras), so raw coords.Extras is request-only parity on
+		// BOTH sides. UNCHANGED.
 		key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
 			coords.Group, coords.Version, coords.Resource,
 			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)

--- a/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
@@ -1,0 +1,280 @@
+// refresh_subscription_key_parity_test.go — #64: the subscription key MUST
+// fold the SAME inline-extras union the emit key folds, so an armed /refreshes
+// connection matches the key the resolver Puts + PublishRefreshes.
+//
+// Root cause (1.5.5–1.5.10): the emit key folds
+// unionForKey(spec.apiRef.extras, spec.resourcesRefsTemplateExtras, request)
+// (widgets.go genuine-Put), but DeriveSubscriptionKey folded ONLY the request
+// extras → a composition-DETAIL widget with INLINE author extras derived a
+// different subscription key than its cell publishes → delivered:0. The fix
+// reconstructs the union server-side from the widget CR (subscriptionKeyExtras).
+//
+// Hermetic: a fake dynamic client seeds BOTH the RBAC snapshot (for the
+// BindingUID fold) AND the widget CR (so objects.Get serves it from the
+// informer — the C64-6 informer-served read). NO remote go-test, NO apiserver.
+//
+//   ARM 1 (C64-4 DISCRIMINATOR): widget CR has inline spec.apiRef.extras=
+//          {region:eu}; coords.Extras={name:demo-vpc} — DISJOINT (coords does
+//          NOT pre-contain the inline; that disjointness is what the old golden
+//          lacked). DeriveSubscriptionKey(coords) MUST == the emit key folding
+//          unionForKey(inline,{name}) = {region,name}. RED on the old code
+//          (folds {name} only), GREEN on the fix.
+//   ARM 2 (C64-5 backward-compat): empty inline → DeriveSubscriptionKey == the
+//          request-only emit key (no regression for inline-free widgets).
+//   ARM 3: widgetContent class, same disjoint inline shape — RED/GREEN.
+//   ARM 4: restactions class — request-only on BOTH sides (branch UNCHANGED).
+//   ARM 5 (C64-1 fail-closed): the widget CR is NOT gettable (absent) →
+//          DeriveSubscriptionKey returns ("", false) — the coord is SKIPPED,
+//          NOT armed with a request-only key.
+package dispatchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var widgetParityGVR = schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
+
+// buildWidgetParityWatcher seeds an RBAC snapshot granting userA get/list on
+// the widget GVR + a widget CR (panel-1 in ns demo) carrying the supplied
+// inline spec.apiRef.extras, published as cache.Global() for the test. When
+// inlineApiRefExtras is nil the widget is seeded with no inline block. When
+// seedWidget is false the widget CR is omitted (ARM 5 fail-closed: objects.Get
+// finds nothing).
+func buildWidgetParityWatcher(t *testing.T, seedWidget bool, inlineApiRefExtras map[string]any) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		widgetParityGVR: "PanelList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"widgets.templates.krateo.io"}, Resources: []string{"panels"}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "panel-reader"}, Rules: rule},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "a-bind", UID: types.UID("uid-A")},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "userA"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+		},
+	}
+	if seedWidget {
+		spec := map[string]any{}
+		if inlineApiRefExtras != nil {
+			spec["apiRef"] = map[string]any{
+				"name":      "some-ra",
+				"namespace": "demo",
+				"extras":    inlineApiRefExtras,
+			}
+		}
+		w := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1",
+			"kind":       "Panel",
+			"metadata":   map[string]any{"name": "panel-1", "namespace": "demo"},
+			"spec":       spec,
+		}}
+		seed = append(seed, w)
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	// Make the widget GVR servable so objects.Get serves it from the informer
+	// (C64-6) rather than falling through to a (non-existent) apiserver.
+	_, _ = rw.EnsureResourceType(widgetParityGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+func ctxUserA() context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "userA"}))
+}
+
+func panelCoords(class string, extras map[string]any) SubscriptionCoordinates {
+	return SubscriptionCoordinates{
+		Class:     class,
+		Group:     widgetParityGVR.Group,
+		Version:   widgetParityGVR.Version,
+		Resource:  widgetParityGVR.Resource,
+		Namespace: "demo",
+		Name:      "panel-1",
+		Extras:    extras,
+	}
+}
+
+// ARM 1 — C64-4 DISCRIMINATOR. Inline {region:eu} in the CR; coords {name:demo-vpc}
+// disjoint. The subscription key must == the emit key folding the union.
+func TestFalsifier64_ARM1_WidgetsInlineExtrasUnion(t *testing.T) {
+	inline := map[string]any{"region": "eu"}
+	buildWidgetParityWatcher(t, true, inline)
+	ctx := ctxUserA()
+	coords := panelCoords(classWidgets, map[string]any{"name": "demo-vpc"})
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok || subKey == "" {
+		t.Fatalf("DeriveSubscriptionKey failed (ok=%v key=%q) — RBAC/objects.Get setup wrong?", ok, subKey)
+	}
+
+	// The emit key: the resolver folds unionForKey(GetApiRefExtras, GetResourcesRefsExtras, request).
+	got := objects.Get(ctx, templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: "panel-1", Namespace: "demo"},
+		APIVersion: "widgets.templates.krateo.io/v1beta1",
+		Resource:   "panels",
+	})
+	if got.Err != nil || got.Unstructured == nil {
+		t.Fatalf("objects.Get(panel-1) failed in setup: err=%v", got.Err)
+	}
+	emitExtras := unionForKey(
+		widgets.GetApiRefExtras(got.Unstructured.Object),
+		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
+		map[string]any{"name": "demo-vpc"},
+	)
+	emitKey, handle, _ := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		coords.PerPage, coords.Page, emitExtras)
+	if handle == nil || emitKey == "" {
+		t.Fatalf("emit key derivation failed")
+	}
+
+	// Sanity: the union actually changed the key vs request-only (else the test
+	// can't discriminate — the inline must be load-bearing).
+	reqOnlyKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		coords.PerPage, coords.Page, map[string]any{"name": "demo-vpc"})
+	if emitKey == reqOnlyKey {
+		t.Fatalf("ARM1 setup: inline {region:eu} did not change the emit key — not discriminating")
+	}
+
+	if subKey != emitKey {
+		t.Fatalf("ARM1 C64-4 RED: subscription key %q != emit key %q. DeriveSubscriptionKey must fold the inline "+
+			"extras union (subscriptionKeyExtras), not request-only — else an inline-extras widget never matches "+
+			"its published cell (the 1.5.5–1.5.10 zero-delivery).", subKey, emitKey)
+	}
+}
+
+// ARM 2 — C64-5 backward-compat: inline-free widget → subscription key == the
+// request-only emit key (no regression).
+func TestFalsifier64_ARM2_WidgetsNoInlineBackwardCompat(t *testing.T) {
+	buildWidgetParityWatcher(t, true, nil) // no inline block
+	ctx := ctxUserA()
+	coords := panelCoords(classWidgets, map[string]any{"name": "demo-vpc"})
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok {
+		t.Fatalf("DeriveSubscriptionKey failed for inline-free widget")
+	}
+	reqOnlyKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		coords.PerPage, coords.Page, map[string]any{"name": "demo-vpc"})
+	if subKey != reqOnlyKey {
+		t.Fatalf("ARM2 C64-5: inline-free widget subscription key %q != request-only key %q — backward-compat regression",
+			subKey, reqOnlyKey)
+	}
+}
+
+// ARM 3 — widgetContent class, same disjoint inline shape.
+func TestFalsifier64_ARM3_WidgetContentInlineExtrasUnion(t *testing.T) {
+	inline := map[string]any{"region": "eu"}
+	buildWidgetParityWatcher(t, true, inline)
+	ctx := ctxUserA()
+	coords := panelCoords(cache.CacheEntryClassWidgetContent, map[string]any{"name": "demo-vpc"})
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok || subKey == "" {
+		t.Fatalf("DeriveSubscriptionKey(widgetContent) failed (ok=%v)", ok)
+	}
+	got := objects.Get(ctx, templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: "panel-1", Namespace: "demo"},
+		APIVersion: "widgets.templates.krateo.io/v1beta1", Resource: "panels",
+	})
+	emitExtras := unionForKey(
+		widgets.GetApiRefExtras(got.Unstructured.Object),
+		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
+		map[string]any{"name": "demo-vpc"})
+	emitKey, _, _ := dispatchWidgetContentKey(ctx,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		coords.PerPage, coords.Page, emitExtras)
+	if subKey != emitKey {
+		t.Fatalf("ARM3 RED: widgetContent subscription key %q != emit key %q (inline-extras union missing)", subKey, emitKey)
+	}
+}
+
+// ARM 4 — restactions class: request-only on BOTH sides (branch UNCHANGED). The
+// subscription key must equal the request-only key, and must NOT fetch/fold the
+// widget CR's inline extras (a RESTAction is not a widget).
+func TestFalsifier64_ARM4_RestActionsRequestOnlyUnchanged(t *testing.T) {
+	inline := map[string]any{"region": "eu"} // present in the CR, but restactions must ignore it
+	buildWidgetParityWatcher(t, true, inline)
+	ctx := ctxUserA()
+	coords := panelCoords(classRestActions, map[string]any{"name": "demo-vpc"})
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok {
+		t.Fatalf("DeriveSubscriptionKey(restactions) failed")
+	}
+	reqOnlyKey, _, _ := dispatchCacheLookupKey(ctx, classRestActions,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		coords.PerPage, coords.Page, map[string]any{"name": "demo-vpc"})
+	if subKey != reqOnlyKey {
+		t.Fatalf("ARM4: restactions subscription key %q != request-only key %q — the restactions branch must "+
+			"stay request-only (no inline-extras fold)", subKey, reqOnlyKey)
+	}
+}
+
+// ARM 5 — C64-1 fail-closed: the widget CR is NOT gettable → DeriveSubscriptionKey
+// returns ("", false). The coord is SKIPPED, never armed with a request-only key
+// (which would re-introduce the mismatch for an inline-extras widget).
+func TestFalsifier64_ARM5_FailClosedOnMissingCR(t *testing.T) {
+	buildWidgetParityWatcher(t, false, nil) // widget CR absent
+	ctx := ctxUserA()
+	coords := panelCoords(classWidgets, map[string]any{"name": "demo-vpc"})
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if ok || subKey != "" {
+		t.Fatalf("ARM5 C64-1: widget CR absent but DeriveSubscriptionKey returned (%q, %v) — must fail-closed "+
+			"(\"\", false) and SKIP the coord, never arm a request-only key", subKey, ok)
+	}
+}

--- a/internal/handlers/refreshes_test.go
+++ b/internal/handlers/refreshes_test.go
@@ -24,7 +24,15 @@ import (
 	"time"
 
 	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 const refreshTestSignKey = "test-sign-key-ship1-live-refresh"
@@ -60,6 +68,78 @@ func subParam(t *testing.T) string {
 	}}
 	raw, _ := json.Marshal(body)
 	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// seedAuthTestWidget wires cache.Global() with the dashboard-piechart panel CR
+// that subParam() arms + an RBAC binding granting userA's group (devs) get/list
+// on panels, so the #64 subscriptionKeyExtras objects.Get (informer-served,
+// RBAC-gated under the connection identity) succeeds and DeriveSubscriptionKey
+// derives a valid key.
+//
+// WHY (#64): the auth tests exercise the REAL arming path, which now (correctly,
+// C64-1 fail-closed) requires a fetchable widget CR — a widget the user can't
+// GET is not live-refreshable, so it is not armed. Pre-#64 these coords
+// phantom-armed (200, but the request-only key was WRONG → never delivered, the
+// very bug). Seeding the CR tests the honest arming path.
+func seedAuthTestWidget(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	panelGVR := schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		panelGVR: "PanelList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"widgets.templates.krateo.io"}, Resources: []string{"panels"}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "panel-reader"}, Rules: rule},
+		// Grant the "devs" GROUP (userA's mintToken group) get/list panels.
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "devs-bind", UID: types.UID("uid-devs")},
+			Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "devs"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1",
+			"kind":       "Panel",
+			"metadata":   map[string]any{"name": "dashboard-piechart", "namespace": "krateo-system"},
+			"spec":       map[string]any{}, // no inline extras — request-only key, byte-identical to emit
+		}},
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer syncCancel()
+	if err := rw.WaitForCacheSync(syncCtx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(panelGVR)
+	_ = rw.WaitForCacheSync(syncCtx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
 }
 
 // refreshServer wires the production chain (RefreshAuth -> Refreshes) on a
@@ -103,6 +183,7 @@ func TestRefreshes_Auth_HeaderTokenReachesHandler(t *testing.T) {
 	t.Setenv("CACHE_ENABLED", "true")
 	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
 	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t) // #64: the armed widget CR must be fetchable (C64-1 fail-closed)
 	base := refreshServer(t)
 
 	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
@@ -127,6 +208,7 @@ func TestRefreshes_Auth_CookieTokenReachesHandler(t *testing.T) {
 	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
 	t.Setenv("REFRESH_SSE_ENABLED", "")
 	t.Setenv("REFRESH_SESSION_COOKIE", "krateo-session")
+	seedAuthTestWidget(t) // #64: the armed widget CR must be fetchable (C64-1 fail-closed)
 	base := refreshServer(t)
 
 	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {


### PR DESCRIPTION
Real fix for /refreshes zero-delivery (1.5.10 smoke proved #61's dep-edge necessary-not-sufficient). Emit key folds unionForKey(spec.apiRef.extras ∪ spec.resourcesRefsTemplateExtras ∪ request); subscription key folded request-only → detail widgets with inline extras had emit-key≠sub-key → delivered:0. Fix: DeriveSubscriptionKey fetches the widget CR (informer-served, under connection identity) + folds the same union (reusing GetApiRefExtras/GetResourcesRefsExtras/unionForKey). Fail-closed-skip on unfetchable (honest-400 > phantom-200). Dual-gate GREEN (arch PASS + PM ACCEPT, RED-discriminating golden, isolation invariants intact, forgery-proof preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)