### PR TITLE
feat(prewarm): Fix-3 rank hygiene — deterministic widget-capable-first identity ranking

### DIFF
--- a/docs/fix3-rank-hygiene-design-2026-07-07.md
+++ b/docs/fix3-rank-hygiene-design-2026-07-07.md
@@ -1,0 +1,232 @@
+# Fix-3 rank hygiene — deterministic, widget-capable-first identity ranking (design, 2026-07-07)
+
+Repo: main @ bbaba28 (1.6.2). Origin: docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md §3a/§4
+(Fix 3). Live evidence: fresh2 60K boot600 (/tmp/boot600.log) + boot krkbl (1.6.2). Design only —
+no code in this change.
+
+**Paths (as-built correction, 2026-07-07):** every `prewarm_engine_boot.go` /
+`prewarm_enumeration.go` / `phase1_pip_seed.go` / `prewarm_first_nav_latch_segment_test.go`
+reference below lives under **`internal/handlers/dispatchers/`** (NOT `internal/prewarm/` —
+that package does not exist). The ranking site is
+`internal/handlers/dispatchers/prewarm_engine_boot.go`; the CollapsedBindings enumerator is
+`internal/handlers/dispatchers/../cache/prewarm_enumeration.go`
+(package `cache`, imported as `EnumeratePrewarmTargetsForGVR`).
+
+## 0. Prior-art check
+
+- k8s.io/apimachinery `sets.Set[T].List()` / `sets.List` is the canonical "never emit Go map
+  order" idiom — sorted keys, total order. We already follow it structurally
+  (sort.SliceStable over a full-key comparator, prewarm_engine_boot.go:701-706); the defect is
+  not the SORT, it is the sort KEY: `noteIdentity` records a map-iteration-order-dependent
+  VALUE (first-seen CollapsedBindings, :683-685). No client-go/apimachinery primitive ranks
+  identities; the canonical fix for order-dependent aggregation is a commutative/associative/
+  idempotent fold (max), which needs no library. Nothing to reuse beyond what is already used.
+- client-go workqueue priority/rate-limiting queues solve scheduling fairness, not static
+  precomputed ordering — not applicable.
+
+## 1. Root cause recap (TRACED, from the §3a trace, re-verified at 1.6.2 line numbers)
+
+1. **Nondeterministic rank value.** `noteIdentity` keeps the FIRST-SEEN `CollapsedBindings`
+   (prewarm_engine_boot.go:680-686, `if _, ok := rankOf[k]; !ok`). The same identity carries a
+   DIFFERENT count per GVR bucket by construction (per-bucket counting,
+   prewarm_enumeration.go:192-208: count = raw bindings collapsing into the identity within
+   that bucket ∪ wildcard). Widget seeds are noted first (:687-691) in deterministic NavOrder,
+   but restaction refs iterate the harvester snapshot in Go map order upstream, and any
+   identity NOT present in a widget set gets whichever restaction bucket's count happens to be
+   seen first → ranked order flips across boots (observed: rank-1 flipped between the bench SA
+   and devs across consecutive 1.6.1 boots).
+2. **Rank won by a widget-less identity.** Nothing prefers identities that can actually render
+   the portal: the bench SA (present only in RA target enumerations via the 1,344-binding
+   `apps/deployments` bucket, absent from the 16-identity widget floor) took ranked[0] on
+   boot600 → the prime seed slot = 8 restaction seeds ALL skipped `empty_binding`, and the
+   #102 keepwarm sweep (rank1Only → ranked[0], :872-874) re-seeded the same useless cohort
+   every TTL×3/4 window (16 empty-binding skips observed in the first live sweep window).
+   #99b fixed the LATCH (segKey scan :816-844) but deliberately left ranking + seed order
+   untouched.
+
+## 2. Chosen shape
+
+**Rank key = (widgetMax DESC, allMax DESC, identityKey ASC)**, where both counts are
+**max-folds** over every observation of the identity across all precomputed target sets:
+
+- `widgetMax` = max CollapsedBindings over the identity's WIDGET-target observations
+  (0 if it appears in no widget target set).
+- `allMax` = max CollapsedBindings over ALL observations (widget + restaction).
+
+Properties, by construction:
+
+- **Deterministic.** max is commutative/associative/idempotent → the fold result is a pure
+  function of the observation MULTISET, independent of widgetSeeds/restactionSeeds iteration
+  order and of Go map order. Combined with the existing full-key comparator there is exactly
+  one ranked order per (harvest, index) snapshot.
+- **Widget-capable-first as a tier, without a tier flag.** CollapsedBindings ≥ 1 always
+  (prewarm_enumeration.go:207), so `widgetMax ≥ 1 ⇔ widget-capable`. Sorting widgetMax DESC
+  alone places every widget-capable identity strictly above every widget-less one; no boolean
+  field, no second sort pass.
+- **Population-proxy fidelity (FIX-D intent).** Within the widget-capable tier the primary
+  metric is the identity's largest widget-bucket collapse — i.e. the per-composition
+  RoleBinding population that can actually LIST widget kinds (devs ≫ singleton users). This
+  deliberately does NOT let a huge NON-widget bucket (the deployments whale) outrank a real
+  login cohort inside tier 1 — the exact pollution class recurring one tier down. `allMax` is
+  the secondary key: it orders the widget-less tier (their only observations) and breaks
+  widget-count ties inside tier 1 by breadth elsewhere.
+- **Tie behavior.** The uniform widget floor makes the same identity's count IDENTICAL across
+  widget buckets (same binding set per bucket) — max/sum/first coincide there — but counts
+  DIFFER between identities within a bucket (devs collapse hundreds; singletons are 1), so
+  tier-1 order is not degenerate. Genuine ties (e.g. many singleton users at
+  widgetMax=1,allMax=1) fall to the existing `identityKey` ascending tie-break
+  (prewarm_engine_boot.go:705) — total, deterministic, no starvation.
+
+**Rejected alternatives (Q1):**
+
+- *sum across buckets*: double-counts — a wildcard binding lands in EVERY bucket
+  (prewarm_enumeration.go:145-147), so sum scales with the number of GVRs enumerated, and on
+  the uniform floor sum = count × nWidgetGVRs (same order as max, more distortion elsewhere).
+  Deterministic but semantically mushy.
+- *max over ALL buckets as the tier-1 primary*: deterministic, but re-admits the pollution
+  class within tier 1 (an identity with one widget binding + a whale RA bucket outranks devs).
+- *first-seen (status quo)*: the defect.
+
+## 3. Q2 adjudication — widget-less identities: order last, do NOT exclude
+
+- **Frontend grounding (TRACED, SPA source /Users/diegobraga/krateo/frontend-draganddrop/
+  frontend):** every RESTAction consumption path in the portal is widget-mediated —
+  src/hooks/useWidgetQuery.ts, src/hooks/useHandleActions*, src/widgets/Table/Table.tsx,
+  src/components/CommandPalette/CommandPalette.tsx; grep for non-widget restaction fetch paths
+  is empty. A user who can list no widget kind renders no page and therefore never triggers an
+  RA /call from the SPA. So a widget-less identity's RA cells have NO frontend consumer — the
+  only possible consumer is a direct /call API client (machine SA), which is outside the
+  north-star (feedback_north_star_is_frontend_ux, feedback_prewarm_follows_frontend).
+- **Server grounding (TRACED):** the restactions /call path has no widget-capability
+  precondition — any identity whose RBAC allows the RA is served; lazily populated on first
+  call like any cold cell. Excluding widget-less identities from SEEDING would not break them,
+  only leave them cold.
+- **Decision: pure ordering, set unchanged (recommended).** Widget-less identities keep their
+  RA seeds, ranked at the tail (tier 2, ordered by allMax). Rationale: (a) FIX-E's load-bearing
+  "PURE ORDERING: the seed SET is unchanged" invariant (prewarm_engine_boot.go:606-609)
+  survives — this ship changes only the SEQUENCE, so the lossless/leak-free proofs need no
+  re-derivation; (b) excluding is a seed-SET change that buys ~nothing: on the observed
+  topology the bench SA's 8 seeds ALL skip `empty_binding` in ~25ms each (fail-closed populate
+  guard, phase1_pip_seed.go FIX-C A4) — the cost merely moves from the FRONT of boot to the
+  tail; (c) proving "no RA-only cohort is ever customer-valuable" for ALL topologies is not
+  needed if we don't remove them. Option B (exclude from boot ordering, keep for nothing) is
+  strictly dominated and rejected.
+- **#99b segKey scan: KEEP.** After Fix-3, ranked[0] is widget-capable by construction, so the
+  scan binds segRank=0 in the boot600 topology — but "widget-capable" means ≥1 widget target
+  ANYWHERE, not ≥1 RootIndex==0 widget target. On a multi-root config an identity present only
+  in non-first-root widgets can still take ranked[0], and the scan (:816-844) is the guard
+  that walks down to the first identity with a genuine first-nav target. It is cheap, already
+  RED-proven, and becomes a safety net rather than dead code.
+
+## 4. Q3 — keepwarm repair, no keepwarm code change (TRACED)
+
+`rePrewarmKeepwarm` → `rePrewarmBootScoped(rank1Only=true)` (prewarm_engine_boot.go:214-219)
+→ `seedScopeYielding` (:375) recomputes the ranking from a FRESH harvest+index snapshot on
+every sweep; the sweep bound is `if rank1Only && ri > 0 { break }` (:872-874) over that
+recomputed `ranked`. Fixing the ranking function therefore fixes the sweep automatically:
+ranked[0] = the dominant widget-capable cohort (devs), which is exactly #102's stated scope
+("dominant-CollapsedBindings cohort's cells", :867-871). Zero keepwarm-side edits; the
+observed 16-empty-binding-skip sweep waste disappears as a direct consequence. The
+ARM-KEEPWARM-SEGRANK ruling (prewarm_first_nav_latch_segment_test.go:204-263 — "segRank must
+NOT retarget the keepwarm bound; the ranking is the thing to fix") is honored: we fix the
+ranking, not the loop bound.
+
+## 5. Q4 — FIX-E / FIX-F / F.4 interactions
+
+- **FIX-E order properties are preserved, one fixture's rank assignment changes.** Rank-major,
+  class-interleave, within-rank NavOrder, RA ascending-len tiebreak (all asserted in
+  prewarm_engine_seed_order_test.go) are untouched — only WHICH identity holds which rank
+  changes when a widget-less identity previously out-counted a widget-capable one. Test-impact
+  enumeration in §7.
+- **segKey/segRank semantics unchanged**; expected steady-state becomes segRank==0 (new
+  telemetry assertion opportunity: a boot logging segRank>0 now signals a multi-root/partial-
+  visibility topology, not pollution).
+- **F.4 chunk resume gains a stability property.** Ranking is recomputed per scope execution;
+  today two chunks of the same boot could disagree on ranked order (map-order value), so a
+  deadline-cut + requeue could resume in a DIFFERENT order. Post-Fix-3: same snapshot →
+  identical order (stated as R3-C1); across chunks the snapshot may still legitimately change
+  (index rebuild after re-walk) — that residual is bounded by the F.4 boot-only fresh-skip
+  (already-seeded cells are cheap re-encounters), and is a property statement, not a code
+  change.
+
+## 6. Mechanism + LOC bound
+
+Single site: `seedScopeYielding` step (3), prewarm_engine_boot.go:674-706. ~25 LOC delta.
+
+- `rankedIdentity{key, widgetMax, allMax int}` (replaces `collapsed`).
+- `noteIdentity(c seedTarget, isWidget bool)`: max-fold both fields (unconditional write of
+  `rankOf[k]` with folded maxima; no first-seen guard).
+- Widget loop passes `isWidget=true`, restaction loop `false`.
+- Comparator: widgetMax DESC, then allMax DESC, then key ASC.
+- Ride-along observability (~6 LOC): one `prewarm.engine.seed.rank` Info line per ranked
+  identity at boot scope (rank, cohort label, widget_max, all_max) — bounded by identity count
+  (16–52 observed; same order as the existing 175 widget_targets lines), emitted only when
+  `!rank1Only` to keep sweep logs quiet. The latch line already carries segKey/segRank (#99b).
+
+No knobs, no static lists, no caps; rank metric stays data-derived CollapsedBindings
+(feedback_no_special_cases, feedback_dynamic_cohort_prewarm_no_static_no_cold_fill). Cost:
+same single O(T) fold + O(I log I) sort per scope execution (R3-C7).
+
+## 7. Test impact (enumerated — R3-C6)
+
+| Test | Impact |
+|---|---|
+| prewarm_seed_identity_rank_test.go `TestFixD_IdentityRankMajorSeedOrder` | GREEN unchanged (all fixture identities appear in widget sets with one count each; fold = identity) |
+| prewarm_engine_seed_order_test.go `TestFixE_RankMajorClassInterleaveFirstNavOrder` | GREEN unchanged (devs/ops both widget-capable; order properties orthogonal to rank values) |
+| prewarm_first_nav_latch_segment_test.go `TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment` | Premise inverts: M (RA-only, 50) now ranks BELOW U1/U2 → segRank binds 0. Keep the arm (asserts fire-on-widget-segment) with updated rank expectation; ADD a new multi-root arm that keeps the #99b scan discriminating (ranked[0] widget-capable but RootIndex==1-only → segRank>0) — see falsifier F5 |
+| prewarm_first_nav_latch_segment_test.go `TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment` | Expectation INVERTS by design: sweep must now seed U1 (widget-capable dominant), not M. Rewrite as the R3-C4 keepwarm-repair arm; the ruling it encoded (don't retarget the loop bound via segRank) stays honored — the loop bound is untouched |
+| prewarm_keepwarm_sweep_test.go (cadence/enqueue/rank1-bound) | GREEN unchanged (mechanism, not rank values) |
+| prewarm_engine_seed_latch_test.go | GREEN unchanged (counter/queue semantics) |
+
+## 8. PM-gateable conditions
+
+- **R3-C1 (determinism).** Ranked order is a pure function of the target multiset: same
+  harvest+index snapshot → byte-identical ranked order across N≥20 in-process runs with input
+  orders shuffled per run (widget list permuted, restaction list permuted — the map-order
+  proxy). Mutation arm: restore first-seen fold → RED (some permutation flips ranked[0]).
+- **R3-C2 (pollution).** boot600 shape (M: RA-only, CollapsedBindings 1344; U1: widget 5;
+  U2: widget 2) → ranked = [U1, U2, M]. Mutation: drop the widgetMax primary key → RED
+  (M first).
+- **R3-C3 (pure ordering / set unchanged).** The seeded (unit×identity) event MULTISET is
+  identical pre/post-change on the same fixture — widget-less identities still seed their RA
+  targets, at the tail. RED if any seed disappears.
+- **R3-C4 (keepwarm repair).** rank1Only sweep on the boot600 shape seeds U1's targets and
+  none of M's; diff scope check: no edits outside the step-(3) ranking block (keepwarm loop
+  bound untouched).
+- **R3-C5 (segKey alignment + scan retention).** Boot600 shape → segRank==0, segKey==U1;
+  multi-root arm (ranked[0] widget-capable with RootIndex==1 targets only) → segRank>0 and the
+  latch still fires on the true first-nav segment (the #99b scan stays live and discriminating).
+- **R3-C6 (falsifier re-run).** Every §7 row runs and is green (=== RUN verified, no
+  bare-green "no tests to run" — feedback_falsifier_must_actually_run_under_gate_tag_env);
+  FixD/FixE order arms unmodified except the two enumerated latch-file expectation changes.
+- **R3-C7 (cost).** No per-seed work added; ranking stays one fold + one sort per scope
+  execution (code-inspection + existing bench unaffected).
+- **R3-C8 (on-cluster symptom-disappear, next 60K boot).** (a) the first `site=seed` diag
+  lines after `rewalk_complete` are WIDGET seeds under a login cohort (not the bench SA), zero
+  `empty_binding` skips in the rank-1 prefix; (b) `prewarm.first_nav.latch` shows
+  `reason=segment-complete` with segRank=0 and a login-cohort segKey; (c) the first keepwarm
+  sweep window shows re-seeds under that same cohort — the 16-empty-binding-skip pattern is
+  gone; (d) rank order identical across two consecutive boots of the same cluster state
+  (`prewarm.engine.seed.rank` lines diff clean).
+
+## 9. Falsifier plan (hermetic, existing seams — enumeratePrewarmTargetsForGVRFn /
+restActionTargetGVRFn / seedOne*Fn / resetFirstNavLatchForTest / firstNavFireObserver)
+
+- **F1 determinism arm** = R3-C1 (N-run shuffle, mutation RED).
+- **F2 pollution arm** = R3-C2 (revert-to-first-seen mutation RED on the boot600 shape).
+- **F3 tie-break arm**: two identities with equal widgetMax+allMax → order by identityKey ASC,
+  stable across runs.
+- **F4 keepwarm-repair arm** = R3-C4.
+- **F5 segKey arms** = R3-C5 (both fixtures).
+- **F6 set-equality arm** = R3-C3.
+- **On-cluster proof** = R3-C8 grep set.
+
+## 10. Options surfaced (strategic)
+
+- **Q2 widget-less handling — recommended: order-last, keep seeding (chosen above).**
+  Alternative (exclude from seed set) rejected: set change, FIX-E proof re-derivation, zero
+  observed payoff. If Diego later wants machine-SA seeds gone entirely, that is a separate
+  seed-SET ship with its own lossless proof — not rank hygiene.
+- **Q1 tier-1 metric — recommended: widgetMax primary.** Alternative (allMax primary, single
+  metric) is simpler by one field but re-admits within-tier pollution; called out in §2 for
+  the gate to overrule if simplicity is preferred.

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -671,27 +671,63 @@ func seedScopeYielding(ctx context.Context,
 		return ri.Namespace+"/"+ri.Name < rj.Namespace+"/"+rj.Name
 	})
 
-	// (3) Rank the identities over BOTH classes' targets, DESCENDING by
-	// CollapsedBindings; ties on the identity key (deterministic, no starvation).
+	// (3) FIX-3 RANK HYGIENE: rank the identities over BOTH classes' targets by
+	// (widgetMax DESC, allMax DESC, identityKey ASC), where both counts are
+	// MAX-FOLDS over every observation of the identity across the precomputed
+	// target sets. This supersedes the FIX-D first-seen CollapsedBindings rank
+	// (docs/fix3-rank-hygiene-design-2026-07-07.md):
+	//
+	//   - DETERMINISTIC. The old noteIdentity kept the FIRST-SEEN count (a
+	//     map-iteration-order-dependent value: an identity carries a different
+	//     count per GVR bucket, and restaction refs iterate a Go-map snapshot
+	//     upstream), so ranked order flipped across boots. max is commutative/
+	//     associative/idempotent → the fold is a pure function of the
+	//     observation multiset, independent of widgetSeeds/restactionSeeds order
+	//     and of Go map order. With the full-key comparator there is exactly one
+	//     ranked order per (harvest, index) snapshot.
+	//   - WIDGET-CAPABLE-FIRST as a tier, without a tier flag. CollapsedBindings
+	//     is >=1 for every observation (prewarm_enumeration.go:207), so
+	//     widgetMax>=1 IFF the identity appears in some widget target set.
+	//     Sorting widgetMax DESC alone places every widget-capable identity
+	//     strictly above every widget-less one (widgetMax==0). This fixes the
+	//     boot600 pollution: a machine SA present ONLY in a 1,344-binding RA
+	//     bucket (widgetMax 0) no longer out-ranks a login cohort's dashboard
+	//     widgets — the prime seed slot goes to an identity that renders a page.
+	//   - allMax is the secondary key: it orders the widget-less tail and breaks
+	//     widget-count ties inside the widget-capable tier by breadth elsewhere.
+	//     Genuine ties fall to identityKey ASC (total, deterministic, no
+	//     starvation).
+	//
+	// PURE ORDERING (FIX-E invariant preserved): the seeded (unit x identity)
+	// SET is unchanged — widget-less identities keep their RA seeds, ranked at
+	// the tail; only the SEQUENCE changes. No caps/skips/static lists; the rank
+	// metric stays data-derived CollapsedBindings.
 	type rankedIdentity struct {
 		key       string
-		collapsed int
+		widgetMax int
+		allMax    int
 	}
 	rankOf := map[string]rankedIdentity{}
-	noteIdentity := func(c seedTarget) {
+	noteIdentity := func(c seedTarget, isWidget bool) {
 		k := identityKey(c)
-		if _, ok := rankOf[k]; !ok {
-			rankOf[k] = rankedIdentity{key: k, collapsed: c.CollapsedBindings}
+		ri := rankOf[k] // zero value {key:"", 0, 0} for a first observation
+		ri.key = k
+		if c.CollapsedBindings > ri.allMax {
+			ri.allMax = c.CollapsedBindings
 		}
+		if isWidget && c.CollapsedBindings > ri.widgetMax {
+			ri.widgetMax = c.CollapsedBindings
+		}
+		rankOf[k] = ri
 	}
 	for _, ws := range widgetSeeds {
 		for _, c := range ws.targets {
-			noteIdentity(c)
+			noteIdentity(c, true)
 		}
 	}
 	for _, rs := range restactionSeeds {
 		for _, c := range rs.targets {
-			noteIdentity(c)
+			noteIdentity(c, false)
 		}
 	}
 	ranked := make([]rankedIdentity, 0, len(rankOf))
@@ -699,11 +735,28 @@ func seedScopeYielding(ctx context.Context,
 		ranked = append(ranked, ri)
 	}
 	sort.SliceStable(ranked, func(i, j int) bool {
-		if ranked[i].collapsed != ranked[j].collapsed {
-			return ranked[i].collapsed > ranked[j].collapsed
+		if ranked[i].widgetMax != ranked[j].widgetMax {
+			return ranked[i].widgetMax > ranked[j].widgetMax
+		}
+		if ranked[i].allMax != ranked[j].allMax {
+			return ranked[i].allMax > ranked[j].allMax
 		}
 		return ranked[i].key < ranked[j].key
 	})
+	// Ride-along observability (boot scope only): one line per ranked identity
+	// so two consecutive boots' rank order can be diffed clean (R3-C8 d).
+	// Suppressed under rank1Only to keep the keepwarm sweep logs quiet.
+	if !rank1Only {
+		for r := range ranked {
+			log.Info("prewarm.engine.seed.rank",
+				slog.String("subsystem", "cache"),
+				slog.Int("rank", r),
+				slog.String("identity", ranked[r].key),
+				slog.Int("widget_max", ranked[r].widgetMax),
+				slog.Int("all_max", ranked[r].allMax),
+			)
+		}
+	}
 
 	// Emit per-unit target-count telemetry ONCE up front (the seed loop below is
 	// rank-major, so the *_targets line no longer pairs 1:1 with a contiguous
@@ -775,24 +828,25 @@ func seedScopeYielding(ctx context.Context,
 	// The readyz gate flips when the FIRST-NAV WIDGET SEGMENT has seeded — NOT
 	// the whole rank pass, NOT the full seed (prewarm_first_nav_latch.go).
 	//
-	// #99b: the segment identity is NOT hard-wired to ranked[0]. ranked is
-	// built over the UNION of widget- AND restaction-target identities
-	// (:635-667, first-seen CollapsedBindings), so ranked[0] can be an
-	// identity that appears ONLY in a restaction target set and has ZERO
-	// RootIndex==0 widget targets (the live boot600 case: a machine SA present
-	// only in RA enumerations out-ranks every widget-floor identity → the
-	// old rank1==ranked[0] arming counted 0 first-nav targets → the latch
-	// zero-fired with the login cohorts' dashboards COLD). Instead we scan
-	// ranked in order and pick the FIRST identity that actually has ≥1
-	// RootIndex==0 widget target as the segment (segKey at rank segRank). The
+	// #99b: the segment identity is NOT hard-wired to ranked[0], and the scan
+	// stays live as a SAFETY NET after FIX-3. Post-FIX-3, widgetMax DESC makes
+	// ranked[0] widget-capable by construction in a single-root topology, so the
+	// old "machine SA out-ranks the widget floor" pollution is gone at the RANK
+	// level. But "widget-capable" means >=1 widget target ANYWHERE, not >=1
+	// RootIndex==0 widget target: on a MULTI-ROOT config an identity whose ONLY
+	// widget targets live in a non-first root (RootIndex!=0) can still take
+	// ranked[0]. Then rank1==ranked[0] arming would count 0 FIRST-NAV targets
+	// and the latch would zero-fire with the first-root dashboard COLD. So we
+	// still scan ranked in order and pick the FIRST identity that actually has
+	// >=1 RootIndex==0 widget target as the segment (segKey at rank segRank). The
 	// segment is that identity's RootIndex==0 widget-target PAIRS; the latch
 	// fires the instant the LAST one seeds (mid-segRank pass, before the
 	// RootIndex>0 widgets and before ANY of that rank's restactions — the
 	// heavy NON-first-nav tail is still mid-seed, ARM-TAIL). Seed ORDER is
 	// UNTOUCHED: this is a pure gate fix; the rank-major loop below is
-	// unchanged, so any lower-ranked identity that spends the prime seed slot
-	// (e.g. the bench-SA rank-1 restaction pass) remains a cheap skipped
-	// prefix — the latch simply no longer keys its readiness on it.
+	// unchanged, so a higher-ranked identity with only RootIndex!=0 widgets
+	// remains a cheap non-first-nav prefix — the latch simply keys its readiness
+	// on the first identity that renders the first-nav page.
 	//
 	// RootIndex is stamped on widgets only (phase1_pip_seed.go
 	// BeginRoot/RootIndex); restactions carry no first-nav marker, so the

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -1,27 +1,34 @@
 // prewarm_first_nav_latch_segment_test.go — #99b FIX-F segment-identity
-// falsifier set (docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md §5).
+// falsifier set (docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md §5),
+// updated 2026-07-07 for FIX-3 rank hygiene
+// (docs/fix3-rank-hygiene-design-2026-07-07.md §7).
 //
-// The live 60K boot600 defect: `ranked` is built over the UNION of widget- AND
-// restaction-target identities, first-seen CollapsedBindings. A machine SA that
-// appears ONLY in a restaction target set (a bench-ns SA, all seeds
-// empty_binding-skipped) can out-rank every login-cohort widget-floor identity
-// and become ranked[0] — with ZERO RootIndex==0 widget targets. The pre-#99b
-// arming (rank1 := ranked[0].key) then counts 0 first-nav targets → the latch
-// zero-fires (reason=zero-first-nav-targets) BEFORE any widget seed, flipping
-// /readyz with the login cohorts' dashboards cold. #99b makes the segment
-// identity the FIRST ranked identity that actually has a RootIndex==0 widget
-// target (segKey/segRank), so the latch keys readiness on the real dashboard.
+// Pre-FIX-3 defect: `ranked` was built over the UNION of widget- AND
+// restaction-target identities by FIRST-SEEN CollapsedBindings. A machine SA
+// present ONLY in a restaction target set (a bench-ns SA, all seeds
+// empty_binding-skipped) out-ranked every login-cohort widget-floor identity
+// and became ranked[0] — with ZERO RootIndex==0 widget targets. #99b's segKey
+// scan then keyed the latch on the FIRST ranked identity with a RootIndex==0
+// widget target (not ranked[0]) so /readyz gated on the real dashboard.
 //
-//   ARM-GREEN-BOOT600 (§5 GREEN, Fix 1): 2 RootIndex==0 widgets {U1 c=5, U2
-//     c=2} + 1 RootIndex==1 widget; 1 restaction whose target set = {M c=50},
-//     M in NO widget set. ranked[0] is M (restaction-only, out-ranks by
-//     collapsed). The latch MUST fire reason=segment-complete, first_nav_
-//     widgets=2, first_nav_targets=2 (U1's 2 RootIndex==0 pairs — U1 out-ranks
-//     U2 among widget-capable identities), positioned AFTER the 2nd U1
-//     RootIndex==0 widget seed and BEFORE the RootIndex==1 widget + the RA tail
-//     (ARM-TAIL). segment_identity == U1, segment_rank == 1 (M is rank 0).
-//   The RED companion (pre-#99b code) is captured empirically to /tmp/fix99b/
-//     (git-stash the fix; the same fixture zero-fires before any widget seed).
+// FIX-3 changes WHO holds each rank: widgetMax DESC now places every
+// widget-capable identity strictly above every widget-less one, so on a
+// SINGLE-root topology the segment identity IS ranked[0] and segRank binds 0
+// (the machine SA drops to the tail). The #99b scan is retained as a SAFETY NET
+// for the MULTI-root case — an identity whose only widget targets are in a
+// non-first root (RootIndex!=0) can still take ranked[0] yet have zero
+// FIRST-NAV targets → segRank>0. TestFirstNavLatch_SegmentIdentity_MultiRoot_*
+// below is the mandatory arm that keeps that scan discriminating post-FIX-3.
+//
+//   ARM-GREEN-BOOT600 (§5 GREEN, now FIX-3 premise): 2 RootIndex==0 widgets {U1
+//     c=5, U2 c=2} + 1 RootIndex==1 widget; 1 restaction whose target set = {M
+//     c=50}, M in NO widget set. Post-FIX-3 ranked = [U1(widgetMax 5),
+//     U2(widgetMax 2), M(widgetMax 0)] — M's 50 no longer wins because it has
+//     zero widget observations. The latch MUST fire reason=segment-complete,
+//     first_nav_widgets=2, first_nav_targets=2 (U1's 2 RootIndex==0 pairs),
+//     positioned AFTER the 2nd U1 RootIndex==0 widget seed and BEFORE the
+//     RootIndex==1 widget (ARM-TAIL). segment_identity == U1, segment_rank == 0
+//     (U1 is ranked[0] post-FIX-3, not rank 1).
 //
 //   ARM-FIX2-REDRIVE (§5 Fix-2 arm): 2 config roots; the boot-walk pass
 //     harvests NOTHING (empty subtrees); a SECOND walk pass (redrive shape:
@@ -30,12 +37,18 @@
 //     they resume from the boot walk's curRoot and stamp 1). Exercised at the
 //     harvester level (BeginWalk/BeginRoot are the unit under test).
 //
-//   ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling): the #102
-//     keepwarm sweep (rank1Only=true) re-seeds ranked[0]'s CELLS, NOT the
-//     segment identity's. With ranked[0]=M (a restaction-only identity), the
-//     sweep MUST still seed M's restaction targets — segRank is a latch-only
-//     concept and does NOT retarget the keepwarm loop bound. Asserts the sweep
-//     seeds the ranked[0] (M) target set, not the segment (U1) set.
+//   ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3 divergence
+//     fixture): the #102 keepwarm sweep (rank1Only=true) re-seeds ranked[0]'s
+//     CELLS, NOT the segment identity's. segRank is a latch-only concept and
+//     does NOT retarget the keepwarm loop bound. Post-FIX-3 the pre-FIX-3
+//     fixture (ranked[0]=RA-only M) no longer diverges — M drops to the tail
+//     and ranked[0]=U1 is BOTH widget-capable AND the segment, so it would not
+//     discriminate. TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment now uses
+//     a MULTI-ROOT divergence fixture: W (widgetMax 9, but ALL its widgets are
+//     RootIndex==1) is ranked[0]; the segment identity is V (a lower-ranked
+//     identity with a RootIndex==0 widget) at segRank>0. The sweep MUST seed W
+//     (ranked[0]), NOT V (the segment) — proving the loop bound follows
+//     ranked[0], not segKey.
 //
 // Hermetic, -race, seams only. Serializes on engineLatchTestMu.
 
@@ -62,10 +75,11 @@ func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(
 	resetFirstNavLatchForTest()
 	ensureFirstNavLatch()
 
-	// The boot600 shape: M (collapsed 50) is the highest-ranked identity but
-	// appears ONLY in the restaction target set — no widget authorises it.
-	// U1 (collapsed 5) and U2 (collapsed 2) are the login-cohort widget
-	// identities. ranked = [M(0), U1(1), U2(2)].
+	// The boot600 shape: M (collapsed 50) appears ONLY in the restaction target
+	// set — no widget authorises it, so post-FIX-3 its widgetMax is 0. U1
+	// (widgetMax 5) and U2 (widgetMax 2) are the login-cohort widget identities.
+	// FIX-3 ranked = [U1(0), U2(1), M(2)] — widgetMax DESC drops the RA-only M
+	// to the tail; U1 is ranked[0] and segRank binds 0.
 	m := eID{name: "machine-sa", collapsed: 50}
 	u1 := eID{name: "u1", group: true, collapsed: 5}
 	u2 := eID{name: "u2", group: true, collapsed: 2}
@@ -144,12 +158,98 @@ func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(
 	if tailIdx < len(ev) && latchIdx > tailIdx {
 		t.Fatalf("§5 GREEN/ARM-TAIL: latch fired at idx %d AFTER the RootIndex==1 tail widget (U2, rank 2) at idx %d — readyz would wait on non-first-nav tail; events=%+v", latchIdx, tailIdx, ev)
 	}
-	// The M restaction is ranked[0] (rank 0) and legitimately seeds FIRST under
-	// the rank-major loop — it is NOT the segment's tail, so the latch firing
-	// after it is correct (M is a cheap prefix, not first-nav work readyz gates
-	// on). We only assert the U1 segment fired and the RootIndex>0 widget tail
-	// is excluded. raIdx is retained only to document its position.
-	_ = raIdx
+	// Post-FIX-3 the M restaction is ranked[2] (widgetMax 0) and legitimately
+	// seeds LAST under the rank-major loop — it is NOT the segment (U1 rank 0),
+	// so the latch fires at U1's segment before M's RA tail ever runs. ARM-TAIL:
+	// readyz must not wait on the RA-only tail. Assert the latch fired at or
+	// before the RA (M) seed to pin the segment-before-tail order under FIX-3.
+	if raIdx < len(ev) && latchIdx > raIdx {
+		t.Fatalf("§5 GREEN/ARM-TAIL: latch fired at idx %d AFTER the RA-only tail (M, rank 2) at idx %d — post-FIX-3 M is the widget-less tail, readyz must not wait on it; events=%+v", latchIdx, raIdx, ev)
+	}
+}
+
+// ── COND-2 (FIX-3 mandatory): MULTI-ROOT segKey scan stays discriminating ───
+// Post-FIX-3, ranked[0] is widget-capable by construction — but "widget-capable"
+// means >=1 widget target ANYWHERE, not >=1 RootIndex==0 (first-nav) target. On
+// a MULTI-ROOT config an identity whose ONLY widget targets live in a non-first
+// root can take ranked[0] yet have ZERO first-nav targets. The #99b segKey scan
+// is the guard that walks past it to the first identity with a genuine
+// RootIndex==0 widget. This arm re-covers the retired #99b "scan walks past
+// ranked[0]" property under FIX-3:
+//   (i) ranked[0] = W (widgetMax 9) but ALL W's widgets are RootIndex==1;
+//   (ii) V (widgetMax 2) has a RootIndex==0 widget → segKey==V, segRank>0;
+//   (iii) the latch fires reason=segment-complete on V's FIRST-NAV segment.
+// RED (captured to /tmp/r3/ empirically): neuter the scan (segRank hard-bound
+// to 0) → the latch counts 0 first-nav targets on W → fires
+// "zero-first-nav-targets" BEFORE V's RootIndex==0 widget → the fire-after-V's-
+// widget + reason=segment-complete asserts below both fail.
+func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	resetFirstNavLatchForTest()
+	ensureFirstNavLatch()
+
+	// W (widgetMax 9) is ranked[0], widget lives in RootIndex==1 only. V
+	// (widgetMax 2) has a RootIndex==0 widget → the segment identity, segRank>0.
+	w := eID{name: "w", group: true, collapsed: 9}
+	v := eID{name: "v", group: true, collapsed: 2}
+
+	h := newNavWidgetHarvester()
+	firstNavW := latchWidgetGVR("flexes")     // RootIndex 0 — V's first-nav widget
+	nonFirstNavW := latchWidgetGVR("tailwid") // RootIndex 1 — W's only widget
+	harvestWidgetAtRoot(h, "first-nav", firstNavW, 0)
+	harvestWidgetAtRoot(h, "non-first-nav", nonFirstNavW, 1)
+	widgets := h.snapshot()
+
+	rec := &latchRecorder{}
+	installLatchSeams(t, rec,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case firstNavW:
+				return latchTargets(gvr, v) // V, RootIndex 0 → segment
+			case nonFirstNavW:
+				return latchTargets(gvr, w) // W, RootIndex 1 → ranked[0], not first-nav
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return schema.GroupVersionResource{}, false
+		})
+
+	var fireReason string
+	firstNavFireObserver = func(reason string) {
+		fireReason = reason
+		rec.rec(latchSeedEvent{class: "LATCH", label: reason, rootIdx: -1})
+	}
+	t.Cleanup(func() { firstNavFireObserver = nil })
+
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	ev := rec.snapshot()
+
+	// (iii) fired segment-complete — NOT zero-first-nav-targets (the neutered-
+	// scan RED reason: W has no first-nav widget so a segRank-hard-0 impl would
+	// find nothing and fire the provably-zero path).
+	if fireReason != "segment-complete" {
+		t.Fatalf("COND-2: latch fired reason=%q; want \"segment-complete\" — with the #99b scan neutered (segRank hard-bound to ranked[0]=W, which has zero RootIndex==0 widgets) the latch would fire \"zero-first-nav-targets\"; events=%+v", fireReason, ev)
+	}
+	// (ii)+(iii) the latch fired AFTER V's RootIndex==0 widget seeded — i.e. it
+	// keyed on the true first-nav segment (segRank>0, segKey==V), not ranked[0].
+	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
+	vWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:v" && e.rootIdx == 0 })
+	if latchIdx == len(ev) {
+		t.Fatalf("COND-2: latch never fired; events=%+v", ev)
+	}
+	if vWidgetIdx == len(ev) {
+		t.Fatalf("COND-2 setup: V's RootIndex==0 widget never seeded; events=%+v", ev)
+	}
+	if latchIdx < vWidgetIdx {
+		t.Fatalf("COND-2: latch fired at idx %d BEFORE V's first-nav (RootIndex==0) widget at idx %d — the scan did NOT walk past ranked[0]=W to the real first-nav segment; events=%+v", latchIdx, vWidgetIdx, ev)
+	}
 }
 
 // ── ARM-FIX2-REDRIVE (§5 Fix-2 arm) ─────────────────────────────────────────
@@ -201,13 +301,24 @@ func harvestWidgetAtRootNoReset(h *navWidgetHarvester, name string, gvr schema.G
 	eHarvestWidget(h, name, gvr)
 }
 
-// ── ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling) ──────────────
+// ── ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3) ───────
 // The #102 keepwarm sweep (rank1Only=true) bounds the seed to ranked[0] — the
-// dominant-CollapsedBindings cohort's CELLS — regardless of whether ranked[0]
-// has a first-nav widget. segRank (the latch segment identity, #99b) is a
+// dominant cohort's CELLS — regardless of whether ranked[0] has a FIRST-NAV
+// (RootIndex==0) widget. segRank (the latch segment identity, #99b) is a
 // LATCH-ONLY (boot-gate) concept and must NOT retarget the keepwarm loop bound.
-// With ranked[0]=M (restaction-only) and segRank pointing at U1, the sweep MUST
-// still seed M's restaction target (rank 0), NOT U1's widget (rank 1).
+//
+// This arm PINS: sweep bound follows ranked[0], NOT retargeted by segRank. It
+// requires ranked[0] != segKey (a DIVERGENCE fixture) or the assert is a
+// tautology. Post-FIX-3, ranked[0] is always widget-capable, so we force
+// divergence via MULTI-ROOT topology: W (widgetMax 9) is ranked[0] but ALL its
+// widgets are RootIndex==1 → segRank>0 (the segment falls to V, a lower-ranked
+// identity with a RootIndex==0 widget). The sweep MUST seed W (ranked[0]), NOT
+// V (the segment). The property "the loop bound is `ri>0 break`, untouched by
+// segRank" is exactly what this now pins; the old RA-only-ranked[0] property
+// (pre-FIX-3) is subsumed — a widget-less identity can no longer be ranked[0],
+// so the surviving divergence is ranked[0]-widget-capable-but-non-first-nav,
+// covered here. (The multi-root first-nav LATCH behaviour itself is pinned by
+// TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget below.)
 func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
@@ -221,45 +332,47 @@ func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 	latch := ensureFirstNavLatch()
 	latch.fire("boot-already-fired", 0, 0, "", -1, 0)
 
-	m := eID{name: "machine-sa", collapsed: 50}
-	u1 := eID{name: "u1", group: true, collapsed: 5}
+	// W (widgetMax 9) is ranked[0], but its widget is RootIndex==1 (non-first-
+	// nav) → segRank>0. V (widgetMax 2) has a RootIndex==0 widget → V is the
+	// segment identity, at a lower rank. ranked = [W(0), V(1)].
+	w := eID{name: "w", group: true, collapsed: 9}
+	v := eID{name: "v", group: true, collapsed: 2}
 
 	h := newNavWidgetHarvester()
-	dash := latchWidgetGVR("flexes")
-	harvestWidgetAtRoot(h, "dash", dash, 0) // U1's first-nav widget (rank 1)
+	firstNavW := latchWidgetGVR("flexes")     // RootIndex 0 — V's first-nav widget
+	nonFirstNavW := latchWidgetGVR("tailwid") // RootIndex 1 — W's only widget
+	harvestWidgetAtRoot(h, "first-nav", firstNavW, 0)
+	harvestWidgetAtRoot(h, "non-first-nav", nonFirstNavW, 1)
 	widgets := h.snapshot()
-
-	fanoutRA := latchRA("machine-fanout-ra")
-	ras := []templatesv1.ObjectReference{fanoutRA}
 
 	rec := &latchRecorder{}
 	installLatchSeams(t, rec,
 		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
 			switch gvr {
-			case dash:
-				return latchTargets(gvr, u1)
-			case eFanoutRAGVR:
-				return latchTargets(eFanoutRAGVR, m) // M = ranked[0].
+			case firstNavW:
+				return latchTargets(gvr, v) // V, RootIndex 0 → the segment
+			case nonFirstNavW:
+				return latchTargets(gvr, w) // W, RootIndex 1 → ranked[0], not first-nav
 			}
 			return nil
 		},
 		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
-			return eFanoutRAGVR, true
+			return schema.GroupVersionResource{}, false
 		})
 
 	// rank1Only=true — the keepwarm sweep.
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", true, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", true, false); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
 
-	seededM := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" && e.identity == "user:machine-sa" }) < len(ev)
-	seededU1 := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:u1" }) < len(ev)
+	seededW := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:w" }) < len(ev)
+	seededV := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:v" }) < len(ev)
 
-	if !seededM {
-		t.Fatalf("keepwarm ruling: rank1Only sweep did NOT seed ranked[0] (M) restaction target — the sweep must re-seed the dominant cohort's cells; events=%+v", ev)
+	if !seededW {
+		t.Fatalf("keepwarm ruling: rank1Only sweep did NOT seed ranked[0] (W, widgetMax 9) — the sweep bound must follow ranked[0], the dominant cohort's cells; events=%+v", ev)
 	}
-	if seededU1 {
-		t.Fatalf("keepwarm ruling: rank1Only sweep seeded U1 (rank 1, the SEGMENT identity) — segRank must NOT retarget the keepwarm loop bound (that would be a scope change, out of #99b); events=%+v", ev)
+	if seededV {
+		t.Fatalf("keepwarm ruling: rank1Only sweep seeded V (rank 1, the SEGMENT identity) — segRank must NOT retarget the keepwarm loop bound (that would be a scope change, out of #99b); events=%+v", ev)
 	}
 }

--- a/internal/handlers/dispatchers/prewarm_seed_rank_hygiene_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_rank_hygiene_test.go
@@ -1,0 +1,380 @@
+// prewarm_seed_rank_hygiene_test.go — FIX-3 rank hygiene falsifier set
+// (docs/fix3-rank-hygiene-design-2026-07-07.md §8 R3-C1..C8, §9 F1..F6 + the
+// PM design-gate conditions COND-1..COND-4).
+//
+// FIX-3 changed the identity rank KEY from first-seen CollapsedBindings (a
+// map-iteration-order-dependent value) to (widgetMax DESC, allMax DESC,
+// identityKey ASC), both counts MAX-FOLDED over every observation. These arms
+// prove the four load-bearing properties through the REAL seedScopeYielding
+// path (rank-major loop) — no shadow rank function, no prod mutation seam:
+//
+//   F1 / COND-4 (determinism, MAP-ORDER variance): N>=20 in-process runs, each
+//     rebuilding rankOf FRESH inside a fresh seedScopeYielding call, so Go map
+//     iteration over rankOf (ranked := range rankOf, before the sort) naturally
+//     varies across runs. The fixture includes a GENUINE TIE (two identities
+//     equal on widgetMax AND allMax) so the ONLY thing keeping order stable is
+//     the identityKey ASC tie-break — the load-bearing determinism guarantee.
+//     Assert byte-identical ranked order every run. Mutation (drop the
+//     identityKey tie-break → equal-maxima identities keep Go map order) RED is
+//     captured empirically to /tmp/r3/ (source revert + rerun): the tied pair
+//     flips across runs. This pins map-order variance through the REAL rankOf
+//     map, not a slice-shuffle proxy.
+//   F2 / COND-2-adjacent (pollution): boot600 shape (M: RA-only,
+//     CollapsedBindings 1344; U1: widget 5; U2: widget 2) → ranked [U1, U2, M].
+//     Mutation (drop the widgetMax primary key → allMax-only) RED captured to
+//     /tmp/r3/ (M first).
+//   F3 (tie-break): two identities with equal (widgetMax, allMax) → order by
+//     identityKey ASC, stable.
+//   F6 / COND-1 (set-equality, TUPLE-MULTISET): the seeded (unit x identity)
+//     tuple-multiset is identical pre/post FIX-3 on the same fixture. The RED
+//     arm swaps ONE tuple (a seed moved to the wrong unit) and shows the assert
+//     fails — discriminating a SWAP, not only a DROP.
+//
+// The keepwarm-repair (F4/COND-3) and multi-root segKey (F5/COND-2) arms live
+// in prewarm_first_nav_latch_segment_test.go (they need the latch/keepwarm
+// seams already wired there). This file cross-references them.
+//
+// Hermetic, -race, seams only (seedOneWidgetFn / seedOneRestactionFn /
+// enumeratePrewarmTargetsForGVRFn / restActionTargetGVRFn). Serializes on
+// engineLatchTestMu (shares the seed seams + the customerInFlight atomic with
+// the sibling prewarm tests). Does NOT touch ./internal/rbac/... .
+
+package dispatchers
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// rankObsEvent records one seed in call order with the seeding identity and the
+// unit (widget name or RA name) it seeded — the (unit x identity) tuple COND-1
+// asserts the multiset of.
+type rankObsEvent struct {
+	class    string // "widget" | "restaction"
+	unit     string // ns/name of the widget or RA
+	identity string // "user:<u>" | "group:<g>" | "anon"
+}
+
+// installRankObsSeams wires the seed seams to record rankObsEvents and the
+// enumerator/target-GVR seams from the given fixture closures.
+func installRankObsSeams(t *testing.T, ev *[]rankObsEvent,
+	enumerate func(schema.GroupVersionResource) []cache.PrewarmTarget,
+	raTargetGVR func(templatesv1.ObjectReference) (schema.GroupVersionResource, bool)) {
+	t.Helper()
+
+	prevEnum := enumeratePrewarmTargetsForGVRFn
+	enumeratePrewarmTargetsForGVRFn = func(gvr schema.GroupVersionResource, _ string) []cache.PrewarmTarget {
+		return enumerate(gvr)
+	}
+	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
+
+	prevTGVR := restActionTargetGVRFn
+	restActionTargetGVRFn = func(_ context.Context, ref templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+		return raTargetGVR(ref)
+	}
+	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
+
+	prevW := seedOneWidgetFn
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
+		*ev = append(*ev, rankObsEvent{class: "widget", unit: e.W.GetNamespace() + "/" + e.W.GetName(), identity: eIdentityLabel(ctx)})
+		return nil
+	}
+	t.Cleanup(func() { seedOneWidgetFn = prevW })
+
+	prevR := seedOneRestactionFn
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
+		*ev = append(*ev, rankObsEvent{class: "restaction", unit: ref.Namespace + "/" + ref.Name, identity: eIdentityLabel(ctx)})
+		return nil
+	}
+	t.Cleanup(func() { seedOneRestactionFn = prevR })
+}
+
+// rankedOrderFromEvents recovers the ranked identity order from a rank-major
+// seed stream: the order in which each identity is FIRST seeded == its rank
+// (the loop seeds rank-major, so rank r's targets all precede rank r+1's). This
+// reads the order off the REAL prod loop, not a shadow rank function.
+func rankedOrderFromEvents(ev []rankObsEvent) []string {
+	seen := map[string]bool{}
+	var order []string
+	for _, e := range ev {
+		if !seen[e.identity] {
+			seen[e.identity] = true
+			order = append(order, e.identity)
+		}
+	}
+	return order
+}
+
+// ── F1 / COND-4: DETERMINISM through the REAL rankOf map, with a GENUINE TIE ──
+// The fixture puts MANY identities at IDENTICAL (widgetMax, allMax) so the only
+// thing keeping ranked order stable is the identityKey ASC tie-break. rankOf is
+// rebuilt fresh inside each seedScopeYielding call, so `ranked := range rankOf`
+// iterates in a DIFFERENT Go map order each run. Over N>=20 runs the ranked
+// order must be byte-identical. Mutation (drop the identityKey tie-break) RED is
+// captured empirically to /tmp/r3/ (the tied identities flip across runs).
+func TestFix3Rank_Determinism_MapAndInputOrderInvariant(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	// 8 singleton widget cohorts, ALL widgetMax=1, allMax=1 → a full 8-way tie.
+	// Names chosen so identityKey ASC order is unambiguous (g0..g7).
+	h := newNavWidgetHarvester()
+	w := latchWidgetGVR("flexes")
+	harvestWidgetAtRoot(h, "dash", w, 0)
+	widgets := h.snapshot()
+
+	tied := make([]eID, 0, 8)
+	for i := 0; i < 8; i++ {
+		tied = append(tied, eID{name: string(rune('0' + i)), group: true, collapsed: 1})
+	}
+	// Prepend a group-prefixed name so identityKey (join of groups) sorts g0<g1<..
+	for i := range tied {
+		tied[i].name = "g" + tied[i].name
+	}
+
+	enumerate := func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+		if gvr == w {
+			// Hostile enumeration order (reversed) — the comparator must still
+			// produce g0..g7 regardless of input or map order.
+			rev := make([]eID, len(tied))
+			for i := range tied {
+				rev[len(tied)-1-i] = tied[i]
+			}
+			return eIdentityTargets(gvr, rev...)
+		}
+		return nil
+	}
+	raTargetGVR := func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+		return schema.GroupVersionResource{}, false
+	}
+
+	want := []string{"group:g0", "group:g1", "group:g2", "group:g3", "group:g4", "group:g5", "group:g6", "group:g7"}
+
+	const runs = 24
+	for r := 0; r < runs; r++ {
+		var ev []rankObsEvent
+		installRankObsSeams(t, &ev, enumerate, raTargetGVR)
+
+		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+			t.Fatalf("run %d: seedScopeYielding returned %v; want nil", r, err)
+		}
+		order := rankedOrderFromEvents(ev)
+		if strings.Join(order, ",") != strings.Join(want, ",") {
+			t.Fatalf("F1/COND-4 DETERMINISM VIOLATED: run %d ranked order = %v differs from the identityKey-ASC order %v — the tied identities leaked Go map order (the identityKey tie-break is the load-bearing determinism guarantee)", r, order, want)
+		}
+	}
+}
+
+// ── F2: POLLUTION — the boot600 shape ranks the login cohorts above the whale.
+// M is RA-only with CollapsedBindings 1344; U1/U2 are widget cohorts (5/2).
+// FIX-3 ranked = [U1, U2, M] because M's widgetMax is 0. Pre-FIX-3 (first-seen /
+// allMax-primary) M would take rank 0. Mutation RED (drop widgetMax primary) is
+// captured to /tmp/r3/ empirically.
+func TestFix3Rank_Pollution_Boot600_LoginCohortsOverWhale(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	h := newNavWidgetHarvester()
+	dashA := latchWidgetGVR("flexes")
+	dashB := latchWidgetGVR("estategraphs")
+	harvestWidgetAtRoot(h, "dash-a", dashA, 0)
+	harvestWidgetAtRoot(h, "dash-b", dashB, 0)
+	widgets := h.snapshot()
+
+	fanoutRA := latchRA("machine-fanout-ra")
+	ras := []templatesv1.ObjectReference{fanoutRA}
+
+	u1 := eID{name: "u1", group: true, collapsed: 5}
+	u2 := eID{name: "u2", group: true, collapsed: 2}
+	m := eID{name: "machine-sa", collapsed: 1344}
+
+	var ev []rankObsEvent
+	installRankObsSeams(t, &ev,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case dashA:
+				return eIdentityTargets(gvr, u1)
+			case dashB:
+				return eIdentityTargets(gvr, u2)
+			case eFanoutRAGVR:
+				return eIdentityTargets(eFanoutRAGVR, m) // M appears ONLY here.
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return eFanoutRAGVR, true
+		})
+
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	order := rankedOrderFromEvents(ev)
+	want := []string{"group:u1", "group:u2", "user:machine-sa"}
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Fatalf("F2 POLLUTION: ranked order = %v; want %v — the RA-only whale (M, CollapsedBindings 1344, widgetMax 0) must rank BELOW the login-cohort widgets (U1 wMax 5, U2 wMax 2). Pre-FIX-3 M took rank 0 → the prime seed slot warmed a page-less machine SA", order, want)
+	}
+	// Discriminator: M is strictly LAST — the pollution is fully drained, not
+	// merely demoted by one.
+	if order[len(order)-1] != "user:machine-sa" {
+		t.Fatalf("F2: M (widgetMax 0) is not the LAST-ranked identity; order=%v", order)
+	}
+}
+
+// ── F3: TIE-BREAK — equal (widgetMax, allMax) → identityKey ASC, stable. ─────
+func TestFix3Rank_TieBreak_IdentityKeyAscending(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	h := newNavWidgetHarvester()
+	w := latchWidgetGVR("flexes")
+	harvestWidgetAtRoot(h, "dash", w, 0)
+	widgets := h.snapshot()
+
+	// Three singleton cohorts, all widgetMax=1, allMax=1 → genuine tie. Provide
+	// in a hostile (reverse-sorted) enumeration order; the comparator must sort
+	// them identityKey ASC (group:zed > group:mid > group:abe lexically → abe,
+	// mid, zed). identityKey = Username\x1f join(Groups) so "group" identities
+	// key on the group name.
+	abe := eID{name: "abe", group: true, collapsed: 1}
+	mid := eID{name: "mid", group: true, collapsed: 1}
+	zed := eID{name: "zed", group: true, collapsed: 1}
+
+	var ev []rankObsEvent
+	installRankObsSeams(t, &ev,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			if gvr == w {
+				return eIdentityTargets(gvr, zed, mid, abe) // hostile order
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return schema.GroupVersionResource{}, false
+		})
+
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	order := rankedOrderFromEvents(ev)
+	want := []string{"abe", "mid", "zed"} // identity labels are "group:<g>"; check suffix order
+	var got []string
+	for _, id := range order {
+		got = append(got, strings.TrimPrefix(id, "group:"))
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("F3 TIE-BREAK: ranked order = %v; want identityKey ASC %v (equal widgetMax/allMax must fall to the deterministic key tie-break, no starvation)", got, want)
+	}
+}
+
+// ── F6 / COND-1: SET-EQUALITY (TUPLE-MULTISET), swap-RED discriminating. ─────
+// The seeded (unit x identity) tuple-multiset is unchanged pre/post FIX-3 —
+// FIX-3 is PURE ORDERING (FIX-E invariant). We assert the multiset the real
+// FIX-3 run produces equals the expected set, then SWAP one tuple (move a seed
+// to the wrong unit) and show the multiset-equality assert goes RED — proving
+// the assert catches a SWAP, not only a DROP.
+func TestFix3Rank_SetEquality_TupleMultiset_SwapIsRed(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	h := newNavWidgetHarvester()
+	wA := latchWidgetGVR("wa")
+	wB := latchWidgetGVR("wb")
+	harvestWidgetAtRoot(h, "wa", wA, 0)
+	harvestWidgetAtRoot(h, "wb", wB, 0)
+	widgets := h.snapshot()
+
+	fanoutRA := latchRA("fan")
+	ras := []templatesv1.ObjectReference{fanoutRA}
+
+	devs := eID{name: "devs", group: true, collapsed: 9}
+	ops := eID{name: "ops", group: true, collapsed: 2}
+	m := eID{name: "sa", collapsed: 50} // RA-only tail
+
+	var ev []rankObsEvent
+	installRankObsSeams(t, &ev,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case wA:
+				return eIdentityTargets(gvr, devs, ops)
+			case wB:
+				return eIdentityTargets(gvr, devs)
+			case eFanoutRAGVR:
+				return eIdentityTargets(eFanoutRAGVR, devs, m)
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return eFanoutRAGVR, true
+		})
+
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+
+	// The expected (unit x identity) tuple-multiset — widget-less M keeps its RA
+	// seed at the tail (PURE ORDERING: nothing dropped).
+	want := tupleMultiset([]rankObsEvent{
+		{class: "widget", unit: "krateo-system/wa", identity: "group:devs"},
+		{class: "widget", unit: "krateo-system/wa", identity: "group:ops"},
+		{class: "widget", unit: "krateo-system/wb", identity: "group:devs"},
+		{class: "restaction", unit: "krateo-system/fan", identity: "group:devs"},
+		{class: "restaction", unit: "krateo-system/fan", identity: "user:sa"},
+	})
+	got := tupleMultiset(ev)
+	if !multisetEqual(got, want) {
+		t.Fatalf("F6/COND-1 SET-EQUALITY: seeded (unit x identity) tuple-multiset differs from the pre/post-FIX-3 invariant set.\n got=%v\nwant=%v\nFIX-3 must be PURE ORDERING — no seed added/dropped (a widget-less identity still seeds its RA at the tail)", got, want)
+	}
+
+	// SWAP-RED: move ONE seed to the wrong unit (devs's wb seed → wa). The
+	// multiset now has two (wa,devs) and zero (wb,devs). Assert the equality
+	// check DISCRIMINATES this swap (not just a drop).
+	swapped := append([]rankObsEvent(nil), ev...)
+	for i := range swapped {
+		if swapped[i].class == "widget" && swapped[i].unit == "krateo-system/wb" && swapped[i].identity == "group:devs" {
+			swapped[i].unit = "krateo-system/wa" // moved to the wrong unit
+			break
+		}
+	}
+	if multisetEqual(tupleMultiset(swapped), want) {
+		t.Fatalf("F6/COND-1 SWAP NOT DISCRIMINATED: moving a seed from wb to wa left the tuple-multiset equal to the expected set — the assert only catches DROPs, not SWAPs; the COND-1 shape is degenerate")
+	}
+}
+
+// tupleMultiset renders a stable string-keyed count map of the events.
+func tupleMultiset(ev []rankObsEvent) map[string]int {
+	m := map[string]int{}
+	for _, e := range ev {
+		m[e.class+"\x1f"+e.unit+"\x1f"+e.identity]++
+	}
+	return m
+}
+
+func multisetEqual(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	// stable iteration not needed for equality; sort only used in error render
+	return true
+}
+
+var _ = sort.Strings


### PR DESCRIPTION
## Fix-3 rank hygiene — deterministic, widget-capable-first identity ranking

Design: `docs/fix3-rank-hygiene-design-2026-07-07.md` (in this PR).

### Root cause (live 60K boot600)
The boot seed's identity rank was a **first-seen** `CollapsedBindings` value — map-iteration-order-dependent (an identity carries a different count per GVR bucket, and restaction refs iterate a Go-map snapshot upstream), so ranked order **flipped across consecutive boots** (rank-1 flipped between the bench SA and devs on back-to-back 1.6.1 boots). Worse, nothing preferred identities that can actually render the portal: a machine SA present only in the 1,344-binding `apps/deployments` RA bucket (absent from the 16-identity widget floor) took `ranked[0]` → the prime seed slot spent 8 restaction seeds all `empty_binding`-skipped, and the #102 keepwarm sweep (`rank1Only`→`ranked[0]`) re-seeded that same page-less cohort every TTL×3/4 window (16 empty-binding skips observed in the first live sweep). #99b fixed the latch key but deliberately left ranking + seed order untouched.

### Mechanism (single site, `internal/handlers/dispatchers/prewarm_engine_boot.go` step-(3), ~40 net LOC)
Rank key = **(widgetMax DESC, allMax DESC, identityKey ASC)**, both counts **unconditional max-folds** over every observation (`noteIdentity(c, isWidget)`: `allMax` always folds `c.CollapsedBindings`, `widgetMax` folds only when `isWidget`; widget loop passes `true`, RA loop `false`).

- **Deterministic** — max is commutative/associative/idempotent → rank is a pure function of the observation multiset, independent of iteration/map order.
- **Widget-capable-first as a tier, without a tier flag** — `CollapsedBindings ≥ 1` always ⇒ `widgetMax ≥ 1 ⇔ widget-capable` ⇒ `widgetMax DESC` places every widget-capable identity strictly above every widget-less one; the RA-only whale drops to the tail.
- **Pure ordering** — the seeded (unit × identity) **set is unchanged** (widget-less identities keep their RA seeds at the tail; only the SEQUENCE changes), so the FIX-E lossless/leak-free proofs need no re-derivation.
- Ride-along: one `prewarm.engine.seed.rank` INFO line per identity, boot scope only (`if !rank1Only`), bounded by identity count.
- The **#99b segKey scan is retained** as a multi-root safety net (post-Fix-3 `ranked[0]` is widget-capable in single-root, but a multi-root config can put a `RootIndex!=0`-only widget identity at `ranked[0]` with zero first-nav targets → `segRank>0`); scan code + keepwarm loop bound (`rank1Only && ri>0 break`) unchanged.

No knobs, no static lists, no caps; the rank metric stays data-derived `CollapsedBindings`.

### PM conditions & resolutions (all 4 landed, RED-proven)
- **COND-1 (tuple-multiset, swap-RED):** `TestFix3Rank_SetEquality_TupleMultiset_SwapIsRed` asserts the seeded (unit × identity) tuple-**multiset** is identical pre/post-Fix-3; the in-test SWAP arm moves one seed to the wrong unit and shows the equality goes false → discriminates a SWAP, not just a DROP.
- **COND-2 (HARD — multi-root, re-covers the retired #99b "scan walks past ranked[0]" property):** new `TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget` — `ranked[0]`=W (widgetMax 9, `RootIndex==1`-only), V (widgetMax 2) has a `RootIndex==0` widget → asserts `reason=segment-complete` AND the latch fires after V's first-nav widget (⇒ `segRank>0`, `segKey==V`). RED captured at `/tmp/r3/mutation-C-segrank-hardbound0-COND2.txt` (scan neutered to `ranked[0]`-only → fires `zero-first-nav-targets`).
- **COND-3 (keepwarm divergence):** `TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment` rewritten as a `ranked[0]≠segKey` divergence fixture (W widget-capable-but-root-1-only ≠ segment V) → asserts the `rank1Only` sweep seeds W (`ranked[0]`), NOT V (segment), pinning "sweep bound follows `ranked[0]`, not retargeted by segRank". The old RA-only-`ranked[0]` property is subsumed (a widget-less identity can no longer be `ranked[0]`).
- **COND-4 (map-order determinism):** `TestFix3Rank_Determinism_MapAndInputOrderInvariant` — an 8-way tie (all `widgetMax==allMax==1`) with `rankOf` rebuilt fresh per run so `range rankOf` map order varies naturally across N=24; asserts byte-identical `identityKey`-ASC order. RED captured at `/tmp/r3/mutation-A-drop-keytiebreak-COND4.txt` (drop the tie-break → tied identities leak Go map order, flips run 0). Map-rebuild is load-bearing, not a slice-shuffle proxy.

Existing FIX-D/FIX-E order arms stay GREEN unchanged; the `RestactionOnlyRank0` arm premise-flips per design §7 (M now `ranked[2]` widgetMax 0, `segRank==0`, U1=`ranked[0]`). All arms hermetic, `-race`, `=== RUN` verified; full dispatchers package green `-race` (23.6s); `go build`+`vet` clean. F2 pollution RED at `/tmp/r3/mutation-B-drop-widgetMax-F2.txt`. No prod mutation seam was added (avoids the #66 shadow-drift anti-pattern) — all three code-mutation REDs were captured by source-revert-rerun.

### Gate verdicts (frozen ref)
- **Arch: PASS**, no blocking conditions — both empirical mutations independently re-verified; both test rewrites ruled strengthening.
- **PM: ACCEPT**, all 4 conditions confirmed incl. the corrected COND-4 reading (identityKey-tie-break drop is the load-bearing map-order mutation; right-reason RED re-verified across 3 process invocations).
- Non-blocking cosmetic notes (fold whenever a diff next touches these): stale `prewarm_engine_boot.go` header comment predating this diff; dead `var _ = sort.Strings` anchor in the new test file.

### R3-C8 on-cluster deploy probe (next 60K boot)
(a) first `site=seed` diag lines after `rewalk_complete` are WIDGET seeds under a login cohort, zero `empty_binding` skips in the rank-1 prefix; (b) `prewarm.first_nav.latch` `reason=segment-complete` with `segRank=0` and a login-cohort `segKey`; (c) the first keepwarm sweep window re-seeds under that same login cohort (16-empty-binding-skip pattern gone); (d) `prewarm.engine.seed.rank` lines diff clean across two consecutive boots of the same cluster state.

### Customer framing (honest)
This is an **ordering + stability** ship: the boot prime-seed slot now warms a login cohort (renders a page) instead of a page-less machine SA, ranked order is byte-identical across boots, and the keepwarm sweep re-seeds the dominant widget cohort. **No north-star latency delta is claimed** — this is a correctness/ordering fix, not a latency mechanism. No CRD/chart change, no new env knob, seed set unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
