### PR TITLE
feat(widgets): inline-rendered-children Phase 1 — producer, default-off (#72)

### DIFF
--- a/apis/templates/v1/resourcesrefs.go
+++ b/apis/templates/v1/resourcesrefs.go
@@ -23,6 +23,12 @@ type ResourceRef struct {
 	Verb string `json:"verb,omitempty"`
 	// Slice is used for pagination
 	Slice *Slice `json:"slice,omitempty"`
+	// Inline, when true on a GET ref, asks snowplow to resolve this child
+	// server-side under the requesting user's identity and embed the resolved
+	// envelope into the result's Rendered field (#72, inline-rendered-children).
+	// Additive + opt-in: a ref without Inline is byte-identical to today. A
+	// non-GET / not-allowed inline ref is NOT embedded.
+	Inline bool `json:"inline,omitempty"`
 }
 
 // ResourceRefResult defines the action result after evaluating a template.
@@ -37,6 +43,22 @@ type ResourceRefResult struct {
 	Payload *ResourceRefPayload `json:"payload,omitempty"`
 	// Allowed is this resource reference allowed (or not) for the user
 	Allowed bool `json:"allowed"`
+	// Inline carries the source ref's Inline flag through to the dispatcher,
+	// which (post-resolve) decides whether to embed the child (#72). Carried,
+	// not re-read — the dispatcher inline-walk consumes it.
+	Inline bool `json:"inline,omitempty"`
+	// Rendered is the resolved child envelope, embedded server-side when this
+	// ref is Inline+Allowed+GET (#72). Empty/omitted for every non-inline ref —
+	// so the served shape is byte-identical to today until a widget authors
+	// inline:true. map[string]any (NOT json.RawMessage): the dispatcher embeds
+	// it into the resolved *unstructured.Unstructured, which is deep-copied on
+	// the cache Put / refresher path — runtime.DeepCopyJSONValue PANICS on a
+	// json.RawMessage but handles a standard map. So the child is decoded once
+	// into a map and re-encoded with the parent's single encode (A1 path i, the
+	// design's documented fallback; §6-bench-gated). NOTE: path ii
+	// (RawMessage-verbatim) encodes fine but is unsound here — it panics the
+	// unstructured deep-copy.
+	Rendered map[string]any `json:"rendered,omitempty"`
 }
 
 // ResourceRefPayload is the template action result payload.

--- a/internal/handlers/dispatchers/widget_content.go
+++ b/internal/handlers/dispatchers/widget_content.go
@@ -370,6 +370,19 @@ func isRBACSensitiveApiRefWidget(obj map[string]any) bool {
 	if obj == nil {
 		return false
 	}
+	// #72 / C-INLINE-1 (HARD) — independent OR-clause AT THE TOP, BEFORE the
+	// apiRef short-circuit below. A widget bearing any inline+GET resourcesRefs
+	// item embeds a server-resolved child `rendered` body that is narrowed per
+	// requesting-user identity; it MUST route to the per-user `widgets` L1, NEVER
+	// the shared identity-free `widgetContent` cell (or the SA-maximal child
+	// render would leak cross-user — the task #69 leak class). This MUST run
+	// before the `apiRef.Name == ""` return at the next stmt: an inline widget
+	// with NO apiRef would otherwise fall through to `return false` → shared
+	// cell → leak. Gates symmetrically at the serve-READ (widgets.go) and the
+	// populate-WRITE (widget_content.go) sites that both call this predicate.
+	if hasInlineGETRef(obj) {
+		return true
+	}
 	apiRef, err := widgets.GetApiRef(obj)
 	if err != nil || apiRef.Name == "" {
 		return false

--- a/internal/handlers/dispatchers/widget_content_rbac_sensitive_falsifier_test.go
+++ b/internal/handlers/dispatchers/widget_content_rbac_sensitive_falsifier_test.go
@@ -131,6 +131,72 @@ func TestRBACSensitive_PredicateTruthTable(t *testing.T) {
 	}
 }
 
+// widgetWithInlineSpecRef builds a widget CR `.Object` whose SPEC declares one
+// resourcesRefs item, optionally inline + with the given verb, and optionally
+// an apiRef. This is the C-INLINE-1 (#72) classification surface: the predicate
+// reads spec.resourcesRefs.items[] for an inline GET ref.
+func widgetWithInlineSpecRef(inline bool, verb, apiRefName string) map[string]any {
+	spec := map[string]any{
+		"resourcesRefs": map[string]any{
+			"items": []any{
+				map[string]any{
+					"id": "child", "apiVersion": "widgets.templates.krateo.io/v1beta1",
+					"resource": "panels", "namespace": "demo", "name": "child-1",
+					"inline": inline, "verb": verb,
+				},
+			},
+		},
+	}
+	if apiRefName != "" {
+		spec["apiRef"] = map[string]any{"name": apiRefName, "namespace": "krateo-system"}
+	}
+	return map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata":   map[string]any{"namespace": "krateo-system", "name": "detail-card"},
+		"spec":       spec,
+	}
+}
+
+// TestRBACSensitive_InlineGETRef_C_INLINE_1 — the #72 C-INLINE-1 arm: a widget
+// bearing an inline GET resourcesRefs ref MUST classify RBAC-sensitive so its
+// embedded `rendered` child never lands in the shared identity-free
+// widgetContent cell. The discriminating case is the NO-apiRef inline widget:
+// it must STILL classify true — which only holds because hasInlineGETRef is an
+// OR-clause BEFORE the apiRef.Name=="" short-circuit. (RED arm: move the clause
+// AFTER the short-circuit → this case returns false → shared cell → leak.)
+func TestRBACSensitive_InlineGETRef_C_INLINE_1(t *testing.T) {
+	cases := []struct {
+		name           string
+		inline         bool
+		verb           string
+		apiRefName     string
+		wantClassified bool
+	}{
+		// THE discriminator: inline GET ref, NO apiRef → MUST be classified
+		// (only true if the OR-clause runs before the apiRef short-circuit).
+		{"no-apiRef + inline GET ref (C-INLINE-1 discriminator)", true, "GET", "", true},
+		// inline GET ref WITH apiRef → classified (both clauses agree).
+		{"apiRef + inline GET ref", true, "GET", "compositions-list", true},
+		// inline ref but NON-GET → not an inline-render candidate; no apiRef/tpl
+		// → not classified.
+		{"no-apiRef + inline POST ref", true, "POST", "", false},
+		// non-inline GET ref, no apiRef → static widget, not classified
+		// (byte-identical to today; the inline clause does not over-fire).
+		{"no-apiRef + non-inline GET ref", false, "GET", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			obj := widgetWithInlineSpecRef(c.inline, c.verb, c.apiRefName)
+			if got := isRBACSensitiveApiRefWidget(obj); got != c.wantClassified {
+				t.Fatalf("isRBACSensitiveApiRefWidget(%s) = %v; want %v "+
+					"(C-INLINE-1: an inline GET ref must route to the per-user widgets L1, never the shared cell)",
+					c.name, got, c.wantClassified)
+			}
+		})
+	}
+}
+
 // TestRBACSensitive_ServeRoutingDecision — the serve path gates the ENTIRE
 // identity-free `widgetContent` lookup block on
 // `!isRBACSensitiveApiRefWidget(got.Unstructured.Object)` (widgets.go). This

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -284,6 +284,22 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	// #72 inline-rendered-children PRODUCER (Phase 1, default-off): embed any
+	// inline+allowed+GET resourcesRefs child's resolved envelope into
+	// items[i].rendered, server-side under THIS per-user ctx (carrying
+	// WithUserInfo + the SA transport + WithL1KeyContext(cacheKey)). No-op when
+	// no item carries inline → byte-identical to today. Runs BEFORE the single
+	// encodeResolvedJSON so the spliced json.RawMessage children are encoded
+	// once with the parent. RBAC is enforced per-child by ResolveNestedCall;
+	// the inline widget is routed to the per-user `widgets` L1 (not the shared
+	// content cell) by isRBACSensitiveApiRefWidget's hasInlineGETRef OR-clause.
+	if n := embedInlineChildren(ctx, log, res, perPage, page, extras); n > 0 {
+		log.Info("inline-rendered-children embedded",
+			slog.Int("count", n),
+			slog.String("widget", got.Unstructured.GetNamespace()+"/"+got.Unstructured.GetName()),
+		)
+	}
+
 	encoded, err := encodeResolvedJSON(res)
 	if err != nil {
 		log.Error("unable to encode widget response", slog.Any("err", err))

--- a/internal/handlers/dispatchers/widgets_inline.go
+++ b/internal/handlers/dispatchers/widgets_inline.go
@@ -1,0 +1,185 @@
+// widgets_inline.go — #72 Phase 1: inline-rendered-children PRODUCER.
+//
+// After widgets.Resolve returns and BEFORE the parent envelope is encoded
+// (widgets.go), walk the just-built status.resourcesRefs.items[]; for each item
+// whose source ref was Inline AND Allowed AND verb==GET, resolve the child
+// server-side UNDER THE REQUESTING USER'S ctx via ResolveNestedCall (in-package
+// — no import cycle, C-INLINE-0) and embed the resolved child envelope into
+// items[i].rendered.
+//
+// WHY THIS PLACEMENT (dispatcher, not resolver — C-INLINE-0): resolvers/widgets
+// importing dispatchers.ResolveNestedCall closes a Go import cycle (dispatchers
+// already imports widgets). Here ResolveNestedCall is in-package, AND the ctx
+// already carries WithUserInfo + the SA transport + WithL1KeyContext(cacheKey)
+// (widgets.go) — so the §5 dep-edge preservation (child resource dep-edges the
+// PARENT L1 key, via the L1KeyFromContext ResolveNestedCall preserves) is
+// automatic, and RBAC is enforced under the requesting identity by
+// ResolveNestedCall's checkDispatchRBAC gate (C-INLINE-1's runtime half).
+//
+// A1 single-encode (C-INLINE-0 / task #30): ResolveNestedCall returns the child
+// ALREADY ENCODED ONCE. We splice those bytes as a json.RawMessage into the
+// parent dict so the parent's single encodeResolvedJSON copies them VERBATIM —
+// no second per-child encode. (encodeResolvedJSON uses encoding/json, which
+// emits a json.RawMessage map value verbatim.) The Phase-1 falsifier verifies
+// the RawMessage splice survives the unstructured-map encode; if it does not,
+// the documented fallback is decode-into-map (option i) gated by the §6 RSS
+// bench — Phase-1 dev reports which path landed (RawMessage preferred).
+//
+// DEPTH — ONE LEVEL HARD (C-INLINE-2): this walk resolves an inline ref's child
+// but does NOT re-enter the inline-walk on that child's own inline refs — the
+// recursive arm is gated OFF until the grandchild Edge-type-3 dep-edge is proven
+// (the one-level case rides recordWidgetDeps' path-decode union, #61; the
+// grandchild case is only comment-asserted). ResolveNestedCall's own
+// NestedCallMaxDepth remains the safety ceiling for apiRef-transitive chains.
+//
+// DEFAULT-OFF / byte-identical: when no resourcesRefs item carries inline (the
+// only state until a widget authors inline:true), this walk makes ZERO changes
+// — no `rendered` field is written, the served shape is exactly today's.
+package dispatchers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/krateoplatformops/plumbing/maps"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// embedInlineChildren mutates res.Object in place: for each
+// status.resourcesRefs.items[] entry flagged inline+allowed+GET, resolve the
+// child via ResolveNestedCall under ctx and set items[i]["rendered"] to the
+// resolved envelope (as json.RawMessage — single-encode). perPage/page/extras
+// are the parent request's, threaded into the child resolve so an inline grid
+// embeds the SAME page the parent requested (bounding rides the declared
+// slice/pager, no magic cap). Returns the number of children embedded (0 when
+// no inline ref → byte-identical to today).
+//
+// Errors resolving an individual child are logged and SKIPPED (the item keeps
+// its path so an old SPA still follows it; the parent envelope is still served).
+// A child the user cannot read returns a forbidden-class error from
+// ResolveNestedCall → skipped → no rendered body → no leak.
+func embedInlineChildren(ctx context.Context, log *slog.Logger, res *unstructured.Unstructured, perPage, page int, extras map[string]any) int {
+	if res == nil {
+		return 0
+	}
+	// NoCopy: we mutate the item maps IN PLACE (they are the live references
+	// inside res.Object), so the embedded `rendered` lands directly in the dict
+	// that encodeResolvedJSON will encode — no write-back needed.
+	items, ok, err := maps.NestedSliceNoCopy(res.Object, "status", "resourcesRefs", "items")
+	if !ok || err != nil || len(items) == 0 {
+		return 0
+	}
+
+	embedded := 0
+	for i := range items {
+		m, ok := items[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Only inline + allowed + GET refs are embedded. The inline flag was
+		// carried from the source ref onto the ResourceRefResult
+		// (resourcesrefs/resolve.go) and marshalled into the item map.
+		inline, _ := m["inline"].(bool)
+		allowed, _ := m["allowed"].(bool)
+		verb, _ := m["verb"].(string)
+		if !inline || !allowed || verb != "GET" {
+			continue
+		}
+		pathStr, _ := m["path"].(string)
+		ref, ok := objects.ParseCallPathToObjectRef(pathStr)
+		if !ok {
+			// Non-/call path (external link / missing resource|apiVersion) —
+			// nothing to resolve in-process; leave the item as-is.
+			continue
+		}
+
+		// Resolve the child UNDER ctx (per-user identity + SA transport +
+		// L1KeyFromContext already threaded). ResolveNestedCall gates RBAC
+		// (checkDispatchRBAC) + bounds depth + preserves the parent L1 key for
+		// the §5 dep-edge. ONE LEVEL: ResolveNestedCall resolves THIS child; it
+		// does not re-enter embedInlineChildren on the child's own inline refs.
+		childBytes, cerr := ResolveNestedCall(ctx, ref, perPage, page, extras)
+		if cerr != nil {
+			log.Warn("inline child resolve failed; serving parent without this rendered child",
+				slog.String("id", asString(m["id"])),
+				slog.String("path", pathStr),
+				slog.Any("err", cerr),
+				slog.String("effect", "item keeps its path (old SPA follows it); no rendered body embedded"),
+			)
+			continue
+		}
+
+		// A1 (path i — decode-into-map, the design's documented fallback).
+		// The RawMessage-verbatim splice (path ii) ENCODES fine but PANICS the
+		// unstructured deep-copy (runtime.DeepCopyJSONValue rejects
+		// json.RawMessage) — and res IS deep-copied on the cache Put / refresher
+		// path, so path ii is unsound here. Decode the child bytes into a
+		// standard map[string]any so res.Object stays a pure JSON-value tree
+		// (deep-copy-safe); the parent's single encodeResolvedJSON re-encodes it
+		// once with the parent. Cost: a per-child decode+re-encode (NOT a second
+		// INDEPENDENT encode of the whole parent) — gated by the §6 RSS bench.
+		var childMap map[string]any
+		if uerr := json.Unmarshal(childBytes, &childMap); uerr != nil {
+			log.Warn("inline child decode failed; serving parent without this rendered child",
+				slog.String("id", asString(m["id"])),
+				slog.String("path", pathStr),
+				slog.Any("err", uerr),
+			)
+			continue
+		}
+		// Mutated in place on the live item map (NoCopy slice above).
+		m["rendered"] = childMap
+		embedded++
+	}
+	return embedded
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// hasInlineGETRef reports whether the widget CR declares any
+// spec.resourcesRefs.items[] ref with inline:true whose verb is GET (or
+// unset → defaults to GET on resolve). PRE-RESOLVE — reads the fetched widget
+// CR's spec directly (no apiserver round-trip), symmetric with the existing
+// pre-resolve classifiers. This is the C-INLINE-1 RBAC-sensitivity signal: a
+// widget that will embed a server-resolved child `rendered` body MUST route to
+// the per-user `widgets` L1, never the shared identity-free `widgetContent`
+// cell (or the SA-maximal child render leaks cross-user).
+//
+// Scope: the STATIC spec.resourcesRefs.items[] (where `inline` is a real field).
+// resourcesRefsTemplate refs are jq-templated and have no static pre-resolve
+// inline field to read here; a templated inline ref would still be embedded at
+// resolve time, but the classification signal is the static declaration — which
+// is what an author sets to opt a widget into inline. (If a future template
+// surface needs inline, the classifier extends there; today no template carries
+// it.)
+func hasInlineGETRef(obj map[string]any) bool {
+	if obj == nil {
+		return false
+	}
+	arr, ok, err := maps.NestedSliceNoCopy(obj, "spec", "resourcesRefs", "items")
+	if !ok || err != nil {
+		return false
+	}
+	for _, raw := range arr {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		inline, _ := m["inline"].(bool)
+		if !inline {
+			continue
+		}
+		// verb unset → resolves to GET (mapVerbs default includes get); an
+		// explicit non-GET verb is not an inline-render candidate.
+		v, _ := m["verb"].(string)
+		if v == "" || v == "get" || v == "GET" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handlers/dispatchers/widgets_inline_falsifier_test.go
+++ b/internal/handlers/dispatchers/widgets_inline_falsifier_test.go
@@ -1,0 +1,374 @@
+// widgets_inline_falsifier_test.go — #72 Phase 1 producer falsifiers (§3/§5/§6),
+// driving the REAL embedInlineChildren over the nested-call watcher harness
+// (newNestedCallWatcher: a seeded inner RESTAction resolvable via
+// ResolveNestedCall under a per-user identity + RBAC). Hermetic, no kubeconfig.
+//
+//   §3 single-response content — an inline+allowed+GET ref's child envelope is
+//      embedded into items[i].rendered (non-empty, correct content) in ONE
+//      pass; a non-inline ref carries NO rendered (byte-identical to today).
+//   §5 central dep-edge — embedInlineChildren resolves the child via
+//      ResolveNestedCall UNDER WithL1KeyContext(parentKey), so the child
+//      resource's dep edge lands on the PARENT L1 key (→ a child change
+//      dirty-marks the parent → PublishRefresh → fresh embedded child on
+//      re-resolve). RED arm: resolve the child on a FRESH ctx WITHOUT
+//      L1KeyFromContext → the dep edge does NOT land on the parent key → stale.
+//   §5 grandchild one-level cap — embedInlineChildren resolves the child but
+//      does NOT re-enter itself on the child's own inline refs (recursive arm
+//      gated OFF, C-INLINE-2). Asserts the child's rendered body is embedded
+//      but a grandchild ref inside it is NOT (only its path remains).
+package dispatchers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	restactionsapi "github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// inlineChildCallPath builds the /call path the resourcesRefs resolver writes
+// for the seeded inner RESTAction — exactly what ParseCallPathToObjectRef
+// decodes back to the (restactions, ns, name) ObjectReference.
+func inlineChildCallPath(ns, name string) string {
+	return "/call?resource=" + nestedCallInnerGVR.Resource +
+		"&apiVersion=" + nestedCallInnerGVR.Group + "/" + nestedCallInnerGVR.Version +
+		"&namespace=" + ns + "&name=" + name
+}
+
+// parentWithInlineRef builds a resolved parent widget `res` whose
+// status.resourcesRefs.items[0] is an inline GET ref pointing at the seeded
+// child RA. `inline`/`allowed` are parameterised so the arms can toggle them.
+func parentWithInlineRef(ns, childName string, inline, allowed bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata":   map[string]any{"namespace": "krateo-system", "name": "detail-card"},
+		"status": map[string]any{
+			"resourcesRefs": map[string]any{
+				"items": []any{
+					map[string]any{
+						"id":      "child",
+						"path":    inlineChildCallPath(ns, childName),
+						"verb":    "GET",
+						"allowed": allowed,
+						"inline":  inline,
+					},
+				},
+			},
+		},
+	}}
+}
+
+func inlineTestCtx(t *testing.T, user, parentKey string) context.Context {
+	t.Helper()
+	restactionsapi.RegisterNestedCallResolver(ResolveNestedCall)
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: user}))
+	if parentKey != "" {
+		ctx = cache.WithL1KeyContext(ctx, parentKey)
+	}
+	ctx = cache.WithInternalEndpoint(ctx, &endpoints.Endpoint{ServerURL: "http://test.invalid"})
+	return ctx
+}
+
+// firstItem returns status.resourcesRefs.items[0] as a map.
+func firstItem(t *testing.T, res *unstructured.Unstructured) map[string]any {
+	t.Helper()
+	items, _, _ := unstructuredNestedSlice(res, "status", "resourcesRefs", "items")
+	if len(items) == 0 {
+		t.Fatalf("no items")
+	}
+	m, _ := items[0].(map[string]any)
+	return m
+}
+
+func unstructuredNestedSlice(res *unstructured.Unstructured, fields ...string) ([]any, bool, error) {
+	return unstructured.NestedSlice(res.Object, fields...)
+}
+
+// §3 — single-response content: an inline+allowed+GET ref embeds the resolved
+// child envelope into items[0].rendered (non-empty, correct), in ONE pass.
+func TestFalsifier72_S3_InlineChildEmbeddedInSingleResponse(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+	ctx := inlineTestCtx(t, "u1", "parent-L1-key")
+
+	res := parentWithInlineRef(ns, childName, true, true)
+	n := embedInlineChildren(ctx, slog.Default(), res, -1, -1, nil)
+	if n != 1 {
+		t.Fatalf("§3: embedded %d children, want 1", n)
+	}
+	item := firstItem(t, res)
+	rendered, ok := item["rendered"]
+	if !ok || rendered == nil {
+		t.Fatalf("§3: items[0].rendered not set — inline child not embedded")
+	}
+	// Content check (feedback_validate_content_not_just_status): the embedded
+	// envelope must carry the child's resolved body, not an empty shell.
+	// rendered is now a map[string]any (path i, deep-copy-safe); re-encode it to
+	// assert the resolved content is present.
+	rm, ok := rendered.(map[string]any)
+	if !ok {
+		t.Fatalf("§3: rendered must be a map[string]any (deep-copy-safe), got %T", rendered)
+	}
+	rb, _ := json.Marshal(rm)
+	if !strings.Contains(string(rb), `"resolved":true`) || !strings.Contains(string(rb), childName) {
+		t.Fatalf("§3: rendered child body missing resolved content; got: %s", string(rb))
+	}
+	// The path is KEPT alongside rendered (backward-compat — old SPA follows path).
+	if p, _ := item["path"].(string); p == "" {
+		t.Fatalf("§3: items[0].path must be KEPT alongside rendered (backward-compat)")
+	}
+}
+
+// §3 negative — a NON-inline ref embeds NOTHING (byte-identical to today).
+func TestFalsifier72_S3_NonInlineRefNotEmbedded(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+	ctx := inlineTestCtx(t, "u1", "parent-L1-key")
+
+	res := parentWithInlineRef(ns, childName, false /*inline*/, true)
+	n := embedInlineChildren(ctx, slog.Default(), res, -1, -1, nil)
+	if n != 0 {
+		t.Fatalf("§3-neg: embedded %d children for a NON-inline ref, want 0 (must be byte-identical to today)", n)
+	}
+	if _, ok := firstItem(t, res)["rendered"]; ok {
+		t.Fatalf("§3-neg: non-inline ref must NOT carry rendered")
+	}
+}
+
+// §5 — central dep-edge: the inline child resolve (under WithL1KeyContext)
+// lands the child RA's dep edge on the PARENT L1 key. RED arm: resolve under a
+// fresh ctx WITHOUT the L1 key → the edge does NOT land on the parent → a child
+// change would never dirty-mark the parent → stale embedded child.
+func TestFalsifier72_S5_ChildDepEdgeLandsOnParentKey(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	const parentKey = "parent-L1-key-dep"
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+
+	// GREEN: ctx carries the parent L1 key.
+	ctx := inlineTestCtx(t, "u1", parentKey)
+	res := parentWithInlineRef(ns, childName, true, true)
+	if n := embedInlineChildren(ctx, slog.Default(), res, -1, -1, nil); n != 1 {
+		t.Fatalf("§5: embedded %d, want 1", n)
+	}
+	matched := cache.Deps().CollectMatchesForTest(nestedCallInnerGVR, ns, childName)
+	if _, ok := matched[parentKey]; !ok {
+		t.Fatalf("§5: child RA dep edge did NOT land on the PARENT key %q (matched=%v) — a child change "+
+			"would never dirty-mark the parent → stale embedded child (the central correctness claim).",
+			parentKey, matched)
+	}
+}
+
+// §5 RED control — resolve the SAME inline child on a fresh ctx WITHOUT the
+// parent L1 key; the dep edge must NOT land on the parent key (proving the
+// GREEN case's edge came from L1KeyFromContext, not incidentally).
+func TestFalsifier72_S5_NoL1KeyNoParentDepEdge(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	const parentKey = "parent-L1-key-red"
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+
+	// No parent key on ctx (the RED-arm shape: a fresh ctx).
+	ctx := inlineTestCtx(t, "u1", "" /*no L1 key*/)
+	res := parentWithInlineRef(ns, childName, true, true)
+	_ = embedInlineChildren(ctx, slog.Default(), res, -1, -1, nil)
+
+	matched := cache.Deps().CollectMatchesForTest(nestedCallInnerGVR, ns, childName)
+	if _, ok := matched[parentKey]; ok {
+		t.Fatalf("§5 RED: child dep edge landed on parentKey %q despite no L1KeyFromContext — the §5 GREEN "+
+			"result must come from the threaded L1 key, not coincidence", parentKey)
+	}
+}
+
+// §5 grandchild ONE-LEVEL CAP (C-INLINE-2, the gate-to-lift). embedInlineChildren
+// embeds the inline CHILD but does NOT recurse into the child's OWN inline refs:
+// the embedded rendered child envelope's status.resourcesRefs.items[] carry NO
+// `rendered` (the grandchild is left as a path-only ref the SPA follows). This
+// pins the one-level-hard property — the recursive arm is gated OFF until the
+// grandchild Edge-type-3 dep-edge is proven. RED (hypothetical recursive impl
+// that re-entered embedInlineChildren on the child): the grandchild item WOULD
+// carry rendered.
+//
+// Mechanism: embedInlineChildren is called ONLY from the widgets.go dispatcher
+// (top level); ResolveNestedCall resolves the child but NEVER calls
+// embedInlineChildren — so a child resolved via ResolveNestedCall never has its
+// own inline refs embedded. The child here is a RESTAction whose resolved
+// top-level filter PRODUCES a status.resourcesRefs.items[] carrying an inline
+// grandchild ref; the embedded rendered child must keep that grandchild
+// PATH-ONLY (no `rendered`), proving the walk did not recurse.
+func TestFalsifier72_S5_GrandchildOneLevelCap(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-with-grandchild"
+	// The child RA's filter yields an envelope whose status.resourcesRefs.items
+	// already contains a grandchild ref flagged inline. (embedInlineChildren is
+	// NOT applied to this child — ResolveNestedCall returns it verbatim — so the
+	// grandchild MUST stay path-only.)
+	inner := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "templates.krateo.io/v1",
+		"kind":       "RESTAction",
+		"metadata":   map[string]any{"namespace": ns, "name": childName},
+		"spec": map[string]any{
+			"filter": `{"status":{"resourcesRefs":{"items":[` +
+				`{"id":"grandchild","path":"/call?resource=configmaps&apiVersion=v1&namespace=` + ns + `&name=gc","verb":"GET","allowed":true,"inline":true}` +
+				`]}}}`,
+			"api": []any{},
+		},
+	}}
+	newNestedCallWatcherWithInner(t, ns, childName, inner, nestedCallRoleBinding(ns, "u1"))
+	ctx := inlineTestCtx(t, "u1", "parent-L1-key-gc")
+
+	res := parentWithInlineRef(ns, childName, true, true)
+	if n := embedInlineChildren(ctx, slog.Default(), res, -1, -1, nil); n != 1 {
+		t.Fatalf("§5-gc: embedded %d, want 1 (the child)", n)
+	}
+	item := firstItem(t, res)
+	rendered, _ := item["rendered"].(map[string]any)
+	if rendered == nil {
+		t.Fatalf("§5-gc: child not embedded")
+	}
+	// ONE-LEVEL CAP: NOWHERE inside the embedded child envelope may a `rendered`
+	// key appear — embedInlineChildren is called ONLY at the top dispatcher
+	// level, and ResolveNestedCall (which produced this child) never calls it.
+	// So a grandchild ref inside the child stays path-only. A recursive impl
+	// (re-entering embedInlineChildren on the child) WOULD inject a nested
+	// `rendered` and trip this scan — the discriminating RED.
+	if path := findNestedRendered(rendered, "rendered"); path != "" {
+		t.Fatalf("§5-gc ONE-LEVEL CAP VIOLATED: a nested `rendered` exists inside the embedded child at %s — "+
+			"embedInlineChildren recursed (recursive arm must stay gated OFF until the grandchild dep-edge "+
+			"falsifier is green)", path)
+	}
+	// Sanity: the child envelope is non-empty (the embed actually happened).
+	if len(rendered) == 0 {
+		t.Fatalf("§5-gc: embedded child envelope is empty")
+	}
+}
+
+// findNestedRendered returns a dotted path to the first occurrence of `key`
+// anywhere in the tree rooted at v, or "" if absent. Used to prove the embedded
+// child has NO nested `rendered` (one-level cap).
+func findNestedRendered(v any, key string) string {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if k == key {
+				return k
+			}
+			if p := findNestedRendered(child, key); p != "" {
+				return k + "." + p
+			}
+		}
+	case []any:
+		for i, child := range t {
+			if p := findNestedRendered(child, key); p != "" {
+				return "[" + itoa(i) + "]." + p
+			}
+		}
+	}
+	return ""
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// §4 — cross-user RBAC inequality (the leak-proof). The SAME inline parent,
+// embedded under two identities with DIFFERENT RBAC: u1 (granted the child RA)
+// gets a populated rendered child; u2 (NOT granted) gets NO rendered —
+// ResolveNestedCall's checkDispatchRBAC gate denies u2's resolve, so no child
+// body is embedded. The two users' served parents therefore DIFFER on the
+// rendered child = no cross-user leak (the embedded child is resolved under the
+// REQUESTING identity, never a shared/SA-maximal render). RED arm (a hypothetical
+// impl that embedded under a shared/parent identity): u2 would get u1's rendered.
+func TestFalsifier72_S4_CrossUserRBACInequality(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	// Bind ONLY u1 to the child-RA getter role; u2 has no grant.
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+
+	// u1 (granted) — rendered populated.
+	ctxU1 := inlineTestCtx(t, "u1", "parent-key-u1")
+	resU1 := parentWithInlineRef(ns, childName, true, true)
+	embedInlineChildren(ctxU1, slog.Default(), resU1, -1, -1, nil)
+	renderedU1, hasU1 := firstItem(t, resU1)["rendered"]
+
+	// u2 (NOT granted) — ResolveNestedCall denies → no rendered embedded.
+	ctxU2 := inlineTestCtx(t, "u2", "parent-key-u2")
+	resU2 := parentWithInlineRef(ns, childName, true, true)
+	embedInlineChildren(ctxU2, slog.Default(), resU2, -1, -1, nil)
+	_, hasU2 := firstItem(t, resU2)["rendered"]
+
+	if !hasU1 || renderedU1 == nil {
+		t.Fatalf("§4: u1 (granted) must get a populated rendered child")
+	}
+	if hasU2 {
+		t.Fatalf("§4 LEAK: u2 (NOT granted) got a rendered child — the inline child must be resolved under the "+
+			"REQUESTING identity (ResolveNestedCall's RBAC gate), never shared/SA-maximal. Cross-user leak.")
+	}
+	// The two served parents DIFFER on the rendered child — the inequality.
+}
+
+// §6 — hermetic single-encode bound (the full 50K RSS bench is the tester's
+// Phase 3 arm). Asserts the A1 cost is LINEAR in child count, not quadratic:
+// embedInlineChildren does ONE decode per child (into the map carrier) + the
+// parent's SINGLE encode re-encodes the tree once — it does NOT independently
+// re-encode the whole parent per child. We assert that embedding N children
+// allocates within a calibrated multiple of embedding 1 (linear scaling), not
+// N× the whole-parent encode. Calibrated empirically (feedback_capacity_caps_
+// empirical_per_entry_cost), not a design-time magic number.
+func TestFalsifier72_S6_LinearNotQuadraticEmbedCost(t *testing.T) {
+	const ns, childName = "krateo-system", "inner-restaction"
+	// One seeded child; N items all reference it (each a distinct embed). The
+	// linear-vs-quadratic property is about per-item embed cost (decode +
+	// in-place set), not distinct children — so one CR suffices.
+	newNestedCallWatcher(t, ns, childName, nestedCallRoleBinding(ns, "u1"))
+	ctx := inlineTestCtx(t, "u1", "parent-key-s6")
+
+	build := func(k int) *unstructured.Unstructured {
+		items := make([]any, 0, k)
+		for i := 0; i < k; i++ {
+			items = append(items, map[string]any{
+				"id": "child" + itoa(i), "path": inlineChildCallPath(ns, childName),
+				"verb": "GET", "allowed": true, "inline": true,
+			})
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1", "kind": "Panel",
+			"metadata": map[string]any{"namespace": "krateo-system", "name": "p"},
+			"status":   map[string]any{"resourcesRefs": map[string]any{"items": items}},
+		}}
+	}
+
+	// Embed 1 child, then 8 children; the per-child marginal cost must be
+	// roughly constant (linear total), not growing per added child (quadratic
+	// = re-encoding the whole tree per child).
+	alloc1 := testing.AllocsPerRun(20, func() {
+		r := build(1)
+		_ = embedInlineChildren(ctx, slog.Default(), r, -1, -1, nil)
+	})
+	alloc8 := testing.AllocsPerRun(20, func() {
+		r := build(8)
+		_ = embedInlineChildren(ctx, slog.Default(), r, -1, -1, nil)
+	})
+	// Linear: alloc8 ≈ 8×(per-child) + fixed. Quadratic would be ≳ 8× alloc1
+	// AND super-linear in k. Bound: alloc8 must be < 8× alloc1 × a generous
+	// linear-slack multiple (3), i.e. NOT quadratic. (Per-child = 1 decode +
+	// 1 resolve; the parent encode is amortized once.)
+	if alloc8 > alloc1*8*3 {
+		t.Fatalf("§6: embedding 8 children allocated %.0f vs 1 child %.0f — > linear×3 bound; the per-child "+
+			"cost is super-linear (a quadratic whole-parent re-encode per child?), A1 worsened", alloc8, alloc1)
+	}
+	t.Logf("§6 linear-cost OK: alloc(1)=%.0f alloc(8)=%.0f (ratio %.1f, linear bound 24)", alloc1, alloc8, alloc8/alloc1)
+}

--- a/internal/resolvers/widgets/resourcesrefs/resolve.go
+++ b/internal/resolvers/widgets/resourcesrefs/resolve.go
@@ -107,6 +107,9 @@ func resolveOne(ctx context.Context, rc *rest.Config, in *templatesv1.ResourceRe
 		el := templatesv1.ResourceRefResult{
 			ID:   in.ID,
 			Verb: kubeToREST[verb],
+			// #72: carry the source ref's Inline flag through to the dispatcher
+			// inline-walk (it consumes it post-resolve; not re-read off spec).
+			Inline: in.Inline,
 		}
 
 		el.Allowed = rbac.UserCan(ctx, rbac.UserCanOptions{


### PR DESCRIPTION
## What (Phase 1 — producer only, default-OFF, PARKED for Diego's merge)
Snowplow resolves a widget's `inline`+GET+`allowed` resourcesRefs CHILD server-side **under the requesting user's identity** and embeds the resolved envelope into `status.resourcesRefs.items[i].rendered`. Design: `docs/inline-rendered-children-design-2026-06-30.md` (arch CONDITIONAL PASS C-INLINE-0/1/2 + PM ACCEPT + Diego green-lit). **Byte-identical until a widget authors `inline:true`.** Frozen SHA the gate runs against: `8ea3066`.

## Conditions
- **C-INLINE-0** placement: new `widgets_inline.go`, `embedInlineChildren` from `widgets.go` after `widgets.Resolve` / before `encodeResolvedJSON`; in-package `ResolveNestedCall` (no import cycle), under the per-user ctx (`WithUserInfo`+SA transport+`WithL1KeyContext`). One level hard; depth capped `NestedCallMaxDepth`.
- **C-INLINE-1** (leak gate): `hasInlineGETRef` OR-clause at the TOP of `isRBACSensitiveApiRefWidget`, BEFORE the apiRef short-circuit → inline widget → per-user `widgets` L1, never the shared cell. Gates serve-READ + populate-WRITE symmetrically.
- **C-INLINE-2**: one level hard; the grandchild falsifier is the gate-to-lift (recursive arm gated OFF).

## ⚠️ DEVIATION from the design doc — A1 single-encode: as-built is **path (i) decode-into-map**, NOT the doc's "RawMessage (ii) preferred"
The `json.RawMessage`-verbatim splice (ii) **encodes fine but PANICS the unstructured deep-copy** (`runtime.DeepCopyJSONValue` rejects `json.RawMessage`) on the **cache-Put / refresher path** — a production-panic-class defect caught pre-ship by the §3/§5 falsifier (an encode-only probe missed it). The `map[string]any` carrier is deep-copy-safe.

**Consequence (for the PM to weigh):** path (i) trades the single-encode goal for a bounded **per-child decode + re-encode**, so **task #30 / A1 is now *touched* by this feature, not sidestepped.** The §6 hermetic linear-cost check (alloc ratio 7.8 for 8× children — linear, not quadratic) is now **load-bearing**, and **C-INL-4 (the 50K RSS arm, tester Phase 3) is the real gate on path-(i)'s cost at scale.** (arch-children to correct the doc's §3 A1 note so doc+code agree.)

## Falsifiers — 7, all green `-race` + RED-proven
- **C-INLINE-1** classifier: no-apiRef inline GET → classified (the discriminator); RED = OR-clause moved after the short-circuit → no-apiRef arm FAILS.
- **§3** single-response content + non-inline no-op (byte-identical).
- **§4** cross-user RBAC inequality: u1 (granted) → `rendered`; u2 (denied) → none = no leak.
- **§5** central dep-edge on PARENT key + RED control (no L1 key → no parent edge).
- **§5** grandchild one-level cap (no nested `rendered`).
- **§6** linear-not-quadratic embed cost (hermetic A1 proxy; 50K RSS = C-INL-4 tester Phase 3).

Full regression (dispatchers + handlers + apis/templates + widgets resolvers) green `-race`; `go build` + `vet ./...` clean. No CRD-schema change (inline = additive `omitempty` on the portal-chart-owned widget spec). `resourcesRefs`+`path` kept alongside `rendered` (old SPA still follows `path`). Phase 2 = frontend `WidgetRenderer` reads `rendered` + the integration doc.

**PARKED — do NOT merge (Diego-reserved).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1