### PR TITLE
fix(resolver): Class 3 — provenance-discriminated flatten (no raw-response scalar splice)

### DIFF
--- a/internal/resolvers/restactions/api/handler.go
+++ b/internal/resolvers/restactions/api/handler.go
@@ -182,32 +182,58 @@ func jsonHandlerCore(ctx context.Context, opts jsonHandlerOptions, tmp any) erro
 		return nil
 	}
 
+	// #74 Class 3 R1' — PROVENANCE-DISCRIMINATED flatten. A bare []any element
+	// `tmp` is SPLICED into the accumulator (its members appended element-wise)
+	// ONLY when it is FILTER-PRODUCED — `opts.filter != nil`, i.e. the per-stage
+	// gojq filter constructed the array (e.g. composition-schema's
+	// `getCompositionDefinitionNamespace … | map(.metadata.namespace)`, where
+	// element-wise concat is intended). A RAW-RESPONSE []any (`opts.filter ==
+	// nil`) is appended as a SINGLE element, never spliced.
+	//
+	// Why: the dispatch never returns a bare []any for a no-filter step — a
+	// GET-by-name is an object, a LIST GET is the {items} envelope OBJECT
+	// (listEnvelopeValue, apistage.go), discovery is an APIResourceList OBJECT.
+	// A no-filter bare []any arises ONLY when a resolve:true nested element
+	// resolves to an RA/widget whose top-level value is an array — the Class 3
+	// `allCompositionResources` self/nested resolve returning ["v1", …].
+	// Splicing THAT poisons the parent list with bare scalars ("v1"), which the
+	// downstream portal filter then indexes as `.metadata` → "expected an object
+	// but got: string". Corpus-proven safe (docs/errzero-class3-decision §7.2):
+	// getCompositionDefinitionNamespace = 10/10 filter-bearing (still flattens),
+	// allCompositionResources = 0/34 (stops splicing), no identity-passthrough
+	// filter exists, no no-filter LIST-GET returns a bare []any.
+	//
+	// STRUCTURAL predicate (feedback_no_special_cases) — keyed on
+	// `opts.filter != nil`, never on a resource/name/GVR literal. Global, no
+	// per-RA config, no CRD field.
+	flatten := opts.filter != nil
 	switch existingSlice := got.(type) {
 	case []any:
-		if v := wrapAsSlice(tmp); len(v) > 0 {
-			opts.out[opts.key] = append(existingSlice, v...)
+		if arr, isArr := tmp.([]any); isArr {
+			if flatten && len(arr) > 0 {
+				// (A) filter-produced array → splice members (preserves the
+				// pre-R1' len>0 empty-slice skip).
+				opts.out[opts.key] = append(existingSlice, arr...)
+			} else if !flatten {
+				// (B) raw-response array → single element, never spliced.
+				opts.out[opts.key] = append(existingSlice, tmp)
+			}
+			// flatten && len==0: empty filtered array contributes nothing
+			// (unchanged from the pre-R1' len(v) > 0 guard).
+		} else {
+			// scalar/object element → single element (wrapAsSlice's old
+			// default branch).
+			opts.out[opts.key] = append(existingSlice, tmp)
 		}
 	default:
-		opts.out[opts.key] = []any{got, tmp}
-
-		switch v := tmp.(type) {
-		case []any:
-			all := []any{got}
-			all = append(all, v...)
-			opts.out[opts.key] = all
-		default:
-			opts.out[opts.key] = []any{got, v}
+		// Second element arriving (existing accumulator value is not yet a
+		// slice). Same A/B discrimination as above.
+		if arr, isArr := tmp.([]any); isArr && flatten {
+			opts.out[opts.key] = append([]any{got}, arr...)
+		} else {
+			opts.out[opts.key] = []any{got, tmp}
 		}
 	}
 
 	return nil
-}
-
-func wrapAsSlice(value any) []any {
-	switch v := value.(type) {
-	case []any:
-		return v
-	default:
-		return []any{v}
-	}
 }

--- a/internal/resolvers/restactions/api/handler_flatten_provenance_test.go
+++ b/internal/resolvers/restactions/api/handler_flatten_provenance_test.go
@@ -1,0 +1,128 @@
+//go:build unit
+// +build unit
+
+// handler_flatten_provenance_test.go — #74 Class 3 R1' falsifier pair.
+//
+// The accumulator in jsonHandlerCore (handler.go) splices a bare []any element
+// into the per-key accumulator ONLY when it is FILTER-PRODUCED (opts.filter !=
+// nil). A RAW-RESPONSE []any (opts.filter == nil) is appended as a SINGLE
+// element, never spliced. This is the Class 3 fix: the iterator step
+// allCompositionResources (NO filter) had one element resolve to ["v1", …] and
+// the old wrapAsSlice flatten spliced the bare scalar "v1" into the parent
+// list, which the downstream portal filter indexed as .metadata → "expected an
+// object but got: string (\"v1\")".
+//
+// These drive the REAL jsonHandlerCore accumulator (not a hand-rolled copy) by
+// seeding out[key] with a first element, then accumulating a second element
+// whose value is a bare []any — exactly the multi-element iterator path.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/ptr"
+)
+
+// accumulate runs jsonHandlerCore for a sequence of already-decoded element
+// values under the given filter pointer, returning the final out[key]. This is
+// the production accumulator path (handler.go) — the elements arrive one per
+// iterator yield, accumulated into out[key].
+func accumulate(t *testing.T, filter *string, key string, elements ...any) any {
+	t.Helper()
+	out := map[string]any{}
+	opts := jsonHandlerOptions{
+		key:    key,
+		out:    out,
+		dict:   map[string]any{},
+		filter: filter,
+	}
+	for i, el := range elements {
+		if err := jsonHandlerCore(context.Background(), opts, el); err != nil {
+			t.Fatalf("jsonHandlerCore element %d: %v", i, err)
+		}
+	}
+	return out[key]
+}
+
+// containsBareString reports whether v is a []any with a top-level bare-string
+// member — the poisoned shape Class 3 produced.
+func containsBareString(v any, s string) bool {
+	arr, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	for _, m := range arr {
+		if str, isStr := m.(string); isStr && str == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestClass3R1_RawResponseArrayNotSpliced is the RED arm (cured by R1'). A
+// no-filter iterator step (opts.filter == nil) whose second element resolves to
+// a bare []any{"v1","apps/v1"} must NOT splice "v1" / "apps/v1" as top-level
+// bare-string members of the accumulator — the array is appended as a SINGLE
+// element. RED on the old wrapAsSlice flatten (the scalar WAS spliced); GREEN
+// after R1'.
+func TestClass3R1_RawResponseArrayNotSpliced(t *testing.T) {
+	// First element: a real resource object (what allCompositionResources
+	// resolves for a well-formed path). Second element: the poisoned bare
+	// array (a resolve:true element resolving to a groupVersion-string list).
+	obj := map[string]any{"metadata": map[string]any{"name": "cm-a"}}
+	poison := []any{"v1", "apps/v1"}
+
+	got := accumulate(t, nil /* opts.filter == nil → RAW response */, "allCompositionResources", obj, poison)
+
+	if containsBareString(got, "v1") || containsBareString(got, "apps/v1") {
+		j, _ := json.Marshal(got)
+		t.Fatalf("Class 3 RED: a RAW-response []any was SPLICED — bare scalar leaked to the parent "+
+			"(this poisons the downstream filter's .metadata index). got=%s", j)
+	}
+	// Positive: the array must still be PRESENT as a single element (not
+	// dropped) — the no-filter element is preserved, just not flattened.
+	arr, ok := got.([]any)
+	if !ok || len(arr) != 2 {
+		j, _ := json.Marshal(got)
+		t.Fatalf("Class 3: expected 2 accumulated elements (obj + the array-as-single-element), got=%s", j)
+	}
+	if _, isArr := arr[1].([]any); !isArr {
+		j, _ := json.Marshal(got)
+		t.Fatalf("Class 3: the raw-response array must be a SINGLE nested element, got element[1]=%s", j)
+	}
+}
+
+// TestClass3R1_FilterProducedArrayStillFlattens is the GREEN arm (regression
+// guard). composition-schema's getCompositionDefinitionNamespace has a per-stage
+// filter that CONSTRUCTS an array (map(.metadata.namespace)); the intended
+// behaviour is element-wise concat into one flat namespace list. With
+// opts.filter != nil and two elements ["ns-a"] / ["ns-b"], the accumulator must
+// stay FLAT ["ns-a","ns-b"] — NOT nested [["ns-a"],["ns-b"]]. GREEN before AND
+// after R1' (proves R1' did not break the load-bearing flatten).
+func TestClass3R1_FilterProducedArrayStillFlattens(t *testing.T) {
+	// The filter yields the per-element array as a SINGLE value (so tmp is a
+	// []any at the accumulator, exercising the filter-produced splice branch).
+	// This mirrors getCompositionDefinitionNamespace's `[ … | .metadata.namespace ]`
+	// which constructs an array per iterator element.
+	got := accumulate(t, ptr.To(".getCompositionDefinitionNamespace") /* filter != nil → array tmp */,
+		"getCompositionDefinitionNamespace", []any{"ns-a"}, []any{"ns-b"})
+
+	arr, ok := got.([]any)
+	if !ok {
+		j, _ := json.Marshal(got)
+		t.Fatalf("GREEN: filter-produced arrays must accumulate to a []any, got=%s", j)
+	}
+	if len(arr) != 2 {
+		j, _ := json.Marshal(got)
+		t.Fatalf("GREEN: expected FLAT [\"ns-a\",\"ns-b\"] (filter-produced flatten preserved), got %d members: %s", len(arr), j)
+	}
+	for i, want := range []string{"ns-a", "ns-b"} {
+		s, isStr := arr[i].(string)
+		if !isStr || s != want {
+			j, _ := json.Marshal(got)
+			t.Fatalf("GREEN: filter-produced flatten broken — member[%d]=%v, want %q (flat). got=%s", i, arr[i], want, j)
+		}
+	}
+}


### PR DESCRIPTION
Class 3 error-zero (dual-gate GREEN: arch-listshape soundness PASS + PM ACCEPT, both falsifier arms RED-proven both directions, both tag-modes). jsonHandlerCore accumulator: flatten := opts.filter != nil — a bare []any iterator-element is spliced ONLY when filter-produced (provenance A, e.g. composition-schema's map(.metadata.namespace)); a raw-response []any (filter==nil, provenance B) is appended as a single element, never spliced. Stops allCompositionResources (0/34 filter-bearing) splicing the stray "v1" that poisoned the portal filter. Removed now-unused wrapAsSlice. Global, no per-RA config, no special-case. Root cause: #40 (416a620, loopback retirement) is the regression introduction (confirmed-by-elimination) — it changed the per-element feed from raw-CR to a resolve:true envelope, so a bare []any reached the unchanged-since-0.30.144 accumulator splice; R1' is a new forward guard restoring the old outcome. UAF exonerated (fsa-y* has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)