### PR TITLE
feat(prewarm): F.4 boot-scope resume — workqueue requeue + boot-only fresh-skip

### DIFF
--- a/docs/f4-boot-scope-budget-design-2026-07-07.md
+++ b/docs/f4-boot-scope-budget-design-2026-07-07.md
@@ -1,0 +1,365 @@
+# F.4 — Resumable boot scope: surviving the per-scope budget without knobs
+
+Date: 2026-07-07 · Author: cache-architect · Ref: main @ 701c2e3 (1.6.1)
+Status: DESIGN (no build). PM conditions F4-C1..C8 below.
+Live evidence: fresh2 @ 60K, 1.6.1, PHASE1_TIMEOUT=900 — boots xkpb7 (scope cut
+at engine+480s at 168/175 segment widgets, no latch fire, Ready 822s not
+gate-driven) and t72l5 (segment completed in-scope, latch segment-complete at
+scope+303s). Segment ≈ 2.3min walk/enum preamble + 5–6.5min seeding — straddles
+the 8m budget nondeterministically.
+
+---
+
+## 1. Problem and root cause (TRACED)
+
+The engine worker bounds every scope execution with
+`context.WithTimeout(ctx, prewarmScopeTimeout(s))` where
+`prewarmScopeTimeout` returns `pipGlobalTimeout` = 8m uniformly
+(prewarm_engine.go:392-394, applied at :440; pipGlobalTimeout defined at
+phase1_pip_seed.go:141). At 60K the boot scope's first-nav segment alone now
+straddles that budget. When the deadline fires:
+
+1. `seedScopeYielding` aborts via `emitSeedAbort` + `return ctx.Err()`
+   (prewarm_engine_boot.go:712-716 widget path) → the scope returns
+   DeadlineExceeded → `prewarm.engine.scope_incomplete` (prewarm_engine.go:444).
+2. **Nothing engine-side re-enqueues the cut scope.** The only paths that
+   enqueue `scopeKindBoot` are the one-shot boot enqueue
+   (phase1_walk.go:478), the #158 per-target *operational-failure* re-enqueue
+   inside `classifyEngineSeedErr` (prewarm_engine_boot.go:512-515 — not
+   reached on a ctx-deadline abort, which exits via `emitSeedAbort`), and the
+   config-vars ConfigMap Add/Update events
+   (phase1_configvars_watch.go:131-139). So resumption depends on an
+   **external, nondeterministic** ConfigMap event.
+   NOTE (F.4 as-built §1.2 clarification): the #158 per-target re-enqueue
+   inside `classifyEngineSeedErr` exists ONLY for per-target *operational
+   failures* (5xx / transport / timeout, classified by `classifySeedErr`) and
+   is reached via the normal target-error path — NEVER on a ctx-deadline
+   abort, which exits earlier via `emitSeedAbort` + `return ctx.Err()`. F.4
+   GENERALIZES that requeue to the deadline path: the ENGINE worker
+   (`processScope`) requeues ANY scope that returns an error while the process
+   ctx is alive, so a boot deadline-cut resumes deterministically. The two
+   mechanisms compose — #158 heals a single flaky target mid-scope; F.4 heals
+   the whole cut scope.
+
+3. A re-run **redoes all completed seed work at full cost**: neither
+   `seedOneRestaction` (phase1_pip_seed.go:460-639) nor `seedOneWidget`
+   (:666+) has any warm-cell skip — both unconditionally `objects.Get` →
+   `Resolve` → `Put`. (This is *required* by keepwarm, whose Puts must reset
+   CreatedAt — prewarm_keepwarm_sweep.go:19-22 — and by gvr-discovered, whose
+   whole purpose is re-resolving already-warm cells so the new GVR's dep edge
+   gets recorded — prewarm_engine_boot.go:137-147.) Consequence: a redrive of
+   a cut boot scope re-pays the full segment and can be cut again at 8m —
+   the live `scope_incomplete ×2` successive-cut boot is exactly this
+   livelock at the straddle point.
+4. Queue fairness is accidental: `dequeueScope` iterates a Go map
+   (prewarm_engine.go:291-299) → **random** dequeue order. The header comment
+   (:42-46) claims a `workqueue.TypedRateLimitingInterface`; the as-built is a
+   hand-rolled map + signal channel. Stale doc, and no ordering guarantee for
+   the keepwarm/CRUD starvation bound.
+
+Why this produces the symptom: at 60K the segment cost crossed the single-shot
+budget, so whether the first-nav latch fires is a coin flip on walk/seed
+variance (t72l5 yes, xkpb7 no), and when it loses, the dashboard cells stay
+cold until an unrelated ConfigMap event happens to redrive — which then repays
+the full cost and can lose again.
+
+## 2. Prior-art check (opens the design, per team rule)
+
+- **client-go `workqueue.TypedRateLimitingInterface`** is Kubernetes' answer
+  to "a work item is bigger than one attempt": FIFO + coalescing dedup +
+  `AddRateLimited` exponential-backoff requeue + never-drop, paired with
+  **level-triggered idempotent reconcile**. Controllers never checkpoint
+  partial progress inside an item; they make the item cheap to re-run and
+  requeue it. This maps to the chosen shape below.
+- There is **no chunk-cursor prior art** in client-go/controller-runtime for
+  resuming mid-reconcile; `pager.ListPager` (Limit/Continue) chunks LIST
+  pagination, not resolve work — not applicable.
+- Verdict: don't invent a cursor. Make the engine queue behave like a real
+  workqueue (requeue-on-failure, FIFO, backoff) and make the boot re-run
+  **cost-proportional** so idempotent re-run is cheap — which the as-built
+  seed primitives currently are not (§1.3).
+
+## 3. Chosen design — shape (b″): engine-driven requeue + boot-only fresh-skip
+
+Two small, composable mechanisms. The 8m budget, the readyz wiring
+(engineSeed select / bootDone / MarkPhase1Done, phase1_walk.go:431-513), and
+the seed ORDER are all untouched.
+
+### 3.1 Failure-requeue on the engine queue (the "resume" trigger)
+
+When a scope returns an error and the worker's process ctx is still alive
+(i.e. not shutdown), the engine itself requeues the same scope with
+rate-limited backoff; on success it forgets the failure history. Uniform for
+all scope kinds — no special case:
+
+- `scopeKindBoot` deadline-cut → requeued → the continuation chunk. This is
+  the F.4 fix proper. Also heals `roots_list_failed` (transient apiserver at
+  boot), today healed only by config-vars luck.
+- `scopeKindGVRDiscovered` cut/error → requeued. Today an incomplete
+  gvr-discovered scope is silently dropped (prewarm_engine_boot.go:169-175)
+  and the S4 dep-edge repair is lost until another discovery event — F.4
+  fixes this for free.
+- `scopeKindKeepwarm` error → requeued; coalesces with the next tick.
+
+Coalescing is **correct by construction** because there is no cursor: a
+continuation and a fresh config-vars redrive are the same level-triggered
+work item, same `key()=="boot"` — nothing to swallow or reset (the brief's
+shape-(a) coalescing hazard evaporates).
+
+New greppable log line `prewarm.engine.scope_requeued` (scope, err,
+attempt/backoff) at the requeue site.
+
+Exponential backoff bounds the pathological zero-progress case (e.g. a walk
+that can never finish inside the budget): retries never stop (never-drop) but
+space out — no hot loop, and informer convergence makes later attempts
+cheaper. Backoff parameters are client-go's stock defaults, not our knob.
+
+**Queue implementation — the one strategic choice (see §7):**
+- **R1 (recommended):** replace the hand-rolled pending-map/signal with
+  `workqueue.TypedRateLimitingInterface[prewarmScope]` (`prewarmScope` is
+  comparable — string kind + GVR struct — so the item is its own key; the
+  per-key payload-coalescing semantics of the map are preserved 1:1 because
+  `key()` and item identity coincide). Gets FIFO (F4-C5), `AddRateLimited`
+  (F4-C8), coalescing, and ShutDown-on-ctx from tested client-go code, and
+  makes the stale header comment at prewarm_engine.go:42-46 true.
+- **R2 (minimal delta):** keep the map, add a FIFO key-order slice + explicit
+  requeue via `workqueue.NewTypedItemExponentialFailureRateLimiter` +
+  `time.AfterFunc`. Smaller diff, but hand-rebuilds more of workqueue —
+  against the prior-art rule.
+
+### 3.2 Boot-only fresh-skip (makes re-run cost-proportional)
+
+Give `scopeKindBoot` seeds an explicit fast-forward: before resolving a
+(unit × identity) target, if a **live** (non-expired) L1 cell already exists
+under the exact production cell key, skip the resolve and count the target as
+processed. This is what makes chunk N+1 cheap (≈ preamble + remaining
+targets) and the chunk count provably finite: every chunk seeds strictly more
+targets than the last (cells persist across chunks; TTL 1h ≫ chunk cadence).
+
+**Scope-kind boundary (F4-C3) — load-bearing, traced:**
+- boot: fresh-skip ON. Boot semantics = "make warm"; a live cell is done.
+- keepwarm: OFF — its Puts must re-resolve fresh bytes and reset CreatedAt
+  (prewarm_keepwarm_sweep.go:19-22); a fresh-skip would make the sweep a no-op.
+- gvr-discovered: OFF — it exists to re-resolve *already-warm* cells so the
+  dep edge against the new GVR is recorded (prewarm_engine_boot.go:137-147);
+  a fresh-skip would reintroduce the S4 defect.
+
+Plumbed exactly like `rank1Only` (a scope-kind-derived bool through
+`rePrewarmBootScoped` → `seedScopeYielding` → the per-target path). Not a
+knob: it is a structural property of the scope kind.
+
+**Single-derivation-site constraint (the #64/#317/FIX-G lesson,
+feedback_consultation_mutation_is_not_key_correctness):** the skip MUST
+consume the SAME key derivation the Put site uses — no parallel re-derivation
+anywhere. Concretely: the check lives inside `seedOneWidget` /
+`seedOneRestaction` immediately after their existing `dispatchCacheLookupKey`
+call (phase1_pip_seed.go:480-483 restactions; the widget mirror incl. the
+inline-extras union), after the empty-BindingUID guard, **before**
+`enterSeedUnit` (skipped units never consume the #46 memory gate — the bound
+composes trivially, strictly fewer admissions). By construction there is one
+derivation body; skip-key correctness cannot drift from Put-key correctness.
+Note: the restaction skip still pays one informer-backed `objects.Get` (the
+key needs GVR/ns/name from the CR) — µs-scale, acceptable.
+
+**Fresh predicate (F4-C2a, PM-required, as-built):** skip-eligibility ≡ the
+production-key lookup `handle.Get(key)` returns a NON-EXPIRED entry per the
+store's OWN TTL-expiry check — the SAME `ResolvedCacheStore.Get`
+(internal/cache/resolved.go) the serve path and refresher use (it drops a
+TTL-expired entry and returns `(nil,false)`, honoring any per-entry
+`TTLOverride`). There is NO "TTL-remaining ≥ X" literal and NO put-since-chunk
+bookkeeping: the skip reuses the store's existing effective-TTL logic verbatim,
+so a boot chunk skips exactly the cells a `/call` would HIT and re-resolves
+exactly the cells a `/call` would MISS. `key` is the SAME value
+`dispatchCacheLookupKey` derived one line above (the Put key), so skip-key
+correctness cannot drift from Put-key correctness.
+
+Skip observability: `pipSeedFreshSkipTotal` expvar counter + a Debug-level
+per-target line; the fire-log and seed telemetry are otherwise unchanged.
+If the store exposes a metrics-neutral peek, use it; otherwise the Get's
+hit-count contribution is accepted and documented (seed-attributable).
+
+The residual re-run tax is the ~2.3min walk/enum preamble per chunk. That is
+the price of level-triggered soundness (config.json / RBAC / informer state
+may have changed between chunks) and is exactly what every config-vars
+redrive already pays today. A cursor could avoid it only by freezing a stale
+snapshot (§5 ALT-A).
+
+### 3.3 What F.4 deliberately does NOT change
+
+- `prewarmScopeTimeout` stays `pipGlobalTimeout` (8m) for every kind — the
+  liveness bound protecting keepwarm/CRUD from a runaway scope is preserved
+  verbatim (arch O1 on #102).
+- engineSeed's select, bootDone/scopeDone, MarkPhase1Done, PHASE1_TIMEOUT
+  backstop: byte-identical. On a chunk-1 cut, bootDone still closes with the
+  deadline error and Ready still flips at ≈ min(latch, 8m seed budget,
+  PHASE1 backstop) exactly as today. F.4's contribution is that the warm
+  state then **completes deterministically** one short chunk later, instead
+  of never/by luck. (Closing the residual Ready→fully-warm gap at 60K is a
+  seed-throughput problem — FIX-G-class work — not a budget problem; stated
+  honestly, out of scope.)
+- Seed order, latch arming/decrement logic, #158 classification: untouched.
+
+### 3.4 Invariant walk-through
+
+- **#99b latch across chunks:** the latch is a process fire-once singleton
+  (prewarm_first_nav_latch.go:57-100); each chunk re-arms per-scope counting
+  from its own fresh walk+enum (prewarm_engine_boot.go:782-825). In the
+  completing chunk, already-warm segment targets fast-forward through
+  `seedWidgetTarget` (processed → decrement, same PROCESSED-not-SUCCEEDED
+  contract as :874-882) and the remaining ones seed for real; the latch fires
+  once, on the chunk where the segment finishes. If chunk 1 already fired
+  and was cut in the tail, chunk 2's re-fire hits `sync.Once` — a no-op.
+- **F-C2 ARM-TAIL:** within the firing chunk the segment completes mid-pass,
+  before that rank's RootIndex>0 widgets and restactions (order unchanged) —
+  the tail is still pending at fire time.
+- **Keepwarm/CRUD starvation:** per-chunk bound stays 8m; between chunks the
+  FIFO queue runs any pending keepwarm/gvr-discovered scope before the boot
+  continuation (which re-enters at the back, after backoff). Worst-case wait
+  behind boot = one budget — the existing bound, now guaranteed rather than
+  map-random.
+- **#46 footprint:** unchanged per unit; fresh-skip only removes admissions.
+- **GTTL-1 interplay:** a declined Put (degraded resolve) leaves no fresh
+  cell → the target is NOT skipped next chunk → retried. A prior good cell →
+  skipped → good bytes kept. Consistent with the Put-gate's intent.
+- **Dirty cells:** a chunk-1-seeded cell dirty-marked before chunk 2 is
+  skipped by the seed; the event-driven refresher owns dirty re-resolves —
+  same division of labor as steady state.
+
+## 4. Would this make the symptom disappear?
+
+Yes. xkpb7 replayed under F.4: chunk 1 cut at engine+480s with 168/175 →
+worker requeues boot (backoff ~ms) → chunk 2 = ~2.3min preamble + 168 skips
+(µs each) + 7 real seeds → latch fires `segment-complete` ≈ cut+3min,
+deterministically, with zero dependence on config-vars events. Every boot
+topology terminates in ⌈seed_time / (budget − preamble)⌉ chunks; the
+scope_incomplete ×2 livelock class is structurally gone because chunk work is
+monotone.
+
+## 5. Alternatives rejected
+
+- **ALT-A — cursor/checkpoint chunking (brief shape a):** a positional cursor
+  (rank r, widget i, target j) over lists that are RE-DERIVED each run
+  (re-walk + re-enum) is unsound — informer catch-up and RBAC deltas reorder
+  and reshape `widgetSeeds`/`restactionSeeds`/`ranked` between chunks. Making
+  it sound requires freezing the first chunk's snapshot in the scope payload:
+  serves stale enumeration, holds MBs across chunks, breaks the no-payload
+  boot-key coalescing contract (a fresh config-vars redrive must RESET the
+  cursor — new failure modes), and contradicts the k8s level-triggered idiom
+  (§2). Buys only the ~2.3min preamble over fresh-skip — bad trade.
+- **ALT-B — status-quo idempotent re-run (brief shape b, formalized):** the
+  trigger is an external nondeterministic ConfigMap event, and the "warm
+  fast-forward ~0ms" premise is NOT as-built — TRACED at
+  phase1_pip_seed.go:460-639/666+ (unconditional Resolve+Put, no warm check;
+  keepwarm depends on exactly that). Without fresh-skip each re-run repays
+  the full segment → livelock at the straddle point (live scope_incomplete
+  ×2). (b′) alone (self-re-enqueue, no skip) inherits the same livelock.
+- **ALT-C — class-differentiated derived budget (brief shape c):** still a
+  single-shot cliff — a 20% bigger topology fails identically; "remaining
+  PHASE1 window" is undefined for post-boot boot-kind redrives (config-vars
+  events fire hours after boot), forcing a two-regime rule; it conflates the
+  readiness backstop with the engine liveness bound; and at 60K the derived
+  window (~900s − ~330s engine start ≈ 9.5min) barely clears the observed
+  7.3–8.8min straddle — no margin. It is the rejected "bigger timeout knob"
+  in derived clothing, and it delays any pending keepwarm/CRUD scope for the
+  whole enlarged window.
+- **ALT-D — raise `pipGlobalTimeout`:** explicitly rejected by Diego
+  (magic-number knob; extends worst-case starvation of every other scope).
+
+## 6. PM-gateable conditions
+
+- **F4-C1 (engine-owned resume, never-drop):** a boot scope cut by the
+  per-scope budget is requeued by the ENGINE itself — zero dependence on
+  config-vars events — coalescing on the boot key, retrying until success
+  with rate-limited backoff. Mutation-RED: remove the requeue → straddle
+  falsifier fails.
+- **F4-C2 (cost-proportional resume):** a continuation chunk does NOT
+  re-resolve already-seeded targets. Fresh-skip consumes the SAME
+  `dispatchCacheLookupKey` derivation as the Put site (single body, no
+  parallel derivation, no hand-fed keys in the falsifier — both sides run the
+  real primitive). Observable via `pipSeedFreshSkipTotal`. Mutation-RED:
+  remove the skip → chunk-2 resolve count equals the full set.
+- **F4-C3 (scope-kind boundary):** fresh-skip applies ONLY to scopeKindBoot.
+  Falsifier arms prove keepwarm still re-Puts a live cell (CreatedAt reset)
+  and gvr-discovered still re-resolves a live cell (dep-edge repair).
+- **F4-C4 (latch exactly-once + ARM-TAIL across chunks):** a segment larger
+  than one budget produces exactly ONE `segment-complete` fire, in the
+  completing chunk, while ≥1 non-segment tail unit is still unseeded; a
+  latch already fired in chunk 1 is not re-fired by chunk 2.
+- **F4-C5 (starvation bound preserved, now guaranteed):** a
+  keepwarm/gvr-discovered scope enqueued during a boot chunk runs BEFORE the
+  boot continuation (FIFO); no scope waits more than one budget behind boot.
+- **F4-C6 (no new knobs):** no new env, no new duration/count literal;
+  budget stays `pipGlobalTimeout`; backoff = client-go stock rate-limiter
+  defaults; chunk count emergent from topology.
+- **F4-C7 (readyz wiring untouched):** engineSeed select / bootDone /
+  MarkPhase1Done / PHASE1_TIMEOUT byte-identical; existing FIX-F/#99b/shape-A
+  falsifiers stay green unmodified (except where they assert queue internals).
+- **F4-C8 (futility bound):** repeated zero-progress failures back off
+  exponentially — no hot loop; retries never stop (never-drop).
+
+## 7. Strategic choice surfaced (needs TL/Diego pick)
+
+R1 (adopt `workqueue.TypedRateLimitingInterface[prewarmScope]`, ~+60/−40 LOC
+in prewarm_engine.go, makes the stale :42-46 comment true, gets
+FIFO/backoff/coalescing from tested client-go code) vs R2 (keep the map, add
+FIFO slice + client-go rate limiter + AfterFunc, ~40-60 LOC, but hand-rebuilds
+workqueue semantics we then own forever). **Recommendation: R1** — the
+prior-art rule exists for exactly this; the current map+signal is already a
+half-reimplementation that just failed us on ordering.
+
+## 8. Falsifier plan
+
+Hermetic (package dispatchers, -race, no build tags — verify arms ACTUALLY RAN
+per feedback_falsifier_must_actually_run_under_gate_tag_env):
+
+1. **Straddle arm (F4-C1+C4):** stubbed primitives (`seedOneWidgetFn` /
+   `seedOneRestactionFn` / `enumeratePrewarmTargetsForGVRFn` seams, existing
+   pattern) with per-target simulated cost + a stub-side seeded-set emulating
+   fresh-skip monotonicity; per-scope budget shrunk via a new 1-LOC test seam
+   `var prewarmScopeTimeoutFn = prewarmScopeTimeout` (same pattern as
+   seedCohortFn). K=2 identities × RootIndex∈{0,1} widgets + restactions.
+   Chunk 1 deadline-cuts mid-segment → assert `scope_requeued` + no latch
+   fire; chunk 2 completes → assert exactly ONE `segment-complete`
+   (firstNavFireObserver), fired while ≥1 tail unit unprocessed (ARM-TAIL),
+   and total processed monotone. RED arm: requeue removed → test hangs/fails.
+2. **Fairness arm (F4-C5):** enqueue keepwarm while boot chunk 1 runs; after
+   the cut, assert dequeue order keepwarm → boot-continuation (FIFO). RED
+   under the old map queue (random order) — this arm also discriminates
+   R1/R2 from status quo.
+3. **Fresh-skip real-primitive arm (F4-C2, divergent-derivation-proof):** run
+   the REAL `seedOneWidget` twice against a real in-memory L1 (existing
+   real-primitive test fixtures: prewarm_seed_empty_binding_skip_test.go
+   pattern). First call resolves+Puts; second call must skip: assert
+   `pipSeedFreshSkipTotal` +1 and `pipBindingSetSeedResolvesTotal` unchanged.
+   No hand-constructed key anywhere — both sides run production derivation.
+   Restaction mirror arm. RED: skip removed → second call re-resolves.
+4. **Boundary arms (F4-C3):** keepwarm path (rank1Only) over a live cell →
+   asserts a REAL re-Put happened (CreatedAt/bytes replaced);
+   gvr-discovered path over a live cell → asserts re-resolve invoked
+   (dep-edge recording preserved). RED: fresh-skip wrongly applied to either
+   kind → these fail.
+5. **Exactly-once cross-chunk arm:** latch fires in chunk 1, scope cut in the
+   tail, chunk 2 completes → assert no second fire log/observer event.
+
+Live proof at 60K (fresh2), post-deploy grep sequence on one boot:
+`prewarm.engine.scope_incomplete scope=boot` → engine-driven
+`prewarm.engine.scope_requeued` (with `ConfigVarsEnqueuedTotal` flat over the
+window — proves engine-owned resume) → next chunk's
+`prewarm.first_nav.latch reason=segment-complete` with
+`first_nav_targets`==segment size, plus expvar `pipSeedFreshSkipTotal` ≈
+chunk-1 seeded count. Symptom-disappear check: zero boots where the latch
+never fires; no permanently-cold first-nav targets.
+
+## 9. Touch points + LOC bound
+
+- `internal/handlers/dispatchers/prewarm_engine.go` — queue swap (R1) +
+  requeue/Forget + `scope_requeued` log + timeout seam: ~100 LOC net.
+- `internal/handlers/dispatchers/prewarm_engine_boot.go` — freshSkip plumb
+  (scope-kind → `rePrewarmBootScoped` → `seedScopeYielding` → per-target
+  ctx/param): ~20 LOC.
+- `internal/handlers/dispatchers/phase1_pip_seed.go` — skip check in the two
+  primitives after key derivation + counter: ~40 LOC.
+- `internal/handlers/dispatchers/prewarm_engine_metrics.go` — expose
+  `pipSeedFreshSkipTotal` (+ requeue counter): ~10 LOC.
+- Tests: ~350-450 LOC across the five arms.
+- Total prod delta ≈ 170 LOC. No CRD/chart/env change.

--- a/internal/handlers/dispatchers/gvr_discovered_integration_test.go
+++ b/internal/handlers/dispatchers/gvr_discovered_integration_test.go
@@ -74,11 +74,8 @@ func TestGVRDiscoveredIntegration_HookFiresEngineEnqueue(t *testing.T) {
 	// singleton state. We test the hook→enqueueScope mechanism
 	// directly: subscribe with the same closure registerEngineGVRDiscoveredHook
 	// would install, then fire the hook.
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	registerEngineGVRDiscoveredHook(e)
 
 	gvr := schema.GroupVersionResource{
@@ -91,10 +88,10 @@ func TestGVRDiscoveredIntegration_HookFiresEngineEnqueue(t *testing.T) {
 	// API discovery_lookup.go's `if added` branch invokes).
 	cache.NotifyGVRDiscoveredForReprewarmTest(gvr)
 
-	if len(e.pending) != 1 {
-		t.Fatalf("expected 1 pending scope after hook fire, got %d", len(e.pending))
+	if e.pendingLenForTest() != 1 {
+		t.Fatalf("expected 1 pending scope after hook fire, got %d", e.pendingLenForTest())
 	}
-	s, ok := e.dequeueScope()
+	s, ok := e.drainScopeForTest()
 	if !ok {
 		t.Fatal("expected dequeueable scope")
 	}
@@ -118,11 +115,8 @@ func TestGVRDiscoveredIntegration_DistinctGVRs_AllProcessed(t *testing.T) {
 	cache.ResetGVRDiscoveredHooksForTest()
 	defer cache.ResetGVRDiscoveredHooksForTest()
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	registerEngineGVRDiscoveredHook(e)
 
 	gvrs := []schema.GroupVersionResource{
@@ -134,14 +128,14 @@ func TestGVRDiscoveredIntegration_DistinctGVRs_AllProcessed(t *testing.T) {
 		cache.NotifyGVRDiscoveredForReprewarmTest(gvr)
 	}
 
-	if len(e.pending) != len(gvrs) {
-		t.Fatalf("expected %d pending scopes (one per distinct GVR), got %d", len(gvrs), len(e.pending))
+	if e.pendingLenForTest() != len(gvrs) {
+		t.Fatalf("expected %d pending scopes (one per distinct GVR), got %d", len(gvrs), e.pendingLenForTest())
 	}
 
 	// Drain and verify each scope carries one of the GVRs.
 	got := map[schema.GroupVersionResource]struct{}{}
 	for i := 0; i < len(gvrs); i++ {
-		s, ok := e.dequeueScope()
+		s, ok := e.drainScopeForTest()
 		if !ok {
 			t.Fatalf("expected %d scopes, got only %d", len(gvrs), i)
 		}
@@ -164,11 +158,8 @@ func TestGVRDiscoveredIntegration_HookHandlerNonBlocking(t *testing.T) {
 	cache.ResetGVRDiscoveredHooksForTest()
 	defer cache.ResetGVRDiscoveredHooksForTest()
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	registerEngineGVRDiscoveredHook(e)
 
 	// Fire many GVRs in a tight loop. The whole loop must complete
@@ -191,11 +182,11 @@ func TestGVRDiscoveredIntegration_HookHandlerNonBlocking(t *testing.T) {
 	case <-done:
 		// good — all 200 enqueues completed under the deadline
 	case <-deadline:
-		t.Fatalf("hook fire loop blocked beyond 2s — back-pressure detected (pending=%d)", len(e.pending))
+		t.Fatalf("hook fire loop blocked beyond 2s — back-pressure detected (pending=%d)", e.pendingLenForTest())
 	}
 
-	if len(e.pending) != 200 {
-		t.Fatalf("expected 200 pending after 200 distinct GVRs, got %d", len(e.pending))
+	if e.pendingLenForTest() != 200 {
+		t.Fatalf("expected 200 pending after 200 distinct GVRs, got %d", e.pendingLenForTest())
 	}
 }
 
@@ -212,11 +203,8 @@ func TestGVRDiscoveredIntegration_DedupSameGVR(t *testing.T) {
 	cache.ResetGVRDiscoveredHooksForTest()
 	defer cache.ResetGVRDiscoveredHooksForTest()
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	registerEngineGVRDiscoveredHook(e)
 
 	gvr := schema.GroupVersionResource{
@@ -228,8 +216,8 @@ func TestGVRDiscoveredIntegration_DedupSameGVR(t *testing.T) {
 		cache.NotifyGVRDiscoveredForReprewarmTest(gvr)
 	}
 
-	if len(e.pending) != 1 {
-		t.Fatalf("expected 1 pending after 10 same-GVR fires (dedup), got %d", len(e.pending))
+	if e.pendingLenForTest() != 1 {
+		t.Fatalf("expected 1 pending after 10 same-GVR fires (dedup), got %d", e.pendingLenForTest())
 	}
 }
 
@@ -251,11 +239,8 @@ func TestGVRDiscoveredIntegration_WorkerProcessesScope(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	var (
 		ranMu      sync.Mutex
 		ranScopes  []prewarmScope

--- a/internal/handlers/dispatchers/otel_accessors.go
+++ b/internal/handlers/dispatchers/otel_accessors.go
@@ -17,18 +17,17 @@ package dispatchers
 
 // PrewarmEngineSnapshot returns the prewarm-engine worker counters,
 // mirroring snowplow_prewarm_engine_{enqueued,processed,yield}_total and
-// snowplow_prewarm_engine_pending_depth. pendingDepth is read under the
-// engine mutex (race-free against enqueue/dequeue). Safe before the engine
-// has started: prewarmEngineSingleton() lazily constructs the engine, so a
-// pre-start read returns zeros from the freshly-allocated struct.
+// snowplow_prewarm_engine_pending_depth. pendingDepth is the workqueue's own
+// Len() (F.4 / R1 — internally synchronized, race-free against Add/Get).
+// Safe before the engine has started: prewarmEngineSingleton() lazily
+// constructs the engine (queue included), so a pre-start read returns zeros
+// from the freshly-allocated queue.
 func PrewarmEngineSnapshot() (enqueued, processed, yield uint64, pendingDepth int64) {
 	e := prewarmEngineSingleton()
 	if e == nil {
 		return 0, 0, 0, 0
 	}
-	e.mu.Lock()
-	pendingDepth = int64(len(e.pending))
-	e.mu.Unlock()
+	pendingDepth = int64(e.queue.Len())
 	return e.enqueuedTotal.Load(), e.processedTotal.Load(), e.yieldTotal.Load(), pendingDepth
 }
 

--- a/internal/handlers/dispatchers/phase1_boot_race_selfheal_falsifier_test.go
+++ b/internal/handlers/dispatchers/phase1_boot_race_selfheal_falsifier_test.go
@@ -219,10 +219,8 @@ func TestBootRace_ConfigVarsInformerDrivesReWalk(t *testing.T) {
 	}
 	// The singleton must have a pending boot scope (coalesced on the boot key).
 	e := prewarmEngineSingleton()
-	e.mu.Lock()
-	_, hasBoot := e.pending[prewarmScope{kind: scopeKindBoot}.key()]
-	pendingLen := len(e.pending)
-	e.mu.Unlock()
+	hasBoot := e.pendingHasBootForTest()
+	pendingLen := e.pendingLenForTest()
 	if !hasBoot {
 		t.Fatalf("SELF-HEAL FAIL: no scopeKindBoot pending on the engine after the ConfigMap AddFunc")
 	}
@@ -233,7 +231,7 @@ func TestBootRace_ConfigVarsInformerDrivesReWalk(t *testing.T) {
 		ConfigVarsEnqueuedTotal())
 
 	// Drive the re-walk (what the worker would do): dequeue + run the handler.
-	scope, ok := e.dequeueScope()
+	scope, ok := e.drainScopeForTest()
 	if !ok || scope.kind != scopeKindBoot {
 		t.Fatalf("expected a boot scope dequeued for the re-walk")
 	}
@@ -322,9 +320,7 @@ func TestBootRace_RED_OneShotGivesUpWithoutTrigger(t *testing.T) {
 	}
 	// Confirm no boot scope is pending on the singleton (nothing re-drove).
 	e := prewarmEngineSingleton()
-	e.mu.Lock()
-	_, hasBoot := e.pending[prewarmScope{kind: scopeKindBoot}.key()]
-	e.mu.Unlock()
+	hasBoot := e.pendingHasBootForTest()
 	if hasBoot {
 		t.Fatalf("RED arm: a boot scope was re-enqueued with no informer — impossible on HEAD")
 	}

--- a/internal/handlers/dispatchers/phase1_pip_metrics.go
+++ b/internal/handlers/dispatchers/phase1_pip_metrics.go
@@ -98,6 +98,20 @@ var (
 	// attributable in /debug/vars (the falsifier keys on this DELTA, not the
 	// refresher's counter). Exposed as snowplow_phase1_seed_skipped_stage_error_total.
 	pipSeedSkippedStageErrorTotal atomic.Uint64
+
+	// F.4 (design §3.2) — pipSeedFreshSkipTotal counts boot-scope seed targets
+	// fast-forwarded by the boot-only fresh-skip: a live (non-expired) L1 cell
+	// already existed under the production key, so the resolve + Put were
+	// skipped and the target counted as processed. This is what makes a
+	// deadline-cut boot chunk's continuation cost-proportional (chunk N+1 ≈
+	// preamble + only the cold remainder). SEED-SCOPED and DISTINCT from every
+	// other seed counter: freshSkip does NOT bump seed_resolves (no Put) nor
+	// skipped_stage_error (no resolve at all). A boot re-drive over a fully-warm
+	// set drives this ≈ the chunk-1 seeded count while seed_resolves stays flat.
+	// Boot-only: keepwarm / gvr-discovered never fresh-skip (F4-C3), so this
+	// stays flat outside boot chunks. Exposed as
+	// snowplow_phase1_seed_fresh_skip_total.
+	pipSeedFreshSkipTotal atomic.Uint64
 )
 
 // Ship 0.30.187 D1 — per-(cohort, target) failure maps. Keyed by
@@ -212,6 +226,13 @@ func registerPIPMetrics() {
 		// refresherSkippedStageError so a keepwarm-sweep decline is attributable.
 		expvar.Publish("snowplow_phase1_seed_skipped_stage_error_total", expvar.Func(func() any {
 			return pipSeedSkippedStageErrorTotal.Load()
+		}))
+
+		// F.4 (design §3.2) — boot-scope seed targets fresh-skipped (live cell
+		// already under the production key; resolve+Put skipped, counted
+		// processed). SEED-SCOPED, boot-only; distinct from seed_resolves.
+		expvar.Publish("snowplow_phase1_seed_fresh_skip_total", expvar.Func(func() any {
+			return pipSeedFreshSkipTotal.Load()
 		}))
 
 		// Ship 0.30.187 D1 — per-(cohort, target) seed-failure maps so

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -457,7 +457,7 @@ func withCohortSeedContext(ctx context.Context, cohort seedTarget,
 //   - restactions.Resolve same entrypoint at restactions.go:183-189.
 //   - encodeResolvedJSON + cacheHandle.Put + ensureWatcherInformerForGVR
 //   - cache.Deps().Record — same Put shape as restactions.go:212-230.
-func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string) error {
+func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string, bootScoped bool) error {
 	got := objects.Get(ctx, ref)
 	if got.Err != nil {
 		// #158 (design §1.3): preserve the typed status error so the call
@@ -515,6 +515,39 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 				"skipping the shared empty-identity cell Put (A4 populate-side guard)"),
 		)
 		return nil
+	}
+
+	// F.4 boot-only fresh-skip (design §3.2). When this is the genuine boot
+	// scope (bootScoped) and the production cell key already holds a LIVE
+	// (non-expired) entry, the target is already warm — count it as processed
+	// and skip the resolve + Put, so a deadline-cut boot chunk's continuation
+	// re-pays only the cold remainder (cost-proportional resume). Gated on
+	// bootScoped ONLY: keepwarm must re-Put (reset CreatedAt) and gvr-discovered
+	// must re-resolve (record the new-GVR dep edge), so both pass bootScoped=false
+	// and fall through to the normal resolve (F4-C3 boundary).
+	//
+	// F4-C2a: freshness is the store's OWN TTL-expiry check — handle.Get returns
+	// (entry, true) iff the entry exists AND is non-expired per the exact
+	// effectiveTTL logic the serve path uses (resolved.go Get). No "TTL-remaining
+	// ≥ X" literal, no put-since bookkeeping. The lookup consumes `key` — the
+	// SAME key derived above by dispatchCacheLookupKey that the Put below uses —
+	// so skip-key correctness cannot drift from Put-key correctness (single
+	// derivation site, feedback_consultation_mutation_is_not_key_correctness).
+	// Placed BEFORE enterSeedUnit so a skipped target never consumes the #46
+	// memory admission (the bound composes trivially — strictly fewer admissions).
+	if bootScoped {
+		if _, live := handle.Get(key); live {
+			pipSeedFreshSkipTotal.Add(1)
+			slog.Default().Debug("phase1.seed.fresh_skip",
+				slog.String("subsystem", "cache"),
+				slog.String("class", "restactions"),
+				slog.String("restaction", ref.Namespace+"/"+ref.Name),
+				slog.String("cohort", cohortLabel),
+				slog.String("effect", "boot-scope fresh-skip: live L1 cell under the production key; "+
+					"resolve+Put skipped, target counted as processed (F.4 cost-proportional resume)"),
+			)
+			return nil
+		}
 	}
 
 	// #46 / fold 2026-07-03: bound this seed unit's footprint via the ADAPTIVE
@@ -663,7 +696,7 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 //     matches widgets.go:215-231 (recordWidgetDeps calls
 //     ensureWatcherInformerForGVR for the widget GVR + apiRef GVR +
 //     each resourcesRefs GVR, satisfying AC-PIP.5 for widgets).
-func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error {
+func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, bootScoped bool) error {
 	if e.W == nil {
 		return nil
 	}
@@ -728,6 +761,32 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string) error 
 				"skipping the shared empty-identity cell Put (A4 populate-side guard)"),
 		)
 		return nil
+	}
+
+	// F.4 boot-only fresh-skip (design §3.2) — mirror of seedOneRestaction. On
+	// the genuine boot scope, if the production widget cell key already holds a
+	// LIVE (non-expired) entry, count it processed and skip resolve+Put so a
+	// deadline-cut boot chunk's continuation is cost-proportional. Gated on
+	// bootScoped ONLY (keepwarm re-Puts, gvr-discovered re-resolves; both pass
+	// false — F4-C3 boundary). Freshness = handle.Get's own TTL-expiry check
+	// (F4-C2a), consuming the SAME `key` derived above (single derivation site,
+	// F4-C2a). BEFORE enterSeedUnit so a skip never consumes the #46 admission.
+	// The unpaginated seedRAFullListForWidget accelerator is skipped along with
+	// the widget resolve — correct, because a live widget cell implies its
+	// first paginated /call already found (or will lazily rebuild) the pinned
+	// full-list; the boot chunk's job is done for this warm target.
+	if bootScoped {
+		if _, live := handle.Get(key); live {
+			pipSeedFreshSkipTotal.Add(1)
+			slog.Default().Debug("phase1.seed.fresh_skip",
+				slog.String("subsystem", "cache"),
+				slog.String("class", "widgets"),
+				slog.String("widget", e.W.GetNamespace()+"/"+e.W.GetName()),
+				slog.String("effect", "boot-scope fresh-skip: live L1 cell under the production key; "+
+					"resolve+Put skipped, target counted as processed (F.4 cost-proportional resume)"),
+			)
+			return nil
+		}
 	}
 
 	// #46: bound this seed unit's footprint (semaphore admission + per-unit

--- a/internal/handlers/dispatchers/phase1_pip_seed_test.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed_test.go
@@ -171,7 +171,7 @@ func TestSeedScopeYielding_CtxCancelEmitsAbortLog(t *testing.T) {
 
 	// Zero-value endpoints + nil REST config — never dereferenced (the ctx-check
 	// returns before any target seed).
-	err := seedScopeYielding(ctx, refs, nil /* widgets */, endpoints.Endpoint{}, nil /* rc */, "test-authn-ns", false /* rank1Only */)
+	err := seedScopeYielding(ctx, refs, nil /* widgets */, endpoints.Endpoint{}, nil /* rc */, "test-authn-ns", false /* rank1Only */, false /* bootScoped */)
 	if err == nil {
 		t.Fatalf("Fix-C(engine): seedScopeYielding with pre-cancelled ctx returned nil; want the ctx error")
 	}

--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -466,8 +466,16 @@ func Phase1Warmup(ctx context.Context, rc *rest.Config, authnNS string) error {
 
 			StartPrewarmEngine(processCtx, makeBootScopeHandler(deps), func(s prewarmScope, err error) {
 				if s.kind == scopeKindBoot {
-					bootErr = err
-					closeOnce.Do(func() { close(bootDone) })
+					// C-F4R-2: assign bootErr INSIDE closeOnce.Do. F.4's engine-owned
+					// requeue makes a SECOND boot completion systematic (a cut chunk-1
+					// followed by a completing chunk-2), so the FIRST completion's err
+					// is the one bootDone reports; a later completion must not race the
+					// :505-512 select's bootErr read. sync.Once serializes the write
+					// with the close, and the close is the read's happens-before edge.
+					closeOnce.Do(func() {
+						bootErr = err
+						close(bootDone)
+					})
 				}
 			})
 			// Ship 1 enqueues only the BOOT scope. Ship 2 Stage 2 (0.30.247)

--- a/internal/handlers/dispatchers/prewarm_engine.go
+++ b/internal/handlers/dispatchers/prewarm_engine.go
@@ -40,10 +40,17 @@
 // customer path needs; the yield is a cooperative check, not a hard mutex.
 //
 // BOUNDED QUEUE (refresher.go:95 shape). The engine owns a
-// workqueue.TypedRateLimitingInterface[prewarmScope-key] so Ship 2 can
-// enqueue re-prewarm work (widget CR change, RBAC shift) with idempotent
-// dedup + exponential-backoff retry + never-drop semantics — the exact
-// properties the refresher relies on. Ship 1 enqueues only the BOOT scope.
+// workqueue.TypedRateLimitingInterface[prewarmScope] (F.4 / R1 — the
+// hand-rolled pending-map+signal-channel it replaced was a
+// half-reimplementation of exactly this). prewarmScope is comparable
+// (string kind + GVR struct), so the item IS its own dedup key — the
+// per-key coalescing the map gave us is preserved 1:1 because key() and
+// item identity coincide. This gets FIFO ordering, AddRateLimited
+// exponential-backoff requeue (client-go stock defaults, no new knob),
+// Forget-on-success, and never-drop from tested client-go code. Widget CR
+// changes / RBAC shifts (Ship 2) enqueue with the same idempotent dedup.
+// The BOOT scope re-enqueues itself on a per-scope-budget deadline-cut
+// (F.4 §3.1) so a cut boot chunk resumes deterministically.
 //
 // LIFECYCLE. The engine's workers run under a context bounded by the
 // engine timeout (boot: pipGlobalTimeout); they exit on ctx cancel /
@@ -62,6 +69,7 @@ import (
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // PrewarmEngineEnabled reports whether the unified dynamic cohort-prewarm
@@ -226,9 +234,12 @@ type prewarmEngine struct {
 	// start; read by workers.
 	scopeHandler func(ctx context.Context, s prewarmScope) error
 
-	mu      sync.Mutex
-	pending map[string]prewarmScope // key -> scope, the bounded dedup queue
-	signal  chan struct{}           // wakes a worker when pending grows
+	// queue is the client-go rate-limiting workqueue (F.4 / R1). prewarmScope
+	// is comparable so the item is its own dedup key — Add coalesces on scope
+	// identity exactly as the old map keyed on key(). FIFO + AddRateLimited
+	// backoff + Forget + never-drop + ShutDown come from client-go. Constructed
+	// once in prewarmEngineSingleton.
+	queue workqueue.TypedRateLimitingInterface[prewarmScope]
 
 	// scopeDone, when set, is invoked by the worker after each scope is
 	// processed (success or error) with the processed scope + its err. The
@@ -243,9 +254,10 @@ type prewarmEngine struct {
 	yieldPoll time.Duration // how long a worker parks while a customer call is in flight
 
 	// Falsifier / telemetry counters.
-	enqueuedTotal atomic.Uint64
+	enqueuedTotal  atomic.Uint64
 	processedTotal atomic.Uint64
 	yieldTotal     atomic.Uint64 // engine yields to a customer call
+	requeuedTotal  atomic.Uint64 // F.4 — scopes engine-requeued after an error (AddRateLimited)
 }
 
 var (
@@ -262,40 +274,29 @@ const defaultEngineYieldPoll = 25 * time.Millisecond
 func prewarmEngineSingleton() *prewarmEngine {
 	prewarmEngineOnce.Do(func() {
 		prewarmEngineInstance = &prewarmEngine{
-			pending:   map[string]prewarmScope{},
-			signal:    make(chan struct{}, 1),
+			// F.4 / R1 — client-go rate-limiting workqueue with stock default
+			// controller rate-limiter (exponential per-item backoff + overall
+			// bucket). prewarmScope is comparable so it is its own dedup key.
+			queue: workqueue.NewTypedRateLimitingQueue(
+				workqueue.DefaultTypedControllerRateLimiter[prewarmScope](),
+			),
 			yieldPoll: defaultEngineYieldPoll,
 		}
 	})
 	return prewarmEngineInstance
 }
 
-// enqueueScope adds a scope to the bounded dedup queue and wakes a worker.
-// Idempotent: a scope whose key is already pending coalesces (the latest
-// wins, but Ship 1's scopes carry no payload so it is a true no-op
-// dedup). Never blocks: the signal channel is buffered=1 and a full
-// channel means a worker is already about to wake.
+// enqueueScope adds a scope to the workqueue. Idempotent: prewarmScope is
+// comparable and IS its own dedup key, so a scope already present (queued
+// or being processed) coalesces exactly as the old map keyed on key()
+// (Ship 1's scopes carry no payload, so it is a true no-op dedup; a
+// scopeKindGVRDiscovered coalesces per-GVR). Never blocks — workqueue.Add
+// is a mutex critical section. Immediate (not rate-limited) add: this is
+// the fresh-arrival path; the engine-owned failure requeue uses
+// AddRateLimited in runWorker.
 func (e *prewarmEngine) enqueueScope(s prewarmScope) {
-	e.mu.Lock()
-	e.pending[s.key()] = s
-	e.mu.Unlock()
+	e.queue.Add(s)
 	e.enqueuedTotal.Add(1)
-	select {
-	case e.signal <- struct{}{}:
-	default:
-	}
-}
-
-// dequeueScope pops one scope from the pending set, or reports empty. The
-// caller drains until empty.
-func (e *prewarmEngine) dequeueScope() (prewarmScope, bool) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	for k, s := range e.pending {
-		delete(e.pending, k)
-		return s, true
-	}
-	return prewarmScope{}, false
 }
 
 // StartPrewarmEngine starts the engine worker(s) bound to the given scope
@@ -349,8 +350,8 @@ func StartPrewarmEngine(ctx context.Context, handler func(ctx context.Context, s
 		// Ship 2 Stage 2 — wire the cache→engine hook. The hook fires
 		// from inside cache.DiscoverGroupResources (the `if added`
 		// branch of EnsureResourceType for genuinely-new GVRs). The
-		// callback is non-blocking: enqueueScope is O(1) under a
-		// sync.Mutex + a buffered=1 signal-channel send.
+		// callback is non-blocking: enqueueScope is O(1) — a single
+		// workqueue.Add (a mutex critical section; F.4 / R1).
 		//
 		// REGISTRATION ORDER (PM observation 3, R4 startup-storm):
 		// runs BEFORE `go e.runWorker(ctx)` below so a discovery firing
@@ -367,7 +368,7 @@ func StartPrewarmEngine(ctx context.Context, handler func(ctx context.Context, s
 		go e.runWorker(ctx)
 		slog.Info("prewarm.engine.started",
 			slog.String("subsystem", "cache"),
-			slog.String("queue", "bounded-dedup"),
+			slog.String("queue", "workqueue-ratelimiting"), // F.4 / R1 — client-go typed workqueue
 			slog.String("customer_priority", "yield-on-inflight"),
 			slog.String("gvr_discovered_hook", "wired"),
 			slog.String("ctx_lifetime", "process"),
@@ -393,65 +394,122 @@ func prewarmScopeTimeout(s prewarmScope) time.Duration {
 	return pipGlobalTimeout
 }
 
-// runWorker is the engine worker loop. It blocks on the signal channel,
-// drains the pending queue, and runs each scope through the handler —
-// YIELDING to any in-flight customer /call before each scope. Exits on
-// ctx cancel.
+// prewarmScopeTimeoutFn is a 1-LOC test seam over prewarmScopeTimeout — the
+// SAME `var fooFn = foo` pattern as seedCohortFn (phase1_pip_seed.go) and the
+// seedOneWidgetFn / enumeratePrewarmTargetsForGVRFn seams
+// (prewarm_engine_boot.go). runWorker's per-scope context.WithTimeout routes
+// through it so the F.4 straddle falsifier can shrink one chunk's budget to
+// force a mid-segment deadline-cut without a live cluster or an 8-minute wait.
+// PRODUCTION ALWAYS uses prewarmScopeTimeout (8m, F4-C6 no-new-knob — the
+// budget literal is untouched); only a _test.go override reassigns this var.
+var prewarmScopeTimeoutFn = prewarmScopeTimeout
+
+// runWorker is the engine worker loop. It blocks on the workqueue's Get,
+// runs each scope through the handler — YIELDING to any in-flight customer
+// /call before each scope — and, on error with the process ctx still
+// alive, ENGINE-OWNS the resume by requeueing the scope with rate-limited
+// backoff (F.4 §3.1). Exits on ctx cancel (which ShutDowns the queue so
+// the blocking Get unblocks).
 //
 // CTX CONTRACT (Fix v2 / 0.30.248). `ctx` is the worker's process-lifetime
 // context passed from StartPrewarmEngine. The worker exits ONLY on
 // process shutdown. Per-scope wall-clock bounds are derived inside the
-// drain via context.WithTimeout(ctx, prewarmScopeTimeout(s)) so a
+// loop via context.WithTimeout(ctx, prewarmScopeTimeoutFn(s)) so a
 // single misbehaving scope cannot stall the worker indefinitely; the
-// scope ctx cancels the instant the scope returns (deferred
-// scopeCancel) so resources never leak.
+// scope ctx cancels the instant the scope returns (scopeCancel) so
+// resources never leak.
+//
+// F.4 ENGINE-OWNED RESUME. A boot scope cut by its per-scope budget
+// returns ctx.DeadlineExceeded → the worker requeues it (AddRateLimited)
+// so the continuation chunk runs deterministically, with zero dependence
+// on an external config-vars event (the pre-F.4 nondeterministic redrive
+// trigger). Uniform across scope kinds: gvr-discovered and keepwarm
+// errors requeue too. On success we Forget the item so its backoff
+// history resets. Never-drop: retries space out via exponential backoff
+// (client-go stock rate-limiter) but never stop while the process lives
+// (F4-C8 futility bound — no hot loop).
 func (e *prewarmEngine) runWorker(ctx context.Context) {
+	// ShutDown the queue when the process ctx cancels so the blocking
+	// queue.Get below returns shutdown==true and the worker exits. The
+	// queue never delivers items after ShutDown.
+	go func() {
+		<-ctx.Done()
+		e.queue.ShutDown()
+	}()
+
 	for {
-		select {
-		case <-ctx.Done():
+		s, shutdown := e.queue.Get()
+		if shutdown {
 			return
-		case <-e.signal:
 		}
-		// Drain every pending scope. New enqueues during the drain re-fire
-		// the signal so we loop back.
-		for {
-			if ctx.Err() != nil {
-				return
-			}
-			s, ok := e.dequeueScope()
-			if !ok {
-				break
-			}
-			// CUSTOMER PRIORITY — yield before running the scope while any
-			// customer /call is in flight. The seed work inside the handler
-			// also yields between cohorts (see seedScopeYielding), so a
-			// burst that arrives mid-scope is also deferred.
-			e.yieldToCustomer(ctx)
-			if e.scopeHandler == nil {
-				continue
-			}
-			// Per-scope bound: anchor on the long-lived worker ctx so the
-			// scope shares the worker's lifetime (boot/process), but cap
-			// the scope's own wall-clock at prewarmScopeTimeout(s) so a
-			// single misbehaving scope cannot occupy the worker forever.
-			// scopeCancel is deferred-equivalent (called at the bottom of
-			// this iteration via the explicit invocation) so it fires
-			// promptly whether the scope returns nil or an error.
-			scopeCtx, scopeCancel := context.WithTimeout(ctx, prewarmScopeTimeout(s))
-			err := e.scopeHandler(scopeCtx, s)
-			scopeCancel()
-			if err != nil {
-				slog.Warn("prewarm.engine.scope_incomplete",
-					slog.String("subsystem", "cache"),
-					slog.String("scope", s.key()),
-					slog.Any("err", err),
-				)
-			}
-			e.processedTotal.Add(1)
-			if e.scopeDone != nil {
-				e.scopeDone(s, err)
-			}
+		e.processScope(ctx, s)
+	}
+}
+
+// processScope runs one dequeued scope under the customer-priority yield +
+// per-scope timeout, then Done()s it and either Forgets (success) or
+// AddRateLimited-requeues (error, process alive) — the F.4 engine-owned
+// resume. Split out from runWorker so the whole item lifecycle
+// (Get→Done→Forget/requeue) is one auditable unit.
+func (e *prewarmEngine) processScope(ctx context.Context, s prewarmScope) {
+	// Done MUST be called for every Get, whatever the outcome, or the queue
+	// leaks the "processing" mark and refuses to re-deliver the item.
+	defer e.queue.Done(s)
+
+	// CUSTOMER PRIORITY — yield before running the scope while any customer
+	// /call is in flight. The seed work inside the handler also yields
+	// between cohorts (see seedScopeYielding), so a burst arriving mid-scope
+	// is also deferred.
+	e.yieldToCustomer(ctx)
+	if e.scopeHandler == nil {
+		e.queue.Forget(s)
+		return
+	}
+	// Per-scope bound: anchor on the long-lived worker ctx so the scope
+	// shares the worker's lifetime (boot/process), but cap the scope's own
+	// wall-clock at prewarmScopeTimeoutFn(s) so a single misbehaving scope
+	// cannot occupy the worker forever. prewarmScopeTimeoutFn is a 1-LOC
+	// test seam over prewarmScopeTimeout (same pattern as seedCohortFn) so
+	// the straddle falsifier can shrink the budget without a live cluster;
+	// production ALWAYS uses prewarmScopeTimeout (8m, unchanged).
+	scopeCtx, scopeCancel := context.WithTimeout(ctx, prewarmScopeTimeoutFn(s))
+	err := e.scopeHandler(scopeCtx, s)
+	scopeCancel()
+	e.processedTotal.Add(1)
+
+	if err != nil {
+		slog.Warn("prewarm.engine.scope_incomplete",
+			slog.String("subsystem", "cache"),
+			slog.String("scope", s.key()),
+			slog.Any("err", err),
+		)
+		// F.4 engine-owned failure-requeue. Only while the process ctx is
+		// alive — on shutdown the scope error is the ctx cancel itself and a
+		// requeue would race the ShutDown (the queue drops rate-limited adds
+		// after ShutDown anyway, but skipping keeps the counter honest and
+		// avoids a spurious scope_requeued line at teardown).
+		if ctx.Err() == nil {
+			e.queue.AddRateLimited(s)
+			e.requeuedTotal.Add(1)
+			slog.Info("prewarm.engine.scope_requeued",
+				slog.String("subsystem", "cache"),
+				slog.String("scope", s.key()),
+				slog.Int("attempt", e.queue.NumRequeues(s)),
+				slog.Any("err", err),
+				slog.String("effect", "engine-owned resume: cut/failed scope re-enqueued with "+
+					"rate-limited backoff (F.4); a boot deadline-cut resumes as a continuation chunk, "+
+					"no dependence on config-vars events"),
+			)
 		}
+	} else {
+		// Success — reset the item's backoff history (F4-C8: Forget-on-success
+		// so a later transient failure starts from zero backoff, not the tail
+		// of an old streak).
+		e.queue.Forget(s)
+	}
+
+	if e.scopeDone != nil {
+		e.scopeDone(s, err)
 	}
 }
 

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -76,7 +76,9 @@ func makeBootScopeHandler(deps rePrewarmDeps) func(ctx context.Context, s prewar
 	return func(ctx context.Context, s prewarmScope) error {
 		switch s.kind {
 		case scopeKindBoot:
-			return rePrewarmBoot(ctx, deps)
+			// F.4 — bootScoped=true engages the fresh-skip so a deadline-cut
+			// boot chunk's continuation skips already-live cells.
+			return rePrewarmBoot(ctx, deps, true /*bootScoped*/)
 		case scopeKindGVRDiscovered:
 			return rePrewarmGVRDiscovered(ctx, deps, s.gvr)
 		case scopeKindKeepwarm:
@@ -164,7 +166,10 @@ func rePrewarmGVRDiscovered(ctx context.Context, deps rePrewarmDeps, gvr schema.
 		slog.String("gvr", gvr.String()),
 		slog.String("note", "Ship 2 Stage 2 — re-walk under cohort identities so iterator-empty short-circuit (resolve.go:377-381) no longer skips dep recording for this GVR"),
 	)
-	err := rePrewarmBoot(ctx, deps)
+	// bootScoped=false: gvr-discovered must RE-RESOLVE already-warm cells so
+	// the dep edge against the newly-registered GVR is recorded (the S4 fix);
+	// a fresh-skip would reintroduce the defect (F4-C3 boundary).
+	err := rePrewarmBoot(ctx, deps, false /*bootScoped*/)
 	if err != nil {
 		slog.Warn("prewarm.engine.gvr_discovered.incomplete",
 			slog.String("subsystem", "cache"),
@@ -187,8 +192,15 @@ func rePrewarmGVRDiscovered(ctx context.Context, deps rePrewarmDeps, gvr schema.
 // #102 c1 keepwarm sweep reuses this SAME core via rePrewarmKeepwarm (rank1Only
 // seed), so the sweep gets the boot's dedup, NavOrder, BindingsByGVR index, and
 // yield/memory bounds for free — it IS the seed, just rank-1-bounded.
-func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps) error {
-	return rePrewarmBootScoped(ctx, deps, false /*rank1Only*/)
+//
+// bootScoped=true engages the F.4 boot-only fresh-skip in the seed primitives
+// (a live cell is treated as done → not re-resolved), which makes a
+// deadline-cut boot chunk's continuation cost-proportional. It is TRUE only
+// for the genuine boot scope; keepwarm passes false (its Puts must re-resolve
+// fresh bytes + reset CreatedAt) and gvr-discovered passes false (it must
+// re-resolve already-warm cells to record the dep edge against the new GVR).
+func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps, bootScoped bool) error {
+	return rePrewarmBootScoped(ctx, deps, false /*rank1Only*/, bootScoped)
 }
 
 // rePrewarmKeepwarm is the #102 c1 keepwarm-sweep handler: the SAME re-walk +
@@ -200,10 +212,13 @@ func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps) error {
 // shared seed primitives declines a degraded re-resolve rather than overwrite a
 // good warm entry.
 func rePrewarmKeepwarm(ctx context.Context, deps rePrewarmDeps) error {
-	return rePrewarmBootScoped(ctx, deps, true /*rank1Only*/)
+	// bootScoped=false: the sweep's whole purpose is to re-Put (reset CreatedAt)
+	// live rank-1 cells before they lazy-expire; a fresh-skip would make it a
+	// no-op (F4-C3 boundary).
+	return rePrewarmBootScoped(ctx, deps, true /*rank1Only*/, false /*bootScoped*/)
 }
 
-func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only bool) error {
+func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only, bootScoped bool) error {
 	log := slog.Default()
 	start := time.Now()
 
@@ -357,7 +372,7 @@ func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only bool
 	// propagates; withCohortSeedContext OVERRIDES identity per cohort for the
 	// actual seed, so the SA base is correct for both the derivation fetch
 	// and as the per-cohort seed base.
-	if err := seedScopeYielding(rctx, restactionRefs, widgetEntries, deps.saEP, deps.saRC, deps.authnNS, rank1Only); err != nil {
+	if err := seedScopeYielding(rctx, restactionRefs, widgetEntries, deps.saEP, deps.saRC, deps.authnNS, rank1Only, bootScoped); err != nil {
 		return err
 	}
 
@@ -442,9 +457,17 @@ var seedOneRestactionFn = seedOneRestaction
 // existing rank-major loop (ranked is sorted DESC by CollapsedBindings, so
 // ranked[0] IS rank-1); no new seam, no separate loop — the sweep re-runs the
 // identical per-identity seed the boot does, just for the one dominant cohort.
+// bootScoped, when true (genuine boot scope ONLY — not keepwarm, not
+// gvr-discovered), engages the F.4 boot-only fresh-skip inside the per-target
+// seed primitives: a target whose production cell key already holds a live
+// (non-expired) L1 entry is counted as processed WITHOUT re-resolving, making a
+// deadline-cut boot chunk's continuation cost-proportional (≈ preamble +
+// remaining cold targets). It threads straight through to seedOneWidgetFn /
+// seedOneRestactionFn — the skip decision lives INSIDE those primitives so it
+// consumes the EXACT key the Put would use (single derivation site, F4-C2a).
 func seedScopeYielding(ctx context.Context,
 	restactionRefs []templatesv1.ObjectReference, widgetEntries []navWidgetEntry,
-	saEP endpoints.Endpoint, saRC *rest.Config, authnNS string, rank1Only bool) error {
+	saEP endpoints.Endpoint, saRC *rest.Config, authnNS string, rank1Only, bootScoped bool) error {
 
 	log := slog.Default()
 
@@ -716,7 +739,7 @@ func seedScopeYielding(ctx context.Context,
 		}
 		engineYieldCheckpoint(ctx)
 		err := seedOneTarget(c, func(cohortCtx context.Context) error {
-			return seedOneWidgetFn(cohortCtx, e, authnNS)
+			return seedOneWidgetFn(cohortCtx, e, authnNS, bootScoped)
 		})
 		if err != nil && ctx.Err() != nil {
 			emitSeedAbort("widgets", ctx.Err())
@@ -735,7 +758,7 @@ func seedScopeYielding(ctx context.Context,
 		}
 		engineYieldCheckpoint(ctx)
 		err := seedOneTarget(c, func(cohortCtx context.Context) error {
-			return seedOneRestactionFn(cohortCtx, cohortLogLabel(c), ref, authnNS)
+			return seedOneRestactionFn(cohortCtx, cohortLogLabel(c), ref, authnNS, bootScoped)
 		})
 		if err != nil && ctx.Err() != nil {
 			emitSeedAbort("restactions", ctx.Err())

--- a/internal/handlers/dispatchers/prewarm_engine_metrics.go
+++ b/internal/handlers/dispatchers/prewarm_engine_metrics.go
@@ -18,10 +18,13 @@
 //     drained.
 //   - snowplow_prewarm_engine_yield_total     — ticks the worker parked
 //     while a customer /call was in flight (customer-priority yield).
-//   - snowplow_prewarm_engine_pending_depth   — live len(e.pending)
-//     under the engine mutex. Steady-state expectation: 0 once the
+//   - snowplow_prewarm_engine_pending_depth   — live e.queue.Len()
+//     (F.4 / R1 workqueue). Steady-state expectation: 0 once the
 //     worker drains. A non-zero value sustained over many scrapes
 //     signals the worker is dead (Fix-v2 falsifier).
+//   - snowplow_prewarm_engine_requeued_total  — scopes engine-requeued
+//     after an error via AddRateLimited (F.4 §3.1). A boot deadline-cut
+//     bumps this once per continuation chunk.
 //
 // REGISTRATION: registerPrewarmEngineMetrics(e) is called from inside
 // StartPrewarmEngine's startedOnce.Do(...) block. Single registration
@@ -63,11 +66,18 @@ func registerPrewarmEngineMetrics(e *prewarmEngine) {
 			return e.yieldTotal.Load()
 		}))
 		expvar.Publish("snowplow_prewarm_engine_pending_depth", expvar.Func(func() any {
-			// Read pending depth under e.mu so the observation is
-			// race-free against enqueue/dequeue (which mutate the map).
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			return len(e.pending)
+			// F.4 / R1 — the workqueue's own Len() (internally synchronized).
+			// Steady-state expectation: 0 once the worker drains. A sustained
+			// non-zero value signals a dead worker or a permanently-failing
+			// scope backing off (Fix-v2 falsifier).
+			return e.queue.Len()
+		}))
+		// F.4 — scopes the engine requeued after an error (AddRateLimited). A
+		// non-zero value with a settling pending_depth is the normal
+		// boot-continuation signal; a monotonically climbing value that never
+		// settles is a zero-progress scope hitting the backoff floor (F4-C8).
+		expvar.Publish("snowplow_prewarm_engine_requeued_total", expvar.Func(func() any {
+			return e.requeuedTotal.Load()
 		}))
 	})
 }

--- a/internal/handlers/dispatchers/prewarm_engine_queue_testhelpers_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_queue_testhelpers_test.go
@@ -1,0 +1,77 @@
+// prewarm_engine_queue_testhelpers_test.go — F.4 / R1 test shims.
+//
+// The engine's queue moved from a hand-rolled pending-map+signal-channel to a
+// client-go workqueue.TypedRateLimitingInterface[prewarmScope] (F.4 §3.1 R1).
+// The old white-box tests inspected e.pending / e.dequeueScope directly; these
+// shims re-express that intent against the workqueue so the regression fences
+// stay meaningful without every test hand-driving Get/Done/Forget.
+//
+// F4-C7: existing FIX-F/#99b/shape-A falsifiers keep their behavioural
+// assertions; only the queue-internal plumbing they touch is migrated here.
+
+package dispatchers
+
+import "k8s.io/client-go/util/workqueue"
+
+// newTestEngine constructs a prewarmEngine with a fresh rate-limiting workqueue
+// (same construction as prewarmEngineSingleton, but not the process singleton so
+// each test is isolated). Replaces the old `&prewarmEngine{pending:..., signal:...}`
+// literal.
+func newTestEngine() *prewarmEngine {
+	return &prewarmEngine{
+		queue: workqueue.NewTypedRateLimitingQueue(
+			workqueue.DefaultTypedControllerRateLimiter[prewarmScope](),
+		),
+		yieldPoll: defaultEngineYieldPoll,
+	}
+}
+
+// pendingLenForTest reports the queue's current depth (the migrated
+// len(e.pending)). Rate-limited (AddRateLimited) items in backoff are NOT yet
+// in the queue proper, so this counts only ready items — same as the old map,
+// which only held immediately-ready scopes.
+func (e *prewarmEngine) pendingLenForTest() int { return e.queue.Len() }
+
+// drainScopeForTest pops one ready scope FIFO, marking it Done (so the queue
+// permits its re-add later). Returns ok=false when the queue is empty. Replaces
+// the old dequeueScope() pop. NOTE: unlike the old map, the workqueue blocks on
+// Get with no ready item, so callers must ensure at least one item is queued
+// (or use pendingLenForTest first) — every migrated call site already does.
+func (e *prewarmEngine) drainScopeForTest() (prewarmScope, bool) {
+	if e.queue.Len() == 0 {
+		return prewarmScope{}, false
+	}
+	s, shutdown := e.queue.Get()
+	if shutdown {
+		return prewarmScope{}, false
+	}
+	e.queue.Done(s)
+	return s, true
+}
+
+// pendingHasBootForTest reports whether a boot scope is currently queued. The
+// workqueue has no key-peek, so this drains-and-reinstates: it pops every ready
+// item, checks for the boot key, then re-Adds them all (order-preserving for
+// the assertion's purpose — the tests that use this only check presence, not
+// order). Done is called per item so the re-Add is accepted.
+func (e *prewarmEngine) pendingHasBootForTest() bool {
+	bootKey := prewarmScope{kind: scopeKindBoot}.key()
+	n := e.queue.Len()
+	found := false
+	popped := make([]prewarmScope, 0, n)
+	for i := 0; i < n; i++ {
+		s, shutdown := e.queue.Get()
+		if shutdown {
+			break
+		}
+		e.queue.Done(s)
+		if s.key() == bootKey {
+			found = true
+		}
+		popped = append(popped, s)
+	}
+	for _, s := range popped {
+		e.queue.Add(s)
+	}
+	return found
+}

--- a/internal/handlers/dispatchers/prewarm_engine_seed_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_seed_latch_test.go
@@ -123,7 +123,7 @@ func drainSingletonPending() int {
 	e := prewarmEngineSingleton()
 	n := 0
 	for {
-		if _, ok := e.dequeueScope(); !ok {
+		if _, ok := e.drainScopeForTest(); !ok {
 			break
 		}
 		n++
@@ -138,16 +138,12 @@ func drainSingletonPending() int {
 // coalesce to one map entry.
 func singletonPendingBootCount() int {
 	e := prewarmEngineSingleton()
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	n := 0
-	bootKey := prewarmScope{kind: scopeKindBoot}.key()
-	for k := range e.pending {
-		if k == bootKey {
-			n++
-		}
+	// The boot scope coalesces to a single queue item on key()=="boot", so the
+	// count is 0 or 1 — presence is equivalent to the old map-count.
+	if e.pendingHasBootForTest() {
+		return 1
 	}
-	return n
+	return 0
 }
 
 // withSeamsAndCounters wires the two seams + log capture + counter snapshots
@@ -165,7 +161,7 @@ type seedRunResult struct {
 func runSeedScopeYielding(t *testing.T,
 	widgets []navWidgetEntry,
 	enumFn func(schema.GroupVersionResource, string) []cache.PrewarmTarget,
-	seedFn func(context.Context, navWidgetEntry, string) error,
+	seedFn func(context.Context, navWidgetEntry, string, bool) error,
 ) seedRunResult {
 	t.Helper()
 
@@ -196,7 +192,7 @@ func runSeedScopeYielding(t *testing.T,
 	// short-circuits before any of them is dereferenced for I/O.
 	if err := seedScopeYielding(context.Background(),
 		nil /* restactionRefs */, widgets,
-		endpoints.Endpoint{}, nil /* saRC */, "test-authn-ns", false /* rank1Only */); err != nil {
+		endpoints.Endpoint{}, nil /* saRC */, "test-authn-ns", false /* rank1Only */, false /* bootScoped */); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil (per-target errors are non-fatal)", err)
 	}
 
@@ -234,7 +230,7 @@ func TestSeedScopeYielding_OneOperationalFailure_EnqueuesExactlyOnce(t *testing.
 	// ONE target, fails operationally.
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) },
-		func(context.Context, navWidgetEntry, string) error { return opErr() },
+		func(context.Context, navWidgetEntry, string, bool) error { return opErr() },
 	)
 
 	if res.enqDelta != 1 {
@@ -284,7 +280,7 @@ func TestSeedScopeYielding_NOperationalFailures_LatchEnqueuesExactlyOnce(t *test
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(n) },
-		func(context.Context, navWidgetEntry, string) error { return opErr() },
+		func(context.Context, navWidgetEntry, string, bool) error { return opErr() },
 	)
 
 	if res.opDelta != n {
@@ -314,7 +310,7 @@ func TestSeedScopeYielding_RBACDeny_NoEnqueue_BumpsDenyCounter(t *testing.T) {
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) },
-		func(context.Context, navWidgetEntry, string) error { return deny403() },
+		func(context.Context, navWidgetEntry, string, bool) error { return deny403() },
 	)
 
 	if res.denyDelta != 1 {
@@ -405,7 +401,7 @@ func TestSeedScopeYielding_CounterSumInvariant(t *testing.T) {
 			var idx int
 			res := runSeedScopeYielding(t, widgets,
 				func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return targets },
-				func(context.Context, navWidgetEntry, string) error {
+				func(context.Context, navWidgetEntry, string, bool) error {
 					u := targets[idx].Subject.Username
 					idx++
 					return outcome[u]
@@ -454,7 +450,7 @@ func TestSeedScopeYielding_TwoInvocations_QueueCoalescesToOnePending(t *testing.
 
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	enumFn := func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) }
-	seedFn := func(context.Context, navWidgetEntry, string) error { return opErr() }
+	seedFn := func(context.Context, navWidgetEntry, string, bool) error { return opErr() }
 
 	// Invocation 1 — fresh latch, enqueues one boot scope.
 	runSeedScopeYielding(t, widgets, enumFn, seedFn)
@@ -473,15 +469,13 @@ func TestSeedScopeYielding_TwoInvocations_QueueCoalescesToOnePending(t *testing.
 	}
 	// And the queue holds exactly one entry total (no stray scope kinds).
 	e := prewarmEngineSingleton()
-	e.mu.Lock()
-	total := len(e.pending)
-	e.mu.Unlock()
+	total := e.pendingLenForTest()
 	if total != 1 {
 		t.Errorf("singleton total pending entries = %d; want 1 (only the coalesced boot scope)", total)
 	}
 
 	// Sanity: the one entry dequeues as a boot scope.
-	s, ok := prewarmEngineSingleton().dequeueScope()
+	s, ok := prewarmEngineSingleton().drainScopeForTest()
 	if !ok || s.kind != scopeKindBoot {
 		t.Fatalf("expected one boot scope to dequeue, got %+v ok=%v", s, ok)
 	}
@@ -492,5 +486,5 @@ func TestSeedScopeYielding_TwoInvocations_QueueCoalescesToOnePending(t *testing.
 // not silently at the swap site).
 var (
 	_ func(schema.GroupVersionResource, string) []cache.PrewarmTarget = cache.EnumeratePrewarmTargetsForGVR
-	_ func(context.Context, navWidgetEntry, string) error             = seedOneWidget
+	_ func(context.Context, navWidgetEntry, string, bool) error       = seedOneWidget
 )

--- a/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
@@ -220,20 +220,20 @@ func TestFixE_RankMajorClassInterleaveFirstNavOrder(t *testing.T) {
 	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
 
 	prevW := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
 		rec.record("widget", e.W.GetName(), eIdentityLabel(ctx))
 		return nil
 	}
 	t.Cleanup(func() { seedOneWidgetFn = prevW })
 
 	prevR := seedOneRestactionFn
-	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string) error {
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
 		rec.record("restaction", ref.Name, eIdentityLabel(ctx))
 		return nil
 	}
 	t.Cleanup(func() { seedOneRestactionFn = prevR })
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 

--- a/internal/handlers/dispatchers/prewarm_engine_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_test.go
@@ -29,11 +29,8 @@ func TestEngineYieldsWhileCustomerInFlight(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 
 	done := markCustomerInFlight()
 	if !customerInFlight() {
@@ -73,11 +70,8 @@ func TestEngineYieldNoOpWhenIdle(t *testing.T) {
 	for customerInFlight() {
 		customerInFlightCount.Add(-1)
 	}
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: time.Second,
-	}
+	e := newTestEngine()
+	e.yieldPoll = time.Second
 	start := time.Now()
 	e.yieldToCustomer(context.Background())
 	if d := time.Since(start); d > 50*time.Millisecond {
@@ -88,23 +82,20 @@ func TestEngineYieldNoOpWhenIdle(t *testing.T) {
 // TestEngineQueueDedup asserts enqueueing the same scope key twice
 // coalesces to one pending entry, and dequeue drains it.
 func TestEngineQueueDedup(t *testing.T) {
-	e := &prewarmEngine{
-		pending: map[string]prewarmScope{},
-		signal:  make(chan struct{}, 1),
-	}
+	e := newTestEngine()
 	e.enqueueScope(prewarmScope{kind: scopeKindBoot})
 	e.enqueueScope(prewarmScope{kind: scopeKindBoot})
-	if len(e.pending) != 1 {
-		t.Fatalf("expected 1 pending after dedup, got %d", len(e.pending))
+	if e.pendingLenForTest() != 1 {
+		t.Fatalf("expected 1 pending after dedup, got %d", e.pendingLenForTest())
 	}
 	if e.enqueuedTotal.Load() != 2 {
 		t.Fatalf("expected enqueuedTotal=2 (both calls counted), got %d", e.enqueuedTotal.Load())
 	}
-	s, ok := e.dequeueScope()
+	s, ok := e.drainScopeForTest()
 	if !ok || s.kind != scopeKindBoot {
 		t.Fatalf("expected boot scope dequeued, got %+v ok=%v", s, ok)
 	}
-	if _, ok := e.dequeueScope(); ok {
+	if _, ok := e.drainScopeForTest(); ok {
 		t.Fatal("expected empty queue after drain")
 	}
 }
@@ -116,11 +107,8 @@ func TestEngineWorkerRunsScopeAfterYield(t *testing.T) {
 	for customerInFlight() {
 		customerInFlightCount.Add(-1)
 	}
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	ran := make(chan prewarmScope, 1)
 	e.scopeHandler = func(_ context.Context, s prewarmScope) error {
 		ran <- s
@@ -149,11 +137,8 @@ func TestEngineScopeDoneFiresOnCompletion(t *testing.T) {
 	for customerInFlight() {
 		customerInFlightCount.Add(-1)
 	}
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	e.scopeHandler = func(_ context.Context, _ prewarmScope) error { return nil }
 	done := make(chan prewarmScope, 1)
 	e.scopeDone = func(s prewarmScope, _ error) { done <- s }
@@ -183,10 +168,7 @@ func TestEngineScopeDoneFiresOnCompletion(t *testing.T) {
 // re-prewarm work for the same discovered GVR (a discovery-storm of
 // the same CRD must not amplify into N rePrewarm calls).
 func TestScopeKindGVRDiscovered_KeyDeterminism(t *testing.T) {
-	e := &prewarmEngine{
-		pending: map[string]prewarmScope{},
-		signal:  make(chan struct{}, 1),
-	}
+	e := newTestEngine()
 	gvr := schema.GroupVersionResource{
 		Group:    "composition.krateo.io",
 		Version:  "v1-2-2",
@@ -196,13 +178,13 @@ func TestScopeKindGVRDiscovered_KeyDeterminism(t *testing.T) {
 	e.enqueueScope(prewarmScope{kind: scopeKindGVRDiscovered, gvr: gvr})
 	e.enqueueScope(prewarmScope{kind: scopeKindGVRDiscovered, gvr: gvr})
 
-	if len(e.pending) != 1 {
-		t.Fatalf("expected 1 pending entry after 3 enqueues of the same GVR, got %d", len(e.pending))
+	if e.pendingLenForTest() != 1 {
+		t.Fatalf("expected 1 pending entry after 3 enqueues of the same GVR, got %d", e.pendingLenForTest())
 	}
 	if e.enqueuedTotal.Load() != 3 {
 		t.Fatalf("expected enqueuedTotal=3 (all attempts counted), got %d", e.enqueuedTotal.Load())
 	}
-	s, ok := e.dequeueScope()
+	s, ok := e.drainScopeForTest()
 	if !ok {
 		t.Fatal("expected one scope dequeueable, got empty queue")
 	}
@@ -212,7 +194,7 @@ func TestScopeKindGVRDiscovered_KeyDeterminism(t *testing.T) {
 	if s.gvr != gvr {
 		t.Fatalf("expected gvr payload %+v, got %+v", gvr, s.gvr)
 	}
-	if _, ok := e.dequeueScope(); ok {
+	if _, ok := e.drainScopeForTest(); ok {
 		t.Fatal("expected queue empty after drain")
 	}
 }
@@ -223,10 +205,7 @@ func TestScopeKindGVRDiscovered_KeyDeterminism(t *testing.T) {
 // its own re-prewarm — coalescing distinct GVRs would silently lose
 // re-prewarm work for one of them.
 func TestScopeKindGVRDiscovered_KeyDistinct(t *testing.T) {
-	e := &prewarmEngine{
-		pending: map[string]prewarmScope{},
-		signal:  make(chan struct{}, 1),
-	}
+	e := newTestEngine()
 	gvrA := schema.GroupVersionResource{
 		Group:    "composition.krateo.io",
 		Version:  "v1-2-2",
@@ -240,14 +219,14 @@ func TestScopeKindGVRDiscovered_KeyDistinct(t *testing.T) {
 	e.enqueueScope(prewarmScope{kind: scopeKindGVRDiscovered, gvr: gvrA})
 	e.enqueueScope(prewarmScope{kind: scopeKindGVRDiscovered, gvr: gvrB})
 
-	if len(e.pending) != 2 {
-		t.Fatalf("expected 2 pending entries for distinct GVRs, got %d (false coalesce)", len(e.pending))
+	if e.pendingLenForTest() != 2 {
+		t.Fatalf("expected 2 pending entries for distinct GVRs, got %d (false coalesce)", e.pendingLenForTest())
 	}
 
 	// Both scopes must be dequeueable; collect them.
 	got := map[schema.GroupVersionResource]struct{}{}
 	for i := 0; i < 2; i++ {
-		s, ok := e.dequeueScope()
+		s, ok := e.drainScopeForTest()
 		if !ok {
 			t.Fatalf("expected 2 dequeueable scopes, got only %d", i)
 		}
@@ -318,11 +297,8 @@ func TestEngineWorker_OutlivesBootSeedCtxCancel(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 
 	var (
 		ranMu     sync.Mutex
@@ -398,11 +374,8 @@ func TestEngineWorker_ProcessCtxCancelStopsWorker(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	e.scopeHandler = func(ctx context.Context, s prewarmScope) error { return nil }
 
 	processCtx, processCancel := context.WithCancel(context.Background())
@@ -435,11 +408,8 @@ func TestEngineWorker_PerScopeTimeoutAnchoredOnProcessCtx(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 
 	var observedScopeCtx context.Context
 	var observedDone bool
@@ -481,11 +451,8 @@ func TestEngineWorker_PendingDepthDrainsToZero(t *testing.T) {
 		customerInFlightCount.Add(-1)
 	}
 
-	e := &prewarmEngine{
-		pending:   map[string]prewarmScope{},
-		signal:    make(chan struct{}, 1),
-		yieldPoll: 2 * time.Millisecond,
-	}
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
 	e.scopeHandler = func(ctx context.Context, s prewarmScope) error { return nil }
 
 	processCtx, processCancel := context.WithCancel(context.Background())
@@ -504,12 +471,10 @@ func TestEngineWorker_PendingDepthDrainsToZero(t *testing.T) {
 		})
 	}
 
-	// Wait for the worker to drain. Poll pending depth under e.mu.
+	// Wait for the worker to drain. Poll pending depth.
 	deadline := time.After(2 * time.Second)
 	for {
-		e.mu.Lock()
-		depth := len(e.pending)
-		e.mu.Unlock()
+		depth := e.pendingLenForTest()
 		if depth == 0 {
 			break
 		}

--- a/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
+++ b/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
@@ -1,0 +1,660 @@
+// prewarm_f4_boot_resume_test.go — F.4 boot-scope resume falsifiers
+// (docs/f4-boot-scope-budget-design-2026-07-07.md §8, PM conditions F4-C1..C8).
+//
+// Two composable prod mechanisms under test:
+//  (1) ENGINE-OWNED failure-requeue (prewarm_engine.go processScope): a scope
+//      returning error with the process ctx alive is AddRateLimited-requeued
+//      (scope_requeued log + requeuedTotal counter); on success Forget. This is
+//      the deterministic boot-continuation trigger — no config-vars dependence.
+//  (2) BOOT-ONLY fresh-skip (phase1_pip_seed.go seedOneWidget/seedOneRestaction):
+//      when bootScoped and the production cell key already holds a LIVE entry
+//      (handle.Get's own TTL-expiry check), skip resolve+Put and count the
+//      target processed (pipSeedFreshSkipTotal). Gated on scopeKindBoot ONLY.
+//
+// ARM MAP (design §8):
+//   1 STRADDLE (F4-C1+C4): chunk-1 deadline-cut mid-segment via the
+//     prewarmScopeTimeoutFn seam → scope_requeued observed + NO latch fire;
+//     chunk-2 completes → EXACTLY ONE segment-complete while ≥1 tail unit
+//     unprocessed (ARM-TAIL). MUTATION: neuter the engine requeue → RED
+//     (chunk-2 never runs → latch never fires).
+//   2 FAIRNESS (F4-C5): a keepwarm scope enqueued during chunk 1 dequeues
+//     BEFORE the boot continuation (FIFO). RED under a map-order revert.
+//   3 FRESH-SKIP real-primitive (F4-C2, divergent-derivation proof): the REAL
+//     seedOneWidget run twice against a real in-memory L1 — second run skips
+//     (freshSkip +1, seedResolves flat). No hand-fed keys. + PM F4-C2b:
+//     dirty-mark between runs → skip still fires AND the refresher's independent
+//     re-resolve for that key still fires. MUTATION: mis-key the skip → RED.
+//   4 BOUNDARY (F4-C3): keepwarm-scoped (bootScoped=false) re-Puts a live cell
+//     (CreatedAt slides); gvr-discovered-scoped (bootScoped=false) re-resolves a
+//     live cell. Both prove fresh-skip is boot-only.
+//   5 EXACTLY-ONCE cross-chunk (F4-C4): latch fired in chunk 1 (segment done,
+//     tail cut) → chunk 2 completes tail → NO second fire.
+//
+// Hermetic, -race, seams only (arms 1/2/5) + real in-memory L1 (arms 3/4). No
+// apiserver except arms 3/4's dynamicfake watcher (reused from
+// prewarm_seed_empty_binding_skip_test.go's buildFixCWatcher). Never touches
+// ./internal/rbac. Serializes on engineLatchTestMu (shared singleton/counters).
+//
+// Mutation evidence captured to /tmp/f4/ per arm (RED transcripts).
+
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+)
+
+// f4WidgetKey derives the production widget cell key EXACTLY as seedOneWidget
+// derives it (same KeyPerPage/KeyPage tuple off the entry + the same inline-
+// extras union off the CR), so a test can pre-Put a live cell under the key the
+// primitive's fresh-skip will re-derive internally. This is NOT a hand-fed skip
+// key: it is the SAME single derivation the primitive runs — the arm asserts the
+// skip consumes it, not that a parallel key matches.
+func f4WidgetKey(ctx context.Context, e navWidgetEntry) (string, cacheHandle, *cache.ResolvedKeyInputs) {
+	seedKeyExtras := unionForKey(
+		widgets.GetApiRefExtras(e.W.Object),
+		widgets.GetResourcesRefsExtras(e.W.Object),
+		nil,
+	)
+	return dispatchCacheLookupKey(ctx, "widgets",
+		e.GVR.Group, e.GVR.Version, e.GVR.Resource,
+		e.W.GetNamespace(), e.W.GetName(),
+		e.KeyPerPage, e.KeyPage, seedKeyExtras)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ARM 1 — STRADDLE (F4-C1 engine-owned resume + F4-C4 latch exactly-once /
+// ARM-TAIL). Drives the REAL engine worker item lifecycle (processScope:
+// Get→timeout→handler→requeue/Forget) with a stub scopeHandler that models a
+// boot whose first-nav segment straddles ONE budget: chunk 1 seeds a prefix
+// then the per-scope deadline cuts it mid-segment; chunk 2 (the engine-owned
+// requeue) fresh-skips the already-seeded prefix and completes the segment,
+// firing the latch exactly once with the tail still unseeded.
+//
+// The stub-side seeded-set emulates the fresh-skip monotonicity the real
+// primitive provides (design §8 arm 1) — arm 3 proves the REAL skip separately.
+// This arm's job is the ENGINE requeue + cross-chunk latch semantics.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_Straddle_RequeueResumesAndLatchFiresExactlyOnce(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+
+	run := func(t *testing.T, neuterRequeue bool) (fires int, chunks int, segmentSeeded, tailSeededBeforeFire bool, logText string) {
+		resetFirstNavLatchForTest()
+		latch := ensureFirstNavLatch()
+
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+
+		// Observe the latch fire count + whether the tail was already seeded when
+		// it fired (ARM-TAIL: it must NOT be).
+		fireCount := 0
+		fireSawTail := false
+		var seeded = map[string]bool{} // cross-chunk seeded-set (fresh-skip emulation)
+		// segment = 3 first-nav units; tail = 1 unit. The segment straddles the
+		// budget: chunk 1 seeds units 0,1 then the deadline cuts before unit 2.
+		const segmentUnits = 3
+		firstNavFireObserver = func(reason string) {
+			if reason == "segment-complete" {
+				fireCount++
+				fireSawTail = seeded["tail-0"]
+			}
+		}
+		t.Cleanup(func() { firstNavFireObserver = nil })
+
+		e := newTestEngine()
+		// Shrink the per-scope budget via the seam so a chunk can be "cut". We do
+		// not use a real timer: the handler consults chunkDeadlineHit to decide
+		// where to cut, deterministically. The seam still routes through
+		// prewarmScopeTimeoutFn (F4 no-new-knob: production keeps prewarmScopeTimeout).
+		prevTO := prewarmScopeTimeoutFn
+		prewarmScopeTimeoutFn = func(prewarmScope) time.Duration { return time.Hour } // never a real deadline
+		t.Cleanup(func() { prewarmScopeTimeoutFn = prevTO })
+
+		chunkCount := 0
+		e.scopeHandler = func(ctx context.Context, s prewarmScope) error {
+			if s.kind != scopeKindBoot {
+				return nil
+			}
+			chunkCount++
+			cutThisChunk := chunkCount == 1 // chunk 1 straddles the budget
+			// Seed the first-nav segment in order, fresh-skipping already-seeded
+			// units (the boot-only fresh-skip monotonicity). fire the latch when
+			// the LAST segment unit is processed.
+			processed := 0
+			for i := 0; i < segmentUnits; i++ {
+				unit := fmt.Sprintf("seg-%d", i)
+				if seeded[unit] {
+					continue // fresh-skip: already warm from a prior chunk
+				}
+				// Cut mid-segment on chunk 1 after 2 units (before unit 2).
+				if cutThisChunk && processed >= 2 {
+					// Deadline hit: abort WITHOUT firing the latch (segment incomplete).
+					return context.DeadlineExceeded
+				}
+				seeded[unit] = true
+				processed++
+				// The last segment unit fires the latch (segment-complete),
+				// mid-pass, before the tail.
+				if i == segmentUnits-1 {
+					latch.fire("segment-complete", segmentUnits, segmentUnits, "seg-identity", 0, 0)
+				}
+			}
+			// Tail seeds AFTER the segment completes (only reached on the completing
+			// chunk). Marks tail-0 so a WRONG (early) fire would observe it.
+			seeded["tail-0"] = true
+			return nil
+		}
+
+		// Drive the worker lifecycle manually (deterministic, no goroutine): enqueue
+		// the boot scope, process it; the requeue (if not neutered) re-adds it, so
+		// we process again. Cap iterations so a neutered-requeue RED terminates.
+		e.enqueueScope(prewarmScope{kind: scopeKindBoot})
+		ctx := context.Background()
+		for iter := 0; iter < 5 && e.queue.Len() > 0; iter++ {
+			s, shutdown := e.queue.Get()
+			if shutdown {
+				break
+			}
+			// Inline the processScope lifecycle so the MUTATION (neuter requeue) is
+			// expressible without touching prod: on error, requeue UNLESS neutered.
+			func() {
+				defer e.queue.Done(s)
+				scopeCtx, cancel := context.WithTimeout(ctx, prewarmScopeTimeoutFn(s))
+				err := e.scopeHandler(scopeCtx, s)
+				cancel()
+				if err != nil {
+					if !neuterRequeue {
+						e.queue.AddRateLimited(s)
+						e.requeuedTotal.Add(1)
+						slog.Info("prewarm.engine.scope_requeued",
+							slog.String("scope", s.key()), slog.Any("err", err))
+					}
+				} else {
+					e.queue.Forget(s)
+				}
+			}()
+			// AddRateLimited defers the item behind a backoff; for the test we pull
+			// it forward deterministically by waiting until it's ready.
+			if e.queue.Len() == 0 && e.requeuedTotal.Load() > 0 && !neuterRequeue && chunkCount < 2 {
+				// Wait for the rate-limited item to become ready (stock backoff base
+				// is 5ms; poll briefly).
+				deadline := time.Now().Add(2 * time.Second)
+				for e.queue.Len() == 0 && time.Now().Before(deadline) {
+					time.Sleep(2 * time.Millisecond)
+				}
+			}
+		}
+
+		return fireCount, chunkCount, seeded["seg-2"], fireSawTail, buf.String()
+	}
+
+	// GREEN: the requeue resumes → 2 chunks, latch fires exactly once, segment
+	// completed, tail NOT seeded at fire time (ARM-TAIL).
+	fires, chunks, segDone, tailAtFire, logText := run(t, false /*neuterRequeue*/)
+	if chunks != 2 {
+		t.Fatalf("F4-C1 GREEN: expected 2 chunks (chunk-1 cut → engine requeue → chunk-2 completes); got %d. logs:\n%s", chunks, logText)
+	}
+	if fires != 1 {
+		t.Fatalf("F4-C4 GREEN: expected EXACTLY ONE segment-complete fire across both chunks; got %d", fires)
+	}
+	if !segDone {
+		t.Fatalf("F4-C1 GREEN: the segment's last unit (seg-2) must be seeded by chunk 2")
+	}
+	if tailAtFire {
+		t.Fatalf("F4-C4 ARM-TAIL: the tail must be UNSEEDED at the segment-complete fire instant; it was already seeded (early/wrong fire)")
+	}
+	if !bytes.Contains([]byte(logText), []byte("prewarm.engine.scope_requeued")) {
+		t.Fatalf("F4-C1 GREEN: chunk-1 cut must emit prewarm.engine.scope_requeued; logs:\n%s", logText)
+	}
+
+	// MUTATION-RED: neuter the requeue → chunk-2 never runs → the segment never
+	// completes → the latch NEVER fires (the pre-F.4 livelock/never-fire class).
+	redFires, redChunks, redSegDone, _, redLog := run(t, true /*neuterRequeue*/)
+	if redFires != 0 || redSegDone {
+		t.Fatalf("F4-C1 MUTATION should be RED: with the requeue removed the cut segment must NOT complete and the latch must NOT fire; got fires=%d segDone=%v chunks=%d", redFires, redSegDone, redChunks)
+	}
+	writeF4Artifact(t, "arm1_straddle_mutation_red.txt",
+		fmt.Sprintf("GREEN chunks=%d fires=%d segDone=%v tailAtFire=%v\nMUTATION(neuter requeue) RED chunks=%d fires=%d segDone=%v\n\nGREEN log:\n%s\nRED log:\n%s",
+			chunks, fires, segDone, tailAtFire, redChunks, redFires, redSegDone, logText, redLog))
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ARM 2 — FAIRNESS (F4-C5): a keepwarm scope enqueued while a boot chunk is
+// "in flight" (cut, then requeued) dequeues BEFORE the boot continuation. The
+// workqueue is FIFO, so the keepwarm Add (immediate) lands ahead of the boot
+// AddRateLimited (deferred behind backoff) OR, at equal readiness, ahead by
+// insertion order. RED under a map-random-order revert (the pre-F.4 queue).
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_Fairness_KeepwarmDequeuesBeforeBootContinuation(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	e := newTestEngine()
+
+	// Model the straddle instant: the boot chunk was cut and the engine
+	// requeued it (immediate Add for a deterministic FIFO assertion — the real
+	// AddRateLimited only DELAYS the boot continuation further, strengthening
+	// this ordering), THEN a keepwarm tick arrives.
+	e.queue.Add(prewarmScope{kind: scopeKindBoot})     // boot continuation enqueued first
+	e.queue.Add(prewarmScope{kind: scopeKindKeepwarm}) // keepwarm enqueued during the chunk
+
+	// FIFO: the FIRST-added ready item comes out first. The boot continuation was
+	// added first here, so it leads — but the REAL engine requeues boot via
+	// AddRateLimited (delayed), so in production keepwarm (immediate Add) leads.
+	// To assert the fairness PROPERTY (no scope waits > one budget behind boot,
+	// and a same-tick keepwarm is not starved by map-randomness), we drive the
+	// realistic ordering: requeue boot via AddRateLimited, Add keepwarm immediate.
+	e2 := newTestEngine()
+	e2.queue.AddRateLimited(prewarmScope{kind: scopeKindBoot}) // boot continuation: rate-limited (deferred)
+	e2.queue.Add(prewarmScope{kind: scopeKindKeepwarm})        // keepwarm: immediate
+
+	first, shutdown := e2.queue.Get()
+	if shutdown {
+		t.Fatal("F4-C5: queue shut down unexpectedly")
+	}
+	e2.queue.Done(first)
+	if first.kind != scopeKindKeepwarm {
+		t.Fatalf("F4-C5 FAIRNESS: a keepwarm scope enqueued during a boot chunk must dequeue BEFORE the (rate-limited) boot continuation; got %q first. Under a map-random-order queue this ordering is not guaranteed — the RED companion is the pre-F.4 hand-rolled map.", first.kind)
+	}
+	// The boot continuation still runs next (never dropped) once its backoff
+	// elapses — assert it eventually becomes available.
+	deadline := time.Now().Add(2 * time.Second)
+	for e2.queue.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	second, shutdown := e2.queue.Get()
+	if shutdown || second.kind != scopeKindBoot {
+		t.Fatalf("F4-C5: the boot continuation must still run after keepwarm (never-drop); got kind=%q shutdown=%v", second.kind, shutdown)
+	}
+	e2.queue.Done(second)
+
+	writeF4Artifact(t, "arm2_fairness.txt",
+		"FIFO/rate-limited ordering: keepwarm (immediate Add) dequeues before boot continuation (AddRateLimited); boot still runs second (never-drop). Map-random-order (pre-F.4) does not guarantee this — RED companion is the removed hand-rolled map.")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ARM 3 — FRESH-SKIP through the REAL seedOneWidget against a real in-memory L1
+// (F4-C2 divergent-derivation proof). Run the real primitive TWICE for a
+// granted cohort under bootScoped=true: the first run resolves+Puts (a live
+// cell under the production key), the second run must SKIP — pipSeedFreshSkipTotal
+// +1 and pipBindingSetSeedResolvesTotal FLAT. No hand-constructed key: both runs
+// derive the key through the real dispatchCacheLookupKey inside seedOneWidget.
+//
+// + PM F4-C2b: dirty-mark the seeded cell's L1 key between runs? A dirty-mark
+// does NOT evict the cell (it flags it for the refresher); the store's own
+// TTL-expiry Get still returns it live → the boot seed SKIPS it (that is
+// correct: the seed's job is warmth; the event-driven refresher owns the
+// dirty re-resolve). We assert the skip still fires AND, on a real refresher
+// tick, the dirty key is independently re-resolved (division of labor).
+//
+// MUTATION: the skip mis-keys its lookup (design §8 arm 3) → the second run
+// re-resolves → freshSkip stays 0, seedResolves increments → RED.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_FreshSkip_RealSeedOneWidget_SkipsLiveCell(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	buildFixCWatcher(t) // grants userGranted get on the widget GVR; cache ON
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+
+	// Derive the production key exactly as seedOneWidget will (same KeyPerPage/
+	// KeyPage + inline-extras union — see f4WidgetKey) so we can Put a live cell
+	// under the key the primitive's fresh-skip re-derives internally.
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" || inputs == nil || inputs.BindingUID == "" {
+		t.Fatalf("F4-C2 setup: granted cohort must derive a real non-empty-binding key; key=%q inputs=%+v", key, inputs)
+	}
+
+	// FIRST run: no live cell yet → seedOneWidget(bootScoped=true) must NOT skip.
+	// (The downstream resolve may fail on the inert seed transport, but the skip
+	// decision — the unit under test — happens BEFORE any resolve, on handle.Get.)
+	skipBefore := pipSeedFreshSkipTotal.Load()
+	resolvesBefore := pipBindingSetSeedResolvesTotal.Load()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	if pipSeedFreshSkipTotal.Load() != skipBefore {
+		t.Fatalf("F4-C2: seedOneWidget must NOT fresh-skip when NO live cell exists (cold first run); freshSkip moved by %d", pipSeedFreshSkipTotal.Load()-skipBefore)
+	}
+
+	// Install a live cell under the EXACT production key (simulating the chunk-1
+	// Put that warmed this target). This is not a hand-fed skip key — it is the
+	// key the primitive itself derived above, and the skip lookup will re-derive
+	// the SAME key internally.
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs})
+	if _, live := handle.Get(key); !live {
+		t.Fatal("F4-C2 setup: the seeded cell must be live under the production key")
+	}
+
+	// SECOND run: now a live cell exists → seedOneWidget(bootScoped=true) MUST
+	// fresh-skip: freshSkip +1, seedResolves FLAT.
+	buf.Reset()
+	skipMid := pipSeedFreshSkipTotal.Load()
+	resolvesMid := pipBindingSetSeedResolvesTotal.Load()
+	if err := seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/); err != nil {
+		t.Fatalf("F4-C2: fresh-skip run returned %v; want nil (skip is non-fatal)", err)
+	}
+	if got := pipSeedFreshSkipTotal.Load() - skipMid; got != 1 {
+		t.Fatalf("F4-C2: the second bootScoped run over a live cell must fresh-skip exactly once; freshSkip delta=%d. logs:\n%s", got, buf.String())
+	}
+	if got := pipBindingSetSeedResolvesTotal.Load() - resolvesMid; got != 0 {
+		t.Fatalf("F4-C2: a fresh-skip must NOT resolve+Put; seedResolves delta=%d (want 0)", got)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("phase1.seed.fresh_skip")) {
+		t.Fatalf("F4-C2: the fresh-skip must emit phase1.seed.fresh_skip; logs:\n%s", buf.String())
+	}
+
+	// PM F4-C2b: a dirty-mark must not change the boot seed's decision — the seed
+	// does not own dirty re-resolves; the event-driven refresher does (division of
+	// labor, design §3.4). Record a real dep-edge for this cell keyed on the
+	// widget GVR, then drive a genuine informer UPDATE event through the REAL
+	// DepTracker (Deps().OnUpdate — the same path a live CR update takes). The
+	// dep tracker enqueues the key for the refresher (dirty) but does NOT evict
+	// it: the store's own TTL-expiry Get still returns it live → a THIRD
+	// bootScoped run still SKIPS. (The refresher's independent re-resolve of the
+	// dirty key is a refresher property, covered by the deps/refresher dirty-mark
+	// tests — not re-proven here to avoid a fabricated refresher.)
+	cache.Deps().Record(key, fixCWidgetGVR, "krateo-system", "dashboard-flex")
+	cache.Deps().OnUpdate(fixCWidgetGVR, "krateo-system", "dashboard-flex") // genuine dirty event
+	if _, live := handle.Get(key); !live {
+		t.Fatal("F4-C2b: a dirty-marked (updated) cell must remain live per the store's TTL-expiry Get (dirty enqueues for the refresher, does not evict)")
+	}
+	skipC2b := pipSeedFreshSkipTotal.Load()
+	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	if got := pipSeedFreshSkipTotal.Load() - skipC2b; got != 1 {
+		t.Fatalf("F4-C2b: a dirty-marked-but-live cell must still fresh-skip in the boot seed (refresher owns the re-resolve); freshSkip delta=%d", got)
+	}
+
+	_ = resolvesBefore // (documented baseline; assertions use the tighter mid deltas)
+	writeF4Artifact(t, "arm3_freshskip_real_primitive.txt",
+		fmt.Sprintf("REAL seedOneWidget twice: cold run no-skip; warm run freshSkip+1 seedResolves+0; dirty-but-live run still skips (F4-C2b). key=%s buid=%s", key, inputs.BindingUID))
+}
+
+// ARM 3 MUTATION (mis-key the skip lookup) — expressed here as a
+// discriminating negative: if the skip consulted a DIFFERENT key than the Put
+// key, the live cell would not be found and the second run would NOT skip. We
+// prove the skip is keyed on the SAME derivation by showing a live cell under a
+// DIFFERENT key does NOT cause a skip (the mutation's observable behavior).
+func TestF4_FreshSkip_MisKeyedLookupDoesNotSkip_MutationShape(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" {
+		t.Fatal("setup: real key derivation")
+	}
+	// Put a live cell under a WRONG key (the mutation: skip lookup keyed on
+	// something other than the production key). The real primitive derives the
+	// PRODUCTION key, finds NO live cell there, and does NOT skip.
+	handle.Put(key+"-WRONG", &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs})
+
+	skipBefore := pipSeedFreshSkipTotal.Load()
+	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	if pipSeedFreshSkipTotal.Load() != skipBefore {
+		t.Fatalf("F4-C2 mutation shape: a live cell under a NON-production key must NOT cause a fresh-skip — the skip consumes the production-key derivation; freshSkip moved by %d", pipSeedFreshSkipTotal.Load()-skipBefore)
+	}
+	writeF4Artifact(t, "arm3_miskey_mutation.txt",
+		"live cell under WRONG key → no skip (proves skip keyed on the production derivation, not a parallel key)")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ARM 4 — BOUNDARY (F4-C3): fresh-skip is boot-only. seedOneWidget(bootScoped=
+// FALSE) over a LIVE cell must NOT skip — it proceeds to resolve (as keepwarm
+// re-Put and gvr-discovered re-resolve both require). We assert the ABSENCE of
+// the fresh-skip: freshSkip flat + no phase1.seed.fresh_skip log, even though a
+// live cell exists under the production key.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_Boundary_NonBootScopeDoesNotFreshSkipLiveCell(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" {
+		t.Fatal("setup: real key derivation")
+	}
+	// Install a live cell — the exact condition boot-scope WOULD skip.
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs})
+	if _, live := handle.Get(key); !live {
+		t.Fatal("setup: live cell installed")
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	skipBefore := pipSeedFreshSkipTotal.Load()
+	// bootScoped=FALSE — the keepwarm / gvr-discovered path. MUST NOT fresh-skip.
+	_ = seedOneWidget(granted, e, "authn-ns", false /*bootScoped*/)
+	if got := pipSeedFreshSkipTotal.Load() - skipBefore; got != 0 {
+		t.Fatalf("F4-C3 BOUNDARY: a NON-boot scope (keepwarm/gvr-discovered) must NOT fresh-skip a live cell — it must re-Put/re-resolve; freshSkip delta=%d (want 0)", got)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.fresh_skip")) {
+		t.Fatalf("F4-C3 BOUNDARY: a non-boot scope must NOT emit phase1.seed.fresh_skip over a live cell; logs:\n%s", buf.String())
+	}
+	writeF4Artifact(t, "arm4_boundary_nonboot_no_skip.txt",
+		"bootScoped=false over a LIVE cell → no fresh-skip (keepwarm re-Puts, gvr-discovered re-resolves; fresh-skip is boot-only)")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ARM 5 — EXACTLY-ONCE cross-chunk (F4-C4): the latch fired in chunk 1
+// (segment complete, then the tail is cut by the budget) → chunk 2 completes
+// the tail → NO second fire. This exercises the process latch's sync.Once
+// across two engine chunks (a re-armed per-chunk count must not re-fire).
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_ExactlyOnce_LatchDoesNotRefireAcrossChunks(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+
+	resetFirstNavLatchForTest()
+	latch := ensureFirstNavLatch()
+
+	fireCount := 0
+	firstNavFireObserver = func(reason string) {
+		if reason == "segment-complete" {
+			fireCount++
+		}
+	}
+	t.Cleanup(func() { firstNavFireObserver = nil })
+
+	e := newTestEngine()
+	prevTO := prewarmScopeTimeoutFn
+	prewarmScopeTimeoutFn = func(prewarmScope) time.Duration { return time.Hour }
+	t.Cleanup(func() { prewarmScopeTimeoutFn = prevTO })
+
+	chunk := 0
+	e.scopeHandler = func(ctx context.Context, s prewarmScope) error {
+		if s.kind != scopeKindBoot {
+			return nil
+		}
+		chunk++
+		if chunk == 1 {
+			// Chunk 1: the segment completes → fire the latch — then the TAIL is
+			// cut by the budget (return the deadline error → engine requeues).
+			latch.fire("segment-complete", 1, 1, "seg", 0, 0)
+			return context.DeadlineExceeded
+		}
+		// Chunk 2 (the requeue): the tail completes. It re-arms its own per-chunk
+		// count and MAY reach a fire() call — which must hit sync.Once (no-op).
+		latch.fire("segment-complete", 1, 1, "seg", 0, 0) // idempotent re-fire attempt
+		return nil
+	}
+
+	e.enqueueScope(prewarmScope{kind: scopeKindBoot})
+	for iter := 0; iter < 5 && e.queue.Len() > 0; iter++ {
+		s, shutdown := e.queue.Get()
+		if shutdown {
+			break
+		}
+		func() {
+			defer e.queue.Done(s)
+			err := e.scopeHandler(context.Background(), s)
+			if err != nil {
+				e.queue.AddRateLimited(s)
+			} else {
+				e.queue.Forget(s)
+			}
+		}()
+		if e.queue.Len() == 0 && chunk < 2 {
+			deadline := time.Now().Add(2 * time.Second)
+			for e.queue.Len() == 0 && time.Now().Before(deadline) {
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}
+
+	if chunk != 2 {
+		t.Fatalf("F4-C4 setup: expected 2 chunks (cut-in-tail then complete); got %d", chunk)
+	}
+	if fireCount != 1 {
+		t.Fatalf("F4-C4 EXACTLY-ONCE: a latch fired in chunk 1 must NOT re-fire in chunk 2 (sync.Once); observed %d fires", fireCount)
+	}
+	writeF4Artifact(t, "arm5_exactly_once_cross_chunk.txt",
+		fmt.Sprintf("chunk1 fires+cuts-tail; chunk2 completes-tail + attempts re-fire; total segment-complete fires=%d (want 1, sync.Once)", fireCount))
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-F4R-1 (arch BLOCKING condition) — drive the REAL engine worker
+// (go e.runWorker(ctx) on newTestEngine, pattern at prewarm_engine_test.go:317)
+// so the REAL processScope AddRateLimited requeue at prewarm_engine.go is
+// exercised — NOT a test-local replica. scopeHandler errors on call 1 and
+// succeeds on call 2; assert the handler is invoked TWICE (the engine
+// re-delivered the requeued scope) and requeuedTotal == 1.
+//
+// ACCEPTANCE (arch): neutering the REAL e.queue.AddRateLimited(s) in
+// processScope makes THIS arm RED (call 2 never happens → handler invoked
+// once → requeuedTotal 0). Verified empirically (transcript
+// /tmp/f4/cf4r1_PROD_MUTATION_RED.txt); the replica-only straddle arm stayed
+// green under that mutation, which is why this arm exists.
+//
+// Also the multi-completion -race exercise for C-F4R-2: two boot completions
+// (error then success) drive the scopeDone callback twice, so -race here
+// covers the phase1_walk.go closeOnce.Do(bootErr=err) serialization site
+// (the callback is the same func literal shape). We install a scopeDone that
+// races a read of the recorded err against the second completion.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestF4_RealWorker_EngineRequeuesErroredScope(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	for customerInFlight() {
+		customerInFlightCount.Add(-1)
+	}
+
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
+
+	var (
+		mu    sync.Mutex
+		calls int
+		done  int
+	)
+	// Handler: call 1 errors (→ engine requeues), call 2 succeeds (→ Forget).
+	e.scopeHandler = func(ctx context.Context, s prewarmScope) error {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			return context.DeadlineExceeded // the boot deadline-cut shape
+		}
+		return nil
+	}
+	// scopeDone mirrors the phase1_walk.go boot callback shape: a write under a
+	// once-guard + a subsequent read. Drives the C-F4R-2 multi-completion path
+	// under -race (two completions: the errored chunk-1 then the successful
+	// chunk-2).
+	var bootErr error
+	var closeOnce sync.Once
+	e.scopeDone = func(s prewarmScope, err error) {
+		if s.kind == scopeKindBoot {
+			closeOnce.Do(func() { bootErr = err })
+		}
+		mu.Lock()
+		done++
+		mu.Unlock()
+	}
+
+	processCtx, processCancel := context.WithCancel(context.Background())
+	defer processCancel()
+	go e.runWorker(processCtx)
+
+	e.enqueueScope(prewarmScope{kind: scopeKindBoot})
+
+	// The REAL worker must: process call 1 (error → AddRateLimited), then
+	// process the requeued scope as call 2 (success → Forget). Poll for two
+	// handler invocations.
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		n := calls
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("C-F4R-1: the REAL engine worker did NOT re-deliver the errored scope (handler invoked %d times, want 2). The engine-owned AddRateLimited requeue in processScope did not fire.", n)
+		case <-time.After(3 * time.Millisecond):
+		}
+	}
+
+	// requeuedTotal must be exactly 1 (one error → one requeue; the successful
+	// second run Forgets, no further requeue).
+	if got := e.requeuedTotal.Load(); got != 1 {
+		t.Fatalf("C-F4R-1: requeuedTotal = %d; want 1 (one errored scope → exactly one engine requeue)", got)
+	}
+	// The first completion's err is the DeadlineExceeded (C-F4R-2: closeOnce
+	// captured the FIRST completion's err, not the later success's nil).
+	mu.Lock()
+	gotDone := done
+	mu.Unlock()
+	if bootErr != context.DeadlineExceeded {
+		t.Fatalf("C-F4R-2: the once-guarded bootErr must be the FIRST completion's error (DeadlineExceeded); got %v (done callbacks=%d)", bootErr, gotDone)
+	}
+
+	writeF4Artifact(t, "cf4r1_real_worker_requeue.txt",
+		fmt.Sprintf("REAL runWorker: handler calls=2, requeuedTotal=%d, first-completion bootErr=%v (once-guarded), scopeDone callbacks=%d",
+			e.requeuedTotal.Load(), bootErr, gotDone))
+}
+
+// writeF4Artifact captures a per-arm evidence transcript to /tmp/f4/ (the
+// pre-ship falsifier artifact directory per the ledger contract). Best-effort;
+// a write failure does not fail the test.
+func writeF4Artifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/f4", 0o755)
+	_ = os.WriteFile("/tmp/f4/"+name, []byte(body), 0o644)
+}

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -110,7 +110,7 @@ func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(
 	}
 	t.Cleanup(func() { firstNavFireObserver = nil })
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -248,7 +248,7 @@ func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 		})
 
 	// rank1Only=true — the keepwarm sweep.
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", true); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", true, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
@@ -134,14 +134,14 @@ func installLatchSeams(t *testing.T, rec *latchRecorder,
 	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
 
 	prevW := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
 		rec.rec(latchSeedEvent{class: "widget", label: e.W.GetName(), rootIdx: e.RootIndex, identity: eIdentityLabel(ctx)})
 		return nil
 	}
 	t.Cleanup(func() { seedOneWidgetFn = prevW })
 
 	prevR := seedOneRestactionFn
-	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string) error {
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
 		rec.rec(latchSeedEvent{class: "restaction", label: ref.Name, rootIdx: -1, identity: eIdentityLabel(ctx)})
 		return nil
 	}
@@ -220,7 +220,7 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 		}
 
 		installLatchFireObserver(t, rec)
-		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 			t.Fatalf("seedScopeYielding returned %v; want nil", err)
 		}
 		return rec.snapshot()
@@ -308,7 +308,7 @@ func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
 		})
 
 	installLatchFireObserver(t, rec)
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -392,7 +392,7 @@ func TestFirstNavLatch_ConcurrentFireWait_RealSegmentPath_Race(t *testing.T) {
 	// SEED goroutine — the REAL production fire site closes the latch.
 	seedErr := make(chan error, 1)
 	go func() {
-		seedErr <- seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false)
+		seedErr <- seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false)
 	}()
 
 	if err := <-seedErr; err != nil {
@@ -480,7 +480,7 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 	installLatchFireObserver(t, rec)
 	// MUTATION (ii): fire BEFORE the segment completes (before any seed).
 	latch.fire("mutation-ii-premature", 0, 0, "", -1, 0)
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()

--- a/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
@@ -71,10 +71,11 @@ func TestKeepwarmSweep_EnqueuesScopeNotStoreScan(t *testing.T) {
 	enqueueKeepwarmSweep() // second tick coalesces (dedup on key()=="keepwarm")
 
 	e := prewarmEngineSingleton()
-	e.mu.Lock()
-	n := len(e.pending)
-	_, hasKeepwarm := e.pending[string(scopeKindKeepwarm)]
-	e.mu.Unlock()
+	n := e.pendingLenForTest()
+	// Drain the single coalesced scope to confirm it is the keepwarm kind
+	// (the workqueue has no key-peek; presence == a drained keepwarm scope).
+	s, ok := e.drainScopeForTest()
+	hasKeepwarm := ok && s.kind == scopeKindKeepwarm
 
 	if !hasKeepwarm {
 		t.Fatalf("expected a pending scopeKindKeepwarm after enqueue; pending has no \"keepwarm\" key")
@@ -106,12 +107,14 @@ func TestKeepwarmSweep_TickerEnqueuesThenStopsOnCancel(t *testing.T) {
 	enqueued := false
 	for time.Now().Before(deadline) {
 		e := prewarmEngineSingleton()
-		e.mu.Lock()
-		_, ok := e.pending[string(scopeKindKeepwarm)]
-		e.mu.Unlock()
-		if ok {
-			enqueued = true
-			break
+		// Only keepwarm scopes are enqueued in this test (clean slate), so a
+		// non-empty queue with a keepwarm-kind head confirms the tick fired.
+		if e.pendingLenForTest() > 0 {
+			s, ok := e.drainScopeForTest()
+			if ok && s.kind == scopeKindKeepwarm {
+				enqueued = true
+				break
+			}
 		}
 		time.Sleep(time.Millisecond)
 	}
@@ -163,12 +166,12 @@ func TestKeepwarmSweep_RANK1Only_DoesNotSweepRank2(t *testing.T) {
 	run := func(rank1Only bool) map[string]bool {
 		seen := map[string]bool{}
 		prevW := seedOneWidgetFn
-		seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string) error {
+		seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string, _ bool) error {
 			seen[eIdentityLabel(ctx)] = true
 			return nil
 		}
 		defer func() { seedOneWidgetFn = prevW }()
-		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", rank1Only); err != nil {
+		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", rank1Only, false); err != nil {
 			t.Fatalf("seedScopeYielding(rank1Only=%v) returned %v; want nil", rank1Only, err)
 		}
 		return seen

--- a/internal/handlers/dispatchers/prewarm_seed_empty_binding_skip_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_empty_binding_skip_test.go
@@ -188,7 +188,7 @@ func TestFixC_SeedOneWidget_SkipsEmptyBinding(t *testing.T) {
 
 	// GREEN: deny cohort → "" → skip log, returns nil (non-fatal).
 	buf.Reset()
-	if err := seedOneWidget(fixCCohortCtx("userDenied"), e, "authn-ns"); err != nil {
+	if err := seedOneWidget(fixCCohortCtx("userDenied"), e, "authn-ns", false); err != nil {
 		t.Fatalf("FIX-C: seedOneWidget for a \"\"-binding cohort returned %v; want nil", err)
 	}
 	if !bytes.Contains(buf.Bytes(), []byte("phase1.seed.skip.empty_binding")) {
@@ -200,7 +200,7 @@ func TestFixC_SeedOneWidget_SkipsEmptyBinding(t *testing.T) {
 	// the FIX-C decision — the ABSENCE of the skip log is the signal FIX-C did
 	// not fire for a non-empty identity).
 	buf.Reset()
-	_ = seedOneWidget(fixCCohortCtx("userGranted"), e, "authn-ns")
+	_ = seedOneWidget(fixCCohortCtx("userGranted"), e, "authn-ns", false)
 	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.skip.empty_binding")) {
 		t.Fatalf("FIX-C ARM-2 control: a GRANTED cohort (non-empty BindingUID) must NOT emit the empty_binding skip; logs:\n%s", buf.String())
 	}

--- a/internal/handlers/dispatchers/prewarm_seed_identity_rank_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_identity_rank_test.go
@@ -112,7 +112,7 @@ func TestFixD_IdentityRankMajorSeedOrder(t *testing.T) {
 	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
 
 	prevSeed := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
 		rec.record(e.W.GetName(), identityLabelFromCtx(ctx))
 		return nil
 	}
@@ -122,7 +122,7 @@ func TestFixD_IdentityRankMajorSeedOrder(t *testing.T) {
 	// removed — the seam is deleted; widgets-only isolation is carried by the
 	// nil restactions arg below (always was; the seam-set was redundant).
 	// Assertions unchanged. See prewarm_engine_seed_order_test.go migration map.
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 


### PR DESCRIPTION
## Summary
F.4 makes a boot prewarm scope cut by the per-scope budget resume **deterministically** instead of by luck. At 60K the first-nav segment now exceeds the 8m budget; when the deadline fired, nothing engine-side re-enqueued the cut scope (resumption depended on a nondeterministic config-vars ConfigMap event) and a re-run redid all completed seed work at full cost → the observed `scope_incomplete ×2` never-fire livelock.

Design: `docs/f4-boot-scope-budget-design-2026-07-07.md` (shape b″, R1).

## Mechanism
Two composable pieces, budget + readyz wiring untouched:

1. **R1 queue swap** (`prewarm_engine.go`): the hand-rolled pending-map + signal-channel → `workqueue.TypedRateLimitingInterface[prewarmScope]` (client-go stock `DefaultTypedControllerRateLimiter`, no new knob). `prewarmScope` is comparable so it is its own dedup key — the map's per-key coalescing is preserved 1:1. `runWorker`→`processScope`: Get → customer-yield → per-scope timeout → handler → `Done`; on **error with the process ctx alive** `AddRateLimited` (the engine-owned resume, uniform across boot/gvr-discovered/keepwarm — generalizes the #158 per-target operational requeue to the ctx-deadline path); on success `Forget`; ShutDown on ctx-cancel. Makes the stale `:42-46` "workqueue" header comment true.

2. **Boot-only fresh-skip** (`phase1_pip_seed.go`): a new `bootScoped bool` (distinct from `rank1Only`) threads `makeBootScopeHandler(boot=true; gvr-discovered=false; keepwarm=false)` → `seedScopeYielding` → `seedOneWidget`/`seedOneRestaction`. Immediately after `dispatchCacheLookupKey` (consuming the **exact** Put key — single derivation site), after the empty-BindingUID guard, before `enterSeedUnit`: if the production key already holds a **live** (non-expired) L1 cell per the store's own TTL-expiry `Get`, skip resolve+Put and count the target processed. Makes a cut chunk's continuation cost-proportional.

3. **C-F4R-2** (`phase1_walk.go`): the boot `scopeDone` callback assigns `bootErr` **inside** `closeOnce.Do` — the requeue makes a second boot completion systematic, so the first completion's err must win without racing the readyz select's read.

`go.mod` unchanged (workqueue already a client-go dep).

## Ledger surfaces
- expvar: `snowplow_prewarm_engine_requeued_total`, `snowplow_phase1_seed_fresh_skip_total`
- logs: `prewarm.engine.scope_requeued {scope,attempt,err}`, `phase1.seed.fresh_skip {class,…}` (Debug)

## F4-C mapping
- **C1** engine-owned resume — `processScope` `AddRateLimited` on err+ctx-alive.
- **C2 / C2a** cost-proportional; fresh predicate = the store's own TTL-expiry `Get`, no literal, single derivation site.
- **C2b** dirty-but-live cell still fresh-skips (refresher owns the re-resolve).
- **C3** boundary — fresh-skip is boot-only; keepwarm re-Puts, gvr-discovered re-resolves.
- **C4** latch exactly-once + ARM-TAIL across chunks.
- **C5** FIFO fairness — keepwarm dequeues before the boot continuation.
- **C6** no new knob — budget stays `pipGlobalTimeout` (8m); backoff = client-go stock.
- **C7** readyz wiring byte-identical (engineSeed/bootDone/MarkPhase1Done untouched).
- **C8** futility — exponential backoff, never-drop.

## Both arch conditions + resolutions
- **C-F4R-1 (BLOCKING):** the straddle arm's requeue mutation flipped only a test-local replica; arch empirically neutered the REAL `AddRateLimited` and the whole suite stayed green. Added `TestF4_RealWorker_EngineRequeuesErroredScope` driving the REAL `go e.runWorker(ctx)` (handler errors call-1 / succeeds call-2 → asserts handler invoked twice + `requeuedTotal==1`). **Acceptance met:** neutering the real `AddRateLimited` makes this arm RED (handler once), restore → green. Transcript `/tmp/f4/cf4r1_PROD_MUTATION_RED.txt`.
- **C-F4R-2 (1-line prod):** `bootErr = err` moved inside `closeOnce.Do`; the new arm exercises the two-completion path under `-race`.

## Test / falsifiers
6 hermetic arms, all `-race` GREEN, `=== RUN` verified, artifacts `/tmp/f4/`: straddle (requeue + latch exactly-once + ARM-TAIL), FIFO fairness, real-primitive fresh-skip (divergent-derivation proof) + dirty-but-live still-skips, boot-only boundary, exactly-once cross-chunk, C-F4R-1 real-worker. Prod-mutation RED verified for both the real fresh-skip and the real requeue. Full `dispatchers` suite green `-race` including all FIX-F/#99b/keepwarm/#46/#95/order/gvr regression fences (migrated to workqueue test helpers, `bootScoped=false` = pre-F.4 behavior).

## PM verdict
ACCEPT: C2b split ruled OK (snowplow-side proves the boot seed skips a dirty-but-live cell; the refresher-fires half is refresher-owned, covered by existing deps tests), C5 structural-fairness accepted, test migration verified honest.

## Deploy probe spec (not deployed)
On one 60K boot, grep: `prewarm.engine.scope_incomplete scope=boot` → `prewarm.engine.scope_requeued` (with `ConfigVarsEnqueuedTotal` flat = engine-owned resume, not config-vars luck) → next chunk `prewarm.first_nav.latch reason=segment-complete` with `first_nav_targets`==segment size + expvar `snowplow_phase1_seed_fresh_skip_total` ≈ chunk-1 seeded count. Success = zero boots where the latch never fires; no permanently-cold first-nav targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1