### PR TITLE
fix(resolver): Class 3 — don't cluster-list-collapse a by-name iterator (restore by-name fan-out)

### DIFF
--- a/internal/resolvers/restactions/api/cluster_list.go
+++ b/internal/resolvers/restactions/api/cluster_list.go
@@ -677,13 +677,33 @@ func deriveTargetGVRForClusterList(
 		return schema.GroupVersionResource{}, false
 	}
 
-	gvr, ns, _, parseOK := cache.ParseAPIServerPathToDep(resolvedPath)
+	gvr, ns, name, parseOK := cache.ParseAPIServerPathToDep(resolvedPath)
 	if !parseOK {
 		return schema.GroupVersionResource{}, false
 	}
 	if ns == "" {
 		// Cluster-scope path already — no collapse needed. The RA's
 		// iterator does not fan out over namespaces; keep verbatim.
+		return schema.GroupVersionResource{}, false
+	}
+	if name != "" {
+		// #74 Class 3 — the iterator's first element resolves to a
+		// BY-NAME GET (/…/namespaces/<ns>/<resource>/<name>), NOT a
+		// per-namespace LIST. A by-name fan-out must NEVER collapse: the
+		// collapse replaces N targeted GET-by-name fetches with ONE
+		// cluster-wide LIST, returning the {apiVersion,kind,items} LIST
+		// ENVELOPE (an OBJECT) instead of the per-element bare objects the
+		// RA filter expects. The RA then runs `map(select(.metadata.name…))`
+		// over the OBJECT and indexes its first scalar field (apiVersion
+		// "v1") → gojq "expected an object but got: string". It is ALSO a
+		// correctness bug (a cluster-wide LIST returns ALL N resources, not
+		// the composition's by-name subset). Collapse is valid ONLY for a
+		// name=="" per-namespace LIST. Bug introduced at Ship 0.30.216
+		// (911b1a8) when collapse flipped on; this restores the by-name
+		// fan-out (= the bare array the RA filter consumes).
+		//
+		// STRUCTURAL guard (feedback_no_special_cases) — keyed on the parsed
+		// path SHAPE (a name segment present), never a resource/name literal.
 		return schema.GroupVersionResource{}, false
 	}
 	return gvr, true

--- a/internal/resolvers/restactions/api/cluster_list_test.go
+++ b/internal/resolvers/restactions/api/cluster_list_test.go
@@ -820,6 +820,64 @@ func TestDeriveTargetGVRForClusterList_NilIterator(t *testing.T) {
 	}
 }
 
+// TestDeriveTargetGVRForClusterList_ByNamePathNotCollapsed is the #74 Class 3
+// RED arm. The iterator's first element resolves to a BY-NAME GET
+// (/…/namespaces/<ns>/<resource>/<name>) — a TARGETED fan-out, not a
+// per-namespace LIST. The collapse must be REJECTED (ok=false): collapsing a
+// by-name fan-out into ONE cluster-wide LIST returns the {apiVersion,kind,items}
+// LIST ENVELOPE (an OBJECT) instead of the per-element bare objects the RA
+// filter `map(select(.metadata.name…))` consumes — the filter then indexes the
+// envelope's first scalar (apiVersion "v1") → "expected an object but got:
+// string". It is also a correctness bug (cluster-wide returns ALL resources,
+// not the composition's by-name subset). This was the live 1.5.18 defect
+// (introduced 0.30.216/911b1a8). RED on the pre-fix code (name discarded → the
+// by-name path reached ok=true), GREEN after the `name != ""` guard.
+func TestDeriveTargetGVRForClusterList_ByNamePathNotCollapsed(t *testing.T) {
+	apiCall := &templates.API{
+		Name: "allCompositionResources",
+		// First element resolves to a by-name GET — note the trailing
+		// /<name> segment (the composition's specific resource).
+		Path: `${ "/api/v1/namespaces/" + .ns + "/configmaps/" + .name }`,
+		DependsOn: &templates.Dependency{
+			Iterator: ptr.To(`[{"ns":"demo-system","name":"fsa-y2-cm"},{"ns":"demo-system","name":"fsa-y2-cm2"}]`),
+		},
+	}
+	gvr, ok := deriveTargetGVRForClusterList(
+		context.Background(), clusterListLogger(t), apiCall, map[string]any{})
+	if ok {
+		t.Fatalf("Class 3 RED: a BY-NAME iterator fan-out must NOT collapse (got ok=true, gvr=%s) — "+
+			"collapsing it to a cluster-wide LIST yields the {apiVersion,items} envelope the RA filter "+
+			"can't consume (\"expected an object but got: string\")", gvr)
+	}
+}
+
+// TestDeriveTargetGVRForClusterList_PerNamespaceListStillCollapses is the #74
+// Class 3 GREEN-guard. A name=="" per-namespace LIST path
+// (/…/namespaces/<ns>/<resource>, NO trailing name) is the LEGITIMATE collapse
+// target — it must STILL collapse (ok=true) after the by-name guard. This is the
+// regression arm proving the fix did not over-reject the real collapse case
+// (routes/navmenuitems/compositionspanels). GREEN before AND after the fix.
+func TestDeriveTargetGVRForClusterList_PerNamespaceListStillCollapses(t *testing.T) {
+	apiCall := &templates.API{
+		Name: "compositionspanels",
+		// LIST path — namespace segment, NO trailing /<name>.
+		Path: `${ "/api/v1/namespaces/" + .ns + "/configmaps" }`,
+		DependsOn: &templates.Dependency{
+			Iterator: ptr.To(`[{"ns":"demo-system"},{"ns":"krateo-system"}]`),
+		},
+	}
+	gvr, ok := deriveTargetGVRForClusterList(
+		context.Background(), clusterListLogger(t), apiCall, map[string]any{})
+	if !ok {
+		t.Fatalf("Class 3 GREEN-guard: a name=='' per-namespace LIST is the legitimate collapse target — "+
+			"the by-name guard must NOT over-reject it (got ok=false)")
+	}
+	want := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	if gvr != want {
+		t.Fatalf("Class 3 GREEN-guard: collapsed gvr=%s want %s", gvr, want)
+	}
+}
+
 // ---------- AC-D5.5 race seal — concurrent validateClusterListShape ----------
 
 // The shape check is a pure function over the input bytes — no shared


### PR DESCRIPTION
Class 3 REAL fix (dual-gate GREEN: arch-listshape soundness PASS + PM ACCEPT, both arms RED-verified both directions). Root cause (PROVEN, arch §16/§17 + runtime C3CtMoBvR trace): clusterListCollapseEnabled flipped on at Ship 0.30.216 / commit 911b1a8; deriveTargetGVRForClusterList discarded the resource name (only rejected empty ns) → a by-name iterator (allCompositionResources/getResource) collapsed into ONE cluster-wide /api/v1/configmaps LIST → {apiVersion,kind,items} envelope → portal filter map(select(.metadata.name)) over the OBJECT → apiVersion "v1" → 'expected an object but got string'. Correctness bug too (97 cluster cms vs the composition's specific resources) + shared identity-free apistage cell poisoning. Fix: capture name + 'if name != "" { return {}, false }' — by-name iterators never collapse; name=='' per-namespace LISTs still collapse (routes/navmenuitems/compositionspanels unaffected — no #46/#42/Path-3 regression). Structural, no special-case. Supersedes R1' (no-op for this mechanism) / .status.Raw / merge-wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)