### PR TITLE
fix(resolver): stop a self-referential nested resolve at reentry (ancestor-set cycle-stop) (#79)

### DIFF
--- a/internal/cache/nested_resolve_ancestor.go
+++ b/internal/cache/nested_resolve_ancestor.go
@@ -1,0 +1,79 @@
+// nested_resolve_ancestor.go — #79: the nested-resolve ANCESTOR-SET seam, the
+// cycle-precise companion to the depth counter (nested_call_depth.go).
+//
+// WHY (distinct from depth): the depth cap (nestedCallMaxDepth=8) is a coarse
+// backstop — it terminates a cycle, but only after 8 wasted hops, and it CANNOT
+// distinguish a genuine self-reference (A resolve:true-refs A) from a legitimate
+// deep-but-acyclic chain. A self-referential RA (fsa-y2-composition-resources's
+// allCompositionResources self-element) recursed to depth 8 EVERY cold /call —
+// the 1.5.20 cold-path amplifier: ~250 resolver invocations + 8× the envelope
+// materialisation per self-ref, per tree. The ancestor set stops the recursion
+// at the FIRST self-reentry (the node is already on the current root→node path),
+// returning the raw CR (resolve:false semantics), leaving the depth cap as the
+// backstop for a non-cyclic pathological chain.
+//
+// ANCESTOR SET ≠ GLOBAL VISITED SET (the crux, RC-1): the set is the nodes on
+// the CURRENT root→here path ONLY. A legitimate DIAMOND P→{C1,C2}→L resolves L
+// on BOTH branches (L is not an ancestor of itself on either branch) — a global
+// visited set would wrongly stop the second L. So the set is scoped to the
+// descent path.
+//
+// IMMUTABLE COPY-ON-DESCEND (the concurrency contract, RC-4 — nested fan-out is
+// a CONCURRENT errgroup): WithNestedResolveAncestor returns a NEW map that is a
+// copy of the parent set plus the one new node. It NEVER mutates the parent's
+// map. Sibling branches therefore each get their own independent extended copy
+// and never write a shared map — no data race, no cross-branch contamination
+// (feedback_shared_vs_copy_is_a_concurrency_change: converting a private copy to
+// a shared reference is a concurrency change; here we deliberately keep each
+// descent's set private via copy-on-descend). The stored map is treated as
+// read-only after construction.
+//
+// Mirrors WithNestedCallDepth: a distinct unexported empty-struct key so
+// external packages cannot collide via a raw string key.
+
+package cache
+
+import "context"
+
+// ctxKeyNestedResolveAncestorType is the typed empty-struct context key.
+type ctxKeyNestedResolveAncestorType struct{}
+
+var ctxKeyNestedResolveAncestor = ctxKeyNestedResolveAncestorType{}
+
+// WithNestedResolveAncestor returns a child context whose ancestor set is the
+// parent set (read off ctx) PLUS node. The returned set is a fresh copy — the
+// parent's set is never mutated (copy-on-descend), so concurrent sibling
+// descents each hold an independent set and never race a shared map.
+//
+// node is the cycle identity of a resolve target — canonically
+// "<resource>/<namespace>/<name>" (the caller builds it; the exact string is
+// opaque to this seam, it only needs set-membership). An empty ctx is returned
+// unchanged.
+func WithNestedResolveAncestor(ctx context.Context, node string) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	parent, _ := ctx.Value(ctxKeyNestedResolveAncestor).(map[string]struct{})
+	// Copy-on-descend: a new map sized parent+1, never a write to `parent`.
+	next := make(map[string]struct{}, len(parent)+1)
+	for k := range parent {
+		next[k] = struct{}{}
+	}
+	next[node] = struct{}{}
+	return context.WithValue(ctx, ctxKeyNestedResolveAncestor, next)
+}
+
+// NestedResolveAncestorPresent reports whether node is already on the current
+// root→here descent path (i.e. resolving it again would be a cycle). Returns
+// false when no ancestor set is attached (the outermost resolve).
+func NestedResolveAncestorPresent(ctx context.Context, node string) bool {
+	if ctx == nil {
+		return false
+	}
+	set, _ := ctx.Value(ctxKeyNestedResolveAncestor).(map[string]struct{})
+	if set == nil {
+		return false
+	}
+	_, present := set[node]
+	return present
+}

--- a/internal/cache/nested_resolve_ancestor_test.go
+++ b/internal/cache/nested_resolve_ancestor_test.go
@@ -1,0 +1,102 @@
+// nested_resolve_ancestor_test.go — #79 RC-1 / RC-4 seam falsifiers. The
+// ancestor-set is an IMMUTABLE copy-on-descend path set, NOT a global visited
+// set. RC-1 proves the diamond distinction; RC-4 (-race) proves concurrent
+// sibling descents never race a shared map.
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestRC1_AncestorSetIsPathNotGlobalVisited is the CRUX (RC-1). A diamond
+// P→{C1,C2}→L: L is reachable on BOTH branches but is NOT an ancestor of itself
+// on either branch, so it must NOT be reported present when descending the
+// second branch. A global visited set would (wrongly) mark L present after the
+// first branch. The ancestor set (path-scoped, copy-on-descend) does not.
+func TestRC1_AncestorSetIsPathNotGlobalVisited(t *testing.T) {
+	root := context.Background()
+
+	// Branch 1: P → C1 → (about to resolve L).
+	p := WithNestedResolveAncestor(root, "P")
+	c1 := WithNestedResolveAncestor(p, "C1")
+	if NestedResolveAncestorPresent(c1, "L") {
+		t.Fatal("RC-1: L must NOT be an ancestor on branch 1 before it is descended")
+	}
+	// Descend L on branch 1.
+	c1L := WithNestedResolveAncestor(c1, "L")
+	if !NestedResolveAncestorPresent(c1L, "L") {
+		t.Fatal("RC-1: L must be its own ancestor once descended (self-ref would stop here)")
+	}
+
+	// Branch 2: P → C2 → L. Crucially, descending from `p` again (NOT from the
+	// branch-1 context) — L was on branch 1's path but is NOT on branch 2's.
+	c2 := WithNestedResolveAncestor(p, "C2")
+	if NestedResolveAncestorPresent(c2, "L") {
+		t.Fatal("RC-1 CRUX: L is on branch-1's path but NOT branch-2's — a diamond must " +
+			"resolve L on BOTH branches (ancestor set != global visited set)")
+	}
+	// And C1 (a sibling) must not leak into branch 2.
+	if NestedResolveAncestorPresent(c2, "C1") {
+		t.Fatal("RC-1: sibling C1 must NOT be an ancestor of branch-2 (path-scoped)")
+	}
+}
+
+// TestRC1_ParentSetNotMutatedByDescent — copy-on-descend: extending a child
+// context must NOT add the node to the PARENT's set (else siblings would see it).
+func TestRC1_ParentSetNotMutatedByDescent(t *testing.T) {
+	p := WithNestedResolveAncestor(context.Background(), "P")
+	_ = WithNestedResolveAncestor(p, "child-A")
+	if NestedResolveAncestorPresent(p, "child-A") {
+		t.Fatal("RC-1: descending child-A wrongly mutated the parent set (not copy-on-descend)")
+	}
+}
+
+// TestRC4_ConcurrentDescentsNoRace is the HARD -race arm (RC-4). Many
+// goroutines each descend their OWN child node from a shared parent context
+// concurrently. If WithNestedResolveAncestor mutated the parent's map instead of
+// copying, the concurrent map writes would data-race (go test -race fails) and
+// siblings would contaminate each other. Each sibling must see ONLY its own node
+// + the parent's, never another sibling's.
+func TestRC4_ConcurrentDescentsNoRace(t *testing.T) {
+	parent := WithNestedResolveAncestor(context.Background(), "P")
+	const N = 64
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			mine := nodeName(i)
+			child := WithNestedResolveAncestor(parent, mine)
+			if !NestedResolveAncestorPresent(child, mine) {
+				errs[i] = errRC4("own node missing", mine)
+				return
+			}
+			if !NestedResolveAncestorPresent(child, "P") {
+				errs[i] = errRC4("parent node missing", mine)
+				return
+			}
+			// A DIFFERENT sibling's node must NOT be present (no shared-map
+			// contamination).
+			other := nodeName((i + 1) % N)
+			if other != mine && NestedResolveAncestorPresent(child, other) {
+				errs[i] = errRC4("sibling node leaked in", other)
+			}
+		}(i)
+	}
+	wg.Wait()
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("RC-4: %v", e)
+		}
+	}
+}
+
+func nodeName(i int) string { return "sib-" + string(rune('A'+i%26)) + string(rune('0'+i/26)) }
+
+type rc4Err struct{ what, node string }
+
+func (e rc4Err) Error() string { return e.what + " (node " + e.node + ")" }
+func errRC4(what, node string) error { return rc4Err{what, node} }

--- a/internal/handlers/dispatchers/nested_call.go
+++ b/internal/handlers/dispatchers/nested_call.go
@@ -132,14 +132,48 @@ func ResolveNestedCall(
 		}
 	}
 
+	// Step 3.5 — CYCLE-STOP (#79). Build this node's cycle identity from the
+	// FETCHED object's GVR + namespace + name (post-Get, post-RBAC: RC-5 the
+	// stop happens only AFTER the identity is confirmed a real, authorized CR —
+	// a cycle-stop is NOT an RBAC bypass). If this exact node is already on the
+	// current root→here descent path, resolving it again is a SELF-REFERENCE
+	// (the composition's managed set includes its own fsa-yN-composition-* RAs,
+	// so allCompositionResources resolves the RA from within itself). Return the
+	// RAW CR (resolve:false semantics — the same encodeResolvedJSON(raw) the
+	// default arm returns) INSTEAD of recursing. This stops the cycle at the
+	// first reentry (not at the depth-8 backstop after 8 wasted hops + 250×
+	// redundant resolves), with NO ERROR — a self-ref is a legitimate graph
+	// shape, not a failure.
+	//
+	// The ancestor SET (not a global visited set): a diamond P→{C1,C2}→L still
+	// resolves L on both independent branches (L is not an ancestor of itself on
+	// either) — only a node ALREADY on the path to here is a cycle (RC-1). The
+	// depth-8 guard above stays as the backstop for a non-cyclic pathologically
+	// deep chain (RC-3).
+	node := got.GVR.Resource + "/" + got.Unstructured.GetNamespace() + "/" + got.Unstructured.GetName()
+	if cache.NestedResolveAncestorPresent(ctx, node) {
+		log.Debug("nested resolve cycle-stop: node already an ancestor — returning raw CR",
+			slog.String("node", node),
+			slog.Int("depth", depth),
+		)
+		encoded, err := encodeResolvedJSON(got.Unstructured.Object)
+		if err != nil {
+			return nil, fmt.Errorf("nested resolve: encode raw object (cycle-stop) %s/%s: %w",
+				ref.Resource, ref.Name, err)
+		}
+		return encoded, nil
+	}
+
 	// Step 4/5 — resolve the inner object under a ctx whose nested-call depth
 	// is incremented by 1 (so a resolve WITHIN this inner object enters one
-	// level deeper and the depth cap bounds the whole recursion). The
-	// L1KeyFromContext on `ctx` (the outer entry's key) is preserved by
-	// WithNestedCallDepth (context.WithValue keeps parent values), so the
+	// level deeper and the depth cap bounds the whole recursion) AND whose
+	// ancestor set is extended with this node (immutable copy-on-descend —
+	// #79). The L1KeyFromContext on `ctx` (the outer entry's key) is preserved
+	// by WithNestedCallDepth (context.WithValue keeps parent values), so the
 	// inner resolve's apiserver-call dep edges land on the OUTER L1 key —
 	// transitive data invalidation works (proposal §5).
-	innerCtx := cache.WithNestedCallDepth(ctx, depth+1)
+	innerCtx := cache.WithNestedResolveAncestor(
+		cache.WithNestedCallDepth(ctx, depth+1), node)
 
 	switch got.GVR.Resource {
 	case nestedResolveRestActionsResource:

--- a/internal/handlers/dispatchers/nested_call_falsifier_test.go
+++ b/internal/handlers/dispatchers/nested_call_falsifier_test.go
@@ -479,3 +479,110 @@ func TestF3_NestedCall_AuthorizedResolveNonEmpty(t *testing.T) {
 			"want 0 (the error-aware Put-gate must not false-fire on a good resolve)", got)
 	}
 }
+
+// --- RC-2 / RC-5 / RC-6 — #79 resolve-cycle self-reference cycle-stop --------
+
+// TestRC2_SelfReferenceReturnsRawCR is the #79 crux RED arm. When the target
+// node is ALREADY on the descent path (self-reference: A resolve:true-refs A),
+// ResolveNestedCall must STOP the cycle by returning the RAW CR (resolve:false
+// semantics) — NOT recurse into restactions.Resolve, NOT hit the depth-8 error.
+// We seed an inner RA whose recursive resolve would yield a distinct
+// (filter-projected) status, mark its node as an ancestor on ctx, and assert
+// the returned bytes are the RAW CR (its status is the UNRESOLVED spec.filter
+// string, not the resolved projection) with NO error and NO depth-limit.
+//
+// This is the on-cluster fsa-yN-composition-resources self-reference that
+// exploded 250×/composition on 1.5.20 (#77 re-enabled the recursion). Neuter
+// the cycle-stop (remove the NestedResolveAncestorPresent branch) → this RA
+// recurses to the depth-8 backstop instead of stopping at reentry.
+func TestRC2_SelfReferenceReturnsRawCR(t *testing.T) {
+	const ns, name = "demo-system", "fsa-y7-composition-resources"
+	// Inner RA with an ARRAY-yielding filter — a RECURSIVE resolve would write
+	// the projected array into status; the RAW CR's status carries no such
+	// projection (spec.filter is the literal string). So raw-vs-resolved is
+	// distinguishable.
+	newNestedCallWatcherWithInner(t, ns, name,
+		nestedInnerRESTActionArrayStatus(ns, name),
+		nestedCallRoleBinding(ns, "authorized-user"))
+
+	base := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "authorized-user"}),
+	)
+	// Mark THIS node as already-an-ancestor — i.e. we are resolving A from
+	// within A's own resolve chain (the self-reference). node identity is the
+	// FETCHED GVR.Resource/ns/name (matches ResolveNestedCall's construction).
+	node := nestedCallInnerGVR.Resource + "/" + ns + "/" + name
+	ctx := cache.WithNestedResolveAncestor(base, node)
+
+	ref := templates.ObjectReference{
+		Reference:  templates.Reference{Name: name, Namespace: ns},
+		Resource:   nestedCallInnerGVR.Resource,
+		APIVersion: nestedCallInnerGVR.Group + "/" + nestedCallInnerGVR.Version,
+	}
+	raw, err := ResolveNestedCall(ctx, ref, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("RC-2: self-reference must cycle-STOP cleanly (raw CR), got error: %v", err)
+	}
+	if strings.Contains(err2s(err), "depth limit exceeded") {
+		t.Fatalf("RC-2: self-reference must stop at reentry, NOT recurse to the depth-8 backstop")
+	}
+	if len(raw) == 0 {
+		t.Fatalf("RC-2: cycle-stop must return the raw CR, got empty")
+	}
+	var envelope map[string]any
+	if uerr := json.Unmarshal(raw, &envelope); uerr != nil {
+		t.Fatalf("RC-2: cycle-stop result is not a JSON object: %v\n got %s", uerr, raw)
+	}
+	// RAW CR: the status must NOT carry the resolved array projection — the raw
+	// object has spec.filter as a literal string and an unresolved/empty status.
+	// The resolved form would put the array under .status; the raw form does
+	// not. Assert the spec.filter literal survived (raw), i.e. we returned the
+	// object as fetched.
+	specBytes, _ := json.Marshal(envelope["spec"])
+	if !strings.Contains(string(specBytes), "team-a") {
+		t.Fatalf("RC-2: expected the RAW CR (spec.filter literal intact), got spec=%s", specBytes)
+	}
+	statusBytes, _ := json.Marshal(envelope["status"])
+	if strings.Contains(string(statusBytes), "team-a") {
+		t.Fatalf("RC-2: status carries the RESOLVED projection — the cycle did NOT stop "+
+			"(it recursed and resolved instead of returning the raw CR); status=%s", statusBytes)
+	}
+}
+
+// TestRC5_CycleStopStillEnforcesRBAC — the cycle-stop happens AFTER
+// objects.Get + checkDispatchRBAC (RC-5: stop != bypass). An UNAUTHORIZED
+// identity hitting a self-reference must STILL get a denial error, never the raw
+// CR. (Proves the stop did not short-circuit ahead of the RBAC gate.)
+func TestRC5_CycleStopStillEnforcesRBAC(t *testing.T) {
+	const ns, name = "demo-system", "fsa-y7-composition-resources"
+	// No RoleBinding for "denied-user" → objects.Get / checkDispatchRBAC denies.
+	newNestedCallWatcherWithInner(t, ns, name,
+		nestedInnerRESTActionArrayStatus(ns, name))
+
+	base := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "denied-user"}),
+	)
+	node := nestedCallInnerGVR.Resource + "/" + ns + "/" + name
+	ctx := cache.WithNestedResolveAncestor(base, node) // ancestor present (would cycle-stop)
+
+	ref := templates.ObjectReference{
+		Reference:  templates.Reference{Name: name, Namespace: ns},
+		Resource:   nestedCallInnerGVR.Resource,
+		APIVersion: nestedCallInnerGVR.Group + "/" + nestedCallInnerGVR.Version,
+	}
+	raw, err := ResolveNestedCall(ctx, ref, 0, 0, nil)
+	if err == nil {
+		t.Fatalf("RC-5: an UNAUTHORIZED self-reference must be DENIED (error), not " +
+			"cycle-stopped to the raw CR — the stop must sit AFTER the RBAC gate")
+	}
+	if raw != nil {
+		t.Fatalf("RC-5: denied cycle-stop must return nil bytes, got %d", len(raw))
+	}
+}
+
+func err2s(e error) string {
+	if e == nil {
+		return ""
+	}
+	return e.Error()
+}


### PR DESCRIPTION
## What
In-flight ancestor-set cycle-stop in `ResolveNestedCall`: re-entry of an ancestor RA returns the RAW CR (resolve:false semantics) instead of recursing. Depth-8 guard stays as backstop.

## Why
#77 (Class 3 cluster-list-collapse removal) re-enabled the recursion the collapse's `name==""` LIST previously suppressed. A composition RA whose `.status.managed` includes its own `fsa-*-composition-*` RAs (`allCompositionResources` iterates `.getComposition.status.managed` with resolve:true) resolves ITSELF → depth-8 guard fires 250×/composition → depth-limit ERROR spam + CPU + liveness /health timeout → pod restart-cycle (killed a 13h pod).

## Fix
`internal/cache/nested_resolve_ancestor.go` (+seam) + `internal/handlers/dispatchers/nested_call.go` (+cycle-stop Step-3.5). Immutable copy-on-descend (concurrent errgroup safe). ~30 LOC + 2 test files.

## Falsifiers (RED-proven, ran under -race)
- `TestRC1_AncestorSetIsPathNotGlobalVisited` — ancestor-set is path-scoped, not global-visited (diamond-DAG green)
- `TestRC2_SelfReferenceReturnsRawCR` — self-ref returns raw CR (RED without fix)
- `TestRC5_CycleStopStillEnforcesRBAC` — cycle-stop preserves RBAC

## Gate
Dual-gate GREEN @ e45cc38: arch soundness PASS + PM dev-diff ACCEPT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1