### PR TITLE
metrics: expand OTLP metric mirror to the operationally-significant expvar families

### DIFF
--- a/internal/cache/otel_accessors.go
+++ b/internal/cache/otel_accessors.go
@@ -1,0 +1,66 @@
+// otel_accessors.go — exported, read-only accessors over cache-package
+// counters that already back expvar but whose snapshot helpers are
+// package-private (refresherStatsSnapshot, controllerHealthSnap). The
+// internal/metrics OTLP mirror (a separate package) reads these at OTLP
+// collection time to observe the SAME live snapshots the expvar `.Func`
+// closures read.
+//
+// ADDITIVE: pure read accessors. They change no incrementer, no populate
+// path, and the expvar surface is untouched.
+
+package cache
+
+// RefresherSnapshot returns the background re-resolve worker-pool counters,
+// mirroring the snowplow_refresher_* expvar family. queueDepth is the live
+// workqueue Len(). Safe before StartRefresher: refresherStatsSnapshot reads
+// the singleton lazily and returns zeros when the pool is not yet built.
+func RefresherSnapshot() (enqueued, completed, failed, retried, dropped,
+	skippedNoEntry, skippedNoHandler, skippedStageError,
+	yielded, capped, floored uint64, queueDepth int64) {
+
+	s := refresherStatsSnapshot()
+	r := refresherInstance
+	if r != nil && r.queue != nil {
+		queueDepth = int64(r.queue.Len())
+	}
+	return s.enqueued, s.completed, s.failed, s.retried, s.dropped,
+		s.skippedNoEntry, s.skippedNoHandler, s.skippedStageError,
+		s.yielded, s.capped, s.floored, queueDepth
+}
+
+// UpstreamHealthSnapshot collapses the per-controller controller-health
+// snapshot into bounded aggregate gauges suitable for OTLP, mirroring the
+// operationally-significant signal of snowplow_upstream_controller_health
+// (every entry Healthy=1) and snowplow_upstream_webhook_failurepolicy (how
+// many discovered webhooks carry a Fail policy). The per-name maps stay the
+// expvar drill-down surface; OTLP gets the alarm-worthy counts so a
+// dashboard can alert on "controllersUnhealthy > 0" or
+// "webhooksFailPolicy > 0 on a degraded controller" without per-name
+// cardinality.
+//
+// Returns all zeros when cache is off or no snapshot has been published yet.
+func UpstreamHealthSnapshot() (controllersHealthy, controllersUnhealthy,
+	webhooksTotal, webhooksFailPolicy int64) {
+
+	if Disabled() {
+		return 0, 0, 0, 0
+	}
+	s := controllerHealthSnap.Load()
+	if s == nil {
+		return 0, 0, 0, 0
+	}
+	for _, c := range s.Controllers {
+		if c.Healthy == 1 {
+			controllersHealthy++
+		} else {
+			controllersUnhealthy++
+		}
+	}
+	for _, w := range s.Webhooks {
+		webhooksTotal++
+		if w.Policy == "Fail" {
+			webhooksFailPolicy++
+		}
+	}
+	return controllersHealthy, controllersUnhealthy, webhooksTotal, webhooksFailPolicy
+}

--- a/internal/handlers/dispatchers/otel_accessors.go
+++ b/internal/handlers/dispatchers/otel_accessors.go
@@ -1,0 +1,83 @@
+// otel_accessors.go — exported, read-only accessors over the dispatchers
+// package's existing prewarm / phase-1 / dispatch-L1 atomic counters, so
+// the internal/metrics OTLP mirror (a separate package) can observe the
+// SAME live snapshots the expvar `.Func` closures read.
+//
+// ADDITIVE: these are pure read accessors. They do NOT change any
+// incrementer, populate path, or the expvar surface. Each reads the same
+// package-private atomics / sync.Maps the existing expvar publishers in
+// this package read (prewarm_engine_metrics.go, phase1_walk_pagination_metrics.go,
+// phase1_walk_metrics.go, phase1_pip_metrics.go, l1_lookup_metrics.go).
+//
+// The metrics package reads these at OTLP collection time only (the
+// observable-instrument callback), so there is zero per-/call cost — same
+// "computed-on-read" semantics as expvar.
+
+package dispatchers
+
+// PrewarmEngineSnapshot returns the prewarm-engine worker counters,
+// mirroring snowplow_prewarm_engine_{enqueued,processed,yield}_total and
+// snowplow_prewarm_engine_pending_depth. pendingDepth is read under the
+// engine mutex (race-free against enqueue/dequeue). Safe before the engine
+// has started: prewarmEngineSingleton() lazily constructs the engine, so a
+// pre-start read returns zeros from the freshly-allocated struct.
+func PrewarmEngineSnapshot() (enqueued, processed, yield uint64, pendingDepth int64) {
+	e := prewarmEngineSingleton()
+	if e == nil {
+		return 0, 0, 0, 0
+	}
+	e.mu.Lock()
+	pendingDepth = int64(len(e.pending))
+	e.mu.Unlock()
+	return e.enqueuedTotal.Load(), e.processedTotal.Load(), e.yieldTotal.Load(), pendingDepth
+}
+
+// Phase1PaginationSnapshot returns the apiRef pagination-coverage grand
+// totals, mirroring snowplow_phase1_units_planned / _units_seeded /
+// _apiref_pages_total / _eligible_no_continue_total.
+func Phase1PaginationSnapshot() (unitsPlanned, unitsSeeded, apiRefPages, eligibleNoContinue uint64) {
+	return prewarmUnitsPlanned.Load(),
+		prewarmUnitsSeeded.Load(),
+		prewarmApiRefPagesTotal.Load(),
+		prewarmEligibleNoContinueTotal.Load()
+}
+
+// Phase1WalkSnapshot returns the boot-walk fan-out totals, mirroring
+// snowplow_phase1_walk_zero_children_total / _walk_observations_total. The
+// per-root walk_children map is high-cardinality + diagnostic-only and is
+// deliberately NOT mirrored to OTLP.
+func Phase1WalkSnapshot() (zeroChildren, observations uint64) {
+	return phase1WalkZeroChildrenTotal.Load(), phase1WalkObservationsTotal.Load()
+}
+
+// Phase1SeedSnapshot returns the per-target phase-1 seed outcome totals,
+// mirroring snowplow_phase1_bindingset_seed_resolves_total /
+// _bindingset_seed_failures_total / _seed_rbac_deny_total /
+// _seed_operational_fail_total. The per-(cohort,target) failure maps and
+// the per-cohort status map are high-cardinality + diagnostic-only and are
+// deliberately NOT mirrored to OTLP.
+func Phase1SeedSnapshot() (resolves, failures, rbacDeny, operationalFail uint64) {
+	return pipBindingSetSeedResolvesTotal.Load(),
+		pipBindingSetSeedFailuresTotal.Load(),
+		pipSeedRBACDenyTotal.Load(),
+		pipSeedOperationalFailTotal.Load()
+}
+
+// DispatchL1LookupTotals returns the cluster-wide aggregate hit/miss totals
+// across every (handlerKind, gvr) dispatch-L1 cell, mirroring the
+// snowplow_dispatch_l1_lookups expvar map collapsed to two grand totals.
+// The per-(handlerKind|gvr) breakdown is intentionally aggregated here to
+// keep OTLP cardinality bounded — the expvar map remains the per-cell
+// drill-down surface.
+func DispatchL1LookupTotals() (hit, miss uint64) {
+	l1LookupCells.Range(func(_, v any) bool {
+		cell, _ := v.(*l1LookupCell)
+		if cell == nil {
+			return true
+		}
+		hit += cell.hit.Load()
+		miss += cell.miss.Load()
+		return true
+	})
+	return hit, miss
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,14 +33,17 @@ import (
 
 	"github.com/krateoplatformops/plumbing/env"
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/dynamic"
+	"github.com/krateoplatformops/snowplow/internal/handlers/dispatchers"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/crds/schema"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
@@ -248,6 +251,141 @@ func registerInstruments(m metric.Meter) error {
 		return err
 	}
 
+	// --- prewarm engine: the unified walk/seed worker (production path) ---
+	prewarmEngEnqueued, err := m.Int64ObservableCounter("snowplow_prewarm_engine_enqueued_total",
+		metric.WithDescription("Cumulative enqueueScope calls (every enqueue, even dedup-coalesced)."))
+	if err != nil {
+		return err
+	}
+	prewarmEngProcessed, err := m.Int64ObservableCounter("snowplow_prewarm_engine_processed_total",
+		metric.WithDescription("Prewarm-engine scopes fully processed by the worker."))
+	if err != nil {
+		return err
+	}
+	prewarmEngYield, err := m.Int64ObservableCounter("snowplow_prewarm_engine_yield_total",
+		metric.WithDescription("Prewarm-engine worker parked for a customer /call (customer-priority yield)."))
+	if err != nil {
+		return err
+	}
+	prewarmEngPending, err := m.Int64ObservableGauge("snowplow_prewarm_engine_pending_depth",
+		metric.WithDescription("Live prewarm-engine pending-scope depth; 0 once the worker drains."))
+	if err != nil {
+		return err
+	}
+
+	// --- prewarm phase-1: apiRef pagination coverage ---
+	phase1UnitsPlanned, err := m.Int64ObservableGauge("snowplow_phase1_units_planned",
+		metric.WithDescription("widgetContent cells the apiRef pagination walk planned to seed."))
+	if err != nil {
+		return err
+	}
+	phase1UnitsSeeded, err := m.Int64ObservableGauge("snowplow_phase1_units_seeded",
+		metric.WithDescription("Page cells handed to populateWidgetContentL1 with a non-nil envelope."))
+	if err != nil {
+		return err
+	}
+	phase1ApiRefPages, err := m.Int64ObservableCounter("snowplow_phase1_apiref_pages_total",
+		metric.WithDescription("Extra apiRef pages (page 2..N) resolved across all paginated widgets."))
+	if err != nil {
+		return err
+	}
+	phase1EligibleNoContinue, err := m.Int64ObservableCounter("snowplow_phase1_eligible_no_continue_total",
+		metric.WithDescription("Distinct eligible widgets whose page-1 resolve produced no continuation."))
+	if err != nil {
+		return err
+	}
+
+	// --- prewarm phase-1: boot-walk fan-out ---
+	phase1WalkZeroChildren, err := m.Int64ObservableCounter("snowplow_phase1_walk_zero_children_total",
+		metric.WithDescription("Boot-walk observations that found zero children."))
+	if err != nil {
+		return err
+	}
+	phase1WalkObservations, err := m.Int64ObservableCounter("snowplow_phase1_walk_observations_total",
+		metric.WithDescription("Total boot-walk children-count observations (zero-children denominator)."))
+	if err != nil {
+		return err
+	}
+
+	// --- prewarm phase-1: per-target seed outcomes ---
+	phase1SeedResolves, err := m.Int64ObservableCounter("snowplow_phase1_bindingset_seed_resolves_total",
+		metric.WithDescription("Per-binding-target phase-1 seed resolves."))
+	if err != nil {
+		return err
+	}
+	phase1SeedFailures, err := m.Int64ObservableCounter("snowplow_phase1_bindingset_seed_failures_total",
+		metric.WithDescription("Grand-total phase-1 seed failures (= rbac_deny + operational)."))
+	if err != nil {
+		return err
+	}
+	phase1SeedRBACDeny, err := m.Int64ObservableCounter("snowplow_phase1_seed_rbac_deny_total",
+		metric.WithDescription("EXPECTED narrow-RBAC seed denies (403/401); cohort genuinely can't read the target."))
+	if err != nil {
+		return err
+	}
+	phase1SeedOpFail, err := m.Int64ObservableCounter("snowplow_phase1_seed_operational_fail_total",
+		metric.WithDescription("UNEXPECTED seed failures (ctx timeout/cancel, 5xx, transport, panic); should be 0."))
+	if err != nil {
+		return err
+	}
+
+	// --- refresher: background re-resolve worker pool (one counter keyed by stat) ---
+	refresher, err := m.Int64ObservableCounter("snowplow_refresher",
+		metric.WithDescription("Refresher worker-pool counters, labelled by stat."))
+	if err != nil {
+		return err
+	}
+	refresherQueueDepth, err := m.Int64ObservableGauge("snowplow_refresher_queue_depth",
+		metric.WithDescription("Live refresher workqueue depth; climbing with stagnant completed = workers stuck."))
+	if err != nil {
+		return err
+	}
+
+	// --- discovery: SA-discovery client (one counter keyed by stat) ---
+	saDiscovery, err := m.Int64ObservableCounter("snowplow_sa_discovery",
+		metric.WithDescription("SA-discovery client counters, labelled by stat."))
+	if err != nil {
+		return err
+	}
+
+	// --- discovery: compiled-CRD-schema memo (one counter keyed by stat) ---
+	crdSchemaMemo, err := m.Int64ObservableCounter("snowplow_crd_schema_memo",
+		metric.WithDescription("Compiled-CRD-schema memo counters, labelled by stat."))
+	if err != nil {
+		return err
+	}
+
+	// --- upstream health: aggregate controller + webhook gauges ---
+	upstreamControllers, err := m.Int64ObservableGauge("snowplow_upstream_controllers",
+		metric.WithDescription("Auto-discovered upstream controllers, labelled by health (healthy/unhealthy)."))
+	if err != nil {
+		return err
+	}
+	upstreamWebhooks, err := m.Int64ObservableGauge("snowplow_upstream_webhooks",
+		metric.WithDescription("Discovered admission webhooks, labelled by policy (total/fail)."))
+	if err != nil {
+		return err
+	}
+
+	// --- dispatch: L1 resolved-output lookup aggregate hit/miss ---
+	dispatchL1, err := m.Int64ObservableCounter("snowplow_dispatch_l1_lookups_total",
+		metric.WithDescription("Cluster-wide dispatch-L1 resolved-output lookups, labelled by outcome (hit/miss)."))
+	if err != nil {
+		return err
+	}
+
+	// --- RAFullList: cheap Go-slice serve outcomes + index drift canary ---
+	raFullListServe, err := m.Int64ObservableCounter("snowplow_ra_full_list_serve",
+		metric.WithDescription("RAFullList serve-outcome counters, labelled by outcome."))
+	if err != nil {
+		return err
+	}
+	bindingsDeltaSkipped, err := m.Int64ObservableCounter("snowplow_bindings_by_gvr_delta_skipped_non_typed",
+		metric.WithDescription("Delta-event objects neither typed nor convertible, DROPPED (index drift canary); should be 0."))
+	if err != nil {
+		return err
+	}
+
 	// Single callback reading every snapshot at collection time.
 	_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		o.ObserveInt64(fallthroughTotal, int64(cache.FallthroughTotal()))
@@ -292,12 +430,122 @@ func registerInstruments(m metric.Meter) error {
 		o.ObserveInt64(memoRefused, int64(refused))
 		o.ObserveInt64(memoDenyUncached, int64(denyUncached))
 		o.ObserveInt64(memoEntries, int64(entries))
+
+		// --- prewarm engine ---
+		engEnq, engProc, engYield, engPending := dispatchers.PrewarmEngineSnapshot()
+		o.ObserveInt64(prewarmEngEnqueued, int64(engEnq))
+		o.ObserveInt64(prewarmEngProcessed, int64(engProc))
+		o.ObserveInt64(prewarmEngYield, int64(engYield))
+		o.ObserveInt64(prewarmEngPending, engPending)
+
+		// --- phase-1 pagination ---
+		planned, seeded, apiRefPages, eligibleNoCont := dispatchers.Phase1PaginationSnapshot()
+		o.ObserveInt64(phase1UnitsPlanned, int64(planned))
+		o.ObserveInt64(phase1UnitsSeeded, int64(seeded))
+		o.ObserveInt64(phase1ApiRefPages, int64(apiRefPages))
+		o.ObserveInt64(phase1EligibleNoContinue, int64(eligibleNoCont))
+
+		// --- phase-1 boot walk ---
+		zeroChildren, walkObservations := dispatchers.Phase1WalkSnapshot()
+		o.ObserveInt64(phase1WalkZeroChildren, int64(zeroChildren))
+		o.ObserveInt64(phase1WalkObservations, int64(walkObservations))
+
+		// --- phase-1 seed outcomes ---
+		seedResolves, seedFailures, seedRBACDeny, seedOpFail := dispatchers.Phase1SeedSnapshot()
+		o.ObserveInt64(phase1SeedResolves, int64(seedResolves))
+		o.ObserveInt64(phase1SeedFailures, int64(seedFailures))
+		o.ObserveInt64(phase1SeedRBACDeny, int64(seedRBACDeny))
+		o.ObserveInt64(phase1SeedOpFail, int64(seedOpFail))
+
+		// --- refresher pool ---
+		rEnq, rComp, rFail, rRetried, rDropped,
+			rSkipNoEntry, rSkipNoHandler, rSkipStageErr,
+			rYielded, rCapped, rFloored, rQueueDepth := cache.RefresherSnapshot()
+		for stat, v := range map[string]uint64{
+			"enqueue":             rEnq,
+			"completed":           rComp,
+			"failed":              rFail,
+			"retried":             rRetried,
+			"dropped":             rDropped,
+			"skipped_no_entry":    rSkipNoEntry,
+			"skipped_no_handler":  rSkipNoHandler,
+			"skipped_stage_error": rSkipStageErr,
+			"yielded":             rYielded,
+			"capped":              rCapped,
+			"floored":             rFloored,
+		} {
+			o.ObserveInt64(refresher, int64(v),
+				metric.WithAttributes(attribute.String("stat", stat)))
+		}
+		o.ObserveInt64(refresherQueueDepth, rQueueDepth)
+
+		// --- SA-discovery ---
+		sa := dynamic.SADiscoveryStatsSnapshot()
+		for stat, v := range map[string]uint64{
+			"builds":        sa.Builds,
+			"invalidations": sa.Invalidations,
+			"fallbacks":     sa.Fallbacks,
+		} {
+			o.ObserveInt64(saDiscovery, int64(v),
+				metric.WithAttributes(attribute.String("stat", stat)))
+		}
+
+		// --- CRD-schema memo ---
+		csHits, csMisses, csStale, csInval := schema.CRDSchemaMemoSnapshot()
+		for stat, v := range map[string]uint64{
+			"hits":          csHits,
+			"misses":        csMisses,
+			"stale_dropped": csStale,
+			"invalidations": csInval,
+		} {
+			o.ObserveInt64(crdSchemaMemo, int64(v),
+				metric.WithAttributes(attribute.String("stat", stat)))
+		}
+
+		// --- upstream controller / webhook health ---
+		ctrlHealthy, ctrlUnhealthy, whTotal, whFail := cache.UpstreamHealthSnapshot()
+		o.ObserveInt64(upstreamControllers, ctrlHealthy,
+			metric.WithAttributes(attribute.String("health", "healthy")))
+		o.ObserveInt64(upstreamControllers, ctrlUnhealthy,
+			metric.WithAttributes(attribute.String("health", "unhealthy")))
+		o.ObserveInt64(upstreamWebhooks, whTotal,
+			metric.WithAttributes(attribute.String("policy", "total")))
+		o.ObserveInt64(upstreamWebhooks, whFail,
+			metric.WithAttributes(attribute.String("policy", "fail")))
+
+		// --- dispatch L1 aggregate ---
+		l1Hit, l1Miss := dispatchers.DispatchL1LookupTotals()
+		o.ObserveInt64(dispatchL1, int64(l1Hit),
+			metric.WithAttributes(attribute.String("outcome", "hit")))
+		o.ObserveInt64(dispatchL1, int64(l1Miss),
+			metric.WithAttributes(attribute.String("outcome", "miss")))
+
+		// --- RAFullList serve outcomes + index drift canary ---
+		ra := cache.RAFullListServeSnapshot()
+		for outcome, v := range map[string]uint64{
+			"hit":            ra.Hit,
+			"repopulate":     ra.Repopulate,
+			"verified_slice": ra.VerifiedSlice,
+			"fallback":       ra.Fallback,
+		} {
+			o.ObserveInt64(raFullListServe, int64(v),
+				metric.WithAttributes(attribute.String("outcome", outcome)))
+		}
+		o.ObserveInt64(bindingsDeltaSkipped, int64(cache.BindingsIndexDeltaSkippedNonTyped()))
 		return nil
 	},
 		fallthroughTotal, assertionViolations, rbacPublishSeq, crdDiscovery,
 		registeredGVRs, prewarmDone, prewarmElapsed,
 		refreshPublished, refreshDelivered, refreshDropped, refreshCoalesced, refreshSubscribers,
 		memoHits, memoMisses, memoSwaps, memoRefused, memoDenyUncached, memoEntries,
+		prewarmEngEnqueued, prewarmEngProcessed, prewarmEngYield, prewarmEngPending,
+		phase1UnitsPlanned, phase1UnitsSeeded, phase1ApiRefPages, phase1EligibleNoContinue,
+		phase1WalkZeroChildren, phase1WalkObservations,
+		phase1SeedResolves, phase1SeedFailures, phase1SeedRBACDeny, phase1SeedOpFail,
+		refresher, refresherQueueDepth,
+		saDiscovery, crdSchemaMemo,
+		upstreamControllers, upstreamWebhooks,
+		dispatchL1, raFullListServe, bindingsDeltaSkipped,
 	)
 	return err
 }

--- a/internal/resolvers/crds/schema/otel_accessors.go
+++ b/internal/resolvers/crds/schema/otel_accessors.go
@@ -1,0 +1,18 @@
+// otel_accessors.go — exported, read-only accessor over the per-GVR
+// compiled-CRD-schema memo counters (package-private crdSchemaMemoStats),
+// so the internal/metrics OTLP mirror (a separate package) can observe the
+// SAME live snapshot the snowplow_crd_schema_memo_* expvar closures read.
+//
+// ADDITIVE: a pure read accessor. It changes no incrementer and leaves the
+// expvar surface untouched.
+
+package schema
+
+// CRDSchemaMemoSnapshot returns the compiled-CRD-schema memo counters,
+// mirroring snowplow_crd_schema_memo_hits_total / _misses_total /
+// _stale_dropped_total / _invalidations_total (Resets is published as
+// _invalidations_total). It is a four-atomic Load read on demand.
+func CRDSchemaMemoSnapshot() (hits, misses, staleDropped, invalidations uint64) {
+	s := crdSchemaMemoStats()
+	return s.Hits, s.Misses, s.StaleDropped, s.Resets
+}


### PR DESCRIPTION
## What

Snowplow exposes a large always-on metric surface via expvar at `GET /debug/vars` (dozens of `snowplow_*` keys), but only **18** of them were mirrored to OTLP in `internal/metrics/metrics.go` and thus reached ClickHouse. The rest never reached the observability stack.

This PR expands the OTLP mirror to cover the operationally-significant additional counter/gauge families. All new instruments are **observable** (async): the SAME single existing `RegisterCallback` reads the live snapshots at collection time — identical computed-on-read semantics to expvar, zero hot-path cost.

## Metric families added (+29 instruments / labelled series)

| Family | Instruments |
|---|---|
| **prewarm engine** | `snowplow_prewarm_engine_enqueued_total` / `_processed_total` / `_yield_total` / `_pending_depth` |
| **phase-1 pagination** | `snowplow_phase1_units_planned` / `_units_seeded` / `_apiref_pages_total` / `_eligible_no_continue_total` |
| **phase-1 boot walk** | `snowplow_phase1_walk_zero_children_total` / `_walk_observations_total` |
| **phase-1 seed** | `snowplow_phase1_bindingset_seed_resolves_total` / `_failures_total` / `_seed_rbac_deny_total` / `_seed_operational_fail_total` |
| **refresher pool** | `snowplow_refresher{stat=...}` (enqueue/completed/failed/retried/dropped/skipped_no_entry/skipped_no_handler/skipped_stage_error/yielded/capped/floored) + `snowplow_refresher_queue_depth` gauge |
| **SA-discovery** | `snowplow_sa_discovery{stat=builds/invalidations/fallbacks}` |
| **CRD-schema memo** | `snowplow_crd_schema_memo{stat=hits/misses/stale_dropped/invalidations}` |
| **upstream health** | `snowplow_upstream_controllers{health=healthy/unhealthy}` + `snowplow_upstream_webhooks{policy=total/fail}` (bounded aggregate gauges) |
| **dispatch L1** | `snowplow_dispatch_l1_lookups_total{outcome=hit/miss}` (cluster-wide aggregate) |
| **RAFullList** | `snowplow_ra_full_list_serve{outcome=hit/repopulate/verified_slice/fallback}` + `snowplow_bindings_by_gvr_delta_skipped_non_typed` (index-drift canary) |

## Deliberately left expvar-only

High-cardinality or diagnostic-only surfaces kept off OTLP to bound series cardinality (expvar remains the per-cell drill-down):
- `snowplow_phase1_walk_children` (per-root map)
- `snowplow_phase1_widget_seed_failure_total` / `_restaction_seed_failure_total` / `_cohort_seed_status` (per-(cohort,target) maps)
- `snowplow_ra_full_list_memo`, `snowplow_sliceability_reverify`
- the per-name `snowplow_upstream_controller_health` / `_webhook_failurepolicy` maps — OTLP gets aggregate healthy/unhealthy + total/fail counts instead of per-name cardinality; dispatch L1's per-(handlerKind,gvr) breakdown is likewise aggregated to two grand totals.

## How

Each value is read through the same accessor the expvar `.Func` uses. New **exported, read-only** accessors were added only where the snapshot helper was package-private:
- `cache.RefresherSnapshot`, `cache.UpstreamHealthSnapshot`
- `dispatchers.PrewarmEngineSnapshot` / `Phase1PaginationSnapshot` / `Phase1WalkSnapshot` / `Phase1SeedSnapshot` / `DispatchL1LookupTotals`
- `schema.CRDSchemaMemoSnapshot`

(`dynamic.SADiscoveryStatsSnapshot`, `cache.RAFullListServeSnapshot`, `cache.BindingsIndexDeltaSkippedNonTyped` were already exported.)

**expvar is untouched** — this is purely additive. Still gated by `OTEL_METRICS_ENABLED` (defaulting to `OTEL_ENABLED`); the **default-off path is byte-identical** — `Setup` registers nothing when the gate is off.

## Verify

`go build ./...`, `go vet ./...`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)