### PR TITLE
fix(prewarm): #99b FIX-F latch segment identity = first widget-capable ranked identity + re-walk root stamping

### DIFF
--- a/docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md
+++ b/docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md
@@ -1,0 +1,215 @@
+# FIX-F first-nav latch zero-fire — root-cause trace (2026-07-06)
+
+Repo: main @ 70b9fba (== tag 1.6.0, verified `git merge-base --is-ancestor` + empty
+`git log 1.6.0..HEAD`; the brief's "dd6d7d4" is an ancestor, the deployed 1.6.0 image
+is byte-identical to this checkout). Live evidence: fresh2 60K, pods kb8bb
+(PHASE1_TIMEOUT=180, /tmp/boot160.log) and mgrt7 (PHASE1_TIMEOUT=600, /tmp/boot600.log).
+boot160.log's capture ends 20:14:03 (before its latch fire); boot600.log contains the
+full arming→fire sequence and is the primary evidence.
+
+## 1. Symptom
+
+`prewarm.first_nav.latch reason=zero-first-nav-targets first_nav_widgets=0
+first_nav_targets=0 elapsed_ms=201` at 20:33:04.202 (boot600 line 5795) — on a boot
+where the harvest was demonstrably present and healthy at arming time:
+
+- `prewarm.engine.boot.rewalk_complete restactions=25 widgets=175 elapsed_ms=161349`
+  20:33:03.772 (line 5386).
+- 175 `prewarm.engine.seed.widget_targets` lines, `nav_order` 0..174 stamped in walk
+  order (`app-shell` nav_order=0, `sider-content` nav_order=1), `targets` = 16 on 174
+  of 175 (15 on one) — the uniform widget-floor identity set.
+- `prewarm.enumerate.dedup` ranking substrate non-empty (16–52 identities per GVR),
+  `index_built bindings_enrolled=4187` (line 5383).
+
+So every input the latch consumes existed — yet the rank-1 × RootIndex==0 count was 0.
+
+## 2. Adjudication of the briefed hypothesis — REFUTED (as the operative mechanism)
+
+Hypothesis: the redrive/re-walk path never calls `BeginRoot()` → widgets harvested by a
+redrive stamp `RootIndex=-1` → the arming count at `RootIndex==0` is 0.
+
+Two code facts kill it for THESE boots:
+
+1. **TRACED — the -1 case cannot exist.** `harvestNavWidget` clamps a negative
+   `curRoot` to 0 at stamp time (phase1_pip_seed.go:301-304: `rootIdx := h.curRoot;
+   if rootIdx < 0 { rootIdx = 0 }`). A harvest that precedes every `BeginRoot` stamps
+   RootIndex=0, never -1.
+2. **TRACED — this deployment is single-root, so curRoot is pinned at 0.** The frontend
+   config.json declares only `.api.INIT`; `.api.ROUTES_LOADER` is empty —
+   `phase1.roots.entry_point_empty field=ROUTES_LOADER` (phase1_roots.go:157-165 logs
+   per FIELD, not per walk failure) at 20:24:32 (initial lister, boot600 line 39) and
+   again at 20:30:22 (re-walk lister, line 3444); `roots_discovered roots_count=1`
+   (line 44). The initial boot walk's resolver closure calls `BeginRoot()` once
+   (phase1_walk.go:401) → curRoot: -1→0. The engine re-walk
+   (prewarm_engine_boot.go:259-290) indeed NEVER calls `BeginRoot` — it builds
+   `newPhase1Walker` and calls `w.walk()` directly (:274-281) — but with curRoot
+   already 0, every widget first-harvested by ANY pass (initial walk, engine re-walk,
+   config-vars redrive re-walk) stamps RootIndex=0.
+
+So on both boots **all 175 harvested widgets carry RootIndex==0**, and the arming loop
+(prewarm_engine_boot.go:755-756 `if ws.e.RootIndex != 0 { continue }`) filtered none of
+them out. RootIndex stamping is NOT why the count was 0.
+
+**The missing `BeginRoot` on the re-walk IS a real latent defect** (TRACED-latent,
+prewarm_engine_boot.go:259-290): with N≥2 config roots the boot walk leaves
+curRoot=N-1, so any widget first-harvested only during a redrive re-walk (the common
+case at 50K+ where the effective harvest comes from the config-vars redrive) stamps
+RootIndex=N-1≠0 → the same zero-fire, for a different reason. It must be fixed for
+multi-root correctness, but it did not produce this boot's symptom.
+
+## 3. TRACED root cause — rank-1 identity has zero widget targets
+
+The latch segment is defined as **ranked[0] ∩ RootIndex==0 widgets**
+(prewarm_engine_boot.go:749-770): `rank1 := ranked[0].key` (:754), and a widget target
+counts only when `identityKey(c) == rank1` (:761-764).
+
+`ranked` is built over the UNION of widget-target and restaction-target identities
+(:635-667): `noteIdentity` records each identity's **first-seen** `CollapsedBindings`
+(:641-647, `if _, ok := rankOf[k]; !ok` — first write wins), widgets loop first
+(:648-652), then restactions (:653-657); sort DESC by collapsed (:662-667). Nothing
+guarantees ranked[0] appears in ANY widget target set.
+
+On boot600 it did not. The rank-major loop seeds ranked[0]'s widgets first, then its
+restactions (:792-845). The complete pre-latch seed activity (20:33:04.001→.202, i.e.
+the entire rank-1 pass) was:
+
+- **zero widget seeds** (no `site=seed handler=widgets` diag line), and
+- **8 restaction seeds, all under cohort
+  `system:serviceaccount:bench-ns-01:benchapps-v0-1-0`**, every one skipped with
+  `phase1.seed.skip.empty_binding` (BindingUID re-derived "" — EvaluateRBAC fail-closed
+  at the RESTAction's own coordinates; the FIX-C A4 populate guard,
+  phase1_pip_seed.go:487-497): settings-krateo-status, blueprint-install-formdef,
+  blueprints-cards, blueprints-catalog, blueprints-list, global-search,
+  marketplace-detail, settings-users.
+
+Since the rank-major loop seeds ranked[0] first, **ranked[0] IS the bench SA**
+(TRACED by loop semantics + observed order). That SA appears only in restaction
+TARGET-GVR enumerations — `apps/deployments` (1344 bindings → 37 identities),
+`core.krateo.io/compositiondefinitions` (48→47), `core/secrets` (62→52) — and NOT in
+the widget-floor set (`widgets.templates.krateo.io/*`: 1308 bindings → 16 identities,
+uniform across all 19 widget GVRs; all 175 widgets logged `targets:16`, and none of the
+16 matched rank1, hence `first_nav_widgets:0`).
+
+Chain: bench-SA identity noted from a restaction target set with a first-seen
+CollapsedBindings higher than every widget-floor identity's (the deployments bucket is
+the only set large enough — 1344 raw bindings; the per-identity split is INFERRED, the
+ranking OUTCOME is TRACED) → ranked[0] = bench SA → the arming scan over all 175
+RootIndex==0 widgets finds zero rank-1 targets → `firstNavTotal=0` → the rank-1
+boundary fires `zero-first-nav-targets` (prewarm_engine_boot.go:854-856) → engineSeed's
+select unblocks (phase1_walk.go:505-507) → deferred `MarkPhase1Done` flips /readyz —
+**without the dominant login cohort's dashboard cells warm, on every boot with this
+RBAC topology**. The gate FIX-F was built to be (#99, F-C1..C3) never actually gates.
+
+### 3a. Secondary findings (all TRACED unless noted)
+
+1. **Rank-1 is nondeterministic across boots.** `noteIdentity` keeps the FIRST-seen
+   CollapsedBindings; the restaction precompute iterates the harvester snapshot in Go
+   map order (prewarm_engine_boot.go:615-626 over `restactionRefs` from
+   `contentPrewarmHarvester.snapshot()`). The same identity carries a different count
+   per enumerate (per-bucket counting, prewarm_enumeration.go:139-147 bucket∪wildcard,
+   :192-208), so which count wins is map-order-dependent → on some boots the bench SA
+   may be noted from the secrets set (small count) and a real cohort ranks first. The
+   zero-fire is therefore intermittent by construction — worse than a deterministic bug.
+2. **The whole rank-1 slot is waste on this topology**: all 8 bench-SA restaction seeds
+   skip on empty_binding (index says the SA can list deployments; EvaluateRBAC at the
+   RA's `templates.krateo.io/restactions ns=krateo-system` coordinates denies). Cheap
+   (~25ms each) but it means the FIX-D "95%-mix dominant cohort" heuristic selected a
+   machine SA that can never log into the portal.
+3. **Observability gap**: `widget_targets` logs `nav_order` but not `root_index`
+   (prewarm_engine_boot.go:672-681), and the latch line does not name the rank-1
+   identity — which is why this trace needed the seed-order inference. NavOrder and
+   RootIndex have no different stamping condition (navSeq increments unconditionally at
+   first harvest, phase1_pip_seed.go:296-297; RootIndex was stamped 0 everywhere here,
+   :301-313) — RootIndex is simply invisible in logs.
+
+### 3b. Answers to the brief's side questions
+
+- **entry_point_empty on both walks**: it is per-FIELD — ROUTES_LOADER is genuinely
+  empty in this deployment's config.json; INIT resolved both times. One root, both
+  passes.
+- **Which walk harvested**: both write into the SAME harvester (shared by reference,
+  first-write-wins dedupe, phase1_pip_seed.go:279-284). The initial walk (20:24:32→
+  sync barrier) harvested whatever was resolvable pre-sync; the engine re-walk
+  (20:30:22→20:33:03, 161s) filled the rest. Neither path's BeginRoot behaviour matters
+  on a single-root config (curRoot pinned at 0). The re-walk path does NOT call
+  BeginRoot — latent multi-root defect only (§2).
+- **nav_order stamped but RootIndex not**: false premise — both stamped; RootIndex==0
+  for all 175; it is not logged.
+
+## 4. Fix design (ranked)
+
+**Fix 1 — latch segment identity = highest-ranked identity that actually has a
+RootIndex==0 widget target (RECOMMENDED, ~20 LOC).**
+At the arming block (prewarm_engine_boot.go:749-770): instead of hard-wiring
+`rank1 := ranked[0].key`, scan `ranked` in order and pick the first identity with ≥1
+RootIndex==0 widget target as `segKey`/`segRank`; count that identity's segment. The
+decrement condition (:827) changes `ri == 0 && ... == rankKey` → `ri == segRank &&
+identityKey(c) == segKey`; the zero-fire boundary (:854) changes `ri == 0` →
+`ri == segRank` (fires only when NO ranked identity has any first-nav widget target —
+preserves F-C3's provably-empty semantics; ranked-empty fire at :861-863 unchanged).
+Seed ORDER is untouched (pure gate fix; the bench-SA rank-1 pass remains a cheap
+skipped prefix). Walk-derived, no name literals, no caps. This makes the latch correct
+REGARDLESS of rank pollution and of finding 1 (nondeterminism).
+
+**Fix 2 — re-walk root stamping for multi-root correctness (~12 LOC, same ship).**
+Add `navWidgetHarvester.BeginWalk()` (reset `curRoot = -1` under mu) and call it at the
+top of each walk pass; call `BeginRoot()` per root in the engine re-walk loop
+(prewarm_engine_boot.go:259, before `w.walk`). NOTE: naively adding only `BeginRoot()`
+to the re-walk loop is WRONG — it would increment past the boot walk's final value and
+stamp redrive-harvested widgets N..2N-1. The reset+increment pair keeps root indices
+stable per pass (roots iterate in config.json order every pass). First-write-wins
+preserves boot-walk stamps. Inert today (single root); required the day ROUTES_LOADER
+is declared.
+
+**Fix 3 — rank hygiene (follow-up, separate gate).** Make `noteIdentity` fold the MAX
+(or sum) CollapsedBindings across enumerates instead of first-seen (kills the
+map-order nondeterminism), and/or rank widget-capable identities ahead of
+restaction-only identities so the prime seed slot is never spent on a machine SA.
+Changes global seed order → needs the FIX-E interleave falsifier re-run; not required
+for gate correctness once Fix 1 lands.
+
+**Observability (ride-along, ~4 LOC).** Add `root_index` to the `widget_targets` line
+and the segment identity (+ its rank) to the `prewarm.first_nav.latch` line.
+
+## 5. Falsifier
+
+Hermetic (uses the existing seams `enumeratePrewarmTargetsForGVRFn` /
+`seedOneWidgetFn` / `restActionTargetGVRFn` / `seedOneRestactionFn` +
+`resetFirstNavLatchForTest` + `firstNavFireObserver`, prewarm_engine_boot.go:394-409,
+prewarm_first_nav_latch.go:133-146):
+
+- Arrange: 2 widgets RootIndex==0 + 1 widget RootIndex==1; widget target sets = {U1
+  (collapsed 5), U2 (collapsed 2)}; 1 restaction whose target set = {M (collapsed
+  50)} — M in NO widget set (the boot600 shape: machine identity out-ranks via a
+  restaction-only enumerate).
+- **RED (current code)**: latch fires `reason=zero-first-nav-targets`,
+  `first_nav_targets=0`, positioned (observer) BEFORE any widget seed.
+- **GREEN (Fix 1)**: latch fires `reason=segment-complete`, `first_nav_widgets=2`,
+  `first_nav_targets=2` (U1 × RootIndex==0 pairs), positioned after the 2nd U1
+  RootIndex==0 widget seed and BEFORE the RootIndex==1 widget and the restaction tail
+  (ARM-TAIL preserved).
+- **Fix 2 arm**: 2 roots; boot-walk pass harvests nothing (empty subtrees); a second
+  walk pass (redrive shape: fresh walkers, shared harvester) harvests both subtrees;
+  assert root-0's widgets stamp RootIndex==0 (RED today: both stamp 1) and the latch
+  then counts them.
+- Verify the arms ACTUALLY RUN (=== RUN lines / arm count — no bare green;
+  feedback_falsifier_must_actually_run_under_gate_tag_env).
+
+On-cluster proof (next 60K boot): `grep prewarm.first_nav.latch` →
+`reason=segment-complete first_nav_targets>0`, fire timestamp strictly after the
+segment identity's RootIndex==0 widget seed diag lines and well before
+`prewarm.engine.boot.complete`; post-Ready `/dashboard` nav#1 l1:HIT content check
+(the F-C4 guard) unchanged.
+
+## 6. Customer-impact framing
+
+No cold-serve regression is attributable to this defect on the observed boots: the
+zero-fire happens AFTER the engine re-walk (content/identity-free L1 already warm —
+live probe was a 3ms content-hit at Ready), and the per-user cells the latch was meant
+to gate are seeded moments later by the same boot scope. This is gate-SEMANTICS
+correctness (readiness flips before the rank-1 first-nav per-user segment is warm —
+exactly the degeneration FIX-F was shipped to remove, plus a nondeterministic rank-1
+selection). Priority: correctness fix on the next ship train, not a hotfix.
+
+Evidence paths: /tmp/boot600.log (lines 38-44, 3441-3444, 5383-5386, 5571-5745,
+5787-5795), /tmp/boot160.log (lines 38-44, 2019-2030; capture ends 20:14:03 pre-latch).

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -236,6 +236,27 @@ func newNavWidgetHarvester() *navWidgetHarvester {
 	return &navWidgetHarvester{entries: map[string]navWidgetEntry{}, curRoot: -1}
 }
 
+// BeginWalk resets the current config-root index to -1 (#99b Fix 2) at the top
+// of EACH walk pass so the following per-root BeginRoot() calls stamp RootIndex
+// 0..N-1 in config.json order every pass — the initial boot walk AND every
+// engine/config-vars re-walk. Without the reset, a re-walk that calls BeginRoot
+// per root would resume from the boot walk's final curRoot (N-1) and stamp
+// re-walk-first-harvested widgets N..2N-1 (the naive-BeginRoot-only defect the
+// doc §4 Fix 2 warns against). First-write-wins dedupe (harvestNavWidget)
+// preserves the boot-walk stamp for any widget already harvested, so a widget
+// FIRST harvested during a re-walk gets the correct root index for its pass.
+// Nil-safe. Inert on this deployment's single-root config (curRoot pinned at 0
+// after the first BeginRoot); required the day a second config root
+// (ROUTES_LOADER) is declared and the effective harvest arrives via a re-walk.
+func (h *navWidgetHarvester) BeginWalk() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.curRoot = -1
+	h.mu.Unlock()
+}
+
 // BeginRoot advances the current config-root index (#42 FIX-F seam, STAMP-ONLY).
 // The phase-1 walk calls this before descending each root; roots resolve
 // sequentially so the increment is deterministic — RootIndex 0 is the first

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -256,10 +256,26 @@ func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only bool
 	}
 
 	rewalked := 0
+	// #99b Fix 2 — reset the harvester's config-root index to -1 at the top of
+	// this walk PASS so the per-root BeginRoot() below stamps RootIndex 0..N-1
+	// in config.json order, exactly like the boot walk (phase1_walk.go:401).
+	// WITHOUT the reset the re-walk would resume from the boot walk's final
+	// curRoot=N-1 and a widget FIRST harvested only during this re-walk (the
+	// 50K+ common case, where the effective harvest comes from the config-vars
+	// redrive) would stamp N..2N-1, so its RootIndex would never be 0 → the
+	// first-nav latch zero-fires (multi-root). First-write-wins dedupe
+	// preserves any boot-walk stamp. Nil-safe. Inert on single-root config
+	// (curRoot pinned 0 after the first BeginRoot); required for multi-root.
+	deps.navHarv.BeginWalk()
 	for _, root := range roots {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		// #99b Fix 2 — advance the config-root index before descending this
+		// root (mirrors the boot walk's resolver closure, phase1_walk.go:401).
+		// Roots iterate in config.json order every pass, so this stamps
+		// RootIndex 0 for the first (default-route/dashboard) subtree. Nil-safe.
+		deps.navHarv.BeginRoot()
 		// FRESH walker per root — new visited map (phase1_walk.go:679).
 		// Harvesters SHARED BY REFERENCE so the re-walk's harvest lands in
 		// the set the seed drains.
@@ -677,6 +693,7 @@ func seedScopeYielding(ctx context.Context,
 			slog.Bool("scoped", ws.scoped),
 			slog.Int("targets", len(ws.targets)),
 			slog.Int("nav_order", ws.e.NavOrder),
+			slog.Int("root_index", ws.e.RootIndex),
 		)
 	}
 	for _, rs := range restactionSeeds {
@@ -732,39 +749,73 @@ func seedScopeYielding(ctx context.Context,
 	}
 
 	// ── #99 FIX-F: FIRST-NAV LATCH ARMING (segment-scoped, F-C2). ──
-	// The readyz gate flips when the rank-1 (ri==0) identity's RootIndex==0
-	// (default-route/dashboard) WIDGET segment has seeded — NOT the whole
-	// rank-1 pass, NOT the full seed (prewarm_first_nav_latch.go). We count
-	// the rank-1 × RootIndex==0 widget-target PAIRS up front so we can fire
-	// the latch the instant the LAST one seeds (mid-rank-1, before the
-	// RootIndex>0 widgets and before ANY rank-1 restaction — the heavy
-	// NON-first-nav tail is still mid-seed, ARM-TAIL). RootIndex is stamped on
-	// widgets only (phase1_pip_seed.go BeginRoot/RootIndex); restactions carry
-	// no first-nav marker, so the segment is the widget subset — the RA cells
-	// warm through FIX-E's ascending-len ordering (cheap dashboard RAs before
-	// the fanout whale) as background tail after the flip. The latch is nil
-	// under the pure-unit seed tests that call seedScopeYielding directly (no
-	// engineSeed wrapper built it) → all fire() calls are nil-safe no-ops, so
-	// those tests are unchanged.
+	// The readyz gate flips when the FIRST-NAV WIDGET SEGMENT has seeded — NOT
+	// the whole rank pass, NOT the full seed (prewarm_first_nav_latch.go).
+	//
+	// #99b: the segment identity is NOT hard-wired to ranked[0]. ranked is
+	// built over the UNION of widget- AND restaction-target identities
+	// (:635-667, first-seen CollapsedBindings), so ranked[0] can be an
+	// identity that appears ONLY in a restaction target set and has ZERO
+	// RootIndex==0 widget targets (the live boot600 case: a machine SA present
+	// only in RA enumerations out-ranks every widget-floor identity → the
+	// old rank1==ranked[0] arming counted 0 first-nav targets → the latch
+	// zero-fired with the login cohorts' dashboards COLD). Instead we scan
+	// ranked in order and pick the FIRST identity that actually has ≥1
+	// RootIndex==0 widget target as the segment (segKey at rank segRank). The
+	// segment is that identity's RootIndex==0 widget-target PAIRS; the latch
+	// fires the instant the LAST one seeds (mid-segRank pass, before the
+	// RootIndex>0 widgets and before ANY of that rank's restactions — the
+	// heavy NON-first-nav tail is still mid-seed, ARM-TAIL). Seed ORDER is
+	// UNTOUCHED: this is a pure gate fix; the rank-major loop below is
+	// unchanged, so any lower-ranked identity that spends the prime seed slot
+	// (e.g. the bench-SA rank-1 restaction pass) remains a cheap skipped
+	// prefix — the latch simply no longer keys its readiness on it.
+	//
+	// RootIndex is stamped on widgets only (phase1_pip_seed.go
+	// BeginRoot/RootIndex); restactions carry no first-nav marker, so the
+	// segment is the widget subset — the RA cells warm through FIX-E's
+	// ascending-len ordering (cheap dashboard RAs before the fanout whale) as
+	// background tail after the flip. The latch is nil under the pure-unit
+	// seed tests that call seedScopeYielding directly (no engineSeed wrapper
+	// built it) → all fire() calls are nil-safe no-ops, so those tests are
+	// unchanged.
 	latch := currentFirstNavLatch()
 	latchStart := time.Now()
 	firstNavRemaining := 0
 	firstNavWidgets := 0
-	if latch != nil && len(ranked) > 0 {
-		rank1 := ranked[0].key
-		for _, ws := range widgetSeeds {
-			if ws.e.RootIndex != 0 {
-				continue
-			}
-			hasRank1Target := false
-			for _, c := range ws.targets {
-				if identityKey(c) == rank1 {
-					firstNavRemaining++
-					hasRank1Target = true
+	// segKey/segRank identify the segment identity + its rank in `ranked`.
+	// segRank stays -1 when NO ranked identity has any RootIndex==0 widget
+	// target (genuinely-no-first-nav topology, F-C3) — the zero-fire boundary
+	// below keys on segRank<0/unreached, preserving the provably-empty
+	// semantics.
+	segKey := ""
+	segRank := -1
+	if latch != nil {
+		for r := range ranked {
+			candidate := ranked[r].key
+			count := 0
+			widgetsWith := 0
+			for _, ws := range widgetSeeds {
+				if ws.e.RootIndex != 0 {
+					continue
+				}
+				hits := 0
+				for _, c := range ws.targets {
+					if identityKey(c) == candidate {
+						hits++
+					}
+				}
+				if hits > 0 {
+					count += hits
+					widgetsWith++
 				}
 			}
-			if hasRank1Target {
-				firstNavWidgets++
+			if count > 0 {
+				segKey = candidate
+				segRank = r
+				firstNavRemaining = count
+				firstNavWidgets = widgetsWith
+				break
 			}
 		}
 	}
@@ -778,7 +829,7 @@ func seedScopeYielding(ctx context.Context,
 	// whatever remains; the zero-targets path reports 0). Nil-safe.
 	fireFirstNav := func(reason string) {
 		if latch != nil {
-			latch.fire(reason, firstNavWidgets, firstNavTotal-firstNavRemaining, time.Since(latchStart))
+			latch.fire(reason, firstNavWidgets, firstNavTotal-firstNavRemaining, segKey, segRank, time.Since(latchStart))
 		}
 	}
 
@@ -808,11 +859,16 @@ func seedScopeYielding(ctx context.Context,
 				if seedWidgetTarget(e, c) {
 					return ctx.Err()
 				}
-				// F-C2: fire the latch the instant the LAST rank-1
-				// RootIndex==0 widget target has been PROCESSED (mid-rank-1).
-				// Only the rank-1 first-nav segment decrements; RootIndex>0
-				// widgets and lower ranks never touch firstNavRemaining, so this
-				// cannot fire early on a RootIndex>0-only seed (F-C3).
+				// F-C2: fire the latch the instant the LAST segment-identity
+				// RootIndex==0 widget target has been PROCESSED (mid-segRank pass).
+				// #99b: the segment is the segKey identity at rank segRank — the
+				// first ranked identity with a RootIndex==0 widget target, NOT
+				// necessarily ranked[0]. Only that identity's first-nav segment
+				// decrements; RootIndex>0 widgets and every other rank never touch
+				// firstNavRemaining, so this cannot fire early on a RootIndex>0-only
+				// seed (F-C3). segRank<0 means no ranked identity has a first-nav
+				// widget → this branch never matches → the provably-empty fire
+				// below is the only path.
 				//
 				// PROCESSED, NOT SUCCEEDED (deliberate, C2 liveness). We reach
 				// this line whenever seedWidgetTarget did not abort on ctx-cancel;
@@ -824,7 +880,7 @@ func seedScopeYielding(ctx context.Context,
 				// real guard that the dashboard is genuinely warm is the
 				// on-cluster post-Ready /dashboard nav#1 l1:HIT content check, not
 				// this counter.
-				if latch != nil && ri == 0 && e.RootIndex == 0 && identityKey(c) == rankKey {
+				if latch != nil && ri == segRank && e.RootIndex == 0 && identityKey(c) == segKey {
 					firstNavRemaining--
 					if firstNavRemaining == 0 {
 						fireFirstNav("segment-complete")
@@ -843,22 +899,18 @@ func seedScopeYielding(ctx context.Context,
 				}
 			}
 		}
-		// ── FIX-F SEAM: rank-1 (ri==0) segment boundary. If the rank-1
-		// first-nav segment had ZERO widget targets (no RootIndex==0 widget
-		// authorised for the rank-1 identity — e.g. an all-tail topology, or
-		// prewarm reached no dashboard widget), there is provably nothing to
-		// warm on the first-nav path → fire here so the latch never hangs
-		// (the PHASE1_TIMEOUT backstop would otherwise be the only escape).
-		// firstNavTotal==0 is the "no first-nav segment exists" case; a
-		// non-zero total already fired above. ──
-		if latch != nil && ri == 0 && firstNavTotal == 0 {
-			fireFirstNav("zero-first-nav-targets")
-		}
 	}
-	// Defensive: if ranked was empty (no identities enumerated at all — nothing
-	// to seed), fire so readyz does not wait on the backstop for a genuinely
-	// empty seed. Nil-safe.
-	if latch != nil && len(ranked) == 0 {
+	// ── FIX-F SEAM: provably-empty first-nav boundary (F-C3, #99b). ──
+	// segRank<0 means NO ranked identity had a RootIndex==0 widget target —
+	// an all-tail topology, or prewarm reached no dashboard widget, or ranked
+	// was empty (no identities enumerated at all). There is provably nothing
+	// to warm on the first-nav path → fire so the latch never hangs (the
+	// PHASE1_TIMEOUT backstop would otherwise be the only escape). A non-empty
+	// segment already fired "segment-complete" mid-loop (segRank>=0), so this
+	// close is a no-op then (idempotent once). Firing AFTER the seed loop (not
+	// at a per-rank boundary) means the RootIndex>0-only tail is fully
+	// processed first — F-C3 never fires early mid-tail. Nil-safe.
+	if latch != nil && segRank < 0 {
 		fireFirstNav("zero-first-nav-targets")
 	}
 	return nil

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch.go
@@ -68,8 +68,12 @@ func newFirstNavLatch() *firstNavLatch {
 // segment-complete path from the provably-zero-targets path (both are
 // legitimate "first-nav is warm / there is no first-nav to warm" states);
 // segWidgets/segTargets are the RootIndex==0 widget + per-target counts the
-// latch waited on (0/0 on the zero-targets path).
-func (l *firstNavLatch) fire(reason string, segWidgets, segTargets int, elapsed time.Duration) {
+// latch waited on (0/0 on the zero-targets path). segIdentity/segRank name the
+// segment identity + its position in the dedup rank (#99b): the identity the
+// latch keyed readiness on — NOT necessarily ranked[0], since ranked[0] can be
+// a restaction-only identity with zero first-nav widgets. Empty/-1 on the
+// zero-targets path (no ranked identity had a first-nav widget).
+func (l *firstNavLatch) fire(reason string, segWidgets, segTargets int, segIdentity string, segRank int, elapsed time.Duration) {
 	l.once.Do(func() {
 		if firstNavFireObserver != nil {
 			// TEST-ONLY synchronous observation of the fire INSTANT (nil in
@@ -85,6 +89,8 @@ func (l *firstNavLatch) fire(reason string, segWidgets, segTargets int, elapsed 
 			slog.String("reason", reason),
 			slog.Int("first_nav_widgets", segWidgets),
 			slog.Int("first_nav_targets", segTargets),
+			slog.String("segment_identity", segIdentity),
+			slog.Int("segment_rank", segRank),
 			slog.Int64("elapsed_ms", elapsed.Milliseconds()),
 			slog.String("effect", "rank-1 RootIndex==0 first-nav segment seeded (or provably empty); "+
 				"engineSeed unblocks → /readyz flips Ready with the dashboard warm. The boot scope "+

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -1,0 +1,265 @@
+// prewarm_first_nav_latch_segment_test.go — #99b FIX-F segment-identity
+// falsifier set (docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md §5).
+//
+// The live 60K boot600 defect: `ranked` is built over the UNION of widget- AND
+// restaction-target identities, first-seen CollapsedBindings. A machine SA that
+// appears ONLY in a restaction target set (a bench-ns SA, all seeds
+// empty_binding-skipped) can out-rank every login-cohort widget-floor identity
+// and become ranked[0] — with ZERO RootIndex==0 widget targets. The pre-#99b
+// arming (rank1 := ranked[0].key) then counts 0 first-nav targets → the latch
+// zero-fires (reason=zero-first-nav-targets) BEFORE any widget seed, flipping
+// /readyz with the login cohorts' dashboards cold. #99b makes the segment
+// identity the FIRST ranked identity that actually has a RootIndex==0 widget
+// target (segKey/segRank), so the latch keys readiness on the real dashboard.
+//
+//   ARM-GREEN-BOOT600 (§5 GREEN, Fix 1): 2 RootIndex==0 widgets {U1 c=5, U2
+//     c=2} + 1 RootIndex==1 widget; 1 restaction whose target set = {M c=50},
+//     M in NO widget set. ranked[0] is M (restaction-only, out-ranks by
+//     collapsed). The latch MUST fire reason=segment-complete, first_nav_
+//     widgets=2, first_nav_targets=2 (U1's 2 RootIndex==0 pairs — U1 out-ranks
+//     U2 among widget-capable identities), positioned AFTER the 2nd U1
+//     RootIndex==0 widget seed and BEFORE the RootIndex==1 widget + the RA tail
+//     (ARM-TAIL). segment_identity == U1, segment_rank == 1 (M is rank 0).
+//   The RED companion (pre-#99b code) is captured empirically to /tmp/fix99b/
+//     (git-stash the fix; the same fixture zero-fires before any widget seed).
+//
+//   ARM-FIX2-REDRIVE (§5 Fix-2 arm): 2 config roots; the boot-walk pass
+//     harvests NOTHING (empty subtrees); a SECOND walk pass (redrive shape:
+//     fresh walkers, shared harvester) harvests both subtrees. root-0's widgets
+//     MUST stamp RootIndex==0 (RED without BeginWalk+BeginRoot in the re-walk:
+//     they resume from the boot walk's curRoot and stamp 1). Exercised at the
+//     harvester level (BeginWalk/BeginRoot are the unit under test).
+//
+//   ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling): the #102
+//     keepwarm sweep (rank1Only=true) re-seeds ranked[0]'s CELLS, NOT the
+//     segment identity's. With ranked[0]=M (a restaction-only identity), the
+//     sweep MUST still seed M's restaction targets — segRank is a latch-only
+//     concept and does NOT retarget the keepwarm loop bound. Asserts the sweep
+//     seeds the ranked[0] (M) target set, not the segment (U1) set.
+//
+// Hermetic, -race, seams only. Serializes on engineLatchTestMu.
+
+package dispatchers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// ── ARM-GREEN-BOOT600 (§5 GREEN, Fix 1) ─────────────────────────────────────
+func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	resetFirstNavLatchForTest()
+	ensureFirstNavLatch()
+
+	// The boot600 shape: M (collapsed 50) is the highest-ranked identity but
+	// appears ONLY in the restaction target set — no widget authorises it.
+	// U1 (collapsed 5) and U2 (collapsed 2) are the login-cohort widget
+	// identities. ranked = [M(0), U1(1), U2(2)].
+	m := eID{name: "machine-sa", collapsed: 50}
+	u1 := eID{name: "u1", group: true, collapsed: 5}
+	u2 := eID{name: "u2", group: true, collapsed: 2}
+
+	h := newNavWidgetHarvester()
+	dashA := latchWidgetGVR("flexes")      // RootIndex 0 — first-nav, U1 target
+	dashB := latchWidgetGVR("estategraphs") // RootIndex 0 — first-nav, U1 target
+	tail := latchWidgetGVR("tailwidgets")   // RootIndex 1 — NON-first-nav, U2 target
+	harvestWidgetAtRoot(h, "dash-a", dashA, 0)
+	harvestWidgetAtRoot(h, "dash-b", dashB, 0)
+	harvestWidgetAtRoot(h, "tail-w", tail, 1)
+	widgets := h.snapshot()
+
+	fanoutRA := latchRA("machine-fanout-ra")
+	ras := []templatesv1.ObjectReference{fanoutRA}
+
+	rec := &latchRecorder{}
+	installLatchSeams(t, rec,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case dashA, dashB:
+				// Both RootIndex==0 dashboard widgets authorise U1 (2 targets each
+				// would over-count; give ONE U1 target per widget so first_nav_
+				// targets == 2 == first_nav_widgets).
+				return latchTargets(gvr, u1)
+			case tail:
+				return latchTargets(gvr, u2)
+			case eFanoutRAGVR:
+				return latchTargets(eFanoutRAGVR, m) // M appears ONLY here.
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return eFanoutRAGVR, true
+		})
+
+	// Capture the fire reason + segment fields via a richer observer.
+	var fireReason string
+	firstNavFireObserver = func(reason string) {
+		fireReason = reason
+		rec.rec(latchSeedEvent{class: "LATCH", label: reason, rootIdx: -1})
+	}
+	t.Cleanup(func() { firstNavFireObserver = nil })
+
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	ev := rec.snapshot()
+
+	// GREEN: fired segment-complete, NOT zero-first-nav-targets (the pre-#99b
+	// RED reason). This is the load-bearing discriminator.
+	if fireReason != "segment-complete" {
+		t.Fatalf("§5 GREEN: latch fired reason=%q; want \"segment-complete\" — the pre-#99b code would fire \"zero-first-nav-targets\" (ranked[0]=M has no first-nav widget); events=%+v", fireReason, ev)
+	}
+
+	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
+	// The two RootIndex==0 U1 widgets seed under identity group:u1.
+	dashAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dash-a" && e.identity == "group:u1" })
+	dashBIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dash-b" && e.identity == "group:u1" })
+	tailIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "tail-w" })
+	raIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
+
+	if latchIdx == len(ev) {
+		t.Fatalf("§5 GREEN: latch never fired; events=%+v", ev)
+	}
+	// Fire AFTER both U1 RootIndex==0 widgets seed (segment complete)...
+	lastSegIdx := dashAIdx
+	if dashBIdx > lastSegIdx {
+		lastSegIdx = dashBIdx
+	}
+	if latchIdx < lastSegIdx {
+		t.Fatalf("§5 GREEN: latch fired at idx %d BEFORE the U1 first-nav segment completed (last U1 widget at idx %d) — ARM-COLD; events=%+v", latchIdx, lastSegIdx, ev)
+	}
+	// ...and BEFORE the RootIndex==1 NON-first-nav tail widget (U2, rank 2) —
+	// the segment identity's own tail. ARM-TAIL: readyz must not wait on it.
+	if tailIdx < len(ev) && latchIdx > tailIdx {
+		t.Fatalf("§5 GREEN/ARM-TAIL: latch fired at idx %d AFTER the RootIndex==1 tail widget (U2, rank 2) at idx %d — readyz would wait on non-first-nav tail; events=%+v", latchIdx, tailIdx, ev)
+	}
+	// The M restaction is ranked[0] (rank 0) and legitimately seeds FIRST under
+	// the rank-major loop — it is NOT the segment's tail, so the latch firing
+	// after it is correct (M is a cheap prefix, not first-nav work readyz gates
+	// on). We only assert the U1 segment fired and the RootIndex>0 widget tail
+	// is excluded. raIdx is retained only to document its position.
+	_ = raIdx
+}
+
+// ── ARM-FIX2-REDRIVE (§5 Fix-2 arm) ─────────────────────────────────────────
+// Two config roots; the boot-walk pass harvests nothing; a SECOND walk pass
+// (redrive shape) harvests both subtrees. Without BeginWalk()+per-root
+// BeginRoot() on the re-walk, the second pass resumes from the boot walk's
+// final curRoot and stamps root-0 widgets with the WRONG RootIndex. Exercised
+// directly on the harvester (the unit BeginWalk/BeginRoot govern).
+func TestNavWidgetHarvester_RedriveWalk_StampsRootIndexZeroForRootZero(t *testing.T) {
+	h := newNavWidgetHarvester()
+	r0w := latchWidgetGVR("root0widgets")
+	r1w := latchWidgetGVR("root1widgets")
+
+	// PASS 1 (boot walk): two roots, but both subtrees are empty (the boot
+	// walk reached no widget — the 50K+ boot-race shape where the effective
+	// harvest is the config-vars redrive). Advance curRoot per root anyway
+	// (mirrors the boot walk's resolver closure) so PASS 1 ends at curRoot=1.
+	h.BeginWalk()
+	h.BeginRoot() // root 0
+	h.BeginRoot() // root 1
+	// (no harvestWidgetAtRoot — subtrees empty)
+
+	// PASS 2 (engine re-walk / redrive): fresh walkers, SAME harvester. With
+	// Fix 2, the re-walk calls BeginWalk() (curRoot→-1) then BeginRoot() per
+	// root, so root-0's widget stamps RootIndex 0.
+	h.BeginWalk() // Fix 2: reset to -1
+	h.BeginRoot() // root 0 → curRoot 0
+	harvestWidgetAtRootNoReset(h, "r0-widget", r0w)
+	h.BeginRoot() // root 1 → curRoot 1
+	harvestWidgetAtRootNoReset(h, "r1-widget", r1w)
+
+	got := map[string]int{}
+	for _, e := range h.snapshot() {
+		got[e.W.GetName()] = e.RootIndex
+	}
+	if got["r0-widget"] != 0 {
+		t.Fatalf("Fix-2: root-0 widget stamped RootIndex %d; want 0 (RED without the re-walk BeginWalk reset: it resumes at curRoot=1 and stamps 2). got=%+v", got["r0-widget"], got)
+	}
+	if got["r1-widget"] != 1 {
+		t.Fatalf("Fix-2: root-1 widget stamped RootIndex %d; want 1; got=%+v", got["r1-widget"], got)
+	}
+}
+
+// harvestWidgetAtRootNoReset stamps a widget through the REAL harvester WITHOUT
+// advancing curRoot (the caller controls BeginRoot). It records at the
+// harvester's CURRENT curRoot — so the assert sees the root index the
+// BeginWalk/BeginRoot sequence produced, not a hand-assigned value.
+func harvestWidgetAtRootNoReset(h *navWidgetHarvester, name string, gvr schema.GroupVersionResource) {
+	eHarvestWidget(h, name, gvr)
+}
+
+// ── ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling) ──────────────
+// The #102 keepwarm sweep (rank1Only=true) bounds the seed to ranked[0] — the
+// dominant-CollapsedBindings cohort's CELLS — regardless of whether ranked[0]
+// has a first-nav widget. segRank (the latch segment identity, #99b) is a
+// LATCH-ONLY (boot-gate) concept and must NOT retarget the keepwarm loop bound.
+// With ranked[0]=M (restaction-only) and segRank pointing at U1, the sweep MUST
+// still seed M's restaction target (rank 0), NOT U1's widget (rank 1).
+func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	// The latch has already fired at boot in production; a keepwarm sweep runs
+	// with the singleton already closed. Reset+prefire so the sweep's fire
+	// calls are the idempotent no-ops they are in prod.
+	resetFirstNavLatchForTest()
+	latch := ensureFirstNavLatch()
+	latch.fire("boot-already-fired", 0, 0, "", -1, 0)
+
+	m := eID{name: "machine-sa", collapsed: 50}
+	u1 := eID{name: "u1", group: true, collapsed: 5}
+
+	h := newNavWidgetHarvester()
+	dash := latchWidgetGVR("flexes")
+	harvestWidgetAtRoot(h, "dash", dash, 0) // U1's first-nav widget (rank 1)
+	widgets := h.snapshot()
+
+	fanoutRA := latchRA("machine-fanout-ra")
+	ras := []templatesv1.ObjectReference{fanoutRA}
+
+	rec := &latchRecorder{}
+	installLatchSeams(t, rec,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case dash:
+				return latchTargets(gvr, u1)
+			case eFanoutRAGVR:
+				return latchTargets(eFanoutRAGVR, m) // M = ranked[0].
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return eFanoutRAGVR, true
+		})
+
+	// rank1Only=true — the keepwarm sweep.
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", true); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	ev := rec.snapshot()
+
+	seededM := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" && e.identity == "user:machine-sa" }) < len(ev)
+	seededU1 := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:u1" }) < len(ev)
+
+	if !seededM {
+		t.Fatalf("keepwarm ruling: rank1Only sweep did NOT seed ranked[0] (M) restaction target — the sweep must re-seed the dominant cohort's cells; events=%+v", ev)
+	}
+	if seededU1 {
+		t.Fatalf("keepwarm ruling: rank1Only sweep seeded U1 (rank 1, the SEGMENT identity) — segRank must NOT retarget the keepwarm loop bound (that would be a scope change, out of #99b); events=%+v", ev)
+	}
+}

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
@@ -479,7 +479,7 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 
 	installLatchFireObserver(t, rec)
 	// MUTATION (ii): fire BEFORE the segment completes (before any seed).
-	latch.fire("mutation-ii-premature", 0, 0, 0)
+	latch.fire("mutation-ii-premature", 0, 0, "", -1, 0)
 	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}


### PR DESCRIPTION
## Root cause (live 60K boot600 zero-fire)

The `#99` FIX-F first-nav readyz latch **zero-fired** on the live 60K `boot600` boot: `prewarm.first_nav.latch reason=zero-first-nav-targets first_nav_widgets=0 first_nav_targets=0` fired at Ready-flip time on a boot where the harvest was demonstrably healthy (175 widgets, `bindings_enrolled=4187`).

The latch segment was hard-wired to `rank1 := ranked[0].key`. But `ranked` is built over the **union** of widget-target AND restaction-target identities (first-seen `CollapsedBindings`). A bench-ns machine SA present **only** in restaction target enumerations (`apps/deployments`: 1344 bindings → 37 identities, all its RA seeds `empty_binding`-skipped) out-ranked every login-cohort widget-floor identity (`widgets.templates.krateo.io/*`: 1308 bindings → 16, uniform). So `ranked[0]` was a machine SA with **zero** `RootIndex==0` widget targets → the arming scan found `firstNavTotal=0` → the `ri==0 && firstNavTotal==0` boundary fired `zero-first-nav-targets` → `/readyz` flipped with the login cohorts' dashboards **cold**. Also **nondeterministic** across boots (`noteIdentity` keeps the first-seen count, iterated in Go map order). The gate FIX-F was built to be never actually gated on this RBAC topology.

Full arch trace: `docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md`.

## What this ships (Fix 1 + Fix 2 + ride-along; Fix 3 rank-hygiene is OUT — separate gate)

**Fix 1** (`prewarm_engine_boot.go`) — the latch segment is no longer `ranked[0]`. Scan `ranked` in order and pick the **first identity with ≥1 `RootIndex==0` widget target** as `segKey`/`segRank`; count that identity's segment. The decrement keys on `ri==segRank && e.RootIndex==0 && identityKey(c)==segKey`; the per-rank `ri==0 && firstNavTotal==0` zero-fire boundary is replaced by a single post-loop `segRank<0` fire (provably-empty F-C3; folds the old `len(ranked)==0` defensive fire). **Seed order is untouched** — pure gate fix; the machine-SA rank-0 restaction pass remains a cheap skipped prefix, the latch just no longer keys readiness on it.

**Fix 2** (`phase1_pip_seed.go` + `prewarm_engine_boot.go`) — `navWidgetHarvester.BeginWalk()` resets `curRoot=-1` at the top of each walk pass; the engine re-walk loop calls `BeginWalk()` then per-root `BeginRoot()` so redrive-harvested root-0 widgets stamp `RootIndex 0`. Multi-root correctness (inert single-root — the latent defect where a re-walk without the reset stamps `N..2N-1`). Naive `BeginRoot`-only would be wrong; the reset+increment pair is deliberate.

**Ride-along** — `root_index` on the `widget_targets` log line; `segment_identity` + `segment_rank` on the `first_nav.latch` line. Closes the observability gap the trace needed seed-order inference to work around.

## Keepwarm / segRank ruling (architect concurred)

`#102` keepwarm `rank1Only` **stays bound to `ranked[0]` (ri==0), NOT `segRank`**. `segRank` is a latch/boot-gate-only concept; keepwarm re-seeds the dominant-`CollapsedBindings` cohort's **cells** (its documented purpose) regardless of first-nav-widget status. Retargeting it to `segRank` would be a seed-**scope** change (Fix-3 territory, out of scope for this ship). Verified: `TestKeepwarmSweep_RANK1Only_DoesNotSweepRank2` unchanged-green + new `TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment`.

## Falsifiers

New arms in `prewarm_first_nav_latch_segment_test.go` (hermetic, `-race`, existing seams):
- **boot600-shape GREEN** — ranked = [M(rank0, restaction-only, c=50), U1(rank1, c=5), U2(rank2, c=2)]; fires `reason=segment-complete` after both U1 `RootIndex==0` dashboard widgets, before the `RootIndex==1` tail widget (ARM-TAIL). K=3 with segment ≠ `ranked[0]` discriminates the selection defect.
- **Fix-2 redrive root-stamp** — root-0 widget stamps `RootIndex 0` via `BeginWalk`+`BeginRoot`.
- **keepwarm/segRank ruling** — asserts `rank1Only` seeds `ranked[0]` (M), not the segment identity (U1).

All 3 new arms + all 6 existing FIX-F arms + 4 keepwarm arms + the `#95` put-gate: `=== RUN` + PASS under `-race`. Full `internal/handlers/dispatchers` package green (`-race`, 23.7s). `go build`/`vet ./...` clean.

**REDs captured** (`/tmp/fix99b/`):
- `fix1_RED_mutation_revert.txt` — revert Fix-1's segment-scan to `ranked[0]` → the latch does not fire `segment-complete`. PM independently re-ran faithful pre-fix code → `reason="zero-first-nav-targets"` (the literal boot600 string).
- `fix2_RED.txt` — redrive without the `BeginWalk` reset → root-0 stamps `RootIndex=2`, not 0.

## Gate

Dual-gate GREEN: architect **PASS** (all 5 checks; initial-walk asymmetry confirmed correct-by-construction) + PM **ACCEPT** (independently reproduced both the pre-fix zero-fire and the fixed `segment-complete` flip; falsifier shape discriminates).

## Deploy note

No CRD/chart/env change → **no chart lockstep needed** for this fix.

## PM close-out condition (on-cluster proof)

The next 60K boot must show `prewarm.first_nav.latch reason=segment-complete` with `segment_identity=<login-cohort>` and `first_nav_targets>0`, fire timestamp strictly after that identity's `RootIndex==0` `widget_targets root_index=0` seed lines and before `prewarm.engine.boot.complete`; the F-C4 post-Ready `/dashboard` nav#1 `l1:HIT` content check unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
