### PR TITLE
feat(resolve): (c) cold-fan-out aggregate-footprint bound — weighted nested-resolve gate (default-off)

### DIFF
--- a/internal/resolvers/restactions/api/nested_resolve_bound.go
+++ b/internal/resolvers/restactions/api/nested_resolve_bound.go
@@ -1,0 +1,230 @@
+// nested_resolve_bound.go — (c) cold-fan-out aggregate-footprint bound on the
+// CUSTOMER nested-resolve path. Sibling of the SHIPPED #46 seed_bound.go, same
+// semaphore.Weighted + empirical-calibration mechanism, applied at the
+// maybeResolveInProcess choke point instead of the seed primitives.
+//
+// THE OOM CLASS (#23 cold-fan-out, RE-EXPOSED by #77): a single cold /call of a
+// heavy composition RA (fsa-y2-composition-resources) recursively resolves ~20
+// nested RA/widget children in-process (resolve:true). Each child envelope is
+// decoded-into-map (A1 #30 double-encode + #72 decode-into-map → encoding/json
+// objectInterface ~67% of inuse_space). One outer /call drove a monotonic
+// 716MB→1172MB climb (heap pprof, traceId C3CtMoBvR follow-up). It is a
+// SINGLE-RESOLVE MULTIPLIER (one /call × N nested trees), NOT a concurrent
+// burst — so the (a) process-wide customer-entry cap (#25, reverted) is the
+// wrong lever; this bounds the AGGREGATE in-flight footprint of the nested
+// subtree(s) regardless of how many top-level /calls are concurrent.
+//
+// PLACEMENT — OUTERMOST nested-resolve ONLY (depth-0):
+//   - Acquire fires in maybeResolveInProcess AFTER Gate 4 (a confirmed
+//     single-CR RA/widget GET that WILL nest-resolve), and ONLY when
+//     NestedCallDepthFromContext(gctx)==0 (the top of a nested subtree). The
+//     inner recursive resolves (depth>0) inherit the ONE permit the outermost
+//     entry holds → ONE permit per whole subtree, no per-node explosion, and no
+//     self-deadlock (a subtree never waits on its own ancestor's permit).
+//   - This sits AFTER the apistage content-serve / cache-hit gates in the
+//     caller (a warm hit never reaches Gate 4's nestedCallResolver), so it is
+//     cost-proportional: only a genuine COLD nested resolve pays
+//     (feedback_bounding_mechanism_discipline — after the cache-hit, bound the
+//     event that still happens, cost-proportional not flat-worst-case).
+//
+// WEIGHT (C46-1 self-calibrating, NOT a design-time constant — the 1.5.1 180×
+// lesson): the per-subtree Acquire weight is calibrated from the FIRST
+// subtree's MEASURED HeapInuse delta (one-shot), reused after. Before
+// calibration (and as the conservative fallback) it is
+// NESTED_RESOLVE_EST_UNIT_BYTES_FALLBACK = 256 MiB (≥5× the observed ~47MB/tree),
+// clamped to the budget so one oversized subtree runs ALONE rather than
+// blocking forever (guaranteed-progress: the bounded event still happens).
+//
+// DEFAULT-OFF / TRANSPARENT: budget=0 (NESTED_RESOLVE_FOOTPRINT_BUDGET_BYTES
+// unset) ⇒ Acquire skipped, release is a no-op — byte-identical to pre-(c)
+// behaviour (project_caching_is_provisional: cleanly removable). Excess
+// BLOCKS, never drops → every nested resolve still completes + is
+// content-correct, just serialized under memory pressure.
+package api
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// envNestedResolveFootprintBudgetBytes caps the aggregate in-flight COLD
+	// nested-resolve HeapInuse. 0 (default) DISABLES the bound — the
+	// transparent posture. Operators set it from the empirical per-subtree cost
+	// × safety (feedback_capacity_caps_empirical_per_entry_cost; the pprof
+	// measured ~47MB/tree, the 1172MB peak motivates a GOMEMLIMIT-fraction
+	// budget).
+	envNestedResolveFootprintBudgetBytes = "NESTED_RESOLVE_FOOTPRINT_BUDGET_BYTES"
+
+	// envNestedResolveEstUnitBytesFallback is the CONSERVATIVE-HIGH per-subtree
+	// weight used before the one-shot empirical calibration lands. Over-reserve
+	// by design (a too-high fallback serializes a bit more — safe; a too-low one
+	// admits too much aggregate — the 1.5.1 under-estimate failure mode). 256
+	// MiB ≥5× the observed ~47MB/tree; clamped to the budget at use.
+	envNestedResolveEstUnitBytesFallback     = "NESTED_RESOLVE_EST_UNIT_BYTES_FALLBACK"
+	defaultNestedResolveEstUnitBytesFallback = 256 * 1024 * 1024 // 256 MiB, conservative-high
+)
+
+var (
+	// nestedBoundOnce-style lazy build (plain mutex double-check, NOT sync.Once,
+	// so resetNestedResolveBoundForTest can rebuild it under t.Setenv).
+	nestedBoundMu     sync.Mutex
+	nestedBoundSem    *semaphore.Weighted
+	nestedBoundBudget int64
+	nestedBoundBuilt  bool
+
+	// nestedEstUnitBytes is the calibrated per-subtree Acquire weight. Starts at
+	// the conservative-high fallback; replaced ONCE by the first subtree's
+	// measured HeapInuse delta (C46-1). Guarded by nestedEstUnitMu.
+	nestedEstUnitMu         sync.Mutex
+	nestedEstUnitBytes      int64
+	nestedEstUnitCalibrated bool
+)
+
+// nestedBudgetBytes reads NESTED_RESOLVE_FOOTPRINT_BUDGET_BYTES (0 = disabled).
+func nestedBudgetBytes() int64 {
+	return int64(env.Int(envNestedResolveFootprintBudgetBytes, 0))
+}
+
+// nestedEstUnitFallback reads the conservative-high fallback per-subtree weight.
+func nestedEstUnitFallback() int64 {
+	return int64(env.Int(envNestedResolveEstUnitBytesFallback, defaultNestedResolveEstUnitBytesFallback))
+}
+
+// nestedResolveBound lazily builds (once) the process-wide nested-resolve
+// semaphore from the budget, returning (sem, budget). Returns (nil, 0) when the
+// budget is 0 (disabled → enterNestedResolveUnit is a transparent pass-through).
+func nestedResolveBound() (*semaphore.Weighted, int64) {
+	nestedBoundMu.Lock()
+	defer nestedBoundMu.Unlock()
+	if !nestedBoundBuilt {
+		nestedBoundBudget = nestedBudgetBytes()
+		if nestedBoundBudget > 0 {
+			nestedBoundSem = semaphore.NewWeighted(nestedBoundBudget)
+		}
+		nestedBoundBuilt = true
+	}
+	return nestedBoundSem, nestedBoundBudget
+}
+
+// currentNestedEstUnit returns the per-subtree Acquire weight, clamped to the
+// budget (a single Acquire can never exceed the semaphore capacity, else it
+// would block forever). Uses the calibrated value once available, else the
+// conservative-high fallback.
+func currentNestedEstUnit(budget int64) int64 {
+	nestedEstUnitMu.Lock()
+	est := nestedEstUnitBytes
+	calibrated := nestedEstUnitCalibrated
+	nestedEstUnitMu.Unlock()
+	if !calibrated || est <= 0 {
+		est = nestedEstUnitFallback()
+	}
+	if budget > 0 && est > budget {
+		est = budget // clamp: one subtree may use up to the whole budget, never more
+	}
+	if est < 1 {
+		est = 1
+	}
+	return est
+}
+
+// calibrateNestedEstUnit records the first subtree's MEASURED HeapInuse delta as
+// the empirical per-subtree weight (C46-1, one-shot). A delta of 0 (GC ran
+// mid-subtree, or a trivial subtree) is ignored so we don't calibrate to an
+// unrealistically small weight.
+func calibrateNestedEstUnit(measuredDelta int64) {
+	if measuredDelta <= 0 {
+		return
+	}
+	nestedEstUnitMu.Lock()
+	if !nestedEstUnitCalibrated {
+		nestedEstUnitBytes = measuredDelta
+		nestedEstUnitCalibrated = true
+	}
+	nestedEstUnitMu.Unlock()
+}
+
+// nestedHeapInuse samples the current HeapInuse. ReadMemStats stops the world
+// briefly; called at most twice per OUTERMOST nested resolve (depth-0 only) —
+// never on a warm hit, never on an inner recursive resolve.
+func nestedHeapInuse() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapInuse
+}
+
+// enterNestedResolveUnit is the cold-fan-out footprint bound, applied as a
+// lifecycle bracket at the OUTERMOST nested resolve. The caller MUST gate it on
+// the depth-0 condition (it is acquired ONLY when
+// cache.NestedCallDepthFromContext(gctx)==0) so the whole nested subtree holds
+// exactly ONE permit — inner recursive resolves (depth>0) do NOT re-enter
+// (no per-node explosion, no self-deadlock).
+//
+// When the budget is 0 it is a transparent pass-through: Acquire is skipped and
+// release() is a no-op. Otherwise: Acquire(weight) [blocks if the aggregate
+// in-flight weight would exceed the budget — completes, never drops] + sample
+// HeapInuse on entry; release() samples HeapInuse again, calibrates the
+// per-subtree weight (one-shot), and Releases.
+//
+// The Acquire weight is clamped to the budget (currentNestedEstUnit) so a single
+// subtree larger than the whole budget runs ALONE rather than blocking forever
+// — the guaranteed-progress / "bounded event still happens" property.
+func enterNestedResolveUnit(ctx context.Context) (release func(), err error) {
+	sem, budget := nestedResolveBound()
+	if sem == nil || budget == 0 {
+		return func() {}, nil // disabled — transparent pass-through.
+	}
+
+	est := currentNestedEstUnit(budget)
+	if aerr := sem.Acquire(ctx, est); aerr != nil {
+		// ctx cancelled/expired while blocked on the bound — propagate so the
+		// outer /call surfaces the cancellation rather than resolving unbounded.
+		return nil, aerr
+	}
+
+	before := nestedHeapInuse()
+	return func() {
+		after := nestedHeapInuse()
+		// HeapInuse can shrink across a GC mid-subtree; a negative delta → 0.
+		var delta int64
+		if after > before {
+			delta = int64(after - before)
+		}
+		calibrateNestedEstUnit(delta)
+		sem.Release(est)
+	}, nil
+}
+
+// isOutermostNestedResolve reports whether gctx is at the TOP of a nested
+// subtree (depth 0) — the single point where enterNestedResolveUnit acquires.
+// Extracted for the falsifier (CN-3 depth-0 verification).
+func isOutermostNestedResolve(ctx context.Context) bool {
+	return cache.NestedCallDepthFromContext(ctx) == 0
+}
+
+// resetNestedResolveBoundForTest rebuilds the lazy semaphore + clears the
+// calibration so a falsifier can drive a fresh budget via t.Setenv. Test-only.
+func resetNestedResolveBoundForTest() {
+	nestedBoundMu.Lock()
+	nestedBoundBuilt = false
+	nestedBoundSem = nil
+	nestedBoundBudget = 0
+	nestedBoundMu.Unlock()
+	nestedEstUnitMu.Lock()
+	nestedEstUnitBytes = 0
+	nestedEstUnitCalibrated = false
+	nestedEstUnitMu.Unlock()
+}
+
+// calibratedNestedEstUnitForTest returns (estUnitBytes, calibrated) for the
+// falsifier. Test-only.
+func calibratedNestedEstUnitForTest() (int64, bool) {
+	nestedEstUnitMu.Lock()
+	defer nestedEstUnitMu.Unlock()
+	return nestedEstUnitBytes, nestedEstUnitCalibrated
+}

--- a/internal/resolvers/restactions/api/nested_resolve_bound_falsifier_test.go
+++ b/internal/resolvers/restactions/api/nested_resolve_bound_falsifier_test.go
@@ -1,0 +1,240 @@
+// nested_resolve_bound_falsifier_test.go — (c) cold-fan-out bound falsifiers
+// (CN-1..6). The real heap-climb is not hermetically assertable, so the
+// discriminating proof is on the SEMAPHORE ADMISSION behaviour: the bound caps
+// the number of concurrently-in-flight nested subtrees to floor(budget/weight),
+// the excess BLOCKS (completes, never drops), and budget=0 is transparent
+// (unbounded). Concurrency is driven > cap (CN-1 non-degenerate: M>1 AND
+// concurrency>cap). Hermetic / in-process ONLY — no kind, no remote, no
+// apiserver.
+package api
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// runConcurrentNestedUnits drives n goroutines each through one
+// enterNestedResolveUnit bracket, holding the permit for `hold` while it counts
+// the peak number concurrently in-flight. Returns the observed peak. Every unit
+// must complete (CN-4 completes-not-drops). ctx depth is 0 (outermost) for all.
+func runConcurrentNestedUnits(t *testing.T, n int, hold time.Duration) (peak int32, completed int32) {
+	t.Helper()
+	ctx := cache.WithNestedCallDepth(context.Background(), 0)
+	var inFlight, peakInFlight, done int32
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := enterNestedResolveUnit(ctx)
+			if err != nil {
+				t.Errorf("enterNestedResolveUnit unexpected err: %v", err)
+				return
+			}
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				p := atomic.LoadInt32(&peakInFlight)
+				if cur <= p || atomic.CompareAndSwapInt32(&peakInFlight, p, cur) {
+					break
+				}
+			}
+			time.Sleep(hold)
+			atomic.AddInt32(&inFlight, -1)
+			atomic.AddInt32(&done, 1)
+			release()
+		}()
+	}
+	wg.Wait()
+	return atomic.LoadInt32(&peakInFlight), atomic.LoadInt32(&done)
+}
+
+// TestCN1_BoundCapsConcurrentSubtrees_RED is the CN-1 RED discriminating arm.
+// M=8 concurrent nested subtrees, each weight=budget/2 (so M×weight ≫ budget,
+// concurrency ≫ cap=2). The bound must cap the peak in-flight at
+// floor(budget/weight)==2. RED arm: budget=0 (gate removed) → all 8 run
+// concurrently (unbounded — the OOM climb). NON-DEGENERATE: M=8>1 AND
+// concurrency(8) > cap(2).
+func TestCN1_BoundCapsConcurrentSubtrees_RED(t *testing.T) {
+	const M = 8
+	const weight = 100
+	const budget = 200 // cap = floor(200/100) = 2
+
+	// Pin the per-subtree weight (skip the empirical calibration so the test is
+	// deterministic) via the fallback env = weight, budget via its env.
+	t.Setenv(envNestedResolveEstUnitBytesFallback, "100")
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "200")
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	if _, b := nestedResolveBound(); b != budget {
+		t.Fatalf("setup: budget=%d want %d", b, budget)
+	}
+	if w := currentNestedEstUnit(budget); w != weight {
+		t.Fatalf("setup: weight=%d want %d", w, weight)
+	}
+
+	peak, completed := runConcurrentNestedUnits(t, M, 40*time.Millisecond)
+	if completed != M {
+		t.Fatalf("CN-4 completes-not-drops: completed=%d want %d", completed, M)
+	}
+	if peak > 2 {
+		t.Fatalf("CN-1: peak concurrent subtrees=%d, want <=2 (budget %d / weight %d) — "+
+			"the bound did not cap the cold fan-out", peak, budget, weight)
+	}
+
+	// RED CONTROL: budget=0 (gate removed) → unbounded, peak should reach M.
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "0")
+	resetNestedResolveBoundForTest()
+	peakOff, completedOff := runConcurrentNestedUnits(t, M, 40*time.Millisecond)
+	if completedOff != M {
+		t.Fatalf("RED control: completed=%d want %d", completedOff, M)
+	}
+	if peakOff <= 2 {
+		t.Fatalf("CN-1 RED control INVALID: with budget=0 the peak should be unbounded (≈%d), "+
+			"got %d — the harness is not actually discriminating", M, peakOff)
+	}
+}
+
+// TestCN2_CostProportional_NoSerializationUnderCap is the CN-2 GREEN arm (the
+// 1.5.1 lesson). When M < cap, NO unit serializes — a light/warm subtree is not
+// starved by the bound. M=2, cap=4 (budget=4×weight) → peak should reach all M
+// (no blocking).
+func TestCN2_CostProportional_NoSerializationUnderCap(t *testing.T) {
+	const M = 2
+	t.Setenv(envNestedResolveEstUnitBytesFallback, "100")
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "400") // cap = 4 > M
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	peak, completed := runConcurrentNestedUnits(t, M, 30*time.Millisecond)
+	if completed != M {
+		t.Fatalf("CN-2: completed=%d want %d", completed, M)
+	}
+	if peak != M {
+		t.Fatalf("CN-2 cost-proportional: M=%d < cap=4 must pay ZERO serialization "+
+			"(peak should reach %d), got peak=%d — the bound is over-serializing", M, M, peak)
+	}
+}
+
+// TestCN3_Depth0OnlyNoSelfDeadlock verifies the depth-0 gate + that a deep
+// recursive subtree does NOT self-deadlock. isOutermostNestedResolve is true at
+// depth 0, false at depth>0; and acquiring at depth 0 while the SAME budget
+// would not admit a second permit must not block the (non-acquiring) inner
+// resolves.
+func TestCN3_Depth0OnlyNoSelfDeadlock(t *testing.T) {
+	t.Setenv(envNestedResolveEstUnitBytesFallback, "100")
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "100") // cap = 1 (one permit total)
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	// Depth gate.
+	if !isOutermostNestedResolve(cache.WithNestedCallDepth(context.Background(), 0)) {
+		t.Fatal("CN-3: depth 0 must be the outermost (acquire) point")
+	}
+	for _, d := range []int{1, 2, 8} {
+		if isOutermostNestedResolve(cache.WithNestedCallDepth(context.Background(), d)) {
+			t.Fatalf("CN-3: depth %d must NOT acquire (inner resolves inherit the permit)", d)
+		}
+	}
+
+	// Self-deadlock: outermost acquires the only permit; an inner resolve
+	// (depth>0) must NOT try to acquire (so it cannot block on the held permit).
+	// Simulate: hold the depth-0 permit, then run a depth-2 "inner" through the
+	// SAME guarded entry — it must skip Acquire and return immediately.
+	outerCtx := cache.WithNestedCallDepth(context.Background(), 0)
+	release, err := enterNestedResolveUnit(outerCtx)
+	if err != nil {
+		t.Fatalf("CN-3: outermost acquire failed: %v", err)
+	}
+	defer release()
+
+	done := make(chan struct{})
+	go func() {
+		innerCtx := cache.WithNestedCallDepth(context.Background(), 2)
+		// The production guard: inner (depth>0) skips enterNestedResolveUnit
+		// entirely. Assert the gate says "do not acquire" so the inner path
+		// never touches the (exhausted) semaphore.
+		if isOutermostNestedResolve(innerCtx) {
+			t.Errorf("CN-3: inner depth-2 wrongly classified as outermost → would self-deadlock")
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CN-3: inner resolve blocked → self-deadlock (the cap=1 permit is held by the outermost)")
+	}
+}
+
+// TestCN4_ExcessBlocksThenCompletes proves excess does not DROP: with cap=1 and
+// M=4, all 4 must complete (serialized), none abandoned.
+func TestCN4_ExcessBlocksThenCompletes(t *testing.T) {
+	const M = 4
+	t.Setenv(envNestedResolveEstUnitBytesFallback, "100")
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "100") // cap = 1
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	peak, completed := runConcurrentNestedUnits(t, M, 15*time.Millisecond)
+	if completed != M {
+		t.Fatalf("CN-4: completed=%d want %d (excess must BLOCK then complete, never drop)", completed, M)
+	}
+	if peak > 1 {
+		t.Fatalf("CN-4: cap=1 but peak=%d — bound not enforced", peak)
+	}
+}
+
+// TestCN_TransparentWhenDisabled — budget=0 is byte-identical pass-through:
+// Acquire skipped, release a no-op, no calibration. (The default posture.)
+func TestCN_TransparentWhenDisabled(t *testing.T) {
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "0")
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	sem, budget := nestedResolveBound()
+	if sem != nil || budget != 0 {
+		t.Fatalf("disabled: sem=%v budget=%d want nil/0", sem, budget)
+	}
+	release, err := enterNestedResolveUnit(cache.WithNestedCallDepth(context.Background(), 0))
+	if err != nil {
+		t.Fatalf("disabled: unexpected err %v", err)
+	}
+	release() // must be a safe no-op
+	if _, calibrated := calibratedNestedEstUnitForTest(); calibrated {
+		t.Fatal("disabled: must NOT calibrate (no Acquire path ran)")
+	}
+}
+
+// TestCN_AcquireWeightClampedToBudget — a single subtree larger than the whole
+// budget runs ALONE (weight clamped to budget) rather than blocking forever
+// (guaranteed-progress).
+func TestCN_AcquireWeightClampedToBudget(t *testing.T) {
+	t.Setenv(envNestedResolveEstUnitBytesFallback, "1000") // > budget
+	t.Setenv(envNestedResolveFootprintBudgetBytes, "200")
+	resetNestedResolveBoundForTest()
+	t.Cleanup(resetNestedResolveBoundForTest)
+
+	if w := currentNestedEstUnit(200); w != 200 {
+		t.Fatalf("clamp: weight=%d want 200 (clamped to budget)", w)
+	}
+	// A single unit must still complete (not block forever on an unsatisfiable
+	// Acquire).
+	done := make(chan struct{})
+	go func() {
+		release, err := enterNestedResolveUnit(cache.WithNestedCallDepth(context.Background(), 0))
+		if err == nil {
+			release()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clamp: an oversized single subtree blocked forever — guaranteed-progress violated")
+	}
+}

--- a/internal/resolvers/restactions/api/resolve_inprocess.go
+++ b/internal/resolvers/restactions/api/resolve_inprocess.go
@@ -150,6 +150,24 @@ func (r *resolveRun) maybeResolveInProcess(
 		APIVersion: apiVersion,
 	}
 
+	// (c) cold-fan-out aggregate-footprint bound — applied at the OUTERMOST
+	// nested resolve ONLY (depth 0). Gates 1-4 above guarantee this is a real
+	// cold single-CR RA/widget resolve that WILL recursively fan out
+	// (resolve:true); a warm apistage/cache hit never reaches here. The
+	// outermost entry holds ONE permit for the whole subtree — inner recursive
+	// resolves (depth>0) inherit it and do NOT re-enter, so there is no
+	// per-node explosion and no self-deadlock. Default-off (budget 0) ⇒
+	// transparent pass-through. See nested_resolve_bound.go.
+	if isOutermostNestedResolve(gctx) {
+		release, berr := enterNestedResolveUnit(gctx)
+		if berr != nil {
+			// ctx cancelled while blocked on the bound — surface as a resolve
+			// error (routed like an HTTP dispatch error by the caller).
+			return nil, false, berr
+		}
+		defer release()
+	}
+
 	resolved, rerr := nestedCallResolver(gctx, ref, r.opts.PerPage, r.opts.Page, r.opts.Extras)
 	if rerr != nil {
 		return nil, false, rerr


### PR DESCRIPTION
Cold-start prod-safety bound for heavy composition /calls (the #23 cold-fan-out OOM class, re-exposed by #77's correct by-name fan-out). DUAL-GATE GREEN: arch §18 soundness PASS + PM dev-diff ACCEPT (CN-1 neuter-RED proven on PM's own run: no-op the Acquire → peak=8 unbounded; restore → bounded; non-degenerate M=8>cap=2 on atomic peak-in-flight). TRACED via heap pprof: cold /call fsa-y2-composition-resources = encoding/json decode-into-interface (objectInterface 67% inuse, dispatchOneCall 948MB/81%) × ~20 nested resolve trees; monotonic climb 716→1172MB toward 8Gi. GOMEMLIMIT can't help (live working set, not GC garbage). FIX: enterNestedResolveUnit (clone of shipped #46 seed_bound.go) — semaphore.NewWeighted(NESTED_RESOLVE_FOOTPRINT_BUDGET_BYTES), Acquire(weight) at OUTERMOST nested resolve ONLY (depth-0, deadlock-safe) inside maybeResolveInProcess after Gate 4; self-calibrating weight + 256MiB clamped fallback; BLOCKS-never-drops; budget=0 ⇒ transparent byte-identical (default-off). NOT the reverted 1.5.1 flat-entry cap (gated, weighted, off-by-default). Orthogonal to #77 (no collapse re-enable). 3 files additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)