### PR TITLE
fix(#57): svc short/FQDN-agnostic self-host match (host-form fix B)

### DIFF
--- a/internal/resolvers/restactions/api/self_host.go
+++ b/internal/resolvers/restactions/api/self_host.go
@@ -9,15 +9,32 @@
 // true for a genuine external endpoint, false for the self-loopback). The
 // self-host is the discriminator.
 //
-// HARD (C-b): the comparison is EXACT (scheme, host, port) field-equality
-// against the PARSED URL_SELF — NEVER strings.Contains / suffix / prefix. An
-// external endpoint whose host merely CONTAINS "snowplow"
-// (snowplow-foo.example.com) must NOT match → the bearer stays off it. No
-// resource/name/path literal — a uniform host predicate (feedback_no_special_cases).
+// HARD (C-b): the comparison is EXACT (scheme, port) field-equality against the
+// PARSED URL_SELF plus a HOST match that is EITHER exact-string OR — when BOTH
+// hosts are in-cluster Kubernetes Service DNS names of the SAME (name,
+// namespace) — svc short/FQDN equivalence (#57 fix B, host-form-agnostic). It
+// is NEVER strings.Contains / suffix / prefix. An external endpoint whose host
+// merely CONTAINS "snowplow" (snowplow-foo.example.com) must NOT match → the
+// bearer stays off it. No resource/name/path literal — a uniform host predicate
+// (feedback_no_special_cases).
+//
+// #57 FIX B (host-form normalization) — WHY: URL_SELF is snowplow-chart-owned
+// (the FQDN form `snowplow.krateo-system.svc.cluster.local:8081`) while the
+// snowplow-endpoint the composition-resources RAs loop back through is
+// PORTAL-chart-owned (the short form `snowplow.krateo-system.svc:8081`). The two
+// charts are mutually blind, so the exact-string predicate never fired for the
+// short form → those loopbacks got no seed bearer → 401. Normalizing the
+// canonical in-cluster Service DNS forms of the SAME (name, namespace) makes
+// snowplow recognize its own service regardless of which form the endpoint uses.
+// Mirrors the existing endpoints.go internal-host normalization precedent
+// (isInternal → ServerURL rewritten to https://kubernetes.default.svc). The
+// leak guard is PRESERVED: any host that is not the canonical svc-DNS shape of
+// the SAME name+ns falls back to EXACT string equality.
 package api
 
 import (
 	"net/url"
+	"strings"
 	"sync/atomic"
 
 	"github.com/krateoplatformops/plumbing/endpoints"
@@ -59,10 +76,65 @@ func SetSelfHost(rawURL string) bool {
 	return true
 }
 
-// parsedHostEqualsSelf reports whether rawURL's (scheme, host, port) EXACTLY
-// equals the configured self-host. False when self-host is unconfigured, when
-// rawURL is unparseable, or on ANY field mismatch. Exact field-equality only
-// — a substring/suffix near-miss (snowplow-foo.example.com) returns false.
+// svcCanonicalKey reports whether host is an in-cluster Kubernetes Service DNS
+// name and, if so, returns its canonical (name, namespace) identity. The
+// recognized shapes are EXACTLY (labels split on '.'):
+//   - name.namespace                       (2 labels)
+//   - name.namespace.svc                   (3 labels, trailing "svc")
+//   - name.namespace.svc.cluster.local     (5 labels, trailing "svc.cluster.local")
+// Any other shape (an external FQDN, a subdomain-of-self leak attempt, a
+// trailing-garbage prefix attempt, a bare hostname) returns ok=false, so the
+// caller falls back to exact-string host equality — the leak guard.
+//
+// This is DELIBERATELY NOT a suffix/prefix/Contains match:
+//   - evil.snowplow.krateo-system.svc.cluster.local → labels[0]="evil" (name),
+//     [1]="snowplow" (ns), trailing {"krateo-system","svc","cluster","local"}
+//     is NOT an allowed trailing set → ok=false → exact-string fallback → no match.
+//   - snowplow.krateo-system.svc.cluster.local.evil.com → trailing set includes
+//     "evil"/"com" → not allowed → ok=false → exact-string fallback → no match.
+//   - snowplow-foo.example.com → trailing {"com"} → not allowed → ok=false.
+// Only the SAME (name, namespace) with a canonical svc trailing set collapses.
+func svcCanonicalKey(host string) (name, namespace string, ok bool) {
+	labels := strings.Split(host, ".")
+	switch len(labels) {
+	case 2: // name.namespace
+	case 3: // name.namespace.svc
+		if labels[2] != "svc" {
+			return "", "", false
+		}
+	case 5: // name.namespace.svc.cluster.local
+		if labels[2] != "svc" || labels[3] != "cluster" || labels[4] != "local" {
+			return "", "", false
+		}
+	default:
+		return "", "", false
+	}
+	if labels[0] == "" || labels[1] == "" {
+		return "", "", false
+	}
+	return labels[0], labels[1], true
+}
+
+// hostsMatch reports whether candidate host a equals self host b — either by
+// EXACT string equality, or (#57 fix B) when BOTH are canonical in-cluster
+// Service DNS names of the SAME (name, namespace). Exact-string is the leak-guard
+// fallback for anything that is not the recognized svc-DNS shape.
+func hostsMatch(a, b string) bool {
+	if a == b {
+		return true
+	}
+	an, ans, aok := svcCanonicalKey(a)
+	bn, bns, bok := svcCanonicalKey(b)
+	return aok && bok && an == bn && ans == bns
+}
+
+// parsedHostEqualsSelf reports whether rawURL matches the configured self-host:
+// EXACT scheme+port equality, plus a host match that is exact-string OR svc
+// short/FQDN equivalence of the SAME (name, namespace) — #57 fix B. False when
+// self-host is unconfigured, rawURL is unparseable, or on any scheme/port
+// mismatch or a host that is neither the exact string nor the same in-cluster
+// Service (a substring/suffix near-miss like snowplow-foo.example.com returns
+// false — the JWT-leak guard).
 func parsedHostEqualsSelf(rawURL string) bool {
 	sh := selfHost.Load()
 	if sh == nil || rawURL == "" {
@@ -72,7 +144,7 @@ func parsedHostEqualsSelf(rawURL string) bool {
 	if err != nil {
 		return false
 	}
-	return u.Scheme == sh.scheme && u.Hostname() == sh.host && u.Port() == sh.port
+	return u.Scheme == sh.scheme && u.Port() == sh.port && hostsMatch(u.Hostname(), sh.host)
 }
 
 // bearerAppendForStage is the #57 (C-b) user-bearer-append DECISION for a

--- a/internal/resolvers/restactions/api/self_host_test.go
+++ b/internal/resolvers/restactions/api/self_host_test.go
@@ -70,6 +70,88 @@ func TestParsedHostEqualsSelf_ExactMatchOnly(t *testing.T) {
 	}
 }
 
+// TestParsedHostEqualsSelf_SvcShortFQDNEquivalence is the #57 fix-B falsifier:
+// the self-loopback arm MUST fire when the resolved endpoint host is the SHORT
+// in-cluster Service form of the SAME service the FQDN URL_SELF names (and vice
+// versa) — because URL_SELF is snowplow-chart-owned (FQDN) while the
+// snowplow-endpoint the composition-resources RAs loop back through is
+// portal-chart-owned (short svc form). Pre-fix (exact-string only) the RED arms
+// below returned false → those loopbacks 401'd. The GUARD arms prove fix B did
+// NOT weaken the leak guard: near-misses + different name/ns stay OFF.
+//
+// RED-proven: with the exact-string-only predicate, the "self FQDN vs candidate
+// short" and "self short vs candidate FQDN" arms FAIL (want true, got false) —
+// they discriminate fix B from the status quo. The GUARD arms pass either way;
+// a suffix/Contains mis-implementation of B would FAIL them.
+func TestParsedHostEqualsSelf_SvcShortFQDNEquivalence(t *testing.T) {
+	const (
+		fqdn  = "http://snowplow.krateo-system.svc.cluster.local:8081"
+		short = "http://snowplow.krateo-system.svc:8081"
+		twoL  = "http://snowplow.krateo-system:8081" // name.namespace (2-label short form)
+	)
+
+	// selfFQDN: URL_SELF is the FQDN (the chart default) — a short-form or
+	// 2-label candidate of the SAME svc MUST match (the #57 fix-B positive).
+	t.Run("self=FQDN", func(t *testing.T) {
+		if !SetSelfHost(fqdn) {
+			t.Fatalf("SetSelfHost(%q) failed", fqdn)
+		}
+		t.Cleanup(func() { SetSelfHost("") })
+		cases := []struct {
+			name   string
+			rawURL string
+			want   bool
+			why    string
+		}{
+			{"RED: short svc form of same svc → MATCH", short, true,
+				"the portal endpoint uses the short svc form; fix B must recognize it as self"},
+			{"RED: 2-label name.ns of same svc → MATCH", twoL, true,
+				"name.namespace is a valid in-cluster short form of the same service"},
+			{"FQDN self → MATCH", fqdn, true, "exact-string still matches"},
+			// GUARD arms — must stay OFF (leak guard preserved):
+			{"GUARD: external contains snowplow → NO", "http://snowplow-foo.example.com:8081", false,
+				"substring 'snowplow' is not a canonical svc form → exact-string fallback → no match"},
+			{"GUARD: self as subdomain suffix → NO", "http://evil.snowplow.krateo-system.svc.cluster.local:8081", false,
+				"labels[0]=evil,[1]=snowplow → different (name,ns) AND non-canonical trailing → no match"},
+			{"GUARD: self as prefix + garbage → NO", "http://snowplow.krateo-system.svc.cluster.local.evil.com:8081", false,
+				"trailing labels include evil/com → not an allowed svc trailing set → exact-string fallback → no match"},
+			{"GUARD: different svc name, same ns → NO", "http://other.krateo-system.svc:8081", false,
+				"name mismatch → not the same service"},
+			{"GUARD: same name, different ns → NO", "http://snowplow.other-ns.svc:8081", false,
+				"namespace mismatch → not the same service"},
+			{"GUARD: wrong port on short form → NO", "http://snowplow.krateo-system.svc:9999", false,
+				"port is still exact-equality — svc equivalence never relaxes scheme/port"},
+			{"GUARD: wrong scheme on short form → NO", "https://snowplow.krateo-system.svc:8081", false,
+				"scheme is still exact-equality"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := parsedHostEqualsSelf(tc.rawURL); got != tc.want {
+					t.Fatalf("parsedHostEqualsSelf(%q) = %v, want %v — %s", tc.rawURL, got, tc.want, tc.why)
+				}
+			})
+		}
+	})
+
+	// selfShort: URL_SELF is the SHORT form — the FQDN candidate of the same svc
+	// MUST match (symmetry; a cluster could configure URL_SELF either way).
+	t.Run("self=short", func(t *testing.T) {
+		if !SetSelfHost(short) {
+			t.Fatalf("SetSelfHost(%q) failed", short)
+		}
+		t.Cleanup(func() { SetSelfHost("") })
+		if !parsedHostEqualsSelf(fqdn) {
+			t.Fatalf("RED: self=short, candidate=FQDN of same svc must MATCH (symmetry)")
+		}
+		if !parsedHostEqualsSelf(twoL) {
+			t.Fatalf("RED: self=short, candidate=name.ns of same svc must MATCH")
+		}
+		if parsedHostEqualsSelf("http://snowplow-foo.example.com:8081") {
+			t.Fatalf("GUARD: external near-miss must NOT match even when self is short-form")
+		}
+	})
+}
+
 // TestParsedHostEqualsSelf_UnconfiguredNeverMatches: with no self-host set
 // (URL_SELF empty), the self-loopback arm is disabled — the predicate is
 // always false, so the bearer-append falls back to the pre-#57 gate exactly.


### PR DESCRIPTION
## #57 host-form fix B — svc short/FQDN self-host normalization

URL_SELF is snowplow-chart-owned (FQDN form `snowplow.krateo-system.svc.cluster.local:8081`) while the snowplow-endpoint the composition-resources RAs loop back through is portal-chart-owned (short form `snowplow.krateo-system.svc:8081`). The two charts are mutually blind, so the pre-fix exact-string predicate never fired for the short form → those loopbacks got no seed bearer → 401.

`parsedHostEqualsSelf` now matches host by exact-string OR svc short/FQDN equivalence of the SAME (name, namespace); scheme+port stay exact-equality; anything not a canonical in-cluster Service DNS shape falls back to exact-string (JWT-leak guard preserved).

- `svcCanonicalKey`: recognizes `name.namespace` / `name.namespace.svc` / `name.namespace.svc.cluster.local` only; subdomain/suffix/garbage attempts return ok=false → exact-string fallback.
- `self_host_test.go`: RED arms (self=FQDN vs candidate short, and symmetry self=short vs candidate FQDN) + GUARD arms (external-contains-snowplow, subdomain, prefix+garbage, different name/ns, wrong port/scheme).

Dual-gate GREEN: architect soundness PASS + PM ACCEPT. build/vet/`go test -race` green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>