### PR TITLE
fix(errzero): seed bare-/api x509 (Class 1) + {placeholder}-ref skip (Class 5)

### DIFF
--- a/internal/cache/discovery_path_test.go
+++ b/internal/cache/discovery_path_test.go
@@ -64,3 +64,54 @@ func TestParseAPIServerDiscoveryPath(t *testing.T) {
 		})
 	}
 }
+
+// TestParseAPIServerDiscoveryRoot — #74 Class 1: the bare-root sibling. ok=true
+// for EXACTLY /api and /apis (the multi-group discovery indexes the
+// group-version predicate rejects), false for every GroupVersion path, every
+// resource path (the RBAC boundary — a root predicate that matched a resource
+// path would reopen the leak), and external/${}/malformed.
+func TestParseAPIServerDiscoveryRoot(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		wantRoot string
+		wantOK   bool
+	}{
+		// --- the two bare roots (ok=true) ---
+		{"core root", "/api", "/api", true},
+		{"multi-group root", "/apis", "/apis", true},
+		{"core root trailing slash", "/api/", "/api", true},
+		{"multi-group root slash", "/apis/", "/apis", true},
+		{"core root with query", "/api?timeout=30s", "/api", true},
+		{"multi-group root with query", "/apis?x=1", "/apis", true},
+
+		// --- GroupVersion paths (ok=false — these go to the GV predicate) ---
+		{"core GroupVersion", "/api/v1", "", false},
+		{"named GroupVersion", "/apis/apps/v1", "", false},
+		{"group version-list", "/apis/templates.krateo.io", "", false},
+
+		// --- resource paths (ok=false — the RBAC boundary, RED arm) ---
+		{"core namespaces LIST", "/api/v1/namespaces", "", false},
+		{"core GET-by-name", "/api/v1/namespaces/krateo", "", false},
+		{"group namespaced GET", "/apis/apps/v1/namespaces/krateo/deployments/x", "", false},
+
+		// --- non-apiserver / malformed (ok=false) ---
+		{"external URL", "https://example.com/api", "", false},
+		{"unresolved JQ", "/api${x}", "", false},
+		{"empty", "", "", false},
+		{"root slash", "/", "", false},
+		{"random", "/healthz", "", false},
+		{"apiserver-ish prefix not root", "/apiserver", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, ok := ParseAPIServerDiscoveryRoot(tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("ParseAPIServerDiscoveryRoot(%q) ok = %v, want %v (root=%q)", tc.path, ok, tc.wantOK, root)
+			}
+			if root != tc.wantRoot {
+				t.Fatalf("ParseAPIServerDiscoveryRoot(%q) root = %q, want %q", tc.path, root, tc.wantRoot)
+			}
+		})
+	}
+}

--- a/internal/cache/inventory.go
+++ b/internal/cache/inventory.go
@@ -416,6 +416,46 @@ func ParseAPIServerDiscoveryPath(path string) (groupVersion string, ok bool) {
 	return "", false
 }
 
+// ParseAPIServerDiscoveryRoot returns ok=true for EXACTLY the two bare
+// discovery ROOTS the apiserver serves as multi-group indexes:
+//   - "/api"  → the core-group *metav1.APIVersions index
+//   - "/apis" → the *metav1.APIGroupList index
+//
+// (#74 Class 1) These are the discovery shape ParseAPIServerDiscoveryPath
+// deliberately rejects (a multi-group index, not a single GroupVersion). A
+// seed/discovery api-step with a BARE `/api` (or `/apis`) path needs the SAME
+// CA-bearing SA transport the #18/#19 group-discovery dispatch uses — without
+// it the bare-root call falls to the external plumbing branch whose token-auth
+// TLS drops the cluster CA → x509 unknown-authority. This sibling lets
+// dispatchViaDiscovery serve the roots via the discovery client's
+// RESTClient().AbsPath(root) (raw apiserver wire bytes — no JQ-contract change).
+//
+// RBAC posture identical to #19: `/api` and `/apis` are anonymous-readable via
+// the system:discovery ClusterRole and carry NO tenant data, so SA-serving them
+// leaks nothing. The predicate matches ONLY the two exact roots (any extra
+// segment → a GroupVersion/resource path → not a root), so the resource-path
+// RBAC boundary the #19 doc relies on is untouched. No special-case
+// (feedback_no_special_cases): keyed on the structural "bare discovery root"
+// shape, never a literal resource/group value.
+func ParseAPIServerDiscoveryRoot(path string) (root string, ok bool) {
+	// Strip query string + trailing slash (so "/api/" and "/apis/?x=1" match).
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.TrimRight(path, "/")
+
+	// Reject unresolved JQ template fragments.
+	if strings.Contains(path, "${") {
+		return "", false
+	}
+
+	switch path {
+	case "/api", "/apis":
+		return path, true
+	}
+	return "", false
+}
+
 // unstructuredSliceField pulls obj[fields...] as []any. Returns
 // (nil, false, nil) when the path is missing or the leaf is not a
 // slice. An error is returned only when an intermediate node has the

--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -1346,6 +1346,11 @@ func (w *phase1Walker) walk(ctx context.Context, in *unstructured.Unstructured, 
 			// (external link, malformed) — nothing to recurse into.
 			continue
 		}
+		// #74 Class 5 — skip a ref whose name/namespace still carries an
+		// UNSUBSTITUTED widget-template token. See refHasUnresolvedTemplateToken.
+		if refHasUnresolvedTemplateToken(ref) {
+			continue
+		}
 		key := navWidgetEndpointKey(ref)
 		if _, seen := w.visited[key]; seen {
 			// Already walked (cycle-safety + shared-subtree dedup). The
@@ -1532,4 +1537,22 @@ func extractResourcesRefsItems(obj map[string]any) []navChildRef {
 // key the visited-set is keyed on.
 func navWidgetEndpointKey(ref templatesv1.ObjectReference) string {
 	return ref.APIVersion + "|" + ref.Resource + "|" + ref.Namespace + "|" + ref.Name
+}
+
+// refHasUnresolvedTemplateToken reports whether a resolved child ref still
+// carries an UNSUBSTITUTED widget-template token ('{') in its name or
+// namespace (#74 Class 5). A widget resourcesRefsTemplate may emit refs like
+// name="{name}-composition-tablist" / namespace="{namespace}" whose `{…}`
+// placeholders are substituted at FRONTEND render time, NOT at snowplow resolve
+// time. The prewarm walk must NOT GET such a literal — it is a guaranteed 404
+// (get.go) + ERROR log-noise, never a real object.
+//
+// PROVABLY NON-LOSSY: a Kubernetes object name/namespace cannot contain '{' (it
+// is an RFC1123 label/subdomain — lowercase alphanumerics, '-', '.'), so a
+// '{'-bearing ref can NEVER name a real resource; skipping it loses nothing.
+// STRUCTURAL token test (feedback_no_special_cases) — keyed on "carries an
+// unresolved template token", uniform across every ref, never a literal
+// resource/name match.
+func refHasUnresolvedTemplateToken(ref templatesv1.ObjectReference) bool {
+	return strings.Contains(ref.Name, "{") || strings.Contains(ref.Namespace, "{")
 }

--- a/internal/handlers/dispatchers/phase1_walk_template_token_test.go
+++ b/internal/handlers/dispatchers/phase1_walk_template_token_test.go
@@ -1,0 +1,56 @@
+// phase1_walk_template_token_test.go — #74 Class 5: the prewarm/resourcesRefs
+// walk must SKIP a child ref whose name/namespace still carries an
+// unsubstituted widget-template token ('{'), so the literal "{name}-…" is never
+// GET'd (a guaranteed 404 + ERROR log-noise). Provably non-lossy: a real K8s
+// object name/namespace cannot contain '{' (RFC1123), so a '{'-bearing ref can
+// never name a resource.
+package dispatchers
+
+import (
+	"testing"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+)
+
+func refOf(name, namespace string) templatesv1.ObjectReference {
+	return templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: name, Namespace: namespace},
+		Resource:   "tablists",
+		APIVersion: "widgets.templates.krateo.io/v1beta1",
+	}
+}
+
+// TestClass5_RefHasUnresolvedTemplateToken — the discriminating skip predicate.
+// A ref with a '{' token (in name OR namespace) is skipped; a fully-substituted
+// RFC1123 ref is walked. RED arm: if the walk did NOT test for the token, the
+// literal "{name}-…" ref would be GET'd → the 404 + ERROR this fix removes.
+func TestClass5_RefHasUnresolvedTemplateToken(t *testing.T) {
+	cases := []struct {
+		name     string
+		refName  string
+		refNS    string
+		wantSkip bool
+	}{
+		// --- unsubstituted template tokens → SKIP (the Class 5 noise) ---
+		{"{name} in name", "{name}-composition-tablist", "demo-system", true},
+		{"{kind}-{name} in name", "{kind}-{name}-composition-tablist", "demo-system", true},
+		{"{namespace} in namespace", "real-tablist", "{namespace}", true},
+		{"token in both", "{name}-x", "{namespace}", true},
+		{"bare brace", "a{b", "demo-system", true},
+
+		// --- fully-substituted real refs → WALK (must NOT skip) ---
+		{"real RFC1123 name", "demo-vpc-composition-tablist", "demo-system", false},
+		{"real dotted name", "my.app.tablist", "krateo-system", false},
+		{"empty (no token)", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := refHasUnresolvedTemplateToken(refOf(c.refName, c.refNS))
+			if got != c.wantSkip {
+				t.Fatalf("refHasUnresolvedTemplateToken(name=%q ns=%q) = %v, want %v "+
+					"(a '{'-bearing ref must be skipped — it can never name a real K8s object; "+
+					"a substituted ref must be walked)", c.refName, c.refNS, got, c.wantSkip)
+			}
+		})
+	}
+}

--- a/internal/resolvers/restactions/api/discovery_dispatch.go
+++ b/internal/resolvers/restactions/api/discovery_dispatch.go
@@ -170,13 +170,14 @@ func dispatchViaDiscovery(ctx context.Context, call httpcall.RequestOptions) ([]
 		return nil, false, nil
 	}
 
-	// Gate 2: shape. ParseAPIServerDiscoveryPath returns ok=true ONLY for
-	// the bare group-discovery shape (/apis/<g>/<v> or /api/<v>, no
-	// resource segment). It returns false for every resource path (F4 —
-	// the RBAC boundary), every non-apiserver / external / ${...} path,
-	// and the bare /apis | /api roots (F3).
-	gv, ok := cache.ParseAPIServerDiscoveryPath(call.Path)
-	if !ok {
+	// Gate 2: shape. A discovery-shaped path is either a single-GroupVersion
+	// path (/apis/<g>/<v> or /api/<v>) OR a bare discovery ROOT (/api | /apis,
+	// #74 Class 1). Both are SA-served via the CA-bearing transport; both
+	// reject every resource path (the RBAC boundary). A non-discovery path
+	// (resource / external / ${...} / malformed) falls through here.
+	gv, gvOK := cache.ParseAPIServerDiscoveryPath(call.Path)
+	root, rootOK := cache.ParseAPIServerDiscoveryRoot(call.Path)
+	if !gvOK && !rootOK {
 		return nil, false, nil
 	}
 
@@ -195,6 +196,22 @@ func dispatchViaDiscovery(ctx context.Context, call httpcall.RequestOptions) ([]
 		return nil, false, cliErr
 	}
 
+	// #74 Class 1 — bare discovery ROOT (/api | /apis): serve the apiserver's
+	// own multi-group index via the discovery client's RESTClient AbsPath,
+	// over the SAME CA-bearing SA transport. DoRaw returns the raw wire bytes
+	// (the apiserver's APIVersions / APIGroupList JSON), so the downstream JQ
+	// pipeline is invariant (feedback_cache_must_not_constrain_jq). This is
+	// the #18/#19 mechanism extended to the discovery root.
+	if rootOK {
+		raw, dErr := cli.RESTClient().Get().AbsPath(root).DoRaw(ctx)
+		if dErr != nil {
+			return nil, false, dErr
+		}
+		return raw, true, nil
+	}
+
+	// Single-GroupVersion discovery (/apis/<g>/<v> or /api/<v>) — the #18/#19
+	// path, unchanged.
 	list, dErr := cli.ServerResourcesForGroupVersion(gv)
 	if dErr != nil {
 		return nil, false, dErr

--- a/internal/resolvers/restactions/api/discovery_dispatch_tls_test.go
+++ b/internal/resolvers/restactions/api/discovery_dispatch_tls_test.go
@@ -235,6 +235,79 @@ func TestDiscoveryDispatch_CoreGroupShape(t *testing.T) {
 	}
 }
 
+// TestDiscoveryDispatch_BareRootServed is the #74 Class 1 POSITIVE arm: the
+// bare discovery ROOTS /api and /apis are served by the discovery branch over
+// the CA-bearing SA transport (via RESTClient AbsPath), returning the
+// apiserver's raw root index — NOT falling through to the external plumbing
+// branch (whose token-auth TLS drops the cluster CA → x509). This is the fix
+// for the seed bare-/api x509 noise. The synthetic TLS server answers any path
+// with a discovery-index body; the assertion is served=true + no x509 + the
+// body round-trips.
+func TestDiscoveryDispatch_BareRootServed(t *testing.T) {
+	for _, root := range []string{"/api", "/apis"} {
+		t.Run(root, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				// The apiserver root index shape (APIVersions for /api,
+				// APIGroupList for /apis). Body content is incidental to the
+				// fix — what matters is it's SA-served over the CA-bearing
+				// transport, not external-fall-through. Return a minimal valid
+				// JSON index.
+				_, _ = io.WriteString(w, `{"kind":"APIVersions","versions":["v1"]}`)
+			}))
+			t.Cleanup(srv.Close)
+			caPEM := pemEncodeCert(srv.Certificate())
+			rc := &rest.Config{Host: srv.URL, BearerToken: "fake-sa-jwt", TLSClientConfig: rest.TLSClientConfig{CAData: caPEM}}
+			withDiscoverySARESTConfig(t, rc)
+
+			raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+				RequestInfo: httpcall.RequestInfo{Path: root},
+			})
+			if err != nil {
+				// A bare-root that fell to the external branch over the
+				// system-root-store TLS would x509 here; the fix routes it to
+				// the CA-bearing SA transport instead.
+				t.Fatalf("Class 1: bare root %q dispatch failed (x509 if it fell external): %v", root, err)
+			}
+			if !served {
+				t.Fatalf("Class 1: bare root %q must be SERVED by the discovery branch (the seed /api x509 fix), "+
+					"not fall through to the external token-auth TLS path", root)
+			}
+			if len(raw) == 0 {
+				t.Fatalf("Class 1: served root %q returned empty bytes", root)
+			}
+		})
+	}
+}
+
+// TestDiscoveryDispatch_BareRootLeakGuard is the #74 Class 1 RBAC-boundary RED
+// arm: widening the dispatch to the bare roots must NOT widen it to any
+// resource path. A resource path under /api or /apis is STILL not served (the
+// root predicate matches ONLY the two exact roots). Pairs with F4.
+func TestDiscoveryDispatch_BareRootLeakGuard(t *testing.T) {
+	withDiscoverySARESTConfig(t, &rest.Config{Host: "https://kubernetes.default.svc"})
+	for _, p := range []string{
+		"/api/v1/namespaces",                // core LIST
+		"/api/v1/namespaces/krateo",         // core GET
+		"/apis/apps/v1/deployments",         // group LIST
+		"/apis/apps/v1/namespaces/x/pods/p", // group namespaced GET
+	} {
+		raw, served, err := dispatchViaDiscovery(context.Background(), httpcall.RequestOptions{
+			RequestInfo: httpcall.RequestInfo{Path: p},
+		})
+		if err != nil {
+			t.Fatalf("Class 1 leak-guard: %q errored (should just not-serve): %v", p, err)
+		}
+		if served {
+			t.Fatalf("Class 1 LEAK: resource path %q was SA-served by the discovery branch — the bare-root "+
+				"widening must NOT route resource paths (RBAC boundary)", p)
+		}
+		if raw != nil {
+			t.Fatalf("Class 1 leak-guard: %q returned %d bytes, want nil (not served)", p, len(raw))
+		}
+	}
+}
+
 // TestDiscoveryDispatch_NonAPIServerPathFallsThrough is F3, behaviour-
 // neutral: a non-discovery (external / non-apiserver) path is NOT served
 // by the discovery branch.
@@ -268,6 +341,14 @@ func TestDiscoveryDispatch_ResourcePathNotRouted(t *testing.T) {
 	// THIS rc; swapping it lets us assert served=false purely on the shape.
 	withDiscoverySARESTConfig(t, &rest.Config{Host: "https://kubernetes.default.svc"})
 
+	// NOTE (#74 Class 1): /apis and /api (the bare ROOTS) were here as
+	// "not served"; they are now SERVED via the dispatch's bare-root branch
+	// (TestDiscoveryDispatch_BareRootServed). They remain NOT-a-single-GV at
+	// the ParseAPIServerDiscoveryPath predicate level (still false there —
+	// asserted in discovery_path_test.go + TestParseAPIServerDiscoveryRoot), so
+	// the GroupVersion predicate's RBAC boundary is unchanged. This list keeps
+	// only the RESOURCE paths + the group-version-list, which must STILL never
+	// be served by EITHER predicate.
 	resourcePaths := []string{
 		"/apis/templates.krateo.io/v1/compositiondefinitions",                              // group LIST
 		"/apis/templates.krateo.io/v1/compositiondefinitions/foo",                          // group GET-by-name
@@ -276,9 +357,7 @@ func TestDiscoveryDispatch_ResourcePathNotRouted(t *testing.T) {
 		"/api/v1/namespaces",        // core LIST
 		"/api/v1/namespaces/krateo", // core GET-by-name
 		"/api/v1/pods",              // core cluster LIST
-		"/apis",                     // multi-group discovery index (not a single GV)
-		"/api",                      // core root (not a single GV)
-		"/apis/templates.krateo.io", // group version list (not a single GV)
+		"/apis/templates.krateo.io", // group version list (not a single GV, not a bare root)
 	}
 	for _, p := range resourcePaths {
 		// Predicate-level: ParseAPIServerDiscoveryPath must return false.


### PR DESCRIPTION
Two snowplow-side rolling-test error-zero fixes (dual-gate GREEN: arch PASS + PM ACCEPT, leak-guard RED-verified). Class 1: the #18/#19 discovery-dispatch predicate matched /api/<version> but not bare /api → seed discovery fell to the external path that drops the cluster CA → x509. ParseAPIServerDiscoveryRoot (exactly /api+/apis) + dispatchViaDiscovery root branch via the CA-bearing SA transport. Resource-path RBAC boundary RED-proven intact (anonymous-readable discovery roots only). Class 5: skip resourcesRefs refs whose name/namespace contains '{' (unsubstituted widget-template token) — provably non-lossy (RFC1123 names can't contain '{'). Default-safe/additive. On-cluster falsifier: zero x509 + zero seed-cancel + zero {token}-404 over 20min (pre-fix 7+1+4). Class 3 (wrapAsSlice scalar) held for separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)