### PR TITLE
fix(refreshes): subscription key must normalize page/perPage to the emit default (#64)

### DIFF
--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -71,11 +71,38 @@ func paginationInfo(log *slog.Logger, req *http.Request) (perPage, page int) {
 		}
 	}
 
+	return normalizePagination(perPage, page)
+}
+
+// normalizePagination is the SINGLE normalization core for the cache-key
+// pagination fold, shared by the EMIT path (paginationInfo, from the /call
+// query) and the SUBSCRIPTION path (DeriveSubscriptionKey, from ?sub= coords)
+// so both stamp byte-identical (perPage, page) into ComputeKey.
+//
+// (#64 real root cause) A non-paginated /call sends no perPage/page query →
+// paginationInfo's -1,-1 default → the emit key folds "-1","-1". The frontend
+// subscription sends perPage:0/page:0 (or omits them → json zero) → 0,0. "-1"
+// != "0" → key mismatch → published + subscribers>=1 + delivered:0, for EVERY
+// class (the fold is class-independent). EXTRACTING the normalization (rather
+// than re-implementing it on the subscription side) is the fix: the drift
+// between two hand-written copies is exactly what caused the bug.
+//
+// Rules (mirrors the historical paginationInfo, the page=1 rule INCLUDED):
+//   - perPage <= 0  → -1 (non-paginated sentinel)
+//   - page    <= 0  → -1 (non-paginated sentinel)
+//   - perPage > 0 && page <= 0 → page = 1 (a paginated request with no/zero
+//     page means the first page; this rule MUST survive the extraction)
+func normalizePagination(perPage, page int) (int, int) {
+	if perPage <= 0 {
+		perPage = -1
+	}
+	if page <= 0 {
+		page = -1
+	}
 	if perPage > 0 && page <= 0 {
 		page = 1
 	}
-
-	return
+	return perPage, page
 }
 
 // checkDispatchRBAC is the cache=on permission gate (Revision 2

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -139,6 +139,18 @@ func subscriptionKeyExtras(ctx context.Context, c SubscriptionCoordinates) (map[
 }
 
 func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) (string, bool) {
+	// (#64 real root cause — page/perPage divergence) The EMIT /call path runs
+	// coords through paginationInfo → normalizePagination, so a non-paginated
+	// widget folds "-1","-1" into ComputeKey. The subscription receives
+	// coords.PerPage/Page from ?sub= as 0,0 (the frontend sends 0, or omits the
+	// fields → json zero). Without normalizing here, the sub key folds "0","0"
+	// ≠ the emit "-1","-1" → the armed key never matches the published one →
+	// delivered:0, for EVERY class (the fold is class-independent). Apply the
+	// SHARED normalization core (the same one paginationInfo calls — extracted,
+	// not re-implemented, so the two sides cannot drift) to ALL classes BEFORE
+	// the per-class derivation below.
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page)
+
 	switch coords.Class {
 	case cache.CacheEntryClassWidgetContent:
 		// Identity-free shared shell. The key is the same for every subject
@@ -201,5 +213,58 @@ func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) 
 	default:
 		// Unknown class — fail closed.
 		return "", false
+	}
+}
+
+// deriveSubscriptionKeyInputsForTest mirrors DeriveSubscriptionKey but returns
+// the PRE-HASH ResolvedKeyInputs (the 3rd value DeriveSubscriptionKey discards)
+// so the #64 golden can assert pre-hash-STRING equality against the emit-side
+// inputs field-by-field — STRONGER than digest equality and independent of the
+// (on-cluster-only) admin BindingUID. Test-only; production uses
+// DeriveSubscriptionKey. Mirrors the exact same normalization + per-class
+// branching so the inputs it returns are what DeriveSubscriptionKey hashes.
+func deriveSubscriptionKeyInputsForTest(ctx context.Context, coords SubscriptionCoordinates) (*cache.ResolvedKeyInputs, bool) {
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page)
+
+	switch coords.Class {
+	case cache.CacheEntryClassWidgetContent:
+		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
+		if !ok {
+			return nil, false
+		}
+		_, handle, inputs := dispatchWidgetContentKey(ctx,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
+		if handle == nil || inputs == nil {
+			return nil, false
+		}
+		return inputs, true
+
+	case classWidgets:
+		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
+		if !ok {
+			return nil, false
+		}
+		_, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
+		if handle == nil || inputs == nil {
+			return nil, false
+		}
+		return inputs, true
+
+	case classRestActions,
+		cache.CacheEntryClassApistage,
+		cache.CacheEntryClassRAFullList:
+		_, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
+			coords.Group, coords.Version, coords.Resource,
+			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
+		if handle == nil || inputs == nil {
+			return nil, false
+		}
+		return inputs, true
+
+	default:
+		return nil, false
 	}
 }

--- a/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
@@ -152,6 +152,11 @@ func TestFalsifier64_ARM1_WidgetsInlineExtrasUnion(t *testing.T) {
 	buildWidgetParityWatcher(t, true, inline)
 	ctx := ctxUserA()
 	coords := panelCoords(classWidgets, map[string]any{"name": "demo-vpc"})
+	// #64 pagination: the emit path normalizes page/perPage (paginationInfo →
+	// normalizePagination), and DeriveSubscriptionKey now does too. Mirror it on
+	// the hand-built emit keys below so this extras golden compares like-for-like
+	// (0,0 → -1,-1) instead of tripping on the pagination fold.
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page)
 
 	subKey, ok := DeriveSubscriptionKey(ctx, coords)
 	if !ok || subKey == "" {
@@ -201,6 +206,7 @@ func TestFalsifier64_ARM2_WidgetsNoInlineBackwardCompat(t *testing.T) {
 	buildWidgetParityWatcher(t, true, nil) // no inline block
 	ctx := ctxUserA()
 	coords := panelCoords(classWidgets, map[string]any{"name": "demo-vpc"})
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page) // #64 pagination parity
 
 	subKey, ok := DeriveSubscriptionKey(ctx, coords)
 	if !ok {
@@ -221,6 +227,7 @@ func TestFalsifier64_ARM3_WidgetContentInlineExtrasUnion(t *testing.T) {
 	buildWidgetParityWatcher(t, true, inline)
 	ctx := ctxUserA()
 	coords := panelCoords(cache.CacheEntryClassWidgetContent, map[string]any{"name": "demo-vpc"})
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page) // #64 pagination parity
 
 	subKey, ok := DeriveSubscriptionKey(ctx, coords)
 	if !ok || subKey == "" {
@@ -250,6 +257,7 @@ func TestFalsifier64_ARM4_RestActionsRequestOnlyUnchanged(t *testing.T) {
 	buildWidgetParityWatcher(t, true, inline)
 	ctx := ctxUserA()
 	coords := panelCoords(classRestActions, map[string]any{"name": "demo-vpc"})
+	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page) // #64 pagination parity
 
 	subKey, ok := DeriveSubscriptionKey(ctx, coords)
 	if !ok {

--- a/internal/handlers/dispatchers/refresh_subscription_pagination_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_pagination_test.go
@@ -1,0 +1,204 @@
+// refresh_subscription_pagination_test.go — #64 REAL root cause: the
+// subscription key must fold the SAME (perPage, page) the EMIT key folds, so a
+// non-paginated widget (emit default -1,-1) matches a subscription that sends
+// 0,0 (json zero / the frontend's ?sub= omits the fields).
+//
+// THE BUG (shipped 1.5.5–1.5.11): the EMIT /call runs page/perPage through
+// paginationInfo → normalizePagination → -1,-1 for a non-paginated widget;
+// DeriveSubscriptionKey folded the raw coords (0,0). "-1" != "0" → key mismatch
+// → published + subscribers>=1 + delivered:0, for EVERY class. The fix extracts
+// normalizePagination and applies it to the subscription coords too.
+//
+// DISCRIMINATOR DISCIPLINE (what masked it 3×): the EMIT key here is computed
+// from the REAL paginationInfo default — a *http.Request with NO page/perPage
+// query — NOT a hand-passed -1,-1 tuple. The SUB coords have PerPage/Page = 0,0
+// (the json-decoded ?sub= zero), NOT hand-set to -1. So the test fails iff the
+// two sides normalize differently, which is exactly the production gap.
+package dispatchers
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// emitKeyRealDefault computes the EMIT cache key the /call dispatcher would
+// stamp for a non-paginated widget: it runs the REAL paginationInfo over a
+// request with no page/perPage query (→ -1,-1, exactly as widgets.go does at
+// the genuine-Put), then folds that into dispatchCacheLookupKey. No tuple is
+// hand-passed — the -1,-1 comes from the production normalization.
+func emitKeyRealDefault(t *testing.T, ctx context.Context, coords SubscriptionCoordinates) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/call?resource=panels&apiVersion=widgets.templates.krateo.io/v1beta1", nil)
+	perPage, page := paginationInfo(slog.Default(), req) // NO page/perPage query → the real -1,-1 default
+	key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		perPage, page, coords.Extras)
+	if handle == nil || key == "" {
+		t.Fatalf("emit key derivation failed (handle=%v key=%q)", handle, key)
+	}
+	return key
+}
+
+// PAGINATION ARM 1 — the real-default discriminator. Non-paginated widget:
+// emit folds -1,-1 (real paginationInfo default); sub coords omit page/perPage
+// (0,0). DeriveSubscriptionKey must normalize 0,0 → -1,-1 and match the emit
+// key byte-for-byte. RED today (0,0 vs -1,-1), GREEN after the fix.
+func TestFalsifier64Pagination_NonPaginatedRealDefault(t *testing.T) {
+	buildWidgetParityWatcher(t, true, nil) // panel CR, no inline extras
+	ctx := ctxUserA()
+
+	// SUB coords: page/perPage OMITTED → Go zero values 0,0 (what ?sub= sends).
+	coords := panelCoords(classWidgets, nil)
+	if coords.PerPage != 0 || coords.Page != 0 {
+		t.Fatalf("setup: sub coords must be the json-zero 0,0 (got perPage=%d page=%d)", coords.PerPage, coords.Page)
+	}
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok || subKey == "" {
+		t.Fatalf("DeriveSubscriptionKey failed (ok=%v key=%q)", ok, subKey)
+	}
+
+	emitKey := emitKeyRealDefault(t, ctx, coords)
+
+	// Sanity: the emit default really is the non-paginated sentinel, not 0,0 —
+	// else the test can't discriminate. (A request with page/perPage=0,0 query
+	// would also normalize to -1,-1, but here we send NO query at all.)
+	emit0Key, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		0, 0, nil)
+	if emitKey == emit0Key {
+		t.Fatalf("pagination setup: emit -1,-1 default equals the raw 0,0 key — ComputeKey is not "+
+			"distinguishing the pagination fold, so this test can't discriminate the bug")
+	}
+
+	if subKey != emitKey {
+		t.Fatalf("PAGINATION ARM1 RED: sub key %q != emit key %q. The subscription coords (0,0) must be "+
+			"normalized through the SAME normalizePagination the emit path uses (→ -1,-1) — else a "+
+			"non-paginated widget's armed key never matches its published cell (the 1.5.5–1.5.11 delivered:0).",
+			subKey, emitKey)
+	}
+}
+
+// PAGINATION ARM 1b — PRE-HASH STRING EQUALITY (the team-lead hard gate,
+// stronger than digest equality + independent of the on-cluster admin
+// BindingUID). Capture the EMIT-side ResolvedKeyInputs (from the real
+// paginationInfo default) and the SUB-side ResolvedKeyInputs (from the
+// json-zero coords) and assert EVERY hashed field is byte-identical — class,
+// GVR, ns, name, BindingUID, PerPage, Page, Stage, and canonicalised Extras.
+// This is the empirical proof the prior 4 cycles lacked: the two ComputeKey
+// INPUTS are equal field-for-field, so the digests must be equal regardless of
+// the (matched-both-sides) BindingUID.
+func TestFalsifier64Pagination_PreHashInputEquality(t *testing.T) {
+	buildWidgetParityWatcher(t, true, nil)
+	ctx := ctxUserA()
+	coords := panelCoords(classWidgets, nil) // json-zero 0,0 sub
+
+	subIn, ok := deriveSubscriptionKeyInputsForTest(ctx, coords)
+	if !ok || subIn == nil {
+		t.Fatalf("sub inputs derivation failed (ok=%v)", ok)
+	}
+
+	// EMIT inputs via the REAL paginationInfo default (no page/perPage query).
+	req := httptest.NewRequest("GET", "/call?resource=panels&apiVersion=widgets.templates.krateo.io/v1beta1", nil)
+	pp, pg := paginationInfo(slog.Default(), req)
+	_, _, emitIn := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		pp, pg, coords.Extras)
+	if emitIn == nil {
+		t.Fatalf("emit inputs nil")
+	}
+
+	// Field-by-field pre-hash equality (every field ComputeKey folds).
+	if subIn.CacheEntryClass != emitIn.CacheEntryClass {
+		t.Fatalf("class: sub %q != emit %q", subIn.CacheEntryClass, emitIn.CacheEntryClass)
+	}
+	if subIn.Group != emitIn.Group || subIn.Version != emitIn.Version || subIn.Resource != emitIn.Resource {
+		t.Fatalf("GVR: sub %s/%s/%s != emit %s/%s/%s", subIn.Group, subIn.Version, subIn.Resource, emitIn.Group, emitIn.Version, emitIn.Resource)
+	}
+	if subIn.Namespace != emitIn.Namespace || subIn.Name != emitIn.Name {
+		t.Fatalf("ns/name: sub %s/%s != emit %s/%s", subIn.Namespace, subIn.Name, emitIn.Namespace, emitIn.Name)
+	}
+	if subIn.BindingUID != emitIn.BindingUID {
+		t.Fatalf("BindingUID: sub %q != emit %q", subIn.BindingUID, emitIn.BindingUID)
+	}
+	if subIn.PerPage != emitIn.PerPage || subIn.Page != emitIn.Page {
+		t.Fatalf("PRE-HASH PAGINATION DIVERGENCE: sub perPage/page %d/%d != emit %d/%d — the #64 bug. The "+
+			"subscription coords must normalize through the SAME normalizePagination the emit path uses.",
+			subIn.PerPage, subIn.Page, emitIn.PerPage, emitIn.Page)
+	}
+	if subIn.Stage != emitIn.Stage {
+		t.Fatalf("Stage: sub %q != emit %q", subIn.Stage, emitIn.Stage)
+	}
+	// And the digests must therefore be equal (the absolute on-cluster digest
+	// vs the frontend header needs the real admin BindingUID; here both sides
+	// derive the SAME test BindingUID, so digest-equality follows from
+	// field-equality and is the hermetic proof).
+	if cache.ComputeKey(*subIn) != cache.ComputeKey(*emitIn) {
+		t.Fatalf("digests differ despite field-equal inputs — ComputeKey non-determinism?")
+	}
+}
+
+// PAGINATION ARM 2 — paginated, no regression. A real paginated /call
+// (perPage=20&page=2) and a sub sending the same 20,2 must still match.
+func TestFalsifier64Pagination_PaginatedNoRegression(t *testing.T) {
+	buildWidgetParityWatcher(t, true, nil)
+	ctx := ctxUserA()
+
+	coords := panelCoords(classWidgets, nil)
+	coords.PerPage = 20
+	coords.Page = 2
+
+	subKey, ok := DeriveSubscriptionKey(ctx, coords)
+	if !ok {
+		t.Fatalf("DeriveSubscriptionKey(paginated) failed")
+	}
+
+	// Emit from the REAL paginationInfo over a 20/2 query.
+	req := httptest.NewRequest("GET", "/call?resource=panels&apiVersion=widgets.templates.krateo.io/v1beta1&perPage=20&page=2", nil)
+	pp, pg := paginationInfo(slog.Default(), req)
+	if pp != 20 || pg != 2 {
+		t.Fatalf("setup: paginationInfo(20,2) returned %d,%d", pp, pg)
+	}
+	emitKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
+		pp, pg, nil)
+
+	if subKey != emitKey {
+		t.Fatalf("PAGINATION ARM2: paginated sub key %q != emit key %q — pagination regression", subKey, emitKey)
+	}
+}
+
+// PAGINATION ARM 3 — per-class: widgetContent + restactions also normalize
+// (the fold is class-independent). Both must match the emit -1,-1 default from
+// a 0,0 sub. RED today / GREEN after.
+func TestFalsifier64Pagination_PerClassNormalize(t *testing.T) {
+	buildWidgetParityWatcher(t, true, nil)
+	ctx := ctxUserA()
+
+	for _, class := range []string{cache.CacheEntryClassWidgetContent, classRestActions} {
+		coords := panelCoords(class, nil) // 0,0 sub
+		subKey, ok := DeriveSubscriptionKey(ctx, coords)
+		if !ok || subKey == "" {
+			t.Fatalf("class %s: DeriveSubscriptionKey failed (ok=%v)", class, ok)
+		}
+		// Emit -1,-1 default for the same class.
+		req := httptest.NewRequest("GET", "/call?resource=panels&apiVersion=widgets.templates.krateo.io/v1beta1", nil)
+		pp, pg := paginationInfo(slog.Default(), req)
+		var emitKey string
+		if class == cache.CacheEntryClassWidgetContent {
+			emitKey, _, _ = dispatchWidgetContentKey(ctx,
+				coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, coords.Extras)
+		} else {
+			emitKey, _, _ = dispatchCacheLookupKey(ctx, class,
+				coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, coords.Extras)
+		}
+		if subKey != emitKey {
+			t.Fatalf("PAGINATION ARM3 class %s RED: sub key %q != emit -1,-1 key %q (per-class normalization missing)",
+				class, subKey, emitKey)
+		}
+	}
+}


### PR DESCRIPTION
REAL #64 root cause (3rd→correct): emit /call folds paginationInfo's -1,-1 non-paginated default; subscription folded raw 0,0 (doc-contract/absent) → ComputeKey digest diverges on page/perPage → published+subscribers≥1+delivered:0 across 1.5.5-1.5.11. Class-independent, extras-orthogonal. Fix: EXTRACT paginationInfo's normalization into shared normalizePagination() that BOTH paginationInfo (emit) AND DeriveSubscriptionKey (sub, all classes) call — can't drift. Arch pre-hash field-by-field diff proved page/perPage the COMPLETE divergence; hermetic pre-hash-equality golden (real-emit-default path) RED-proven. Dual-gate GREEN (arch PASS + PM ACCEPT, RED re-verified). Absolute digest match = on-cluster frontend delivered>0. Follow-up: #seam-shadow refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)