### PR TITLE
fix(loopback): broaden self-loopback forge-guard to any authenticated user (1.5.26)

### DIFF
--- a/internal/handlers/dispatchers/nested_resolve_ingest.go
+++ b/internal/handlers/dispatchers/nested_resolve_ingest.go
@@ -120,11 +120,12 @@ func requestArrivedOnSelfHost(req *http.Request) bool {
 // property was never "only the seed" — it was "only a snowplow-VALIDATED JWT
 // holder", which holds for ANY authenticated user.
 //
-// TRUST ANCHOR (TRACED): xcontext.UserInfo(ctx) is set (userconfig.go:230-231 /
-// refreshauth.go) ONLY AFTER the auth middleware's jwtutil.Validate(signingKey,
-// token) passes (userconfig.go:151); an invalid / missing / spoofed JWT returns
-// Unauthorized BEFORE the handler runs. So `UserInfo present` ⟺ the caller
-// presented a JWT signed by snowplow's OWN signing key — an external / no-JWT /
+// TRUST ANCHOR (TRACED): the auth middleware runs jwtutil.Validate(signingKey,
+// token) at userconfig.go:151 (mirrored in refreshauth.go) and, ONLY on success,
+// sets xcontext.WithUserInfo(userInfo) at userconfig.go:231; an invalid /
+// missing / spoofed JWT returns Unauthorized at userconfig.go:151 BEFORE the
+// handler runs. So `UserInfo present` ⟺ the caller presented a JWT signed by
+// snowplow's OWN signing key (validated at :151) — an external / no-JWT /
 // spoofed-JWT caller can NEVER reach the handler with UserInfo set. The C2 forge
 // hole stays closed by the middleware, not by a token compare here.
 //

--- a/internal/handlers/dispatchers/nested_resolve_ingest.go
+++ b/internal/handlers/dispatchers/nested_resolve_ingest.go
@@ -19,31 +19,34 @@
 //
 // SECURITY (C1, the load-bearing line): the two headers are ADVISORY and
 // SELF-TRUSTED ONLY. isTrustedSelfLoopback gates whether they are read into ctx
-// at all. The trust check uses TOKEN PROVENANCE — the inbound bearer must EXACTLY
-// equal snowplow's OWN authn-issued seed JWT (currentSeedLoopbackToken) — which
-// is minted from snowplow's projected SA token (authn /serviceaccount/login,
-// phase1_walk.go) and never leaves the pod except on a self-host loopback, so an
-// EXTERNAL caller cannot present it. This is strictly stronger than matching an
-// authn-issued USERNAME (which is authn-config-dependent / UNPINNED — memory
-// project_prewarm_authn_loopback_identity_shift; a username match would need a
-// hardcoded subject, violating feedback_no_special_cases). A req.Host==self
-// check is belt-and-suspenders; the cryptographic token match is the primary
-// gate. Any request failing the token match has BOTH headers IGNORED (never read
-// into ctx) → it gets a NORMAL full resolve (C2 — a forged
-// X-Snowplow-Nested-Depth:8 + spoofed ancestor set from a non-seed caller cannot
-// force a premature raw-CR stop or suppress a legitimate resolve).
+// at all. The trust check requires a VALID snowplow-issued identity —
+// xcontext.UserInfo(ctx) present + non-error — which the auth middleware sets
+// ONLY after jwtutil.Validate passes (an external / no-JWT / spoofed-JWT caller
+// is rejected 401 upstream, never reaching the handler with UserInfo set). So
+// `UserInfo present` ⟺ a snowplow-VALIDATED JWT holder. A req.Host==self check
+// is belt-and-suspenders; the validated-identity check is the primary gate. Any
+// request failing it has BOTH headers IGNORED (never read into ctx) → it gets a
+// NORMAL full resolve (C2 — a forged X-Snowplow-Nested-Depth:8 + spoofed ancestor
+// set from an UNAUTHENTICATED caller cannot force a premature raw-CR stop or
+// suppress a legitimate resolve).
 //
-// BLAST-RADIUS BOUND: even a theoretical forge could only make snowplow return
-// THIS ONE call's raw CR (resolve:false) or a bounded depth-stop — it cannot read
-// cross-user data (the resolve still runs checkDispatchRBAC under the CALLER's
-// identity, restactions.go:96, UNCHANGED by R) and cannot poison another user's
-// L1 entry (per-user key). So the forge blast radius is self-DoS of the forger's
-// own call — and the token gate makes even that unreachable for non-seed callers.
+// 1.5.26 broadening (docs/user-path-loopback-storm-trace-fix-2026-07-02.md): the
+// predicate was seed-token-only in 1.5.25, which closed the SEED loopback but not
+// the USER loopback (a real user's JWT ≠ the seed token → guard never fired →
+// user-path storm). The security property was never "only the seed" but "only a
+// snowplow-VALIDATED JWT holder" — which holds for ANY authenticated user, seed
+// included. See isTrustedSelfLoopback for the full trust anchor.
+//
+// BLAST-RADIUS BOUND: even a theoretical forge by an AUTHENTICATED user could
+// only make snowplow return THIS ONE call's raw CR (resolve:false) or a bounded
+// depth-stop — it cannot read cross-user data (the resolve still runs
+// checkDispatchRBAC under the CALLER's identity, restactions.go:96, UNCHANGED by
+// R) and cannot poison another user's L1 entry (per-binding key). So the forge
+// blast radius is self-DoS of the forger's own call.
 package dispatchers
 
 import (
 	"context"
-	"crypto/subtle"
 	"log/slog"
 	"net"
 	"net/http"
@@ -99,65 +102,54 @@ func requestArrivedOnSelfHost(req *http.Request) bool {
 	return host == *sh
 }
 
-// isTrustedSelfLoopback is the C1 forge-guard. TRUE iff the inbound bearer
-// EXACTLY equals snowplow's own current authn-issued seed JWT (token provenance)
-// AND (belt-and-suspenders) the request arrived on the self-host. Only the seed
-// possesses snowplow's SA-minted authn JWT → unforgeable by an external caller.
-// For ANY request that fails EITHER condition the depth/ancestor headers are
-// ignored (the caller re-seeds NOTHING → a normal full resolve).
+// isTrustedSelfLoopback is the C1 forge-guard. TRUE iff the request carries a
+// VALID snowplow-issued identity (xcontext.UserInfo present + non-error) AND
+// (belt-and-suspenders) it arrived on the self-host. For ANY request that fails
+// EITHER condition the depth/ancestor headers are ignored (the caller re-seeds
+// NOTHING → a normal full resolve).
 //
-// TL refinement 1 — LIVE provider value: currentSeedLoopbackToken reads the LIVE
-// seedTokenProvider (authn.Client.Token), NOT a startup snapshot, so a ROTATED
-// seed token still matches. The provider caches the JWT until authn.Client's
-// refreshSkew (60s) before expiry, so an in-flight loopback and this read return
-// the SAME cached string — no rotation gap in practice; the depth-8 backstop
-// covers any theoretical edge miss during re-exchange.
+// 1.5.26 BROADENING (was seed-token-only, docs/user-path-loopback-storm-trace-fix-
+// 2026-07-02.md): 1.5.25 trusted a self-loopback ONLY when the inbound bearer
+// EXACTLY equalled snowplow's OWN seed JWT (token-provenance). That closed the
+// SEED loopback but NOT the USER loopback: a real user's composition-resources
+// /call runs under THEIR JWT ≠ the seed token → the guard returned false → the
+// depth/ancestor headers were ignored → the HTTP-edge cycle-stop never fired →
+// the user-path self-loopback recursed unbounded (the 1.5.24 storm, now
+// user-driven; concause: the per-BINDING L1 entry means the seed's warm entries
+// miss for a user → cold re-resolve → each self-loops unguarded). The security
+// property was never "only the seed" — it was "only a snowplow-VALIDATED JWT
+// holder", which holds for ANY authenticated user.
 //
-// TL refinement 2 — CONSTANT-TIME compare: the bearer is a secret at a trust
-// boundary, so the equality uses subtle.ConstantTimeCompare (no early-exit
-// length/byte-position timing oracle a remote attacker could use to recover the
-// token byte-by-byte). ConstantTimeCompare returns 1 on equal, 0 otherwise, and
-// is itself length-safe (returns 0 for unequal lengths without leaking where).
+// TRUST ANCHOR (TRACED): xcontext.UserInfo(ctx) is set (userconfig.go:230-231 /
+// refreshauth.go) ONLY AFTER the auth middleware's jwtutil.Validate(signingKey,
+// token) passes (userconfig.go:151); an invalid / missing / spoofed JWT returns
+// Unauthorized BEFORE the handler runs. So `UserInfo present` ⟺ the caller
+// presented a JWT signed by snowplow's OWN signing key — an external / no-JWT /
+// spoofed-JWT caller can NEVER reach the handler with UserInfo set. The C2 forge
+// hole stays closed by the middleware, not by a token compare here.
 //
-// TL refinement 3 — EMPTY-TOKEN GUARD *BEFORE* the compare (THE fail-closed
-// correctness line): subtle.ConstantTimeCompare([]byte(""), []byte("")) returns 1
-// — so if either side could be empty and reached the compare, an UNAUTHENTICATED
-// caller (no Authorization header → inbound "") would be TRUSTED when the seed
-// token is also empty (provider unwired/errored). Both len>0 checks below are
-// therefore HARD gates that MUST precede the compare. RED-armed
-// (TestR_C2_EmptyInbound_NotTrusted / TestR_C2_ForgeGuard_NoSeedProviderWired).
+// FORGE-SAFE FOR ANY AUTHENTICATED USER (blast-radius, unchanged from R): the
+// WORST a malicious AUTHENTICATED user can do by forging depth/ancestor headers
+// on their OWN self-loopback is SELF-DoS of their own call — a raw CR
+// (resolve:false) or a bounded 508 for THAT call. They CANNOT read cross-user
+// data (the resolve still runs checkDispatchRBAC under THEIR identity,
+// restactions.go:96) and CANNOT poison another user's L1 entry (per-binding
+// key). No cross-user impact.
 //
-// TL refinement 4 — SAFE-DEGRADE fail-closed: no seed token / provider unwired or
-// erroring (currentSeedLoopbackToken → have=false) ⇒ NOTHING is trusted ⇒ headers
-// ignored. Consistent by construction: in that same state the #57 bearer-append
-// would not fire either (no authn token on the seed ctx), so there is no
-// authenticated self-loopback to guard — the guard being off cannot let a real
-// loopback storm through because a real loopback cannot exist without the token.
-//
-// CO-LOCATION (arch-enforced): the EMIT side appends the SAME token this ingest
-// trusts. Emit rides the #57 bearer-append arm (resolve.go, parsedHostEqualsSelf
-// gate); that bearer is xcontext.AccessToken(r.ctx) — which on the seed path was
-// installed by installSeedLoopbackToken (phase1_walk.go) from seedTokenProvider.
-// This ingest's currentSeedLoopbackToken reads the SAME seedTokenProvider. So the
-// token emit appends == the token ingest trusts, BY SHARED SOURCE — they cannot
-// desync (no parallel token derivation).
+// SEED STAYS TRUSTED: the seed's loopback is a real HTTP /call carrying the
+// authn-issued seed JWT (#57), which the SAME middleware validates → UserInfo is
+// set → trusted under this broadened predicate too (no seed-path regression;
+// gated by the seed-still-trusted falsifier arm).
 func isTrustedSelfLoopback(req *http.Request) bool {
-	// Refinement 3: empty inbound → NOT trusted (an unauthenticated caller must
-	// never reach the constant-time compare).
-	inbound, ok := xcontext.AccessToken(req.Context())
-	if !ok || len(inbound) == 0 {
+	// Primary gate: a snowplow-VALIDATED JWT holder. UserInfo present + non-error
+	// ⟺ the auth middleware ran jwtutil.Validate successfully before the handler
+	// (an unauth / invalid / spoofed JWT is rejected 401 upstream, never reaching
+	// here with UserInfo set) — the forge hole stays closed.
+	if _, err := xcontext.UserInfo(req.Context()); err != nil {
 		return false
 	}
-	// Refinement 1+4: LIVE provider read; unwired/errored/empty → NOT trusted.
-	seedTok, have := currentSeedLoopbackToken(req.Context())
-	if !have || len(seedTok) == 0 {
-		return false // no seed token wired → nothing to trust against (fail-closed)
-	}
-	// Refinement 2: constant-time compare, reached ONLY with both sides non-empty.
-	if subtle.ConstantTimeCompare([]byte(inbound), []byte(seedTok)) != 1 {
-		return false // not snowplow's own seed loopback — headers ignored (C2)
-	}
-	// Belt-and-suspenders secondary (token-provenance is the cryptographic primary).
+	// Belt-and-suspenders secondary (tightens only; returns true when URL_SELF
+	// is unconfigured). The validated-identity check above is the primary anchor.
 	return requestArrivedOnSelfHost(req)
 }
 

--- a/internal/handlers/dispatchers/nested_resolve_ingest_falsifier_test.go
+++ b/internal/handlers/dispatchers/nested_resolve_ingest_falsifier_test.go
@@ -21,7 +21,6 @@
 package dispatchers
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -39,23 +38,16 @@ import (
 // testLogger is a discard slog logger for the guard arms (they read no logs).
 func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
-const (
-	testSeedTok  = "SEED-JWT-snowplow-key-signed-unforgeable"
-	testSelfHost = "snowplow.krateo-system.svc.cluster.local:8081"
-)
+const testSelfHost = "snowplow.krateo-system.svc.cluster.local:8081"
 
-// setSeedProvider wires seedTokenProvider to return tok for the test (this is
-// snowplow's OWN seed JWT — the only credential isTrustedSelfLoopback trusts,
-// C1) and restores nil on cleanup.
-func setSeedProvider(t *testing.T, tok string) {
-	t.Helper()
-	SetSeedLoopbackTokenProvider(func(context.Context) (string, error) { return tok, nil })
-	t.Cleanup(func() { SetSeedLoopbackTokenProvider(nil) })
-}
-
-// buildLoopbackReq builds a request carrying bearer as WithAccessToken (as the
-// auth middleware places it), a UserInfo, the depth/ancestor headers, and Host.
-func buildLoopbackReq(bearer, host, depth, ancestors string) *http.Request {
+// buildLoopbackReq builds a self-loopback request with explicit control over
+// whether a VALID UserInfo is present (the 1.5.26 trust anchor — set ONLY after
+// the auth middleware's jwtutil.Validate passes). username=="" ⇒ NO UserInfo on
+// ctx (models an unauthenticated / rejected-JWT caller that reached the ingest
+// helper hypothetically — the C4 forge arm). A non-empty username ⇒ a valid
+// snowplow-validated identity (any authenticated user, seed included). The
+// depth/ancestor headers + Host are set as the emit side would.
+func buildLoopbackReq(username, host, depth, ancestors string) *http.Request {
 	r := httptest.NewRequest("GET", "http://"+host+"/call?resource=restactions", nil)
 	r.Host = host
 	if depth != "" {
@@ -64,139 +56,121 @@ func buildLoopbackReq(bearer, host, depth, ancestors string) *http.Request {
 	if ancestors != "" {
 		r.Header.Set(cache.ResolveAncestorsHeader, ancestors)
 	}
-	ctx := xcontext.BuildContext(r.Context(),
-		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "some-user"}),
-	)
-	if bearer != "" {
-		ctx = xcontext.BuildContext(ctx, xcontext.WithAccessToken(bearer))
+	ctx := r.Context()
+	if username != "" {
+		// The auth middleware sets UserInfo (and AccessToken) ONLY after a
+		// successful jwtutil.Validate — model that with a present UserInfo.
+		ctx = xcontext.BuildContext(ctx,
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: username}),
+			xcontext.WithAccessToken("VALID-JWT-for-"+username),
+		)
 	}
 	return r.WithContext(ctx)
 }
 
-// TestR_C2_ForgeGuard_NonSeedHeadersIgnored is the HARD forge-guard RED arm. A
-// non-seed/external caller presents a spoofed depth:8 + a spoofed ancestor set
-// that INCLUDES this request's own node (the worst case — it would force a
-// premature raw-CR stop if trusted). It must NOT be trusted, the reseed must be a
-// no-op, and therefore the HTTP-edge stop must NOT fire (a normal full resolve).
-func TestR_C2_ForgeGuard_NonSeedHeadersIgnored(t *testing.T) {
-	setSeedProvider(t, testSeedTok)
+// TestR_C2_ForgeGuard_NonSeedUserFires — 1.5.26 C2 (the arm that would have
+// caught 1.5.25): a self-loopback under a VALID NON-SEED user identity + an
+// ancestor header containing this request's own node → isTrustedSelfLoopback
+// TRUE, reseed installs the ancestors, and the HTTP-edge cycle-stop FIRES. The
+// user-path storm is closed. RED arm (documented): reverting the predicate to the
+// seed-token compare makes a non-seed identity NOT trusted → guard does NOT fire
+// → the exact 1.5.25 bug (the storm) returns. This is the discriminating arm the
+// 1.5.25 seed-only test lacked.
+func TestR_C2_ForgeGuard_NonSeedUserFires(t *testing.T) {
 	SetSelfLoopbackHost("http://" + testSelfHost)
 	t.Cleanup(func() { SetSelfLoopbackHost("") })
 
 	const resource, ns, name = "restactions", "demo-system", "fsa-y7-composition-resources"
 	selfNode := nestedResolveNodeKey(resource, ns, name)
 
-	// External caller: a DIFFERENT bearer (not the seed token) + spoofed headers.
-	req := buildLoopbackReq("ATTACKER-JWT-not-the-seed-token", testSelfHost,
-		"8", selfNode+",restactions/other/decoy")
+	// A NON-seed authenticated user (e.g. admin) — NOT the seed token.
+	req := buildLoopbackReq("admin", testSelfHost, "1", selfNode)
+
+	if !isTrustedSelfLoopback(req) {
+		t.Fatal("C2: a VALID non-seed user self-loopback MUST be trusted (the 1.5.25 user-path gap) — " +
+			"broadened predicate must fire for any snowplow-validated JWT holder")
+	}
+	guardCtx := reseedNestedGuardsFromHeaders(req.Context(), req)
+	if !cache.NestedResolveAncestorPresent(guardCtx, selfNode) {
+		t.Fatal("C2: reseed must install the ancestor header for a trusted user request")
+	}
+	before := cache.HTTPEdgeCycleStop()
+	stop, raw := httpEdgeGuardStop(guardCtx, testLogger(), resource, ns, name)
+	if !stop || !raw {
+		t.Fatalf("C2: a trusted non-seed self-reentry must cycle-STOP with raw CR; got stop=%v raw=%v", stop, raw)
+	}
+	if cache.HTTPEdgeCycleStop() != before+1 {
+		t.Fatalf("C2: cycle-stop counter must increment (guard fired for the USER path); before=%d after=%d",
+			before, cache.HTTPEdgeCycleStop())
+	}
+}
+
+// TestR_C4_ForgeGuard_NoUserInfoIgnored — 1.5.26 C4 (forge arm preserved): an
+// UNAUTHENTICATED caller (NO UserInfo — an invalid/missing JWT would be 401'd
+// upstream, never reaching the handler with UserInfo set) presents a forged
+// depth:8 + a spoofed ancestor set INCLUDING this request's own node (the worst
+// case). It must NOT be trusted → reseed a no-op → the HTTP-edge stop does NOT
+// fire (normal full resolve). Asserts the DOWNSTREAM no-op, not just the boolean.
+func TestR_C4_ForgeGuard_NoUserInfoIgnored(t *testing.T) {
+	SetSelfLoopbackHost("http://" + testSelfHost)
+	t.Cleanup(func() { SetSelfLoopbackHost("") })
+
+	const resource, ns, name = "restactions", "demo-system", "fsa-y7-composition-resources"
+	selfNode := nestedResolveNodeKey(resource, ns, name)
+
+	// username=="" ⇒ NO UserInfo on ctx (unauthenticated). Forged headers.
+	req := buildLoopbackReq("", testSelfHost, "8", selfNode+",restactions/other/decoy")
 
 	if isTrustedSelfLoopback(req) {
-		t.Fatal("C2: a non-seed bearer must NOT be trusted (headers forgeable) — forge-guard breached")
+		t.Fatal("C4: a request with NO valid UserInfo (unauthenticated) must NOT be trusted — forge hole")
 	}
-	// The reseed must be a no-op: guardCtx carries NO depth, NO ancestors (both
-	// forged header types dropped because the caller is untrusted).
+	// Reseed must be a no-op: guardCtx carries NO depth, NO ancestors.
 	guardCtx := reseedNestedGuardsFromHeaders(req.Context(), req)
 	if cache.NestedCallDepthFromContext(guardCtx) != 0 {
-		t.Fatalf("C2: forged depth header was read into ctx (got depth %d) — headers not ignored",
+		t.Fatalf("C4: forged depth header was read into ctx (got %d) — headers not ignored",
 			cache.NestedCallDepthFromContext(guardCtx))
 	}
 	if cache.NestedResolveAncestorPresent(guardCtx, selfNode) {
-		t.Fatal("C2: forged ancestor header was read into ctx — headers not ignored")
+		t.Fatal("C4: forged ancestor header was read into ctx — headers not ignored")
 	}
-	// The handler wiring: NO local node add. With both forged headers dropped,
-	// the HTTP-edge stop must NOT fire → a normal full resolve. Neither counter
-	// moves.
 	beforeCycle := cache.HTTPEdgeCycleStop()
 	beforeDepth := cache.HTTPEdgeDepthStop()
 	stop, _ := httpEdgeGuardStop(guardCtx, testLogger(), resource, ns, name)
 	if stop {
-		t.Fatal("C2: a forged depth:8 + spoofed ancestors from a non-seed caller must NOT stop the resolve")
+		t.Fatal("C4: an unauthenticated caller's forged headers must NOT stop the resolve")
 	}
 	if cache.HTTPEdgeCycleStop() != beforeCycle || cache.HTTPEdgeDepthStop() != beforeDepth {
-		t.Fatal("C2: forged headers bumped a guard counter — headers were trusted")
+		t.Fatal("C4: forged headers bumped a guard counter — headers were trusted")
 	}
 }
 
-// TestR_C2_ForgeGuard_NoSeedProviderWired — with no seed provider (authn not
-// configured), NOTHING is trusted, even the real path. Fail-closed.
-func TestR_C2_ForgeGuard_NoSeedProviderWired(t *testing.T) {
-	SetSeedLoopbackTokenProvider(nil)
-	SetSelfLoopbackHost("http://" + testSelfHost)
-	t.Cleanup(func() { SetSelfLoopbackHost("") })
-	req := buildLoopbackReq(testSeedTok, testSelfHost, "3", "restactions/ns/x")
-	if isTrustedSelfLoopback(req) {
-		t.Fatal("C2: with no seed provider wired, no request may be trusted (fail-closed)")
-	}
-}
-
-// TestR_C2_EmptyInbound_NotTrusted is the TL-refinement-3 RED arm (THE
-// fail-closed correctness line). An UNAUTHENTICATED caller (no Authorization
-// header → empty inbound bearer) MUST NOT be trusted, even with a seed provider
-// wired and the request on the self-host — because subtle.ConstantTimeCompare(
-// "","")==1 would otherwise TRUST it if the empty-guard were missing. This arm
-// RED-proves the len>0 gate precedes the compare.
-func TestR_C2_EmptyInbound_NotTrusted(t *testing.T) {
-	setSeedProvider(t, testSeedTok) // provider wired
-	SetSelfLoopbackHost("http://" + testSelfHost)
-	t.Cleanup(func() { SetSelfLoopbackHost("") })
-
-	// No bearer at all (buildLoopbackReq with bearer=="" installs no AccessToken).
-	req := buildLoopbackReq("", testSelfHost, "8", "restactions/ns/x")
-	if isTrustedSelfLoopback(req) {
-		t.Fatal("C2/refinement-3: an unauthenticated (no-bearer) caller MUST NOT be trusted — " +
-			"the empty-token guard must precede the constant-time compare")
-	}
-}
-
-// TestR_C2_EmptySeedToken_NotTrusted — refinement 3 + 4 conjugate: even a caller
-// sending an EMPTY bearer must not be trusted when the provider ALSO returns empty
-// (the ConstantTimeCompare("","")==1 hole). The empty-seed guard catches it.
-func TestR_C2_EmptySeedToken_NotTrusted(t *testing.T) {
-	SetSeedLoopbackTokenProvider(func(context.Context) (string, error) { return "", nil }) // provider returns empty
-	SetSelfLoopbackHost("http://" + testSelfHost)
-	t.Cleanup(func() {
-		SetSeedLoopbackTokenProvider(nil)
-		SetSelfLoopbackHost("")
-	})
-	// A caller echoing an empty bearer — the classic ConstantTimeCompare("","") trap.
-	req := buildLoopbackReq("", testSelfHost, "8", "restactions/ns/x")
-	if isTrustedSelfLoopback(req) {
-		t.Fatal("C2/refinement-3+4: empty inbound + empty seed must NOT be trusted " +
-			"(subtle.ConstantTimeCompare(\"\",\"\")==1 trap — both empty-guards must fire)")
-	}
-}
-
-// TestR_GREEN_TrustedSelfLoopback_CycleStop is the guard-fires GREEN arm. The
-// TRUSTED seed self-loopback carries an ancestor header that already contains
-// THIS request's own node (the self-reentry). The stop must return raw=true (raw
-// CR) and bump the cycle-stop counter.
-func TestR_GREEN_TrustedSelfLoopback_CycleStop(t *testing.T) {
-	setSeedProvider(t, testSeedTok)
+// TestR_C3_SeedStillTrusted — 1.5.26 C3: the seed's own loopback (a valid
+// authn-issued identity, DISTINCT from C2's admin) is STILL trusted under the
+// broadened predicate → the guard fires. Proves no seed-path regression from the
+// broadening. The seed is modeled as a valid UserInfo holder (its authn JWT is
+// validated by the same middleware).
+func TestR_C3_SeedStillTrusted(t *testing.T) {
 	SetSelfLoopbackHost("http://" + testSelfHost)
 	t.Cleanup(func() { SetSelfLoopbackHost("") })
 
 	const resource, ns, name = "restactions", "demo-system", "fsa-y7-composition-resources"
 	selfNode := nestedResolveNodeKey(resource, ns, name)
 
-	// The seed loopback: the SEED token + an ancestor header that already has
-	// this node (a prior hop resolved it → it's on the descent path).
-	req := buildLoopbackReq(testSeedTok, testSelfHost, "1", selfNode)
+	// The seed identity (distinct from C2's "admin") — a valid snowplow-issued JWT
+	// holder. Same trust path as any authenticated user.
+	req := buildLoopbackReq("system:serviceaccount:krateo-system:snowplow", testSelfHost, "1", selfNode)
 
 	if !isTrustedSelfLoopback(req) {
-		t.Fatal("GREEN: the seed's own bearer on the self-host MUST be trusted")
+		t.Fatal("C3: the seed's own loopback (valid UserInfo) MUST stay trusted — no seed-path regression")
 	}
-	// EXACTLY the handler wiring: seed ONLY the inbound header ancestors (the
-	// self-reentry is detected because selfNode is ALREADY in the header set from
-	// a prior hop), then check WITHOUT adding selfNode locally.
 	guardCtx := reseedNestedGuardsFromHeaders(req.Context(), req)
-
 	before := cache.HTTPEdgeCycleStop()
 	stop, raw := httpEdgeGuardStop(guardCtx, testLogger(), resource, ns, name)
 	if !stop || !raw {
-		t.Fatalf("GREEN: a trusted self-reentry must cycle-STOP with raw CR; got stop=%v raw=%v", stop, raw)
+		t.Fatalf("C3: seed self-reentry must cycle-STOP with raw CR; got stop=%v raw=%v", stop, raw)
 	}
 	if cache.HTTPEdgeCycleStop() != before+1 {
-		t.Fatalf("GREEN: cycle-stop counter must increment (proof the guard fired); before=%d after=%d",
+		t.Fatalf("C3: cycle-stop counter must increment for the seed path; before=%d after=%d",
 			before, cache.HTTPEdgeCycleStop())
 	}
 }
@@ -205,14 +179,13 @@ func TestR_GREEN_TrustedSelfLoopback_CycleStop(t *testing.T) {
 // its own node but has reached depth==NestedCallMaxDepth trips the depth-8
 // backstop (raw=false → bounded error), bumping the depth counter.
 func TestR_DEPTH_Backstop_TrustedDepth8(t *testing.T) {
-	setSeedProvider(t, testSeedTok)
 	SetSelfLoopbackHost("http://" + testSelfHost)
 	t.Cleanup(func() { SetSelfLoopbackHost("") })
 
 	const resource, ns, name = "restactions", "demo-system", "fsa-deep-chain"
-	// depth == max, and an ancestor set that does NOT contain THIS node (so the
-	// cycle-stop does not fire first — the depth backstop is what trips).
-	req := buildLoopbackReq(testSeedTok, testSelfHost,
+	// A valid authenticated user; depth == max, and an ancestor set that does NOT
+	// contain THIS node (so the cycle-stop does not fire first — depth backstop).
+	req := buildLoopbackReq("admin", testSelfHost,
 		strconv.Itoa(cache.NestedCallMaxDepth()), "restactions/other/ancestor-a")
 
 	// Handler wiring: header ancestors only. THIS node is NOT in the header set
@@ -230,42 +203,14 @@ func TestR_DEPTH_Backstop_TrustedDepth8(t *testing.T) {
 	}
 }
 
-// TestR_TokenRotation_LiveProviderValue is the TL-refinement-1 arm: the guard
-// reads the LIVE provider value, so after the seed token ROTATES, a loopback
-// carrying the NEW token is trusted and one carrying the OLD token is not. A
-// startup-snapshot implementation would trust the stale token and reject the new
-// one — this arm RED-proves the live read.
-func TestR_TokenRotation_LiveProviderValue(t *testing.T) {
-	SetSelfLoopbackHost("http://" + testSelfHost)
-	t.Cleanup(func() { SetSelfLoopbackHost("") })
-
-	live := "OLD-seed-jwt" // the "current" seed token the provider returns
-	SetSeedLoopbackTokenProvider(func(context.Context) (string, error) { return live, nil })
-	t.Cleanup(func() { SetSeedLoopbackTokenProvider(nil) })
-
-	// Before rotation: OLD (=current) token is trusted.
-	if !isTrustedSelfLoopback(buildLoopbackReq("OLD-seed-jwt", testSelfHost, "1", "restactions/ns/x")) {
-		t.Fatal("rotation: pre-rotation the OLD (=current) token must be trusted")
-	}
-	live = "NEW-seed-jwt" // rotate
-	// After rotation: NEW token trusted, OLD token rejected (LIVE read, not snapshot).
-	if !isTrustedSelfLoopback(buildLoopbackReq("NEW-seed-jwt", testSelfHost, "1", "restactions/ns/x")) {
-		t.Fatal("rotation: post-rotation the NEW (=current) token must be trusted — provider read must be LIVE")
-	}
-	if isTrustedSelfLoopback(buildLoopbackReq("OLD-seed-jwt", testSelfHost, "1", "restactions/ns/x")) {
-		t.Fatal("rotation: post-rotation the OLD token must be REJECTED (a snapshot impl would wrongly trust it)")
-	}
-}
-
-// TestR_HostMismatch_NotTrusted — even the seed token is not trusted if the
-// request did not arrive on the self-host (belt-and-suspenders, C1).
+// TestR_HostMismatch_NotTrusted — even a valid authenticated user is not trusted
+// if the request did not arrive on the self-host (belt-and-suspenders secondary).
 func TestR_HostMismatch_NotTrusted(t *testing.T) {
-	setSeedProvider(t, testSeedTok)
 	SetSelfLoopbackHost("http://" + testSelfHost)
 	t.Cleanup(func() { SetSelfLoopbackHost("") })
-	req := buildLoopbackReq(testSeedTok, "evil.example.com:8081", "1", "restactions/ns/x")
+	req := buildLoopbackReq("admin", "evil.example.com:8081", "1", "restactions/ns/x")
 	if isTrustedSelfLoopback(req) {
-		t.Fatal("host-mismatch: seed token on a NON-self host must not be trusted (belt-and-suspenders)")
+		t.Fatal("host-mismatch: a valid user on a NON-self host must not be trusted (belt-and-suspenders)")
 	}
 }
 

--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -1010,31 +1010,6 @@ func SetSeedLoopbackTokenProvider(fn func(ctx context.Context) (string, error)) 
 	seedTokenProviderMu.Unlock()
 }
 
-// currentSeedLoopbackToken returns the CURRENT authn-issued seed JWT (the same
-// credential installSeedLoopbackToken installs on the prewarm ctx), or ("",
-// false) when no provider is wired or the exchange fails. Used by the R
-// self-loopback ingest guard (nested_resolve_ingest.go) to recognise snowplow's
-// OWN seed loopback by TOKEN PROVENANCE: the seed JWT is minted from snowplow's
-// projected SA token (authn /serviceaccount/login) and never leaves the pod
-// except on a self-host loopback, so an EXTERNAL caller cannot present it. The
-// provider caches the JWT until shortly before expiry (authn.Client refreshSkew),
-// so the token an in-flight loopback carries is the SAME string this returns —
-// no rotation gap in practice, and the depth-8 backstop covers any edge miss.
-// Read-only wrapper over the wired provider; never mutates ctx.
-func currentSeedLoopbackToken(ctx context.Context) (string, bool) {
-	seedTokenProviderMu.RLock()
-	fn := seedTokenProvider
-	seedTokenProviderMu.RUnlock()
-	if fn == nil {
-		return "", false
-	}
-	tok, err := fn(ctx)
-	if err != nil || tok == "" {
-		return "", false
-	}
-	return tok, true
-}
-
 // seedLoopbackTokenErrTotal counts token-acquisition failures on the seed path
 // (C-a observability — "prewarm loopback ran token-less, nested RA cold").
 var seedLoopbackTokenErrTotal atomic.Uint64


### PR DESCRIPTION
## What

1.5.25's R forge-guard (`isTrustedSelfLoopback`) trusted a self-loopback ONLY when the inbound bearer exactly equalled snowplow's OWN seed JWT (token-provenance). That closed the SEED loopback but NOT the USER loopback: a real user's composition-resources `/call` runs under THEIR JWT ≠ the seed token → the guard returned false → the depth/ancestor headers were ignored → the HTTP-edge cycle-stop never fired → the user-path self-loopback recursed unbounded (the 1.5.24 storm, now user-driven).

Concause: the per-BINDING L1 entry means the seed's warm entries miss for a real user → cold re-resolve → each self-loops unguarded.

## Fix (ingest-only, single function)

`isTrustedSelfLoopback` now trusts iff `xcontext.UserInfo(ctx)` is present + non-error (⟺ a snowplow-**validated** JWT holder: the auth middleware sets UserInfo ONLY after `jwtutil.Validate` passes at userconfig.go:151; an unauth/invalid/spoofed JWT is 401'd upstream, never reaching the handler with UserInfo set) AND `requestArrivedOnSelfHost` (belt-and-suspenders, tightens-only). The security property was never "only the seed" but "only a snowplow-validated JWT holder" — which holds for ANY authenticated user, seed included.

Forge-safe: worst case is self-DoS of the forger's own call (`checkDispatchRBAC` unchanged under the caller's identity, per-binding L1 key = no cross-user impact).

**Orphan cleanup:** removed the now-unused `crypto/subtle` import + the `currentSeedLoopbackToken` accessor (its only caller was the old predicate). `seedTokenProvider`/`installSeedLoopbackToken` stay (the seed still needs its token via #57). Net-negative diff. Emit/codec/HTTP-edge-stop/D UNCHANGED (never the defect).

## Tests (3× -race, all RUN+PASS)

- **C2** `TestR_C2_ForgeGuard_NonSeedUserFires` (the arm that would've caught 1.5.25): a valid NON-seed user self-loopback → trusted, reseed installs ancestors, cycle-stop FIRES. **RED-proven discriminating**: reverting to seed-only narrowness makes C2 FAIL (reproduces the 1.5.25 user-path storm hermetically).
- **C3** `TestR_C3_SeedStillTrusted`: seed identity (distinct) still trusted → guard fires → no regression.
- **C4** `TestR_C4_ForgeGuard_NoUserInfoIgnored`: unauthenticated + forged depth:8 + spoofed ancestors → not trusted → reseed no-op, stop=false, counters unmoved.
- DEPTH backstop + HostMismatch + all D arms.

Dual-gate: arch PASS 5/5 + PM ACCEPT on the frozen review ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1