### PR TITLE
hardening(refreshes): 1.5.14 — sub-key invariant + warmup idle-stream + /debug auth + seam de-shadow + doc (frontend asks #1-4 + #66)

### DIFF
--- a/docs/howto-frontend-live-refresh-sse.md
+++ b/docs/howto-frontend-live-refresh-sse.md
@@ -226,6 +226,17 @@ class RefreshManager {
 - **Reconnect** is automatic (native `EventSource`); on reconnect it re-sends the
   same `?sub=`, so no extra handling — just rebuild `sub` when the widget set
   changes.
+- **Fires on CONTENT CHANGE, not on every reconcile.** A `refresh` event is
+  emitted only when the widget's *resolved rendered output* actually changes —
+  not on every Kubernetes reconcile of the underlying resource. A resource that
+  reconciles repeatedly but produces **stable output** (e.g. a stuck or erroring
+  composition whose status keeps re-writing to the same values) will **never**
+  publish a refresh. This is by design (it avoids spurious refetches), but it
+  confounds a naive test: *"I watched a failing composition and got nothing"* is
+  expected, not a bug. **When testing, pick a target whose rendered content
+  actually changes** (e.g. scale a deployment, edit a value the widget displays)
+  — and use `/debug/refreshes` (`published` climbing) to confirm the server is
+  emitting at all.
 
 ---
 

--- a/internal/cache/rbac_snapshot.go
+++ b/internal/cache/rbac_snapshot.go
@@ -988,6 +988,14 @@ func PublishRBACSnapshotForTest(s *RBACSnapshot) {
 	rbacSnap.Store(s)
 }
 
+// BumpRBACGenForTest increments rbacSnapshotPublishSeq so RBACGen() reports a
+// published snapshot (>0), letting a handler test simulate the WARM readiness
+// state (#68: refreshWarmupIncomplete keys on RBACGen()==0 as one warmup
+// disjunct). Production bumps this only via rebuildRBACSnapshot's publish.
+// ResetRBACGenForTest restores it to 0 (the pre-readiness state).
+func BumpRBACGenForTest()  { rbacSnapshotPublishSeq.Add(1) }
+func ResetRBACGenForTest() { rbacSnapshotPublishSeq.Store(0) }
+
 // RebuildSubjectIndexesForTest exposes the unexported
 // rebuildSubjectIndexes for tests that hand-build snapshots and need
 // to populate the CRBsBy*/RBsBy* subject-index maps (which the rbac

--- a/internal/handlers/debug_refreshes_auth_test.go
+++ b/internal/handlers/debug_refreshes_auth_test.go
@@ -1,0 +1,77 @@
+// debug_refreshes_auth_test.go — #69: /debug/refreshes is auth-gated for prod.
+// The aggregate diagnostic must 401 a bare (unauthenticated) request and serve
+// the counters only to a valid cookie-or-header JWT — the SAME RefreshAuth gate
+// /refreshes uses. The body stays aggregate-only (structurally leak-safe); the
+// gate is defence-in-depth so the diagnostic is not world-readable in prod.
+//
+// Hermetic: httptest + the shared test signing key. NO apiserver.
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
+)
+
+// debugRefreshesServer wires the PRODUCTION gate (RefreshAuth → DebugRefreshes)
+// on a test server, mirroring the main.go mount exactly.
+func debugRefreshesServer(t *testing.T) string {
+	t.Helper()
+	h := middleware.RefreshAuth(refreshTestSignKey)(DebugRefreshes())
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// #69 ARM 1 — bare unauthenticated GET → 401 (the prod hardening: not
+// world-readable).
+func TestDebugRefreshes_Auth_BareRequest401(t *testing.T) {
+	base := debugRefreshesServer(t)
+	resp, err := http.Get(base)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bare /debug/refreshes: status=%d want 401 — the endpoint must be auth-gated in prod "+
+			"(was world-readable before #69)", resp.StatusCode)
+	}
+}
+
+// #69 ARM 2 — header JWT → 200 + the aggregate body (the diagnostic still works
+// for an authenticated operator).
+func TestDebugRefreshes_Auth_HeaderToken200(t *testing.T) {
+	base := debugRefreshesServer(t)
+	req, _ := http.NewRequest(http.MethodGet, base, nil)
+	req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authed /debug/refreshes: status=%d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("authed /debug/refreshes: Content-Type=%q want application/json", ct)
+	}
+}
+
+// #69 ARM 3 — cookie JWT → 200 (the browser EventSource path also reaches the
+// diagnostic).
+func TestDebugRefreshes_Auth_CookieToken200(t *testing.T) {
+	t.Setenv("REFRESH_SESSION_COOKIE", "krateo-session")
+	base := debugRefreshesServer(t)
+	req, _ := http.NewRequest(http.MethodGet, base, nil)
+	req.AddCookie(&http.Cookie{Name: "krateo-session", Value: mintToken(t, "userA")})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("cookie-authed /debug/refreshes: status=%d want 200", resp.StatusCode)
+	}
+}

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -139,16 +139,30 @@ func subscriptionKeyExtras(ctx context.Context, c SubscriptionCoordinates) (map[
 }
 
 func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) (string, bool) {
-	// (#64 real root cause — page/perPage divergence) The EMIT /call path runs
-	// coords through paginationInfo → normalizePagination, so a non-paginated
-	// widget folds "-1","-1" into ComputeKey. The subscription receives
-	// coords.PerPage/Page from ?sub= as 0,0 (the frontend sends 0, or omits the
-	// fields → json zero). Without normalizing here, the sub key folds "0","0"
-	// ≠ the emit "-1","-1" → the armed key never matches the published one →
-	// delivered:0, for EVERY class (the fold is class-independent). Apply the
-	// SHARED normalization core (the same one paginationInfo calls — extracted,
-	// not re-implemented, so the two sides cannot drift) to ALL classes BEFORE
-	// the per-class derivation below.
+	key, _, ok := deriveSubscription(ctx, coords)
+	return key, ok
+}
+
+// deriveSubscription is the SINGLE key-derivation body for /refreshes. It
+// returns BOTH the cache key string AND the pre-hash *cache.ResolvedKeyInputs
+// so the prod path (DeriveSubscriptionKey → key) and the test pre-hash
+// assertion (deriveSubscriptionKeyInputsForTest → inputs) share ONE
+// implementation and cannot drift (#66 — eliminates the parallel-copy shadow
+// that was the same drift class as the #64 root cause itself; see the
+// /refreshes saga regression journal). There is no dead prod code: the
+// dispatch*Key helpers ALREADY compute and return the inputs; we now keep them
+// instead of discarding the third value.
+//
+// (#64 real root cause — page/perPage divergence) The EMIT /call path runs
+// coords through paginationInfo → normalizePagination, so a non-paginated
+// widget folds "-1","-1" into ComputeKey. The subscription receives
+// coords.PerPage/Page from ?sub= as 0,0 (the frontend sends 0, or omits the
+// fields → json zero). Without normalizing here, the sub key folds "0","0" ≠
+// the emit "-1","-1" → the armed key never matches the published one →
+// delivered:0, for EVERY class. Apply the SHARED normalization core (the same
+// one paginationInfo calls — extracted, not re-implemented, so the two sides
+// cannot drift) to ALL classes BEFORE the per-class derivation below.
+func deriveSubscription(ctx context.Context, coords SubscriptionCoordinates) (string, *cache.ResolvedKeyInputs, bool) {
 	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page)
 
 	switch coords.Class {
@@ -164,15 +178,15 @@ func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) 
 		// in place of the request-only coords.Extras.
 		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
 		if !ok {
-			return "", false
+			return "", nil, false
 		}
-		key, handle, _ := dispatchWidgetContentKey(ctx,
+		key, handle, inputs := dispatchWidgetContentKey(ctx,
 			coords.Group, coords.Version, coords.Resource,
 			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
 		if handle == nil || key == "" {
-			return "", false
+			return "", nil, false
 		}
-		return key, true
+		return key, inputs, true
 
 	case classWidgets:
 		// Identity-bound widget. #64: same inline-extras union as widgetContent
@@ -181,15 +195,15 @@ func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) 
 		// armed key never matches the published one for an inline-extras widget.
 		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
 		if !ok {
-			return "", false
+			return "", nil, false
 		}
-		key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
+		key, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
 			coords.Group, coords.Version, coords.Resource,
 			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
 		if handle == nil || key == "" {
-			return "", false
+			return "", nil, false
 		}
-		return key, true
+		return key, inputs, true
 
 	case classRestActions,
 		cache.CacheEntryClassApistage,
@@ -202,69 +216,26 @@ func DeriveSubscriptionKey(ctx context.Context, coords SubscriptionCoordinates) 
 		// widgets — a RESTAction/apistage/raFullList cell's emit key folds only
 		// the request extras), so raw coords.Extras is request-only parity on
 		// BOTH sides. UNCHANGED.
-		key, handle, _ := dispatchCacheLookupKey(ctx, coords.Class,
+		key, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
 			coords.Group, coords.Version, coords.Resource,
 			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
 		if handle == nil || key == "" {
-			return "", false
+			return "", nil, false
 		}
-		return key, true
+		return key, inputs, true
 
 	default:
 		// Unknown class — fail closed.
-		return "", false
+		return "", nil, false
 	}
 }
 
-// deriveSubscriptionKeyInputsForTest mirrors DeriveSubscriptionKey but returns
-// the PRE-HASH ResolvedKeyInputs (the 3rd value DeriveSubscriptionKey discards)
-// so the #64 golden can assert pre-hash-STRING equality against the emit-side
-// inputs field-by-field — STRONGER than digest equality and independent of the
-// (on-cluster-only) admin BindingUID. Test-only; production uses
-// DeriveSubscriptionKey. Mirrors the exact same normalization + per-class
-// branching so the inputs it returns are what DeriveSubscriptionKey hashes.
+// deriveSubscriptionKeyInputsForTest returns the PRE-HASH ResolvedKeyInputs the
+// REAL DeriveSubscriptionKey path computes (#66: now a thin accessor over the
+// SHARED deriveSubscription body — NOT a mirror, so the pre-hash golden
+// exercises the production derivation and cannot test a stale shadow).
+// Test-only.
 func deriveSubscriptionKeyInputsForTest(ctx context.Context, coords SubscriptionCoordinates) (*cache.ResolvedKeyInputs, bool) {
-	coords.PerPage, coords.Page = normalizePagination(coords.PerPage, coords.Page)
-
-	switch coords.Class {
-	case cache.CacheEntryClassWidgetContent:
-		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
-		if !ok {
-			return nil, false
-		}
-		_, handle, inputs := dispatchWidgetContentKey(ctx,
-			coords.Group, coords.Version, coords.Resource,
-			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
-		if handle == nil || inputs == nil {
-			return nil, false
-		}
-		return inputs, true
-
-	case classWidgets:
-		keyExtras, ok := subscriptionKeyExtras(ctx, coords)
-		if !ok {
-			return nil, false
-		}
-		_, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
-			coords.Group, coords.Version, coords.Resource,
-			coords.Namespace, coords.Name, coords.PerPage, coords.Page, keyExtras)
-		if handle == nil || inputs == nil {
-			return nil, false
-		}
-		return inputs, true
-
-	case classRestActions,
-		cache.CacheEntryClassApistage,
-		cache.CacheEntryClassRAFullList:
-		_, handle, inputs := dispatchCacheLookupKey(ctx, coords.Class,
-			coords.Group, coords.Version, coords.Resource,
-			coords.Namespace, coords.Name, coords.PerPage, coords.Page, coords.Extras)
-		if handle == nil || inputs == nil {
-			return nil, false
-		}
-		return inputs, true
-
-	default:
-		return nil, false
-	}
+	_, inputs, ok := deriveSubscription(ctx, coords)
+	return inputs, ok
 }

--- a/internal/handlers/dispatchers/refresh_subscription_invariant_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_invariant_test.go
@@ -1,0 +1,181 @@
+// refresh_subscription_invariant_test.go — #67 (frontend's TOP ask): the
+// standing per-class subscription-key invariant. For coords as the frontend
+// would send them from a /call response, DeriveSubscriptionKey(coords) MUST
+// equal the EMIT cache key ComputeKey(call) — PER CLASS (widgets /
+// widgetContent / restactions), over REAL widget shapes (the
+// descriptions-composition-detail-metadata shape: apiRef-based, NO inline
+// extras) and the REAL emit-default pagination path (paginationInfo, NEVER a
+// hand-set tuple).
+//
+// This codifies the forgery-proof design's load-bearing equality — the one
+// that broke SILENTLY across 1.5.5–1.5.11 (the whole /refreshes saga). It is
+// the guard that would have caught EVERY broken build pre-deploy, hermetically.
+//
+// Built on the #66 shared-seam refactor: it exercises the REAL
+// deriveSubscription body (via DeriveSubscriptionKey + the pre-hash accessor),
+// not a mirror — so it cannot pass against a stale shadow.
+//
+// THE SAGA LESSON, codified: the EMIT side is computed from the REAL paths —
+// paginationInfo's default (no page/perPage query) for pagination, and the
+// SAME unionForKey(GetApiRefExtras, GetResourcesRefsExtras, request) the
+// widgets.go genuine-Put folds for extras. The SUB side is the production
+// DeriveSubscriptionKey over coords shaped as the frontend's ?sub= sends them
+// (page/perPage OMITTED → 0,0). They must be byte-identical for every class.
+package dispatchers
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+)
+
+// emitInputsForClass computes the EMIT-side ResolvedKeyInputs the /call
+// dispatcher would Put for the given class + coords, using ONLY production
+// paths: paginationInfo's real default (no page/perPage query) and, for the
+// widget classes, the SAME inline-extras union widgets.go folds. No hand-set
+// tuple, no constructed extras — the real emit shape.
+func emitInputsForClass(t *testing.T, ctx context.Context, class string, coords SubscriptionCoordinates) *cache.ResolvedKeyInputs {
+	t.Helper()
+	// Drive the REAL paginationInfo over a /call shaped like the frontend's:
+	// NO page/perPage query for the non-paginated case (→ -1,-1 default), or
+	// the explicit query for the paginated case (→ the frontend's 20,2). NEVER
+	// a hand-passed tuple — the emit pagination comes from paginationInfo.
+	url := "/call?resource=" + coords.Resource + "&apiVersion=" + coords.Group + "/" + coords.Version
+	if coords.PerPage > 0 {
+		url += "&perPage=" + strconv.Itoa(coords.PerPage) + "&page=" + strconv.Itoa(coords.Page)
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	pp, pg := paginationInfo(slog.Default(), req)
+
+	switch class {
+	case classWidgets, cache.CacheEntryClassWidgetContent:
+		// Fold the SAME union the widgets.go genuine-Put folds, from the REAL CR.
+		got := objects.Get(ctx, templatesv1.ObjectReference{
+			Reference:  templatesv1.Reference{Name: coords.Name, Namespace: coords.Namespace},
+			APIVersion: coords.Group + "/" + coords.Version,
+			Resource:   coords.Resource,
+		})
+		if got.Err != nil || got.Unstructured == nil {
+			t.Fatalf("emit setup: objects.Get(%s/%s) failed: %v", coords.Namespace, coords.Name, got.Err)
+		}
+		emitExtras := unionForKey(
+			widgets.GetApiRefExtras(got.Unstructured.Object),
+			widgets.GetResourcesRefsExtras(got.Unstructured.Object),
+			coords.Extras)
+		var inputs *cache.ResolvedKeyInputs
+		if class == cache.CacheEntryClassWidgetContent {
+			_, _, inputs = dispatchWidgetContentKey(ctx,
+				coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, emitExtras)
+		} else {
+			_, _, inputs = dispatchCacheLookupKey(ctx, class,
+				coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, emitExtras)
+		}
+		return inputs
+
+	default: // restactions / apistage / raFullList — request-only extras.
+		_, _, inputs := dispatchCacheLookupKey(ctx, class,
+			coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, coords.Extras)
+		return inputs
+	}
+}
+
+// TestFalsifier67_SubscriptionKeyInvariant_PerClass — the standing invariant,
+// over REPRESENTATIVE REAL widget shapes × the three subscribable classes (the
+// arch's HARD constraint against re-creating the masking): a no-inline-extras
+// detail widget (the descriptions-composition-detail-metadata shape that
+// diverged silently for 6 builds), an inline-extras widget, and a paginated
+// request. For each, the SUBSCRIPTION key (production DeriveSubscriptionKey
+// over frontend-shaped coords) MUST equal the EMIT key (real paginationInfo
+// default + real fetched-CR extras union), with field-by-field pre-hash
+// equality as the stronger BindingUID-independent proof.
+func TestFalsifier67_SubscriptionKeyInvariant_PerClass(t *testing.T) {
+	shapes := []struct {
+		name              string
+		inlineApiRefExtra map[string]any // nil → no-inline detail shape
+		perPage, page     int            // 0,0 → frontend non-paginated; >0 → paginated
+	}{
+		{name: "no-inline-detail", inlineApiRefExtra: nil, perPage: 0, page: 0},
+		{name: "inline-extras", inlineApiRefExtra: map[string]any{"region": "eu"}, perPage: 0, page: 0},
+		{name: "paginated", inlineApiRefExtra: nil, perPage: 20, page: 2},
+	}
+	classes := []string{classWidgets, cache.CacheEntryClassWidgetContent, classRestActions}
+
+	for _, sh := range shapes {
+		sh := sh
+		t.Run(sh.name, func(t *testing.T) {
+			// Seed the REAL widget CR for this shape (apiRef-based; inline extras
+			// only when the shape declares them). The emit side reads this exact
+			// CR — never a hand-constructed parallel.
+			buildWidgetParityWatcher(t, true, sh.inlineApiRefExtra)
+			ctx := ctxUserA()
+
+			for _, class := range classes {
+				t.Run(class, func(t *testing.T) {
+					coords := panelCoords(class, nil)
+					coords.PerPage = sh.perPage // frontend sends these verbatim; 0,0 for non-paginated
+					coords.Page = sh.page
+
+					subKey, ok := DeriveSubscriptionKey(ctx, coords)
+					if !ok || subKey == "" {
+						t.Fatalf("%s/%s: DeriveSubscriptionKey failed (ok=%v)", sh.name, class, ok)
+					}
+					subIn, okIn := deriveSubscriptionKeyInputsForTest(ctx, coords)
+					if !okIn || subIn == nil {
+						t.Fatalf("%s/%s: sub inputs failed", sh.name, class)
+					}
+
+					emitIn := emitInputsForClass(t, ctx, class, coords)
+					if emitIn == nil {
+						t.Fatalf("%s/%s: emit inputs nil", sh.name, class)
+					}
+
+					// THE INVARIANT: digest equality (what the broadcaster matches on).
+					if got := cache.ComputeKey(*emitIn); subKey != got {
+						t.Fatalf("%s/%s INVARIANT BROKEN: DeriveSubscriptionKey %q != emit ComputeKey %q — the "+
+							"armed key would never match the published key (the 1.5.5–1.5.11 zero-delivery class).",
+							sh.name, class, subKey, got)
+					}
+					// Field-by-field pre-hash equality (the stronger proof; names
+					// the diverging field if it ever regresses).
+					assertKeyInputsFieldEqual(t, sh.name+"/"+class, subIn, emitIn)
+				})
+			}
+		})
+	}
+}
+
+// assertKeyInputsFieldEqual checks every ComputeKey-folded field of two
+// ResolvedKeyInputs is equal (RepresentativeUsername/Groups are excluded from
+// the hash, so excluded here). On mismatch it names the diverging field — the
+// pre-hash input-string diff the saga prescribes as prevention.
+func assertKeyInputsFieldEqual(t *testing.T, class string, a, b *cache.ResolvedKeyInputs) {
+	t.Helper()
+	if a.CacheEntryClass != b.CacheEntryClass {
+		t.Fatalf("%s field CacheEntryClass: %q != %q", class, a.CacheEntryClass, b.CacheEntryClass)
+	}
+	if a.Group != b.Group || a.Version != b.Version || a.Resource != b.Resource {
+		t.Fatalf("%s field GVR: %s/%s/%s != %s/%s/%s", class, a.Group, a.Version, a.Resource, b.Group, b.Version, b.Resource)
+	}
+	if a.Namespace != b.Namespace || a.Name != b.Name {
+		t.Fatalf("%s field ns/name: %s/%s != %s/%s", class, a.Namespace, a.Name, b.Namespace, b.Name)
+	}
+	if a.BindingUID != b.BindingUID {
+		t.Fatalf("%s field BindingUID: %q != %q", class, a.BindingUID, b.BindingUID)
+	}
+	if a.PerPage != b.PerPage || a.Page != b.Page {
+		t.Fatalf("%s field pagination: %d/%d != %d/%d (the #64 page/perPage divergence class)", class, a.PerPage, a.Page, b.PerPage, b.Page)
+	}
+	if a.Stage != b.Stage {
+		t.Fatalf("%s field Stage: %q != %q", class, a.Stage, b.Stage)
+	}
+	if cache.ComputeKey(*a) != cache.ComputeKey(*b) {
+		t.Fatalf("%s: digests differ despite field-equal scalars — Extras canonicalisation divergence?", class)
+	}
+}

--- a/internal/handlers/refreshes.go
+++ b/internal/handlers/refreshes.go
@@ -103,6 +103,22 @@ func Refreshes(signingKey string) http.HandlerFunc {
 			return
 		}
 		if len(armed) == 0 {
+			// #68: distinguish a TRANSIENT empty (the post-redeploy warmup
+			// window — informer/RBAC snapshot not yet synced, so
+			// DeriveSubscriptionKey skips every coord) from a GENUINELY empty
+			// one (warm, but all coords NotFound / RBAC-denied — the blessed
+			// C64-1 honest-400). During warmup, serve the documented idle
+			// stream (keepalives only; the browser stays connected and starts
+			// delivering once warm) instead of a 400 the frontend must back off
+			// from. The gate keys STRICTLY on warmup readiness
+			// (refreshWarmupIncomplete = !IsPhase1Done || RBACGen==0), NOT on
+			// the armed count or WHY coords were skipped — so a warm
+			// all-NotFound/all-denied subscription still gets the correct 400
+			// (the divert cannot mask "armed nothing valid" once warm).
+			if refreshWarmupIncomplete() {
+				serveIdleSSE(wri, req)
+				return
+			}
 			http.Error(wri, "no valid subscription keys", http.StatusBadRequest)
 			return
 		}
@@ -159,6 +175,27 @@ func Refreshes(signingKey string) http.HandlerFunc {
 			}
 		}
 	}
+}
+
+// refreshWarmupIncomplete reports whether the pod is still in its post-(re)deploy
+// warmup window — the ~4-min span where the informer/RBAC substrate is not yet
+// synced, so DeriveSubscriptionKey legitimately skips every coord (#68). It is
+// the disjunction of the two readiness gates already used elsewhere:
+//   - !cache.IsPhase1Done() — the Tag-B startup warmup gate (the /readyz signal,
+//     phase1.go); false until the prewarm walk completes.
+//   - cache.RBACGen() == 0 — no RBAC snapshot published yet (rbac_snapshot.go);
+//     EvaluateRBAC fails closed until the first publish, so every identity-bound
+//     coord derives the empty/denied key pre-publish.
+// BOTH disjuncts are required: phase1 can complete while the RBAC snapshot is
+// momentarily unpublished (and vice-versa) — either alone leaves
+// DeriveSubscriptionKey unable to produce a real armed key.
+//
+// It deliberately does NOT consult the armed count or the skip reason — so a
+// WARM pod (both gates satisfied) with a genuinely-empty/all-denied
+// subscription still falls through to the honest 400 (C64-1), not the idle
+// stream. The divert is STRICTLY warmup-gated by construction.
+func refreshWarmupIncomplete() bool {
+	return !cache.IsPhase1Done() || cache.RBACGen() == 0
 }
 
 // serveIdleSSE serves a heartbeat-only SSE stream for the disabled / cache-off

--- a/internal/handlers/refreshes_test.go
+++ b/internal/handlers/refreshes_test.go
@@ -306,6 +306,15 @@ func TestRefreshes_Validation_Rejections(t *testing.T) {
 func TestRefreshes_Validation_AllForeignKeysRejected(t *testing.T) {
 	t.Setenv("CACHE_ENABLED", "true")
 	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	// #68: this asserts the WARM-pod honest-400 for unarmable (unknown-class)
+	// keys. Mark the pod warm (both gates: phase1 done + RBAC published) so the
+	// new warmup-divert does NOT serve an idle stream — the divert is for the
+	// transient warmup window only, not for a warm pod with genuinely-empty
+	// subscriptions (C64-1 honest-400 must survive).
+	cache.MarkPhase1Done()
+	cache.BumpRBACGenForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+	t.Cleanup(cache.ResetRBACGenForTest)
 	base := refreshServer(t)
 	tok := mintToken(t, "userA")
 

--- a/internal/handlers/refreshes_warmup_test.go
+++ b/internal/handlers/refreshes_warmup_test.go
@@ -1,0 +1,187 @@
+// refreshes_warmup_test.go — #68: during the post-(re)deploy warmup window,
+// /refreshes serves the documented idle stream (keepalives) instead of a hard
+// 400, but a WARM pod with a genuinely-empty/all-denied subscription still
+// gets the blessed C64-1 honest-400. The divert is STRICTLY warmup-gated
+// (refreshWarmupIncomplete = !IsPhase1Done || RBACGen==0) — it keys on
+// readiness, never on the armed count or skip reason.
+//
+// 4 arms (C68-1 real predicate, C68-2 warm+NotFound stays 400):
+//   ARM A — warmup-incomplete + a would-derive coord → 200 idle stream
+//           (RED 400 today / GREEN after). REAL predicate: ResetPhase1DoneForTest.
+//   ARM B — WARM + RBAC-denied coord → armed==0 → 400 (GREEN before AND after).
+//           Asserts the WARM predicate explicitly so it can't pass via warmup.
+//   ARM C — WARM + valid coord → 200 streaming (armed>=1).
+//   ARM D — WARM + genuinely-NotFound coord → armed==0 → 400 (proves the divert
+//           is warmup-gated, NOT armed-count-gated — the C64-1 honest fail).
+//
+// Hermetic: httptest + the seeded cache.Global() (seedAuthTestWidget) + the
+// MarkPhase1Done / ResetPhase1DoneForTest / RBAC-publish seams. NO apiserver.
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// mintTokenOutsider mints a JWT for a user in a group the seed does NOT grant
+// (seedAuthTestWidget binds the "devs" group only). mintToken hardcodes
+// Groups=["devs"], so every user it mints IS authorized — useless for the
+// RBAC-denied arm. This one puts the user in "outsiders" → genuinely denied.
+func mintTokenOutsider(t *testing.T, username string) string {
+	t.Helper()
+	tok, err := jwtutil.CreateToken(jwtutil.CreateTokenOptions{
+		Username:   username,
+		Groups:     []string{"outsiders"},
+		Duration:   time.Hour,
+		SigningKey: refreshTestSignKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	return tok
+}
+
+// subParamFor builds a ?sub= value for one IDENTITY-BOUND widgets coord on the
+// given panel name (page/perPage omitted → 0,0, frontend-shaped). The widgets
+// class folds the BindingUID, so an unauthorized user / a NotFound CR derives
+// an empty/denied key → skipped → armed==0 (the warm-empty cases ARM B/D need).
+func subParamFor(t *testing.T, name string) string {
+	t.Helper()
+	body := []map[string]any{{
+		"class":     "widgets",
+		"group":     "widgets.templates.krateo.io",
+		"version":   "v1beta1",
+		"resource":  "panels",
+		"namespace": "krateo-system",
+		"name":      name,
+	}}
+	raw, _ := json.Marshal(body)
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// subParamDenied — a widgets coord on the seeded panel; armed by a user with NO
+// binding (userB) → RBAC-denied → empty key → skipped.
+func subParamDenied(t *testing.T) string { return subParamFor(t, "dashboard-piechart") }
+
+// subParamNotFound — a widgets coord on a panel name that has NO CR → objects.Get
+// NotFound → fail-closed skip (the genuinely-empty warm case, NOT RBAC).
+func subParamNotFound(t *testing.T) string { return subParamFor(t, "no-such-panel") }
+
+// warm marks the pod warm: phase1 done AND an RBAC snapshot published
+// (seedAuthTestWidget already publishes one via RebuildRBACSnapshotForTest, so
+// RBACGen>0; MarkPhase1Done flips the other gate). Asserts the WARM predicate
+// holds so the warm arms can't accidentally pass via the warmup path.
+func assertWarm(t *testing.T) {
+	t.Helper()
+	cache.MarkPhase1Done()
+	if !cache.IsPhase1Done() || cache.RBACGen() == 0 {
+		t.Fatalf("warm setup: IsPhase1Done=%v RBACGen=%d — both gates must be satisfied for the WARM arms",
+			cache.IsPhase1Done(), cache.RBACGen())
+	}
+}
+
+// ARM A — warmup-incomplete → 200 idle stream (RED 400 today / GREEN after).
+func TestFalsifier68_ARMA_WarmupServesIdleStream(t *testing.T) {
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t) // seeds the panel CR + RBAC (RBACGen>0)
+	// REAL predicate: drive phase1 NOT done → refreshWarmupIncomplete() true.
+	cache.ResetPhase1DoneForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+	if cache.IsPhase1Done() {
+		t.Fatalf("ARM A setup: phase1 must be NOT done to exercise the warmup window")
+	}
+
+	base := refreshServer(t) // the real /refreshes chain
+	// Use a coord that derives EMPTY (armed==0) — the SAME shape as ARM D's warm
+	// case — so the ONLY difference between this (idle 200) and ARM D (400) is
+	// the warmup gate. (subParamNotFound: a panel with no CR → skip → armed==0.)
+	resp, cancel := openStream(t, base, "?sub="+subParamNotFound(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ARM A RED: warmup-window /refreshes status=%d want 200 idle stream — a browser connecting "+
+			"during the ~4-min warmup (armed==0 because nothing's synced yet) must get the documented keepalive "+
+			"stream, not a 400.", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("ARM A: warmup idle stream Content-Type=%q want text/event-stream", ct)
+	}
+}
+
+// ARM B — WARM + RBAC-denied coord → 400 (GREEN before AND after; proves the
+// divert did NOT swallow a genuine all-denied subscription once warm).
+func TestFalsifier68_ARMB_WarmRBACDeniedStays400(t *testing.T) {
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t)
+	assertWarm(t)
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	base := refreshServer(t)
+	// An "outsiders"-group user that the seed's devs-group binding does NOT
+	// authorize → the widgets coord's objects.Get is RBAC-denied → fail-closed
+	// skip → armed==0 while WARM → honest 400 (must survive the #68 divert).
+	resp, cancel := openStream(t, base, "?sub="+subParamDenied(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintTokenOutsider(t, "outsider1"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("ARM B: WARM + all-denied status=%d want 400 — the honest C64-1 fail must survive #68 "+
+			"(the warmup divert must NOT swallow a genuinely-empty subscription).", resp.StatusCode)
+	}
+}
+
+// ARM C — WARM + valid coord → 200 streaming (the normal armed path).
+func TestFalsifier68_ARMC_WarmValidStreams(t *testing.T) {
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t)
+	assertWarm(t)
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	base := refreshServer(t)
+	resp, cancel := openStream(t, base, "?sub="+subParam(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ARM C: WARM + valid coord status=%d want 200 streaming", resp.StatusCode)
+	}
+}
+
+// ARM D — WARM + genuinely-NotFound coord → 400 (the divert is warmup-gated,
+// NOT armed-count-gated: a warm pod arming a nonexistent widget still gets the
+// honest 400, never a silent idle stream).
+func TestFalsifier68_ARMD_WarmNotFoundStays400(t *testing.T) {
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t)
+	assertWarm(t)
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	base := refreshServer(t)
+	// A coord for a widget that does NOT exist (NotFound) — userA is authorized
+	// on panels, but this name has no CR → objects.Get NotFound → fail-closed
+	// skip → armed==0 while WARM.
+	resp, cancel := openStream(t, base, "?sub="+subParamNotFound(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("ARM D C68-2: WARM + all-NotFound status=%d want 400 — the divert must be STRICTLY "+
+			"warmup-gated; a warm pod arming a nonexistent widget gets the honest 400, never an idle stream.",
+			resp.StatusCode)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -966,7 +966,18 @@ func main() {
 	// exec. NO per-subscription-key/identity enumeration — totals only (a
 	// per-key dump would be a cross-user signal). Mounted next to
 	// /debug/servable + /debug/apistage (docs/rca-refreshes-zero-delivery-2026-06-26.md §5).
-	mux.HandleFunc("GET /debug/refreshes", handlers.DebugRefreshes())
+	//
+	// #69 — AUTH-GATED for prod. Wrapped in middleware.RefreshAuth (the SAME
+	// cookie-or-header JWT gate /refreshes uses), so a bare unauthenticated GET
+	// now 401s instead of returning the counters. The body stays aggregate-only
+	// (uint64 totals + int subscriber count + bool — structurally cannot carry
+	// per-key/per-user data), so even past the gate it is leak-safe; the gate
+	// is defence-in-depth so the diagnostic is not world-readable in prod. Uses
+	// the same RefreshAuth chain form as /refreshes (no apiserver read, no
+	// UserConfig Secret lookup).
+	mux.Handle("GET /debug/refreshes", chain.Append(
+		middleware.RefreshAuth(*signKey)).
+		Then(handlers.DebugRefreshes()))
 
 	ctx, stop := signal.NotifyContext(context.Background(), []os.Signal{
 		os.Interrupt,


### PR DESCRIPTION
1.5.14 /refreshes hardening pass (frontend's 4 follow-up asks + the #66 seam fast-follow). Dual-gate GREEN (arch PASS + PM ACCEPT, both RED-discriminators proven).
- #66: collapse DeriveSubscriptionKey + test accessor onto ONE deriveSubscription core (shadow eliminated — last residual of the #64 saga).
- #67: standing per-class DeriveSubscriptionKey==ComputeKey invariant (real /call emit path) — the permanent guard so the 1.5.5-1.5.11 zero-delivery class can't silently ship again.
- #68: serve idle-stream (not 400) during the warmup window; C64-1 honest-400 preserved for warm+empty/denied/NotFound.
- #69: auth-gate /debug/refreshes (RefreshAuth); aggregate-only body unchanged.
- #70: howto content-change-semantics note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)