### PR TITLE
feat(prewarm): keepwarm c2 — widget-capable cohort sweep + age-skip

### DIFF
--- a/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
+++ b/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
@@ -365,3 +365,38 @@ arm retargeted to gvr-discovered no-skip; prewarm_first_nav_latch_segment_test.g
 arm widened to the widget-capable prefix. Five RED mutations proven by source-revert-rerun:
 (a) boot gains age-skip, (b) keepwarm loses age-skip, (c) gvr-discovered gains a skip, (i)
 c1 rank-1 bound restored, (ii) widgetMax==0 break dropped.
+
+## 10. C2-C10 deploy-probe spec — REAL names (as-built)
+
+The §5 C2-C10 (a-e) on-cluster probes, keyed to the real emitted names + counters
+(fresh2 60K, PRETTY_LOG:false):
+
+- **(a) admin l1:HIT after >1h idle (SCORING artifact).** Replay an admin /call
+  after the idle window; assert `resolved_cache.lookup hit=true` for the admin
+  cell (the 92-miss window shape gone). This is the customer-facing scorecard row.
+- **(b) admin + narrow cohorts re-seeded, not devs-only.** Grep ONE INFO line per
+  swept cohort: `prewarm.keepwarm.cohort_summary` with fields
+  `{identity, widget_max, reseeds, age_skips, attempted}`. Presence of a line for
+  the admin identity + the narrow login cohorts (not just the devs cohort)
+  confirms the widget-capable-prefix coverage. reseeds>0 on a cohort = its quiet
+  cells were refreshed this cycle; age_skips>0 = its young/churny cells were
+  elided.
+- **(c) evictTTL≈0 for widget-capable cells over a multi-hour soak.** Watch
+  `snowplow_phase1_keepwarm_age_skip_total` climb (steady-state age-skips of
+  churny cells) while the store's `evictTTLTotal` stays ≈0 for the swept cohorts'
+  cells (they are re-Put before expiry). A rising age_skip total with flat
+  evictTTL = the sweep is keeping cells warm cost-proportionally.
+- **(d) /call p95 flat during sweep windows (storm band).** The sweep is
+  engine-yielded; p95 must not move when a sweep runs. The sweep window is
+  bracketed by the `prewarm.keepwarm.sweep.tick` INFO line and the final
+  `prewarm.engine.boot.complete scope=keepwarm` line.
+- **(e) completion, not thrash.** Each cycle's final chunk emits
+  `prewarm.engine.boot.complete` with `scope=keepwarm`. Mid-cycle
+  `prewarm.engine.scope_incomplete` / `scope_requeued` lines are NORMAL for
+  keepwarm at 60K (the chunked sweep straddles budgets); the completion signal is
+  the `scope=keepwarm ... complete` line per cycle, NOT their absence.
+
+Per-cohort seed timing (where applicable) still flows through
+`phase1.seed.restaction.timing` / `phase1.seed.widget.timing` (carry the `cohort`
+field), but probe (b) is the one-line-per-cohort grep that closes the "who was
+re-seeded" question without per-cell noise.

--- a/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
+++ b/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
@@ -1,0 +1,367 @@
+# keepwarm c2 — cohort-coverage extension of the G-TTL sweep (design, 2026-07-07)
+
+Repo: main @ 6d8af79 (1.6.3 line, Fix-3 rank hygiene at tip). Design + BUILD (as-built note §9). Prior docs: docs/g-ttl-quiet-page-keepwarm-design-2026-07-04.md (c1),
+docs/fix3-rank-hygiene-design-2026-07-07.md (Fix-3). Live motivating evidence: fresh2 60K,
+1.6.2 pod at 3.4h uptime served the ADMIN user 92 misses / 108 calls with 12–15s cold
+statistic/listy resolves (team-lead observation 2026-07-07).
+
+## 0. Prior-art check
+
+- This is still refresh-ahead caching (Caffeine `refreshAfterWrite`); client-go has no L1
+  facility. What client-go DOES already give us is the completion machinery: the engine's
+  `workqueue.TypedRateLimitingQueue` (prewarm_engine.go:280-284) with AddRateLimited requeue +
+  Forget-on-success (prewarm_engine.go:492-508, F.4) is exactly the "cut chunk resumes
+  deterministically" primitive c2 needs at scale. Nothing new to import; c2 composes with it.
+- No client-go primitive tracks "identities recently served" — predicate (c) would be
+  hand-built state (§2.3).
+
+## 1. Root cause of the motivating symptom (TRACED)
+
+1. The #102 c1 sweep bound is `if rank1Only && ri > 0 { break }` over the Fix-3 ranked slice
+   (prewarm_engine_boot.go:926-928) — ranked[0] ONLY. Post-Fix-3 ranked[0] is the dominant
+   widget-capable cohort (devs on fresh2), deterministically (prewarm_engine_boot.go:737-745).
+2. The admin identity is never ranked[0]: admin's wildcard binding lands in every GVR bucket
+   (prewarm_enumeration.go:145-147 wildcard union) so admin IS widget-capable (widgetMax≥1),
+   but its CollapsedBindings collapse is far below devs' per-composition RoleBinding
+   population, so admin sits at rank ≥1 and the c1 bound never reaches it.
+3. L1 TTL expiry is lazy-on-Get with CreatedAt sliding only on Put (resolved.go:787-791,
+   :807-808); the refresher never touches quiet cells (g-ttl design §1.3). So every admin cell
+   whose data goes quiet dies at TTL=3600s and NOTHING re-creates it → each admin
+   return-after-idle pays the full 60K cold resolve set. That is the observed 92-miss window.
+4. Symptom-disappear check: putting admin (and every widget-capable login cohort) inside the
+   sweep set means its cells are re-Put each cycle before expiry → a return-after-idle is
+   l1:HIT. The fix targets the exact mechanism producing the misses.
+
+c1's own design scoped this deliberately ("c1 now, c2 refinement", g-ttl §3c); c2 is the
+data-justified extension, not a defect fix in c1.
+
+## 2. Q1 — THE SWEEP SET predicate
+
+Candidate predicates, adjudicated:
+
+**(a) all widget-capable identities (widgetMax ≥ 1)** — the Fix-3 tier boundary
+(prewarm_engine_boot.go:688-696: CollapsedBindings ≥ 1 per observation, so widgetMax ≥ 1 ⇔
+the identity appears in some widget target set). Structural, derived, deterministic, and —
+decisive — a CONTIGUOUS PREFIX of `ranked` post-Fix-3 (widgetMax DESC is the primary sort
+key), so the sweep bound stays a pure loop bound: `break` at the first widgetMax==0 entry.
+Caveat the brief raised: widget-capable ⊅ login cohort — a machine SA CAN hold widget
+bindings in some topologies and would be swept. Adjudication: snowplow has no login-ness
+oracle (login identity lives in authn; the frontend consumes RAs only widget-mediated, Fix-3
+§3 TRACED against the SPA source) — any "login cohort" predicate would be either a name
+heuristic (feedback_no_special_cases violation) or an authn coupling (new seam). Capability
+is the only sound derived predicate available; the waste for a hypothetical widget-capable
+machine SA is bounded by its segment cost and is exactly what refinement (c) would trim.
+
+**(b) top-N ranks — REJECTED.** N is a magic count with no data derivation; the brief and
+feedback_prewarm_walk_no_sampling_caps both reject it.
+
+**(c) activity-driven (identities that SERVED a real /call within the last TTL window) —
+DEFER, data-gated.** Cost-proportional to real usage, no magic count — attractive on paper.
+Traced reality:
+  - NO served-identity recency record exists anywhere (grep lastServed/recency/servedIdentity
+    over internal/ = empty; the dispatcher tracks only the in-flight counter
+    prewarm_engine.go:118 and aggregate counters). It would be NEW state: a per-identity
+    last-served map + locking + staleness eviction + restart semantics.
+  - The bridge problem is worse than the state. The serve side's identity is the JWT tuple
+    and the cell key folds a RE-DERIVED first-match BindingUID
+    (helpers.go:227-270 dispatchCacheLookupKey → rbac.EvaluateRBAC); the sweep's rank unit is
+    the binding REPRESENTATIVE tuple (prewarm_enumeration.go:178-190), and PrewarmTarget's
+    BindingUID field is explicitly DIAGNOSTIC-ONLY, not the cell-key value
+    (prewarm_enumeration.go:67-73). Serve tuple (cyberjoker, [devs]) ≠ seed tuple ("", [devs]).
+    Matching them requires re-deriving EvaluateRBAC per (identity × GVR) at sweep-plan time
+    and comparing against recorded served BindingUIDs — a divergent-producer/consumer
+    derivation pair, the exact class feedback_consultation_mutation_is_not_key_correctness and
+    the #64 saga warn about. Provable, but it needs its own G6-style subset lemma + REAL-
+    derivation falsifier arms.
+  - Restart cold-hole: the record is in-memory; after a deploy no cohort is "active" until it
+    navigates once — the motivating admin symptom would recur once per deploy per cohort.
+  - Payoff check against the customer mix (0.95 narrow + 0.05 admin): both dominant cohorts
+    are active essentially always, so (c)'s savings accrue only on the singleton-user /
+    machine-SA tail — the cheapest segments (narrow RBAC → small filtered lists). High
+    machinery, small win, at odds with project_caching_is_provisional (keep layers removable).
+  Verdict: hold (c) as the refinement, gated on live data (§7 trigger), with the bridge lemma
+  as its entry cost.
+
+**(d) all widget-capable, rank-ordered, budget staggers the tail — CHOSEN, as (a)+completion.**
+With the keepwarm-mode age-skip (§4.2) and F.4 requeue, the budget does not CUT the tail —
+it staggers it across chunks and the sweep completes cost-proportionally. So (d) degenerates
+to "(a), swept in the already-deterministic ranked order, chunked by the existing 8m scope
+budget". No new ordering, no new knob.
+
+**Chosen: sweep set = the widget-capable prefix of `ranked` (widgetMax ≥ 1), in ranked order,
+single keepwarm scope, F.4-chunked.** Machine-SA-with-widget-bindings inclusion is accepted
+and documented (falsifier arm F-C2c makes the inclusion explicit); (c) is the deferred trim.
+
+## 3. Q2 — cost model
+
+Identity cardinality: the rank unit is the representative (Username, sorted-Groups) tuple per
+binding (prewarm_enumeration.go:188-190). Group-subject RBAC collapses the user population
+into group cohorts — 50K bindings → ~16 identities observed on fresh2
+(project_50k_widget_gvr_uniform_wildcard_floor). Two regimes at the 1000-user / 50K canon:
+
+- **Group-cohort RBAC (the observed customer shape, 0.95 narrow mix):** identities stay
+  O(dozens) regardless of user count (users collapse into devs-like groups). Fresh2 60K
+  estimate: devs pass ≈ 190s measured (c1); admin (broad RBAC, 12–15s heavy widgets) ≈
+  200–400s INFERRED; ~14 narrow singleton cohorts ≈ 10–30s each INFERRED (uniform wildcard
+  floor puts every identity in every widget bucket, but narrow RBAC filters lists small).
+  First full sweep ≈ 12–17 min. STEADY-STATE sweeps are strictly cheaper: the age-skip (§4.2)
+  skips every cell the refresher or a customer Put already refreshed this window, so a cycle
+  re-resolves only genuinely-quiet cells. Duty ≈ 13min/34min ≈ 30–40% of ONE background
+  worker worst-case first cycle, engine-yielded (yield-on-inflight before every target,
+  prewarm_engine.go:521-535 + seedScopeYielding checkpoints), memory-bounded per unit by #46
+  enterSeedUnit (phase1_pip_seed.go:559) — customers keep absolute priority; the falsifier
+  includes a p95-flat arm.
+- **Per-user-binding worst case (every user individually bound + widget-capable):** identities
+  ≈ users (1000). Σ segment costs exceeds the sweep window → the cycle can no longer cover
+  everyone. Behavior is GRACEFUL by construction: ranked order = population DESC, so the mass
+  cohorts stay covered; tail cohorts degrade to best-effort (re-Put interval grows beyond
+  TTL → occasional cold, never worse than today). This regime is the explicit (c) trigger
+  (§7). No flat cap is added — cost stays proportional to the topology's real cohort count
+  (feedback_bounding_mechanism_discipline: cost-proportional, not flat-worst-case).
+
+Bounding stack (all existing, composed, no additions): engine yield (per target) → #46
+per-unit adaptive memory gate → per-target pipCohortTimeout → 8m per-scope chunk budget →
+F.4 rate-limited requeue → queue coalescing on "keepwarm".
+
+## 4. Mechanism
+
+### 4.1 Sweep-set bound (the Q5 plumbing)
+
+Replace the two accreted bools (`rank1Only`, `bootScoped`) threading through
+rePrewarmBootScoped → seedScopeYielding → seedOneWidget/seedOneRestaction with ONE mode enum:
+
+```go
+type seedScopeMode int
+const (
+    seedModeBoot          seedScopeMode = iota // all ranks; F.4 live-cell fresh-skip
+    seedModeKeepwarm                            // widget-capable prefix; age-skip (§4.2)
+    seedModeGVRDiscovered                       // all ranks; NO skip (must record dep edges)
+)
+```
+
+The set is DERIVED, not configured — no env, no list. Loop bound
+(prewarm_engine_boot.go:926-928) becomes:
+
+```go
+if mode == seedModeKeepwarm && ranked[ri].widgetMax == 0 {
+    break // widget-capable tier exhausted (Fix-3 prefix property)
+}
+```
+
+c1's rank-1 bound is deleted (superseded, not parameterised). The enum also retires the
+illegal 4th state the two bools admitted (rank1Only && bootScoped) and pins each mode's skip
+semantics at the type level. `rePrewarmKeepwarm` (prewarm_engine_boot.go:214-219) passes
+seedModeKeepwarm; handlers for boot/gvr-discovered pass their modes; ticker, scope kind, queue
+key ("keepwarm"), cadence (TTL×3/4, prewarm_keepwarm_sweep.go:60-71) all UNCHANGED.
+
+### 4.2 Keepwarm age-skip — completion at scale without new state
+
+Problem (TRACED): prewarmScopeTimeout returns pipGlobalTimeout=8m for EVERY scope kind
+(prewarm_engine.go:393-395; phase1_pip_seed.go:141). A full-cohort sweep at 60K (§3, ~13min)
+always overruns one chunk → deadline-cut → F.4 AddRateLimited requeue → today's keepwarm
+(bootScoped=false, no skip) would restart from rank-1 and re-pay the whole prefix every
+chunk — a non-completing loop. c1 never hit this (190s < 8m); c2 structurally does.
+
+Fix: a keepwarm-mode AGE-SKIP in the shared seed primitives, at the same site as the F.4
+boot fresh-skip (phase1_pip_seed.go:538-551 restaction / :778-792 widget — before
+enterSeedUnit, consuming the SAME production key the Put uses, single-derivation-site rule
+F4-C2a):
+
+```go
+skip iff entry live AND time.Since(entry.CreatedAt) < ResolvedCacheTTL() - keepwarmSweepInterval()
+```
+
+The threshold is TTL − TTL×3/4 = TTL/4 — derived from the two existing constants, no knob;
+if the cadence ratio ever changes the threshold follows. Properties:
+
+- **Guarantee.** A skipped cell has age < TTL−P (P = sweep period), so it survives to the
+  next cycle's examination at age < TTL — never expires between sweeps. A non-skipped cell is
+  re-resolved and re-Put now. Under Fix-3-deterministic sweep positions each covered cell's
+  re-Put interval ≈ P < TTL; worst-case jitter (chunk backoff, yields) is one cold window,
+  self-healing next cycle — stated honestly, not hidden.
+- **Chunk resume is cost-proportional.** Cells re-Put by an earlier chunk of the same cycle
+  have age ≈ minutes ≪ TTL/4 → skipped → the requeued continuation pays preamble + remainder
+  only. This is F.4's boot property, recovered for keepwarm with zero cycle-tracking state
+  (no cycle timestamp, no scope payload — dedup on the bare "keepwarm" key is preserved).
+- **Refresher/customer dedup for free.** A cell the event-driven refresher (or a customer
+  Put) refreshed within the last TTL/4 is skipped — the sweep stops redundantly re-resolving
+  churny cells, recovering most of option (b)'s cost-proportionality argument (g-ttl §3b)
+  with none of its machinery. This tightens c1's behavior too (today c1 re-Puts rank-1
+  unconditionally each sweep).
+- **Backstop intact (GTTL-1 restated).** The skip never extends a lifetime — it only elides a
+  redundant re-resolve of a cell that is provably young. Every sweep Put remains a fresh
+  RE-RESOLVE, and declineSeedPutOnError (phase1_pip_seed.go:647, :868, :1030) still declines
+  degraded re-resolves, so a persistently-failing cell TTL-expires — TTL stays the load-
+  bearing staleness outer net (g-ttl §1.6). Nothing here is TTL-extend-on-read (option (a)
+  stays rejected).
+
+The entry's CreatedAt is Put-time-stamped (resolved.go:807-808); handle.Get already applies
+the exact effectiveTTL liveness the serve path uses (resolved.go:787-791). If the cacheHandle
+seam doesn't expose CreatedAt on the returned entry, a read-only accessor is the only cache-
+side touch (≤5 LOC).
+
+### 4.3 Q3 — staggering, adjudicated
+
+- **Per-cohort scopes (one queue key per identity) — REJECTED.** Needs a planner tick handler
+  that pre-computes the ranking to fan out scopes (the ranking today is computed inside the
+  seed from a fresh snapshot — prewarm_engine_boot.go:733-745); every cohort scope re-pays
+  the full preamble (nav re-walk + index rebuild + per-unit targetsFor precompute) × N
+  cohorts; dynamic key cardinality tracks identity count (stale keys on RBAC shifts). More
+  machinery, worse cost.
+- **One scope, larger keepwarm budget (e.g. TTL/2) — REJECTED.** A monolithic multi-10-minute
+  scope occupancy makes a CRUD boot/gvr-discovered scope wait the whole sweep (single worker,
+  FIFO) — breaks the one-budget-max-delay fairness c1 relied on.
+- **One scope + 8m chunks + age-skip resume — CHOSEN.** The workqueue is the stagger: a
+  deadline-cut chunk requeues with backoff (prewarm_engine.go:491-503), and any boot /
+  gvr-discovered scope enqueued meanwhile runs FIRST (FIFO + the requeue's rate-limit delay)
+  — CRUD re-prewarm fairness is preserved with max delay = ONE chunk (≤8m), same as today.
+  Ticks arriving mid-sweep still coalesce on the "keepwarm" key. Expected steady-state logs:
+  `prewarm.engine.scope_incomplete`/`scope_requeued` lines per chunk are NORMAL for keepwarm
+  at scale — the completion signal is the final chunk's `prewarm.engine.boot.complete
+  scope=keepwarm` (observability note, R3-C8-style grep set in §6).
+
+### 4.4 Q4 — TTL interplay (intent confirmed)
+
+Yes, deliberately: for widget-capable cohorts the L1 becomes effectively never-expiring —
+BUT freshness is maintained by RE-RESOLUTION each cycle (fresh bytes, error-gated), and TTL
+remains the staleness backstop for anything the sweep can't refresh (persistent resolve
+failures, #36 short-TTL overrides, widget-less identities' RA cells, cells beyond a degraded
+tail). GTTL-1 invariant restated verbatim: the sweep NEVER extends the life of existing
+bytes. Provisional-cache posture preserved: everything rides the existing implicit-on-cache
+gate (PrewarmEngineEnabled → cache.PrewarmEnabled, prewarm_engine.go:89-91); back-out =
+CACHE_ENABLED=false kills prewarm+engine+ticker together; no new flag to strand.
+
+### 4.5 LOC bound + touched sites
+
+~70–90 LOC total (excl. tests):
+- seedScopeMode enum + threading (rePrewarmBoot/rePrewarmKeepwarm/rePrewarmGVRDiscovered,
+  rePrewarmBootScoped, seedScopeYielding, seedOneWidget, seedOneRestaction signatures) —
+  prewarm_engine_boot.go:202-221, :468-470; phase1_pip_seed.go:460, :699. ~30 LOC net.
+- Loop bound swap (prewarm_engine_boot.go:926-928) — ~4 LOC.
+- Age-skip blocks (mirror of :538-551 / :778-792, keepwarm branch) — ~20 LOC + counter
+  (keepwarmAgeSkipTotal expvar alongside pipSeedFreshSkipTotal).
+- Optional CreatedAt accessor on cacheHandle — ≤5 LOC.
+- Comment/doc updates (c1 header prewarm_keepwarm_sweep.go:13-38 rank-1 wording → widget-
+  capable tier).
+No prewarm_keepwarm_sweep.go mechanism change (ticker/cadence/enqueue untouched); no
+resolved.go store change beyond the possible accessor; no scope-key change.
+
+## 5. PM-gateable conditions
+
+- **C2-C1 (sweep set).** On a fixture with widget-capable identities W1(count 200), W2(5) and
+  a widget-less identity M (RA-only, count 1344): keepwarm mode seeds W1 AND W2's targets and
+  NONE of M's. Mutation arms: (i) restore rank-1 bound → RED (W2 unseeded); (ii) drop the
+  widgetMax==0 break → RED (M seeded = boot behavior leaking into keepwarm).
+- **C2-C2 (machine-SA shape, predicate honesty).** A machine SA WITH a widget binding
+  (widgetMax≥1) IS swept — asserted explicitly so the capability-not-login-ness semantics are
+  pinned, not accidental. Documented as the (c) refinement's target.
+- **C2-C3 (age-skip correctness).** Cells Put < TTL/4 ago are skipped (primitive not entered,
+  keepwarmAgeSkipTotal++); cells older are re-resolved and re-Put with fresh CreatedAt.
+  Mutation: remove the age term (skip on bare liveness, the boot predicate) → RED (nothing
+  re-Puts; the sweep is a no-op — the F4-C3 boundary c1 stated).
+- **C2-C4 (completion under chunking).** With prewarmScopeTimeoutFn shrunk (existing F.4
+  seam, prewarm_engine.go:405) so the sweep deadline-cuts mid-cohort: the requeued
+  continuation age-skips the already-swept prefix and completes the remaining cohorts; total
+  seed-primitive invocations across chunks = one full sweep set (no re-pay, no loss).
+  Mutation: force no-skip in keepwarm mode → RED (chunk 2 re-seeds the prefix; tail starved).
+- **C2-C5 (fairness).** A scopeKindBoot enqueued between keepwarm chunks runs BEFORE the
+  requeued keepwarm continuation (max CRUD delay = one chunk). Reuses the F.4 straddle
+  falsifier machinery.
+- **C2-C6 (backstop, GTTL-1 evolution).** A cell whose re-resolve persistently stage-errors is
+  Put-declined (declineSeedPutOnError) every sweep and TTL-expires — the outer net survives.
+  (c1 ARM-BACKSTOP re-run under the new mode.)
+- **C2-C7 (cost / no-knob).** Diff-scope check: no new env var, no static list, no numeric
+  cap; sweep-set = widgetMax tier, threshold = TTL − interval, both derived. Per-cycle
+  seed-primitive invocation count on a K-identity fixture = Σ widget-capable quiet-cell
+  segments only (churny/fresh cells skipped).
+- **C2-C8 (per-user-keyed L1 untouched).** No change to key derivation or cell sharing —
+  cells stay BindingUID-keyed per identity (grep: dispatchCacheLookupKey/ComputeKey diff-
+  clean; feedback_l1_per_user_keyed_never_cohort).
+- **C2-C9 (c1 arms' evolution — every row runs, === RUN verified).** Enumerated in §6.
+- **C2-C10 (on-cluster symptom-disappear, fresh2 60K).** After one full sweep cycle: (a) an
+  admin /call replay after >1h idle is l1:HIT with fresh content (the 92-miss window shape
+  gone); (b) sweep-window logs show re-seeds under admin + the narrow cohorts, not devs only;
+  (c) evictTTLTotal for widget-capable cohorts' cells ≈ 0 over a multi-hour soak; (d) /call
+  p95 flat during sweep windows (storm band); (e) final chunk logs `scope=keepwarm ...
+  complete` each cycle (completion, not thrash).
+
+## 6. Falsifier plan (hermetic seams: enumeratePrewarmTargetsForGVRFn, seedOne*Fn,
+prewarmScopeTimeoutFn, runKeepwarmSweepLoop short-interval driver — all existing)
+
+New arms: F-C2a sweep-set + both mutations (=C2-C1); F-C2b widget-less RED boundary (in
+C2-C1); F-C2c machine-SA-with-widget-bindings inclusion (=C2-C2); F-C2d age-skip GREEN +
+no-op mutation RED (=C2-C3); F-C2e chunk-completion straddle (=C2-C4); F-C2f fairness
+interleave (=C2-C5); F-C2g cost-count arm (=C2-C7).
+
+c1 arm evolution (prewarm_keepwarm_sweep_test.go + prewarm_first_nav_latch_segment_test.go +
+resolved_keepwarm_reresolve_test.go):
+
+| c1 arm | c2 fate |
+|---|---|
+| ARM-KEEPWARM (ticker cadence → enqueue → re-Put resets CreatedAt) | GREEN unchanged (mechanism untouched); the re-Put assertion must seed a cell OLDER than TTL/4 or the new age-skip elides it — fixture ages adjusted, semantics identical |
+| GTTL-3 / ARM-SCOPE (rank1Only seeds devs only; mutation rank1Only=false touches ops → RED) | EXPECTATION INVERTS BY DESIGN: both devs and ops are widget-capable → both swept. Rewritten as C2-C1 (the RED boundary moves from rank-2 to widgetMax==0) |
+| ARM-BACKSTOP (declined Put → TTL expiry survives) | GREEN re-run under seedModeKeepwarm (=C2-C6) |
+| TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment (post-Fix-3: sweep seeds ranked[0] W only) | Widens: sweep seeds W AND V (both widget-capable); the #99b ruling it encodes (segRank never retargets the sweep bound) stays honored — the bound is the widgetMax tier, still not segRank |
+| F.4 boot fresh-skip arms | GREEN unchanged (boot mode untouched); NEW sibling arms assert keepwarm uses the AGE predicate, gvr-discovered still no-skip (F4-C3 boundary re-pinned per mode) |
+
+All arms run under `go test` with === RUN verification
+(feedback_falsifier_must_actually_run_under_gate_tag_env); kind-backed arms serialized
+(feedback_serialize_kind_test_runs).
+
+## 7. Deferred refinement trigger (predicate (c))
+
+Adopt activity-driven trimming ONLY when live data shows: per-cycle sweep duration
+approaching TTL/4 at a customer topology (the graceful-degradation boundary, §3 regime 2), OR
+sweep duty measurably moving /call p95 (C2-C10d violation). Entry cost is stated up front: a
+served-BindingUID recency record + the serve↔seed identity bridge lemma with real-derivation
+falsifier arms on BOTH sides (no hand-fed keys), + restart-cold-hole semantics. Until then,
+capability-set + age-skip is strictly less machinery for the observed mix.
+
+## 8. Options surfaced (strategic)
+
+- **Sweep set — recommended (d′): widget-capable tier, staggered-complete.** Alternative (c)
+  activity-driven is the principled cost trim but is new stateful machinery with a divergent-
+  derivation bridge; deferred with an explicit data trigger (§7). Alternative (b) top-N
+  rejected outright (magic number).
+- **Mode plumbing — recommended: seedScopeMode enum replacing rank1Only+bootScoped.**
+  Alternative (third bool) keeps signatures smaller per-call but admits illegal states and
+  scatters skip semantics; rejected.
+- **Chunk budget — recommended: keep 8m uniform.** Alternative (TTL-derived keepwarm budget)
+  is knob-free but sacrifices CRUD fairness to monolithic occupancy; rejected (§4.3).
+
+## 9. As-built (2026-07-07, feat/keepwarm-c2-cohorts)
+
+Implemented per §4 shape (d′), ~90 LOC net excl. tests:
+
+- **seedScopeMode enum** (prewarm_engine.go) — `seedModeBoot` / `seedModeKeepwarm` /
+  `seedModeGVRDiscovered`, `String()`. Replaces the (rank1Only, bootScoped) bool pair;
+  retires the illegal 4th state. Threaded through makeBootScopeHandler → rePrewarmBoot /
+  rePrewarmKeepwarm / rePrewarmGVRDiscoveredSeed → rePrewarmBootScoped → seedScopeYielding →
+  seedOneWidget/seedOneRestaction (all signatures now take `mode seedScopeMode`).
+- **Sweep-set bound** (prewarm_engine_boot.go seedScopeYielding loop) — the c1
+  `rank1Only && ri>0 break` is DELETED; the keepwarm bound is now
+  `mode == seedModeKeepwarm && ranked[ri].widgetMax == 0 { break }` (the widget-capable
+  contiguous prefix, Fix-3 property). Rank-log suppressed for keepwarm.
+- **Per-mode seed skip** (phase1_pip_seed.go `seedSkipDecision`, single derivation site) —
+  boot = bare-liveness fresh-skip (F.4, `pipSeedFreshSkipTotal`); keepwarm = age-skip
+  (`keepwarmAgeSkipTotal`) with `time.Since(entry.CreatedAt) < keepwarmAgeSkipThreshold()`;
+  gvr-discovered = never skip. Both primitives call it before enterSeedUnit, consuming the
+  SAME production key the Put uses.
+- **Threshold** (prewarm_keepwarm_sweep.go `keepwarmAgeSkipThreshold`) = TTL − sweepInterval
+  = TTL − TTL×3/4 = TTL/4, derived from cache.ResolvedCacheTTL + the existing cadence
+  fraction. No new knob, no literal. Strict `<` preserves the store's strict `>` expiry
+  boundary interplay (resolved.go:787).
+- **Counter** `keepwarmAgeSkipTotal` (phase1_pip_metrics.go) — expvar
+  `snowplow_phase1_keepwarm_age_skip_total`.
+- Ticker/cadence/scope-key/queue-coalescing UNCHANGED (prewarm_keepwarm_sweep.go). GTTL-1
+  intact (every sweep Put behind declineSeedPutOnError = fresh re-resolve).
+
+Falsifiers (all -race, === RUN verified; mutation transcripts /tmp/c2/):
+prewarm_keepwarm_c2_test.go (C2-C3 age-skip crux + age-term-discriminates, C2-C4 chunked
+completion + per-cell interval < TTL via real engine worker + F.4 requeue, C2-C7 cost, plus
+the boot-old-cell arm that catches mutation (a)); prewarm_keepwarm_sweep_test.go (C2-C1
+widget-capable-prefix + both mutations, C2-C2 machine-SA capability inclusion); F.4 boundary
+arm retargeted to gvr-discovered no-skip; prewarm_first_nav_latch_segment_test.go keepwarm
+arm widened to the widget-capable prefix. Five RED mutations proven by source-revert-rerun:
+(a) boot gains age-skip, (b) keepwarm loses age-skip, (c) gvr-discovered gains a skip, (i)
+c1 rank-1 bound restored, (ii) widgetMax==0 break dropped.

--- a/internal/handlers/dispatchers/phase1_pip_metrics.go
+++ b/internal/handlers/dispatchers/phase1_pip_metrics.go
@@ -112,6 +112,21 @@ var (
 	// stays flat outside boot chunks. Exposed as
 	// snowplow_phase1_seed_fresh_skip_total.
 	pipSeedFreshSkipTotal atomic.Uint64
+
+	// keepwarm c2 (design §4.2) — keepwarmAgeSkipTotal counts KEEPWARM-scope seed
+	// targets elided by the AGE-SKIP: a live L1 cell already existed under the
+	// production key AND was YOUNG (age < TTL−sweepInterval = TTL/4), so the
+	// resolve + Put were skipped. This is what makes a deadline-cut keepwarm
+	// chunk's continuation cost-proportional (chunk N+1 skips the prefix the
+	// earlier chunk re-Put) AND lets the sweep dedup churny cells the refresher /
+	// a customer Put already refreshed this window. DISTINCT from
+	// pipSeedFreshSkipTotal (that is BOOT-scope, bare-liveness): a keepwarm sweep
+	// over a set of OLD live cells drives keepwarmAgeSkip ≈ 0 (they are re-Put,
+	// bumping seed_resolves), while a sweep over recently-refreshed cells drives
+	// it up (seed_resolves flat). Keepwarm-only: boot / gvr-discovered never
+	// age-skip (F4-C3 per-mode boundary). Exposed as
+	// snowplow_phase1_keepwarm_age_skip_total.
+	keepwarmAgeSkipTotal atomic.Uint64
 )
 
 // Ship 0.30.187 D1 — per-(cohort, target) failure maps. Keyed by
@@ -233,6 +248,13 @@ func registerPIPMetrics() {
 		// processed). SEED-SCOPED, boot-only; distinct from seed_resolves.
 		expvar.Publish("snowplow_phase1_seed_fresh_skip_total", expvar.Func(func() any {
 			return pipSeedFreshSkipTotal.Load()
+		}))
+
+		// keepwarm c2 (design §4.2) — keepwarm-scope seed targets elided by the
+		// age-skip (live cell younger than TTL/4; resolve+Put skipped). SEED-SCOPED,
+		// keepwarm-only; distinct from fresh_skip (boot, bare-liveness).
+		expvar.Publish("snowplow_phase1_keepwarm_age_skip_total", expvar.Func(func() any {
+			return keepwarmAgeSkipTotal.Load()
 		}))
 
 		// Ship 0.30.187 D1 — per-(cohort, target) seed-failure maps so

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -457,7 +457,85 @@ func withCohortSeedContext(ctx context.Context, cohort seedTarget,
 //   - restactions.Resolve same entrypoint at restactions.go:183-189.
 //   - encodeResolvedJSON + cacheHandle.Put + ensureWatcherInformerForGVR
 //   - cache.Deps().Record — same Put shape as restactions.go:212-230.
-func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string, bootScoped bool) error {
+// seedSkipDecision is the SHARED per-mode seed-skip predicate for both seed
+// primitives (single derivation site — F4-C2a / keepwarm c2 §4.2). It consumes
+// the EXACT `key` the Put will use (passed by the caller, itself the single
+// dispatchCacheLookupKey derivation) so skip-key correctness cannot drift from
+// Put-key correctness. Returns true iff the target should be skipped (resolve +
+// Put elided, target counted processed); the caller returns nil in that case.
+//
+// The mode selects BOTH the skip predicate and the counter:
+//
+//   - seedModeBoot: bare liveness (F.4 boot fresh-skip). A live cell under the
+//     production key is already warm → skip; bumps pipSeedFreshSkipTotal. This
+//     makes a deadline-cut boot chunk's continuation re-pay only the cold
+//     remainder.
+//   - seedModeKeepwarm: age-skip (c2 §4.2). A live cell YOUNGER than
+//     keepwarmAgeSkipThreshold() (= TTL−sweepInterval = TTL/4) is skipped
+//     (bumps keepwarmAgeSkipTotal); a live-but-OLD cell (age ≥ threshold) is NOT
+//     skipped → the caller re-resolves + re-Puts it with a fresh CreatedAt. A
+//     bare-liveness predicate here would make the sweep a no-op (it would skip
+//     the very cells it exists to refresh — the F4-C3 keepwarm boundary); the
+//     age term is what makes the sweep re-Put quiet-but-still-live cells before
+//     they lazy-expire while dedup'ing churny/fresh cells (recovering F.4's
+//     cost-proportional chunk resume for keepwarm with zero cycle-tracking
+//     state).
+//   - seedModeGVRDiscovered: NEVER skip. gvr-discovered must RE-RESOLVE
+//     already-warm cells so the dep edge against the newly-registered GVR is
+//     recorded (the S4 fix; F4-C3 boundary).
+//
+// The store's Get is itself the freshness/liveness oracle — it returns
+// (entry, true) iff the entry exists AND is non-expired per the exact
+// effectiveTTL logic the serve path uses (resolved.go Get, strict `>` expiry).
+// For the age-skip, the entry's CreatedAt (Put-time-stamped, resolved.go Put)
+// is read directly off the returned live entry — no cache-side accessor needed.
+func seedSkipDecision(mode seedScopeMode, handle cacheHandle, key, class, target, cohortLabel string) bool {
+	switch mode {
+	case seedModeBoot:
+		entry, live := handle.Get(key)
+		if !live || entry == nil {
+			return false
+		}
+		pipSeedFreshSkipTotal.Add(1)
+		slog.Default().Debug("phase1.seed.fresh_skip",
+			slog.String("subsystem", "cache"),
+			slog.String("class", class),
+			slog.String("target", target),
+			slog.String("cohort", cohortLabel),
+			slog.String("effect", "boot-scope fresh-skip: live L1 cell under the production key; "+
+				"resolve+Put skipped, target counted as processed (F.4 cost-proportional resume)"),
+		)
+		return true
+	case seedModeKeepwarm:
+		entry, live := handle.Get(key)
+		if !live || entry == nil {
+			return false
+		}
+		// Age-skip: skip iff the live cell is YOUNGER than the threshold. A cell
+		// at or beyond the threshold is re-resolved (return false). Strict `<`
+		// mirrors the store's strict `>` expiry so a cell AT the threshold is
+		// re-resolved, never left to race the expiry edge.
+		if time.Since(entry.CreatedAt) < keepwarmAgeSkipThreshold() {
+			keepwarmAgeSkipTotal.Add(1)
+			slog.Default().Debug("phase1.seed.keepwarm_age_skip",
+				slog.String("subsystem", "cache"),
+				slog.String("class", class),
+				slog.String("target", target),
+				slog.String("cohort", cohortLabel),
+				slog.Int64("age_ms", time.Since(entry.CreatedAt).Milliseconds()),
+				slog.Int64("threshold_ms", keepwarmAgeSkipThreshold().Milliseconds()),
+				slog.String("effect", "keepwarm age-skip: live cell younger than TTL/4; resolve+Put "+
+					"skipped (cell survives to next sweep at age<TTL; refresher/customer-Put dedup)"),
+			)
+			return true
+		}
+		return false
+	default: // seedModeGVRDiscovered — never skip (F4-C3 boundary).
+		return false
+	}
+}
+
+func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string, mode seedScopeMode) error {
 	got := objects.Get(ctx, ref)
 	if got.Err != nil {
 		// #158 (design §1.3): preserve the typed status error so the call
@@ -517,37 +595,16 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 		return nil
 	}
 
-	// F.4 boot-only fresh-skip (design §3.2). When this is the genuine boot
-	// scope (bootScoped) and the production cell key already holds a LIVE
-	// (non-expired) entry, the target is already warm — count it as processed
-	// and skip the resolve + Put, so a deadline-cut boot chunk's continuation
-	// re-pays only the cold remainder (cost-proportional resume). Gated on
-	// bootScoped ONLY: keepwarm must re-Put (reset CreatedAt) and gvr-discovered
-	// must re-resolve (record the new-GVR dep edge), so both pass bootScoped=false
-	// and fall through to the normal resolve (F4-C3 boundary).
-	//
-	// F4-C2a: freshness is the store's OWN TTL-expiry check — handle.Get returns
-	// (entry, true) iff the entry exists AND is non-expired per the exact
-	// effectiveTTL logic the serve path uses (resolved.go Get). No "TTL-remaining
-	// ≥ X" literal, no put-since bookkeeping. The lookup consumes `key` — the
-	// SAME key derived above by dispatchCacheLookupKey that the Put below uses —
-	// so skip-key correctness cannot drift from Put-key correctness (single
-	// derivation site, feedback_consultation_mutation_is_not_key_correctness).
-	// Placed BEFORE enterSeedUnit so a skipped target never consumes the #46
-	// memory admission (the bound composes trivially — strictly fewer admissions).
-	if bootScoped {
-		if _, live := handle.Get(key); live {
-			pipSeedFreshSkipTotal.Add(1)
-			slog.Default().Debug("phase1.seed.fresh_skip",
-				slog.String("subsystem", "cache"),
-				slog.String("class", "restactions"),
-				slog.String("restaction", ref.Namespace+"/"+ref.Name),
-				slog.String("cohort", cohortLabel),
-				slog.String("effect", "boot-scope fresh-skip: live L1 cell under the production key; "+
-					"resolve+Put skipped, target counted as processed (F.4 cost-proportional resume)"),
-			)
-			return nil
-		}
+	// Per-mode seed skip (F.4 boot fresh-skip + keepwarm c2 age-skip, single
+	// derivation site). seedSkipDecision consults `key` — the SAME key derived
+	// above that the Put below uses — via the store's OWN TTL-expiry Get, so
+	// skip-key correctness cannot drift from Put-key correctness (F4-C2a,
+	// feedback_consultation_mutation_is_not_key_correctness). Placed BEFORE
+	// enterSeedUnit so a skipped target never consumes the #46 memory admission.
+	// The mode selects the predicate: boot = bare liveness (F.4), keepwarm =
+	// age-skip (c2 §4.2), gvr-discovered = never skip (F4-C3 boundary).
+	if seedSkipDecision(mode, handle, key, "restactions", ref.Namespace+"/"+ref.Name, cohortLabel) {
+		return nil
 	}
 
 	// #46 / fold 2026-07-03: bound this seed unit's footprint via the ADAPTIVE
@@ -696,7 +753,7 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 //     matches widgets.go:215-231 (recordWidgetDeps calls
 //     ensureWatcherInformerForGVR for the widget GVR + apiRef GVR +
 //     each resourcesRefs GVR, satisfying AC-PIP.5 for widgets).
-func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, bootScoped bool) error {
+func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode seedScopeMode) error {
 	if e.W == nil {
 		return nil
 	}
@@ -763,30 +820,17 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, bootSc
 		return nil
 	}
 
-	// F.4 boot-only fresh-skip (design §3.2) — mirror of seedOneRestaction. On
-	// the genuine boot scope, if the production widget cell key already holds a
-	// LIVE (non-expired) entry, count it processed and skip resolve+Put so a
-	// deadline-cut boot chunk's continuation is cost-proportional. Gated on
-	// bootScoped ONLY (keepwarm re-Puts, gvr-discovered re-resolves; both pass
-	// false — F4-C3 boundary). Freshness = handle.Get's own TTL-expiry check
-	// (F4-C2a), consuming the SAME `key` derived above (single derivation site,
-	// F4-C2a). BEFORE enterSeedUnit so a skip never consumes the #46 admission.
-	// The unpaginated seedRAFullListForWidget accelerator is skipped along with
-	// the widget resolve — correct, because a live widget cell implies its
-	// first paginated /call already found (or will lazily rebuild) the pinned
-	// full-list; the boot chunk's job is done for this warm target.
-	if bootScoped {
-		if _, live := handle.Get(key); live {
-			pipSeedFreshSkipTotal.Add(1)
-			slog.Default().Debug("phase1.seed.fresh_skip",
-				slog.String("subsystem", "cache"),
-				slog.String("class", "widgets"),
-				slog.String("widget", e.W.GetNamespace()+"/"+e.W.GetName()),
-				slog.String("effect", "boot-scope fresh-skip: live L1 cell under the production key; "+
-					"resolve+Put skipped, target counted as processed (F.4 cost-proportional resume)"),
-			)
-			return nil
-		}
+	// Per-mode seed skip (F.4 boot fresh-skip + keepwarm c2 age-skip) — mirror of
+	// seedOneRestaction, via the SHARED seedSkipDecision (single derivation site).
+	// boot = bare liveness (F.4); keepwarm = age-skip (c2 §4.2); gvr-discovered =
+	// never skip (F4-C3). Freshness/age both read the store's OWN TTL-expiry Get
+	// consuming the SAME `key` derived above. BEFORE enterSeedUnit so a skip never
+	// consumes the #46 admission. The unpaginated seedRAFullListForWidget
+	// accelerator is skipped along with the widget resolve — correct, because a
+	// live widget cell implies its first paginated /call already found (or will
+	// lazily rebuild) the pinned full-list.
+	if seedSkipDecision(mode, handle, key, "widgets", e.W.GetNamespace()+"/"+e.W.GetName(), "") {
+		return nil
 	}
 
 	// #46: bound this seed unit's footprint (semaphore admission + per-unit

--- a/internal/handlers/dispatchers/phase1_pip_seed_test.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed_test.go
@@ -171,7 +171,7 @@ func TestSeedScopeYielding_CtxCancelEmitsAbortLog(t *testing.T) {
 
 	// Zero-value endpoints + nil REST config — never dereferenced (the ctx-check
 	// returns before any target seed).
-	err := seedScopeYielding(ctx, refs, nil /* widgets */, endpoints.Endpoint{}, nil /* rc */, "test-authn-ns", false /* rank1Only */, false /* bootScoped */)
+	err := seedScopeYielding(ctx, refs, nil /* widgets */, endpoints.Endpoint{}, nil /* rc */, "test-authn-ns", seedModeBoot)
 	if err == nil {
 		t.Fatalf("Fix-C(engine): seedScopeYielding with pre-cancelled ctx returned nil; want the ctx error")
 	}

--- a/internal/handlers/dispatchers/prewarm_engine.go
+++ b/internal/handlers/dispatchers/prewarm_engine.go
@@ -191,6 +191,52 @@ const (
 	// with no refactor.
 )
 
+// seedScopeMode is the per-scope seed policy the rePrewarm core threads through
+// seedScopeYielding → seedOneWidget/seedOneRestaction. It REPLACES the two
+// accreted bools (rank1Only, bootScoped) that used to thread the same path
+// (keepwarm c2, design §4.1): those two bools admitted an ILLEGAL 4th state
+// (rank1Only && bootScoped — a keepwarm that also fresh-skips) and scattered
+// the per-mode skip semantics across call sites. The enum makes each mode's
+// (sweep-set bound × skip predicate) a single closed choice, pinned at the type
+// level; a cross-mode skip leak is impossible to express and is additionally
+// caught by the per-mode falsifier arms (F-C2 (a)/(b)/(c)).
+//
+// The three modes and their (bound, skip) semantics:
+//   - seedModeBoot: ALL ranks; F.4 live-cell fresh-skip (a live cell is done →
+//     not re-resolved), so a deadline-cut boot chunk's continuation is
+//     cost-proportional. UNCHANGED from the pre-c2 bootScoped=true behavior.
+//   - seedModeKeepwarm: the WIDGET-CAPABLE PREFIX of `ranked` (widgetMax>=1,
+//     a contiguous prefix post-Fix-3); AGE-SKIP (a young live cell is skipped,
+//     an OLD live cell is re-resolved+re-Put). This SUPERSEDES the c1 rank-1
+//     bound + the pre-c2 keepwarm no-skip (which restarted from rank-1 each
+//     deadline-cut chunk — a non-completing loop at 60K, design §4.2).
+//   - seedModeGVRDiscovered: ALL ranks; NO skip (it must RE-RESOLVE already-warm
+//     cells to record the dep edge against the newly-registered GVR — the S4
+//     fix; F4-C3 boundary). UNCHANGED from the pre-c2 gvr-discovered
+//     bootScoped=false behavior.
+type seedScopeMode int
+
+const (
+	seedModeBoot seedScopeMode = iota
+	seedModeKeepwarm
+	seedModeGVRDiscovered
+)
+
+// String renders the mode for the seed's completion log (replaces the old
+// bool→string map at rePrewarmBootScoped's boot.complete line).
+func (m seedScopeMode) String() string {
+	switch m {
+	case seedModeBoot:
+		return "boot"
+	case seedModeKeepwarm:
+		return "keepwarm"
+	case seedModeGVRDiscovered:
+		return "gvr-discovered"
+	default:
+		return "unknown"
+	}
+}
+
 // prewarmScope is one engine work item.
 //
 // SCOPE-KIND-CARRIED PAYLOAD:

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -76,13 +76,13 @@ func makeBootScopeHandler(deps rePrewarmDeps) func(ctx context.Context, s prewar
 	return func(ctx context.Context, s prewarmScope) error {
 		switch s.kind {
 		case scopeKindBoot:
-			// F.4 — bootScoped=true engages the fresh-skip so a deadline-cut
-			// boot chunk's continuation skips already-live cells.
-			return rePrewarmBoot(ctx, deps, true /*bootScoped*/)
+			// seedModeBoot engages the F.4 fresh-skip so a deadline-cut boot
+			// chunk's continuation skips already-live cells (all ranks).
+			return rePrewarmBoot(ctx, deps, seedModeBoot)
 		case scopeKindGVRDiscovered:
 			return rePrewarmGVRDiscovered(ctx, deps, s.gvr)
 		case scopeKindKeepwarm:
-			// #102 c1 — the TTL-cadenced rank-1 keep-warm sweep.
+			// keepwarm c2 — the TTL-cadenced widget-capable-cohort keep-warm sweep.
 			return rePrewarmKeepwarm(ctx, deps)
 		default:
 			// Ship 2 future scopes (scopeKindWidgetCR / scopeKindRBACShift)
@@ -166,10 +166,10 @@ func rePrewarmGVRDiscovered(ctx context.Context, deps rePrewarmDeps, gvr schema.
 		slog.String("gvr", gvr.String()),
 		slog.String("note", "Ship 2 Stage 2 — re-walk under cohort identities so iterator-empty short-circuit (resolve.go:377-381) no longer skips dep recording for this GVR"),
 	)
-	// bootScoped=false: gvr-discovered must RE-RESOLVE already-warm cells so
-	// the dep edge against the newly-registered GVR is recorded (the S4 fix);
-	// a fresh-skip would reintroduce the defect (F4-C3 boundary).
-	err := rePrewarmBoot(ctx, deps, false /*bootScoped*/)
+	// seedModeGVRDiscovered: NO skip — gvr-discovered must RE-RESOLVE already-warm
+	// cells so the dep edge against the newly-registered GVR is recorded (the S4
+	// fix); any skip would reintroduce the defect (F4-C3 boundary).
+	err := rePrewarmGVRDiscoveredSeed(ctx, deps)
 	if err != nil {
 		slog.Warn("prewarm.engine.gvr_discovered.incomplete",
 			slog.String("subsystem", "cache"),
@@ -185,40 +185,46 @@ func rePrewarmGVRDiscovered(ctx context.Context, deps rePrewarmDeps, gvr schema.
 	return nil
 }
 
-// rePrewarmBoot runs the boot re-walk + per-target-GVR-scoped seed. The
-// SAME walk() is used (via the deps.lister + a fresh phase1Walker per
-// root); the harvesters are shared by reference with the boot pass.
-// rePrewarmBoot runs the full re-walk + index rebuild + per-identity seed. The
-// #102 c1 keepwarm sweep reuses this SAME core via rePrewarmKeepwarm (rank1Only
-// seed), so the sweep gets the boot's dedup, NavOrder, BindingsByGVR index, and
-// yield/memory bounds for free — it IS the seed, just rank-1-bounded.
+// rePrewarmBoot runs the full re-walk + index rebuild + per-identity seed under
+// the given seedScopeMode. The SAME walk() is used (via the deps.lister + a
+// fresh phase1Walker per root); the harvesters are shared by reference with the
+// boot pass. The keepwarm sweep + gvr-discovered scope reuse this SAME core via
+// rePrewarmKeepwarm / rePrewarmGVRDiscoveredSeed, so each gets the boot's dedup,
+// NavOrder, BindingsByGVR index, and yield/memory bounds for free — they ARE the
+// seed, just with a different (sweep-set × skip) mode.
 //
-// bootScoped=true engages the F.4 boot-only fresh-skip in the seed primitives
-// (a live cell is treated as done → not re-resolved), which makes a
-// deadline-cut boot chunk's continuation cost-proportional. It is TRUE only
-// for the genuine boot scope; keepwarm passes false (its Puts must re-resolve
-// fresh bytes + reset CreatedAt) and gvr-discovered passes false (it must
-// re-resolve already-warm cells to record the dep edge against the new GVR).
-func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps, bootScoped bool) error {
-	return rePrewarmBootScoped(ctx, deps, false /*rank1Only*/, bootScoped)
+// mode selects the seed policy in seedScopeYielding + the primitives:
+//   - seedModeBoot: all ranks; F.4 fresh-skip (deadline-cut resume is
+//     cost-proportional).
+//   - seedModeKeepwarm: widget-capable prefix; age-skip (keepwarm c2 §4).
+//   - seedModeGVRDiscovered: all ranks; no skip (record the new-GVR dep edge).
+func rePrewarmBoot(ctx context.Context, deps rePrewarmDeps, mode seedScopeMode) error {
+	return rePrewarmBootScoped(ctx, deps, mode)
 }
 
-// rePrewarmKeepwarm is the #102 c1 keepwarm-sweep handler: the SAME re-walk +
-// seed core as boot, but the seed is bounded to rank-1 (the 95%-mix cohort, all
-// pages). Fires on the TTL×3/4 cadence (keepwarmTicker) so rank-1's cells are
-// re-Put — resetting CreatedAt — before they lazy-expire at TTL. Re-resolving
-// (not TTL-extending) preserves the §1.6 staleness backstop by construction:
-// every sweep Put is FRESH bytes, and the GTTL-1 error-aware Put-gate in the
-// shared seed primitives declines a degraded re-resolve rather than overwrite a
-// good warm entry.
+// rePrewarmKeepwarm is the keepwarm-sweep handler (keepwarm c2): the SAME
+// re-walk + seed core as boot, but seedModeKeepwarm bounds the seed to the
+// WIDGET-CAPABLE PREFIX of `ranked` (every login-cohort-shaped identity, all
+// pages) and applies the age-skip. Fires on the TTL×3/4 cadence
+// (keepwarmTicker) so those cells are re-Put — resetting CreatedAt — before they
+// lazy-expire at TTL. Re-resolving (not TTL-extending) preserves the §1.6
+// staleness backstop by construction: every sweep Put is FRESH bytes, and the
+// GTTL-1 error-aware Put-gate in the shared seed primitives declines a degraded
+// re-resolve rather than overwrite a good warm entry.
 func rePrewarmKeepwarm(ctx context.Context, deps rePrewarmDeps) error {
-	// bootScoped=false: the sweep's whole purpose is to re-Put (reset CreatedAt)
-	// live rank-1 cells before they lazy-expire; a fresh-skip would make it a
-	// no-op (F4-C3 boundary).
-	return rePrewarmBootScoped(ctx, deps, true /*rank1Only*/, false /*bootScoped*/)
+	return rePrewarmBootScoped(ctx, deps, seedModeKeepwarm)
 }
 
-func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only, bootScoped bool) error {
+// rePrewarmGVRDiscoveredSeed is the gvr-discovered seed entrypoint
+// (seedModeGVRDiscovered: all ranks, NO skip). Split out from rePrewarmBoot's
+// bool-arg form so the mode is explicit at the call site (the S4 fix depends on
+// the no-skip semantics; naming it prevents a future edit passing the wrong
+// mode).
+func rePrewarmGVRDiscoveredSeed(ctx context.Context, deps rePrewarmDeps) error {
+	return rePrewarmBootScoped(ctx, deps, seedModeGVRDiscovered)
+}
+
+func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, mode seedScopeMode) error {
 	log := slog.Default()
 	start := time.Now()
 
@@ -372,14 +378,13 @@ func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, rank1Only, boo
 	// propagates; withCohortSeedContext OVERRIDES identity per cohort for the
 	// actual seed, so the SA base is correct for both the derivation fetch
 	// and as the per-cohort seed base.
-	if err := seedScopeYielding(rctx, restactionRefs, widgetEntries, deps.saEP, deps.saRC, deps.authnNS, rank1Only, bootScoped); err != nil {
+	if err := seedScopeYielding(rctx, restactionRefs, widgetEntries, deps.saEP, deps.saRC, deps.authnNS, mode); err != nil {
 		return err
 	}
 
 	log.Info("prewarm.engine.boot.complete",
 		slog.String("subsystem", "cache"),
-		slog.Bool("rank1_only", rank1Only),
-		slog.String("scope", map[bool]string{false: "boot", true: "keepwarm"}[rank1Only]),
+		slog.String("scope", mode.String()),
 		slog.Int64("elapsed_ms", time.Since(start).Milliseconds()),
 	)
 	return nil
@@ -451,23 +456,31 @@ var seedOneRestactionFn = seedOneRestaction
 // the regression journal). Deleting the seam also removes test-only prod code
 // (the #66 shadow class).
 
-// rank1Only, when true, bounds the seed to the rank-1 identity (ranked[0], the
-// highest-CollapsedBindings 95%-mix cohort) — the #102 c1 keepwarm sweep scope.
-// The boot seed passes false (all ranks). It is a pure LOOP BOUND on the
-// existing rank-major loop (ranked is sorted DESC by CollapsedBindings, so
-// ranked[0] IS rank-1); no new seam, no separate loop — the sweep re-runs the
-// identical per-identity seed the boot does, just for the one dominant cohort.
-// bootScoped, when true (genuine boot scope ONLY — not keepwarm, not
-// gvr-discovered), engages the F.4 boot-only fresh-skip inside the per-target
-// seed primitives: a target whose production cell key already holds a live
-// (non-expired) L1 entry is counted as processed WITHOUT re-resolving, making a
-// deadline-cut boot chunk's continuation cost-proportional (≈ preamble +
-// remaining cold targets). It threads straight through to seedOneWidgetFn /
-// seedOneRestactionFn — the skip decision lives INSIDE those primitives so it
-// consumes the EXACT key the Put would use (single derivation site, F4-C2a).
+// mode (seedScopeMode) selects BOTH the SWEEP-SET bound and the per-target skip
+// predicate; it replaces the pre-c2 (rank1Only, bootScoped) bool pair (which
+// admitted an illegal 4th state and scattered skip semantics — keepwarm c2
+// §4.1):
+//
+//   - seedModeBoot: ALL ranks; the seed primitives apply the F.4 fresh-skip
+//     (a live cell is done → not re-resolved), so a deadline-cut boot chunk's
+//     continuation is cost-proportional. UNCHANGED from bootScoped=true.
+//   - seedModeKeepwarm: the WIDGET-CAPABLE PREFIX of `ranked` (widgetMax>=1) —
+//     a CONTIGUOUS PREFIX post-Fix-3 (widgetMax DESC is the primary rank key),
+//     so the sweep-set is a pure LOOP BOUND (`break` at the first widgetMax==0
+//     entry); the primitives apply the AGE-SKIP (keepwarm c2 §4.2). This
+//     SUPERSEDES the c1 rank-1 bound: every login-cohort-shaped (widget-capable)
+//     identity is swept, not just ranked[0], so the admin + narrow cohorts
+//     (widget-capable but rank≥1) are covered — the c2 cohort-coverage fix.
+//   - seedModeGVRDiscovered: ALL ranks; NO skip (the primitives re-resolve
+//     already-warm cells to record the new-GVR dep edge — the S4 fix). UNCHANGED
+//     from bootScoped=false / gvr-discovered.
+//
+// The skip decision lives INSIDE seedOneWidgetFn / seedOneRestactionFn (via the
+// shared seedSkipDecision) so it consumes the EXACT key the Put would use
+// (single derivation site, F4-C2a); mode threads straight through.
 func seedScopeYielding(ctx context.Context,
 	restactionRefs []templatesv1.ObjectReference, widgetEntries []navWidgetEntry,
-	saEP endpoints.Endpoint, saRC *rest.Config, authnNS string, rank1Only, bootScoped bool) error {
+	saEP endpoints.Endpoint, saRC *rest.Config, authnNS string, mode seedScopeMode) error {
 
 	log := slog.Default()
 
@@ -745,8 +758,8 @@ func seedScopeYielding(ctx context.Context,
 	})
 	// Ride-along observability (boot scope only): one line per ranked identity
 	// so two consecutive boots' rank order can be diffed clean (R3-C8 d).
-	// Suppressed under rank1Only to keep the keepwarm sweep logs quiet.
-	if !rank1Only {
+	// Suppressed for keepwarm to keep the sweep logs quiet (it runs on a cadence).
+	if mode != seedModeKeepwarm {
 		for r := range ranked {
 			log.Info("prewarm.engine.seed.rank",
 				slog.String("subsystem", "cache"),
@@ -792,7 +805,7 @@ func seedScopeYielding(ctx context.Context,
 		}
 		engineYieldCheckpoint(ctx)
 		err := seedOneTarget(c, func(cohortCtx context.Context) error {
-			return seedOneWidgetFn(cohortCtx, e, authnNS, bootScoped)
+			return seedOneWidgetFn(cohortCtx, e, authnNS, mode)
 		})
 		if err != nil && ctx.Err() != nil {
 			emitSeedAbort("widgets", ctx.Err())
@@ -811,7 +824,7 @@ func seedScopeYielding(ctx context.Context,
 		}
 		engineYieldCheckpoint(ctx)
 		err := seedOneTarget(c, func(cohortCtx context.Context) error {
-			return seedOneRestactionFn(cohortCtx, cohortLogLabel(c), ref, authnNS, bootScoped)
+			return seedOneRestactionFn(cohortCtx, cohortLogLabel(c), ref, authnNS, mode)
 		})
 		if err != nil && ctx.Err() != nil {
 			emitSeedAbort("restactions", ctx.Err())
@@ -918,12 +931,19 @@ func seedScopeYielding(ctx context.Context,
 	// KEPT unobscured — single rank-1 iteration, widgets-then-restactions, no
 	// interleaving of later ranks.
 	for ri := range ranked {
-		// #102 c1: the keepwarm sweep is bounded to rank-1 (ranked[0]) — the
-		// 95%-mix dominant cohort, on ALL pages. Stop after the first rank. This
-		// is the whole c1 scope: re-resolve rank-1's cell set on the TTL×3/4
-		// cadence so those cells never lazy-expire (each sweep Put resets
-		// CreatedAt). Boot passes rank1Only=false and sweeps every rank.
-		if rank1Only && ri > 0 {
+		// keepwarm c2 (design §4.1): the keepwarm sweep set is the WIDGET-CAPABLE
+		// PREFIX of `ranked` — every identity with widgetMax>=1 (i.e. that renders
+		// at least one widget somewhere), on ALL pages. Because widgetMax DESC is
+		// the primary rank key (Fix-3), the widget-capable identities are a
+		// CONTIGUOUS PREFIX, so the sweep set is a pure LOOP BOUND: break at the
+		// first widgetMax==0 entry (the widget-less tail — RA-only machine SAs,
+		// which the keepwarm sweep does not cover; their cells warm on-demand /
+		// via the refresher). This SUPERSEDES the c1 rank-1 bound: the admin +
+		// narrow login cohorts (widget-capable but rank>=1) are now swept, closing
+		// the c1 cohort-coverage gap. Boot / gvr-discovered sweep every rank (no
+		// break). The age-skip (§4.2) + F.4 requeue stagger this prefix across
+		// chunks so a full sweep completes cost-proportionally.
+		if mode == seedModeKeepwarm && ranked[ri].widgetMax == 0 {
 			break
 		}
 		rankKey := ranked[ri].key

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -795,6 +795,14 @@ func seedScopeYielding(ctx context.Context,
 		)
 	}
 
+	// cohortAttempted counts per-cohort targets attempted (widgets + restactions)
+	// for the keepwarm cohort_summary line (below). Incremented in the two
+	// seed-target closures; snapshotted + reset at each cohort boundary. Safe as
+	// a plain int: the keepwarm seed loop runs SERIALLY (one resolve in flight,
+	// WithPrewarmIterSerial; engineYieldCheckpoint only DEFERS, never parallelises)
+	// so there is no concurrent writer.
+	cohortAttempted := 0
+
 	// seedWidgetTarget / seedRestactionTarget — the per-target seed bodies,
 	// shared by the rank-major loop. Each returns (abort bool, err) where abort
 	// signals a ctx-cancel that must stop the whole seed.
@@ -815,6 +823,7 @@ func seedScopeYielding(ctx context.Context,
 			classifyEngineSeedErr("widget", e.W.GetNamespace()+"/"+e.W.GetName(), cohortLogLabel(c), err)
 		}
 		targetsProcessed++
+		cohortAttempted++
 		return false
 	}
 	seedRestactionTarget := func(ref templatesv1.ObjectReference, c seedTarget) bool {
@@ -834,6 +843,7 @@ func seedScopeYielding(ctx context.Context,
 			classifyEngineSeedErr("restaction", ref.Namespace+"/"+ref.Name, cohortLogLabel(c), err)
 		}
 		targetsProcessed++
+		cohortAttempted++
 		return false
 	}
 
@@ -947,6 +957,16 @@ func seedScopeYielding(ctx context.Context,
 			break
 		}
 		rankKey := ranked[ri].key
+		// keepwarm cohort_summary (PM probe (b), design §9): snapshot the
+		// age-skip counter + attempted count at this cohort's start so the
+		// per-cohort delta is exact. The keepwarm seed loop is the SOLE
+		// keepwarm-mode caller and runs SERIALLY (one resolve in flight,
+		// WithPrewarmIterSerial), so keepwarmAgeSkipTotal's delta across this
+		// cohort's targets is precisely this cohort's age-skips — no other
+		// keepwarm writer races it. (Boot/gvr-discovered never age-skip, so this
+		// bookkeeping is inert outside keepwarm; emitted only for keepwarm below.)
+		cohortAgeSkipStart := keepwarmAgeSkipTotal.Load()
+		cohortAttempted = 0
 		for _, ws := range widgetSeeds {
 			e := ws.e
 			for _, c := range ws.targets {
@@ -995,6 +1015,32 @@ func seedScopeYielding(ctx context.Context,
 					return ctx.Err()
 				}
 			}
+		}
+		// keepwarm cohort_summary (PM probe (b), design §9): ONE INFO line per
+		// SWEPT cohort per sweep cycle — {identity, reseeds, age_skips}. age_skips
+		// = the per-cohort delta of keepwarmAgeSkipTotal; reseeds = attempted −
+		// age_skips (a re-resolve+Put, OR a declined/failed re-resolve — all
+		// non-skip work). Emitted at the cohort boundary (bounded by cohort count
+		// per cycle — no per-cell noise) so a PRETTY_LOG:false deployment can grep
+		// ONE line to confirm "admin + narrow cohorts re-seeded, not devs-only".
+		// Keepwarm-only: boot/gvr-discovered would flood this with per-boot ranks
+		// and never age-skip, so it is scoped to the cadence sweep.
+		if mode == seedModeKeepwarm {
+			ageSkips := keepwarmAgeSkipTotal.Load() - cohortAgeSkipStart
+			reseeds := int64(cohortAttempted) - int64(ageSkips)
+			if reseeds < 0 {
+				reseeds = 0 // defensive: attempted is the loop's own count, cannot underflow in practice
+			}
+			log.Info("prewarm.keepwarm.cohort_summary",
+				slog.String("subsystem", "cache"),
+				slog.String("identity", rankKey),
+				slog.Int("widget_max", ranked[ri].widgetMax),
+				slog.Int64("reseeds", reseeds),
+				slog.Int64("age_skips", int64(ageSkips)),
+				slog.Int("attempted", cohortAttempted),
+				slog.String("effect", "keepwarm sweep re-Put this cohort's quiet cells (reseeds) and elided its "+
+					"young/churny cells (age_skips); one line per swept cohort per cycle (probe b)"),
+			)
 		}
 	}
 	// ── FIX-F SEAM: provably-empty first-nav boundary (F-C3, #99b). ──

--- a/internal/handlers/dispatchers/prewarm_engine_seed_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_seed_latch_test.go
@@ -161,7 +161,7 @@ type seedRunResult struct {
 func runSeedScopeYielding(t *testing.T,
 	widgets []navWidgetEntry,
 	enumFn func(schema.GroupVersionResource, string) []cache.PrewarmTarget,
-	seedFn func(context.Context, navWidgetEntry, string, bool) error,
+	seedFn func(context.Context, navWidgetEntry, string, seedScopeMode) error,
 ) seedRunResult {
 	t.Helper()
 
@@ -192,7 +192,7 @@ func runSeedScopeYielding(t *testing.T,
 	// short-circuits before any of them is dereferenced for I/O.
 	if err := seedScopeYielding(context.Background(),
 		nil /* restactionRefs */, widgets,
-		endpoints.Endpoint{}, nil /* saRC */, "test-authn-ns", false /* rank1Only */, false /* bootScoped */); err != nil {
+		endpoints.Endpoint{}, nil /* saRC */, "test-authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil (per-target errors are non-fatal)", err)
 	}
 
@@ -230,7 +230,7 @@ func TestSeedScopeYielding_OneOperationalFailure_EnqueuesExactlyOnce(t *testing.
 	// ONE target, fails operationally.
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) },
-		func(context.Context, navWidgetEntry, string, bool) error { return opErr() },
+		func(context.Context, navWidgetEntry, string, seedScopeMode) error { return opErr() },
 	)
 
 	if res.enqDelta != 1 {
@@ -280,7 +280,7 @@ func TestSeedScopeYielding_NOperationalFailures_LatchEnqueuesExactlyOnce(t *test
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(n) },
-		func(context.Context, navWidgetEntry, string, bool) error { return opErr() },
+		func(context.Context, navWidgetEntry, string, seedScopeMode) error { return opErr() },
 	)
 
 	if res.opDelta != n {
@@ -310,7 +310,7 @@ func TestSeedScopeYielding_RBACDeny_NoEnqueue_BumpsDenyCounter(t *testing.T) {
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	res := runSeedScopeYielding(t, widgets,
 		func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) },
-		func(context.Context, navWidgetEntry, string, bool) error { return deny403() },
+		func(context.Context, navWidgetEntry, string, seedScopeMode) error { return deny403() },
 	)
 
 	if res.denyDelta != 1 {
@@ -401,7 +401,7 @@ func TestSeedScopeYielding_CounterSumInvariant(t *testing.T) {
 			var idx int
 			res := runSeedScopeYielding(t, widgets,
 				func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return targets },
-				func(context.Context, navWidgetEntry, string, bool) error {
+				func(context.Context, navWidgetEntry, string, seedScopeMode) error {
 					u := targets[idx].Subject.Username
 					idx++
 					return outcome[u]
@@ -450,7 +450,7 @@ func TestSeedScopeYielding_TwoInvocations_QueueCoalescesToOnePending(t *testing.
 
 	widgets := []navWidgetEntry{makeWidgetEntry("ns", "w0")}
 	enumFn := func(schema.GroupVersionResource, string) []cache.PrewarmTarget { return makeTargets(1) }
-	seedFn := func(context.Context, navWidgetEntry, string, bool) error { return opErr() }
+	seedFn := func(context.Context, navWidgetEntry, string, seedScopeMode) error { return opErr() }
 
 	// Invocation 1 — fresh latch, enqueues one boot scope.
 	runSeedScopeYielding(t, widgets, enumFn, seedFn)
@@ -486,5 +486,5 @@ func TestSeedScopeYielding_TwoInvocations_QueueCoalescesToOnePending(t *testing.
 // not silently at the swap site).
 var (
 	_ func(schema.GroupVersionResource, string) []cache.PrewarmTarget = cache.EnumeratePrewarmTargetsForGVR
-	_ func(context.Context, navWidgetEntry, string, bool) error       = seedOneWidget
+	_ func(context.Context, navWidgetEntry, string, seedScopeMode) error       = seedOneWidget
 )

--- a/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
@@ -220,20 +220,20 @@ func TestFixE_RankMajorClassInterleaveFirstNavOrder(t *testing.T) {
 	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
 
 	prevW := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
 		rec.record("widget", e.W.GetName(), eIdentityLabel(ctx))
 		return nil
 	}
 	t.Cleanup(func() { seedOneWidgetFn = prevW })
 
 	prevR := seedOneRestactionFn
-	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ seedScopeMode) error {
 		rec.record("restaction", ref.Name, eIdentityLabel(ctx))
 		return nil
 	}
 	t.Cleanup(func() { seedOneRestactionFn = prevR })
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 

--- a/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
+++ b/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
@@ -333,7 +333,7 @@ func TestF4_FreshSkip_RealSeedOneWidget_SkipsLiveCell(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeBoot)
 	if pipSeedFreshSkipTotal.Load() != skipBefore {
 		t.Fatalf("F4-C2: seedOneWidget must NOT fresh-skip when NO live cell exists (cold first run); freshSkip moved by %d", pipSeedFreshSkipTotal.Load()-skipBefore)
 	}
@@ -352,7 +352,7 @@ func TestF4_FreshSkip_RealSeedOneWidget_SkipsLiveCell(t *testing.T) {
 	buf.Reset()
 	skipMid := pipSeedFreshSkipTotal.Load()
 	resolvesMid := pipBindingSetSeedResolvesTotal.Load()
-	if err := seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/); err != nil {
+	if err := seedOneWidget(granted, e, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("F4-C2: fresh-skip run returned %v; want nil (skip is non-fatal)", err)
 	}
 	if got := pipSeedFreshSkipTotal.Load() - skipMid; got != 1 {
@@ -381,7 +381,7 @@ func TestF4_FreshSkip_RealSeedOneWidget_SkipsLiveCell(t *testing.T) {
 		t.Fatal("F4-C2b: a dirty-marked (updated) cell must remain live per the store's TTL-expiry Get (dirty enqueues for the refresher, does not evict)")
 	}
 	skipC2b := pipSeedFreshSkipTotal.Load()
-	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeBoot)
 	if got := pipSeedFreshSkipTotal.Load() - skipC2b; got != 1 {
 		t.Fatalf("F4-C2b: a dirty-marked-but-live cell must still fresh-skip in the boot seed (refresher owns the re-resolve); freshSkip delta=%d", got)
 	}
@@ -414,7 +414,7 @@ func TestF4_FreshSkip_MisKeyedLookupDoesNotSkip_MutationShape(t *testing.T) {
 	handle.Put(key+"-WRONG", &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs})
 
 	skipBefore := pipSeedFreshSkipTotal.Load()
-	_ = seedOneWidget(granted, e, "authn-ns", true /*bootScoped*/)
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeBoot)
 	if pipSeedFreshSkipTotal.Load() != skipBefore {
 		t.Fatalf("F4-C2 mutation shape: a live cell under a NON-production key must NOT cause a fresh-skip — the skip consumes the production-key derivation; freshSkip moved by %d", pipSeedFreshSkipTotal.Load()-skipBefore)
 	}
@@ -423,14 +423,16 @@ func TestF4_FreshSkip_MisKeyedLookupDoesNotSkip_MutationShape(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// ARM 4 — BOUNDARY (F4-C3): fresh-skip is boot-only. seedOneWidget(bootScoped=
-// FALSE) over a LIVE cell must NOT skip — it proceeds to resolve (as keepwarm
-// re-Put and gvr-discovered re-resolve both require). We assert the ABSENCE of
-// the fresh-skip: freshSkip flat + no phase1.seed.fresh_skip log, even though a
-// live cell exists under the production key.
+// ARM 4 — BOUNDARY (F4-C3): the F.4 bare-liveness fresh-skip is boot-only.
+// seedModeGVRDiscovered over a LIVE cell must NOT skip AT ALL (neither the
+// fresh-skip nor the c2 age-skip) — it must re-resolve to record the new-GVR
+// dep edge (the S4 fix). We assert BOTH counters flat + no skip log, even though
+// a live cell exists under the production key. (keepwarm c2 §6 F4-C3 per-mode
+// boundary: this arm now pins the gvr-discovered no-skip; the keepwarm age-skip
+// boundary is pinned by TestC2AgeSkip_* in prewarm_keepwarm_c2_test.go.)
 // ─────────────────────────────────────────────────────────────────────────
 
-func TestF4_Boundary_NonBootScopeDoesNotFreshSkipLiveCell(t *testing.T) {
+func TestF4_Boundary_GVRDiscoveredScopeNeverSkipsLiveCell(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 
@@ -442,7 +444,7 @@ func TestF4_Boundary_NonBootScopeDoesNotFreshSkipLiveCell(t *testing.T) {
 	if handle == nil || key == "" {
 		t.Fatal("setup: real key derivation")
 	}
-	// Install a live cell — the exact condition boot-scope WOULD skip.
+	// Install a live cell — the exact condition boot-scope WOULD fresh-skip.
 	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs})
 	if _, live := handle.Get(key); !live {
 		t.Fatal("setup: live cell installed")
@@ -453,17 +455,22 @@ func TestF4_Boundary_NonBootScopeDoesNotFreshSkipLiveCell(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	skipBefore := pipSeedFreshSkipTotal.Load()
-	// bootScoped=FALSE — the keepwarm / gvr-discovered path. MUST NOT fresh-skip.
-	_ = seedOneWidget(granted, e, "authn-ns", false /*bootScoped*/)
-	if got := pipSeedFreshSkipTotal.Load() - skipBefore; got != 0 {
-		t.Fatalf("F4-C3 BOUNDARY: a NON-boot scope (keepwarm/gvr-discovered) must NOT fresh-skip a live cell — it must re-Put/re-resolve; freshSkip delta=%d (want 0)", got)
+	freshBefore := pipSeedFreshSkipTotal.Load()
+	ageBefore := keepwarmAgeSkipTotal.Load()
+	// seedModeGVRDiscovered — MUST NOT skip (neither predicate); re-resolves to
+	// record the new-GVR dep edge.
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeGVRDiscovered)
+	if got := pipSeedFreshSkipTotal.Load() - freshBefore; got != 0 {
+		t.Fatalf("F4-C3 BOUNDARY: gvr-discovered must NOT fresh-skip a live cell; freshSkip delta=%d (want 0)", got)
 	}
-	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.fresh_skip")) {
-		t.Fatalf("F4-C3 BOUNDARY: a non-boot scope must NOT emit phase1.seed.fresh_skip over a live cell; logs:\n%s", buf.String())
+	if got := keepwarmAgeSkipTotal.Load() - ageBefore; got != 0 {
+		t.Fatalf("F4-C3 BOUNDARY: gvr-discovered must NOT age-skip a live cell (age-skip is keepwarm-only); ageSkip delta=%d (want 0)", got)
 	}
-	writeF4Artifact(t, "arm4_boundary_nonboot_no_skip.txt",
-		"bootScoped=false over a LIVE cell → no fresh-skip (keepwarm re-Puts, gvr-discovered re-resolves; fresh-skip is boot-only)")
+	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.fresh_skip")) || bytes.Contains(buf.Bytes(), []byte("phase1.seed.keepwarm_age_skip")) {
+		t.Fatalf("F4-C3 BOUNDARY: gvr-discovered must NOT emit any skip log over a live cell; logs:\n%s", buf.String())
+	}
+	writeF4Artifact(t, "arm4_boundary_gvrdiscovered_no_skip.txt",
+		"seedModeGVRDiscovered over a LIVE cell → no fresh-skip AND no age-skip (must re-resolve to record the new-GVR dep edge; the S4 fix)")
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
+++ b/internal/handlers/dispatchers/prewarm_f4_boot_resume_test.go
@@ -24,9 +24,10 @@
 //     (freshSkip +1, seedResolves flat). No hand-fed keys. + PM F4-C2b:
 //     dirty-mark between runs → skip still fires AND the refresher's independent
 //     re-resolve for that key still fires. MUTATION: mis-key the skip → RED.
-//   4 BOUNDARY (F4-C3): keepwarm-scoped (bootScoped=false) re-Puts a live cell
-//     (CreatedAt slides); gvr-discovered-scoped (bootScoped=false) re-resolves a
-//     live cell. Both prove fresh-skip is boot-only.
+//   4 BOUNDARY (F4-C3): gvr-discovered-scoped (seedModeGVRDiscovered) re-resolves
+//     a live cell — proves the F.4 bare-liveness fresh-skip is boot-only. (The
+//     keepwarm-mode age-skip boundary is pinned separately in the C2 arms:
+//     keepwarm age-skips a YOUNG live cell but re-resolves an OLD-but-live one.)
 //   5 EXACTLY-ONCE cross-chunk (F4-C4): latch fired in chunk 1 (segment done,
 //     tail cut) → chunk 2 completes tail → NO second fire.
 //

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -124,7 +124,7 @@ func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(
 	}
 	t.Cleanup(func() { firstNavFireObserver = nil })
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -226,7 +226,7 @@ func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *test
 	}
 	t.Cleanup(func() { firstNavFireObserver = nil })
 
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -301,25 +301,25 @@ func harvestWidgetAtRootNoReset(h *navWidgetHarvester, name string, gvr schema.G
 	eHarvestWidget(h, name, gvr)
 }
 
-// ── ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3) ───────
-// The #102 keepwarm sweep (rank1Only=true) bounds the seed to ranked[0] — the
-// dominant cohort's CELLS — regardless of whether ranked[0] has a FIRST-NAV
-// (RootIndex==0) widget. segRank (the latch segment identity, #99b) is a
-// LATCH-ONLY (boot-gate) concept and must NOT retarget the keepwarm loop bound.
+// ── ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3 + c2) ───
+// keepwarm c2 WIDENS this arm (design §6 c1-arm table): the keepwarm sweep now
+// bounds the seed to the WIDGET-CAPABLE PREFIX (widgetMax>=1), not ranked[0]
+// only — so it seeds W AND V (both widget-capable). The #99b ruling this arm
+// encodes SURVIVES the widening: the loop bound is the widgetMax TIER, still NOT
+// segRank. segRank (the latch segment identity, #99b) is a LATCH-ONLY (boot-gate)
+// concept and must NOT retarget the keepwarm loop bound — this arm pins that the
+// sweep's coverage follows the widgetMax tier regardless of which identity is
+// the first-nav segment.
 //
-// This arm PINS: sweep bound follows ranked[0], NOT retargeted by segRank. It
-// requires ranked[0] != segKey (a DIVERGENCE fixture) or the assert is a
-// tautology. Post-FIX-3, ranked[0] is always widget-capable, so we force
-// divergence via MULTI-ROOT topology: W (widgetMax 9) is ranked[0] but ALL its
-// widgets are RootIndex==1 → segRank>0 (the segment falls to V, a lower-ranked
-// identity with a RootIndex==0 widget). The sweep MUST seed W (ranked[0]), NOT
-// V (the segment). The property "the loop bound is `ri>0 break`, untouched by
-// segRank" is exactly what this now pins; the old RA-only-ranked[0] property
-// (pre-FIX-3) is subsumed — a widget-less identity can no longer be ranked[0],
-// so the surviving divergence is ranked[0]-widget-capable-but-non-first-nav,
-// covered here. (The multi-root first-nav LATCH behaviour itself is pinned by
-// TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget below.)
-func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
+// DIVERGENCE fixture (ranked[0] != segKey): W (widgetMax 9) is ranked[0] but ALL
+// its widgets are RootIndex==1 → segRank>0 (the segment falls to V, a
+// lower-ranked identity with a RootIndex==0 widget). Both are widget-capable, so
+// c2 sweeps BOTH; the assert is that the sweep coverage is the widget-capable
+// tier (W and V), NOT keyed on segRank (which would, wrongly, retarget the loop
+// to only V or reorder around it). (The multi-root first-nav LATCH behaviour
+// itself is pinned by TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget
+// below.)
+func TestKeepwarmSweep_WidgetCapablePrefix_SeedsBothNotSegmentOnly(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
@@ -334,7 +334,7 @@ func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 
 	// W (widgetMax 9) is ranked[0], but its widget is RootIndex==1 (non-first-
 	// nav) → segRank>0. V (widgetMax 2) has a RootIndex==0 widget → V is the
-	// segment identity, at a lower rank. ranked = [W(0), V(1)].
+	// segment identity, at a lower rank. ranked = [W(0), V(1)]; BOTH widget-capable.
 	w := eID{name: "w", group: true, collapsed: 9}
 	v := eID{name: "v", group: true, collapsed: 2}
 
@@ -360,8 +360,8 @@ func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 			return schema.GroupVersionResource{}, false
 		})
 
-	// rank1Only=true — the keepwarm sweep.
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", true, false); err != nil {
+	// seedModeKeepwarm — the c2 keepwarm sweep (widget-capable prefix).
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeKeepwarm); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -370,9 +370,9 @@ func TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment(t *testing.T) {
 	seededV := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:v" }) < len(ev)
 
 	if !seededW {
-		t.Fatalf("keepwarm ruling: rank1Only sweep did NOT seed ranked[0] (W, widgetMax 9) — the sweep bound must follow ranked[0], the dominant cohort's cells; events=%+v", ev)
+		t.Fatalf("c2 keepwarm ruling: sweep did NOT seed ranked[0] (W, widgetMax 9) — the widget-capable prefix must include ranked[0]; events=%+v", ev)
 	}
-	if seededV {
-		t.Fatalf("keepwarm ruling: rank1Only sweep seeded V (rank 1, the SEGMENT identity) — segRank must NOT retarget the keepwarm loop bound (that would be a scope change, out of #99b); events=%+v", ev)
+	if !seededV {
+		t.Fatalf("c2 keepwarm ruling: sweep did NOT seed V (widgetMax 2, widget-capable) — c2 WIDENS coverage to the whole widget-capable prefix, not ranked[0] only; the #99b property (bound is the widgetMax tier, NOT segRank) must still seed V; events=%+v", ev)
 	}
 }

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -37,18 +37,17 @@
 //     they resume from the boot walk's curRoot and stamp 1). Exercised at the
 //     harvester level (BeginWalk/BeginRoot are the unit under test).
 //
-//   ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3 divergence
-//     fixture): the #102 keepwarm sweep (rank1Only=true) re-seeds ranked[0]'s
-//     CELLS, NOT the segment identity's. segRank is a latch-only concept and
-//     does NOT retarget the keepwarm loop bound. Post-FIX-3 the pre-FIX-3
-//     fixture (ranked[0]=RA-only M) no longer diverges — M drops to the tail
-//     and ranked[0]=U1 is BOTH widget-capable AND the segment, so it would not
-//     discriminate. TestKeepwarmSweep_RankOne_SeedsRankZeroNotSegment now uses
-//     a MULTI-ROOT divergence fixture: W (widgetMax 9, but ALL its widgets are
-//     RootIndex==1) is ranked[0]; the segment identity is V (a lower-ranked
-//     identity with a RootIndex==0 widget) at segRank>0. The sweep MUST seed W
-//     (ranked[0]), NOT V (the segment) — proving the loop bound follows
-//     ranked[0], not segKey.
+//   ARM-KEEPWARM-SEGRANK (segRank/keepwarm interaction ruling, FIX-3 + c2
+//     divergence fixture): the keepwarm sweep (seedModeKeepwarm) re-seeds the
+//     WIDGET-CAPABLE PREFIX's CELLS; segRank is a latch-only concept and does NOT
+//     retarget the keepwarm loop bound (the bound is the widgetMax tier). c2
+//     WIDENS this from the c1 rank-1-only bound: the sweep now covers every
+//     widget-capable identity. TestKeepwarmSweep_WidgetCapablePrefix_SeedsBothNotSegmentOnly
+//     uses a MULTI-ROOT divergence fixture: W (widgetMax 9, but ALL its widgets
+//     are RootIndex==1) is ranked[0]; the segment identity is V (a lower-ranked
+//     but still widget-capable identity with a RootIndex==0 widget) at segRank>0.
+//     The sweep MUST seed BOTH W and V (both widget-capable), NOT keyed on
+//     segRank — proving the loop bound follows the widgetMax tier, not segKey.
 //
 // Hermetic, -race, seams only. Serializes on engineLatchTestMu.
 

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
@@ -134,14 +134,14 @@ func installLatchSeams(t *testing.T, rec *latchRecorder,
 	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
 
 	prevW := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
 		rec.rec(latchSeedEvent{class: "widget", label: e.W.GetName(), rootIdx: e.RootIndex, identity: eIdentityLabel(ctx)})
 		return nil
 	}
 	t.Cleanup(func() { seedOneWidgetFn = prevW })
 
 	prevR := seedOneRestactionFn
-	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ seedScopeMode) error {
 		rec.rec(latchSeedEvent{class: "restaction", label: ref.Name, rootIdx: -1, identity: eIdentityLabel(ctx)})
 		return nil
 	}
@@ -220,7 +220,7 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 		}
 
 		installLatchFireObserver(t, rec)
-		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 			t.Fatalf("seedScopeYielding returned %v; want nil", err)
 		}
 		return rec.snapshot()
@@ -308,7 +308,7 @@ func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
 		})
 
 	installLatchFireObserver(t, rec)
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()
@@ -392,7 +392,7 @@ func TestFirstNavLatch_ConcurrentFireWait_RealSegmentPath_Race(t *testing.T) {
 	// SEED goroutine — the REAL production fire site closes the latch.
 	seedErr := make(chan error, 1)
 	go func() {
-		seedErr <- seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false)
+		seedErr <- seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot)
 	}()
 
 	if err := <-seedErr; err != nil {
@@ -480,7 +480,7 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 	installLatchFireObserver(t, rec)
 	// MUTATION (ii): fire BEFORE the segment completes (before any seed).
 	latch.fire("mutation-ii-premature", 0, 0, "", -1, 0)
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	ev := rec.snapshot()

--- a/internal/handlers/dispatchers/prewarm_keepwarm_c2_test.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_c2_test.go
@@ -20,12 +20,16 @@ package dispatchers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
 )
@@ -379,4 +383,126 @@ func TestC2Cost_SecondSweepOverYoungSet_AgeSkipsAll(t *testing.T) {
 		t.Fatalf("C2-C7: an age-skipped cell must NOT contribute a resolve (cost = quiet-cell segments only); seedResolves delta=%d", got)
 	}
 	writeC2Artifact(t, "c2c7_cost_proportional.txt", "young/churny cell → age-skip (no re-resolve); cost = Σ quiet-cell segments only")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// cohort_summary LINE-CONTENT (PM rework #3, probe (b); #98 pin-the-line
+// discipline). Drive the REAL seedScopeYielding under seedModeKeepwarm over a
+// MIXED fixture of two widget-capable cohorts on the SAME widget GVR:
+//   - cohort "reseed"  : all targets RE-SEEDED  → summary {reseeds==targets, age_skips==0}
+//   - cohort "skipall" : all targets AGE-SKIPPED → summary {age_skips==targets, reseeds==0}
+// We assert the EMITTED prewarm.keepwarm.cohort_summary line CONTENT per cohort
+// (identity, reseeds, age_skips) — not the plumbing. The seams model each
+// cohort's per-target outcome: the skipall seam bumps keepwarmAgeSkipTotal (as
+// the real primitive does on an age-skip) and the reseed seam does not (as the
+// real primitive's re-Put path does). The cohort-boundary AGGREGATION + the
+// emitted line are the REAL prod code under test (prewarm_engine_boot.go).
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestC2CohortSummary_LineContent_MixedFixture(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+
+	// Two widget-capable cohorts; distinct collapsed counts so ranked order is
+	// deterministic (both widgetMax>=1 → both in the swept prefix).
+	reseed := eID{name: "reseed", group: true, collapsed: 200}
+	skipall := eID{name: "skipall", group: true, collapsed: 50}
+
+	h := newNavWidgetHarvester()
+	widgetGVR := eWidgetGVR("flexes")
+	// Two widgets so each cohort attempts >1 target (targets==2 per cohort).
+	eHarvestWidget(h, "dashboard-flex", widgetGVR)
+	eHarvestWidget(h, "obs-panel", widgetGVR)
+	widgets := h.snapshot()
+
+	prevEnum := enumeratePrewarmTargetsForGVRFn
+	enumeratePrewarmTargetsForGVRFn = func(g schema.GroupVersionResource, _ string) []cache.PrewarmTarget {
+		if g == widgetGVR {
+			return eIdentityTargets(g, reseed, skipall)
+		}
+		return nil
+	}
+	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
+
+	// The seam models each cohort's per-target outcome: skipall bumps the
+	// age-skip counter (the real primitive's age-skip path), reseed does not
+	// (the real primitive's re-Put path). The cohort-boundary aggregation reads
+	// keepwarmAgeSkipTotal's delta, exactly as it does for the real primitive.
+	prevW := seedOneWidgetFn
+	seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string, mode seedScopeMode) error {
+		if eIdentityLabel(ctx) == "group:skipall" {
+			keepwarmAgeSkipTotal.Add(1) // model an age-skip
+		}
+		return nil
+	}
+	t.Cleanup(func() { seedOneWidgetFn = prevW })
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeKeepwarm); err != nil {
+		t.Fatalf("seedScopeYielding(keepwarm) returned %v; want nil", err)
+	}
+
+	// Parse the emitted cohort_summary lines and index by identity.
+	type summary struct {
+		Msg      string `json:"msg"`
+		Identity string `json:"identity"`
+		Reseeds  int64  `json:"reseeds"`
+		AgeSkips int64  `json:"age_skips"`
+		Attempt  int    `json:"attempted"`
+	}
+	// Index by a stable substring of the identity: the emitted `identity` field
+	// is the raw rankKey (identityKey(c) = Username + \x1f + sorted-Groups), so
+	// for a group cohort it CONTAINS the group name. Match on Contains rather
+	// than hardcoding the \x1f separator.
+	find := func(want string) (summary, bool) {
+		for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
+			var s summary
+			if err := json.Unmarshal(line, &s); err != nil {
+				continue
+			}
+			if s.Msg == "prewarm.keepwarm.cohort_summary" && bytes.Contains([]byte(s.Identity), []byte(want)) {
+				return s, true
+			}
+		}
+		return summary{}, false
+	}
+	// Count total cohort_summary lines: EXACTLY two (one per swept cohort).
+	nLines := 0
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		var s summary
+		if len(line) > 0 && json.Unmarshal(line, &s) == nil && s.Msg == "prewarm.keepwarm.cohort_summary" {
+			nLines++
+		}
+	}
+	if nLines != 2 {
+		t.Fatalf("cohort_summary: want exactly 2 lines (one per swept cohort); got %d. logs:\n%s", nLines, buf.String())
+	}
+
+	rs, ok := find("reseed")
+	if !ok {
+		t.Fatalf("cohort_summary: missing line for the reseed cohort. logs:\n%s", buf.String())
+	}
+	if rs.Attempt != 2 || rs.Reseeds != 2 || rs.AgeSkips != 0 {
+		t.Fatalf("cohort_summary(reseed): want {attempted:2, reseeds:2, age_skips:0}; got {attempted:%d, reseeds:%d, age_skips:%d}", rs.Attempt, rs.Reseeds, rs.AgeSkips)
+	}
+
+	sk, ok := find("skipall")
+	if !ok {
+		t.Fatalf("cohort_summary: missing line for the skipall cohort. logs:\n%s", buf.String())
+	}
+	if sk.Attempt != 2 || sk.AgeSkips != 2 || sk.Reseeds != 0 {
+		t.Fatalf("cohort_summary(skipall): want {attempted:2, age_skips:2, reseeds:0} (skips==targets, reseeds==0); got {attempted:%d, reseeds:%d, age_skips:%d}", sk.Attempt, sk.Reseeds, sk.AgeSkips)
+	}
+
+	writeC2Artifact(t, "cohort_summary_line_content.txt", fmt.Sprintf(
+		"reseed cohort: attempted=%d reseeds=%d age_skips=%d\nskipall cohort: attempted=%d reseeds=%d age_skips=%d\n(one INFO line per swept cohort; probe b = grep prewarm.keepwarm.cohort_summary)",
+		rs.Attempt, rs.Reseeds, rs.AgeSkips, sk.Attempt, sk.Reseeds, sk.AgeSkips))
 }

--- a/internal/handlers/dispatchers/prewarm_keepwarm_c2_test.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_c2_test.go
@@ -1,0 +1,382 @@
+// prewarm_keepwarm_c2_test.go — keepwarm c2 age-skip + completion falsifiers
+// (docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md §5/§6, PM conditions
+// C2-C3/C2-C4/C2-C7 + the three per-mode RED mutations).
+//
+// Hermetic, -race, seams + a real in-memory L1 (no apiserver except the fixC
+// dynamicfake watcher reused from prewarm_seed_empty_binding_skip_test.go).
+// Serializes on engineLatchTestMu. Never touches ./internal/rbac.
+//
+// The age-skip threshold is TTL/4; these arms pin RESOLVED_CACHE_TTL_SECONDS to
+// a small fixture value (t.Setenv) so "young" and "old" ages are testable in
+// wall-clock milliseconds, and assert the DERIVED threshold, never a literal.
+//
+// Mutation evidence captured to /tmp/c2/ (RED transcripts) by source-comparison:
+// each RED is expressed as a discriminating observable (the exact assertion the
+// prod predicate makes) so a reviewer can revert the prod line and re-run to see
+// the arm flip, without a prod seam.
+
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// c2TTL pins a small fixture TTL so the age-skip threshold (TTL/4) is a
+// wall-clock-testable duration. 4000ms TTL → sweepInterval 3000ms → threshold
+// (TTL−sweepInterval) 1000ms. Returns the derived threshold for the arm to
+// assert against (never a literal in the assertion).
+func c2SetFixtureTTL(t *testing.T) (ttl, threshold time.Duration) {
+	t.Helper()
+	t.Setenv("RESOLVED_CACHE_TTL_SECONDS", "4") // 4s TTL; threshold = 4s − 3s = 1s
+	ttl = cache.ResolvedCacheTTL()
+	threshold = keepwarmAgeSkipThreshold()
+	if ttl != 4*time.Second || threshold != 1*time.Second {
+		t.Fatalf("c2 fixture TTL setup: want ttl=4s threshold=1s (TTL/4); got ttl=%v threshold=%v", ttl, threshold)
+	}
+	return ttl, threshold
+}
+
+func writeC2Artifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/c2", 0o755)
+	_ = os.WriteFile("/tmp/c2/"+name, []byte(body), 0o644)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C2-C3 (age-skip correctness, the age-vs-liveness crux). Drive the REAL
+// seedOneWidget under seedModeKeepwarm against a real in-memory L1, with the
+// live cell's CreatedAt controlled to be YOUNG (< TTL/4) vs OLD (>= TTL/4):
+//   - YOUNG live cell  → age-skip (keepwarmAgeSkipTotal +1, seedResolves flat).
+//   - OLD live cell    → NOT skipped → re-resolve path entered (no age-skip).
+//
+// GREEN = the OLD cell IS re-examined (not skipped). RED mutation = change the
+// predicate to bare liveness → the OLD cell would ALSO be skipped → the sweep is
+// a no-op. We prove the discriminator by showing the two ages produce DIFFERENT
+// skip outcomes under the SAME production key (a bare-liveness predicate would
+// skip BOTH).
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestC2AgeSkip_YoungSkipped_OldReResolved(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	_, threshold := c2SetFixtureTTL(t)
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" || inputs == nil || inputs.BindingUID == "" {
+		t.Fatalf("C2-C3 setup: granted cohort must derive a real non-empty-binding key; key=%q inputs=%+v", key, inputs)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// ── (a) YOUNG live cell (age well under threshold) → age-skip. Put with a
+	// CreatedAt of "now" (fresh); the store honors an explicit CreatedAt.
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs, CreatedAt: time.Now()})
+	if _, live := handle.Get(key); !live {
+		t.Fatal("C2-C3 setup: young cell must be live")
+	}
+	ageSkipBefore := keepwarmAgeSkipTotal.Load()
+	resolvesBefore := pipBindingSetSeedResolvesTotal.Load()
+	if err := seedOneWidget(granted, e, "authn-ns", seedModeKeepwarm); err != nil {
+		t.Fatalf("C2-C3: keepwarm seed over young cell returned %v; want nil (skip is non-fatal)", err)
+	}
+	if got := keepwarmAgeSkipTotal.Load() - ageSkipBefore; got != 1 {
+		t.Fatalf("C2-C3(a): a YOUNG live cell (age < TTL/4=%v) must AGE-SKIP exactly once; ageSkip delta=%d. logs:\n%s", threshold, got, buf.String())
+	}
+	if got := pipBindingSetSeedResolvesTotal.Load() - resolvesBefore; got != 0 {
+		t.Fatalf("C2-C3(a): an age-skip must NOT resolve+Put; seedResolves delta=%d (want 0)", got)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("phase1.seed.keepwarm_age_skip")) {
+		t.Fatalf("C2-C3(a): the age-skip must emit phase1.seed.keepwarm_age_skip; logs:\n%s", buf.String())
+	}
+
+	// ── (b) OLD live cell (age >= threshold) under the SAME production key →
+	// NOT age-skipped. Re-Put the cell with an OLD CreatedAt (threshold + margin
+	// in the past, but still younger than the full TTL so the store's Get keeps
+	// it LIVE — this is the crux: live BUT old).
+	buf.Reset()
+	oldCreatedAt := time.Now().Add(-(threshold + 500*time.Millisecond)) // age ≈ 1.5s: > TTL/4 (1s), < TTL (4s)
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs, CreatedAt: oldCreatedAt})
+	if _, live := handle.Get(key); !live {
+		t.Fatal("C2-C3(b) setup: the OLD cell must still be LIVE (age < full TTL) — the live-but-old crux")
+	}
+	ageSkipBeforeOld := keepwarmAgeSkipTotal.Load()
+	// The re-resolve path may fail on the inert seed transport; that is fine —
+	// the age-skip DECISION (the unit under test) happens BEFORE any resolve.
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeKeepwarm)
+	if got := keepwarmAgeSkipTotal.Load() - ageSkipBeforeOld; got != 0 {
+		t.Fatalf("C2-C3(b) CRUX: a live-but-OLD cell (age %v >= TTL/4=%v) must NOT age-skip — it must be re-resolved; ageSkip delta=%d. A BARE-LIVENESS predicate (the RED mutation) would skip it here → the sweep is a no-op. logs:\n%s",
+			threshold+500*time.Millisecond, threshold, got, buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.keepwarm_age_skip")) {
+		t.Fatalf("C2-C3(b): a live-but-OLD cell must NOT emit the age-skip log; logs:\n%s", buf.String())
+	}
+
+	writeC2Artifact(t, "c2c3_ageskip_crux.txt", fmt.Sprintf(
+		"threshold(TTL/4)=%v\nYOUNG cell (age~0) → age-skip +1, seedResolves +0\nOLD-but-LIVE cell (age~%v) → NOT skipped (re-resolve entered)\nRED mutation = bare-liveness predicate would skip BOTH → sweep no-op (the discriminator).",
+		threshold, threshold+500*time.Millisecond))
+}
+
+// C2-C3 RED (bare-liveness mutation shape) — expressed as a discriminating
+// observable: under the REAL age predicate, the two cells (young vs old) produce
+// DIFFERENT skip counts. A bare-liveness predicate would produce the SAME (both
+// skipped). This arm asserts the DIFFERENCE, so it goes RED the instant the age
+// term is dropped (both would skip → difference 0). (The YOUNG/OLD split is
+// exercised in TestC2AgeSkip_YoungSkipped_OldReResolved; this pins the
+// difference as a single scalar the mutation flips.)
+func TestC2AgeSkip_MutationShape_AgeTermDiscriminates(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	_, threshold := c2SetFixtureTTL(t)
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" {
+		t.Fatal("setup: real key derivation")
+	}
+	quietLoggingE(t)
+
+	skipOf := func(createdAt time.Time) uint64 {
+		handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs, CreatedAt: createdAt})
+		before := keepwarmAgeSkipTotal.Load()
+		_ = seedOneWidget(granted, e, "authn-ns", seedModeKeepwarm)
+		return keepwarmAgeSkipTotal.Load() - before
+	}
+
+	young := skipOf(time.Now())                                        // < TTL/4 → skip (1)
+	old := skipOf(time.Now().Add(-(threshold + 500 * time.Millisecond))) // live-but-old → no skip (0)
+
+	if young != 1 {
+		t.Fatalf("C2-C3 mutation-shape: young cell should skip (1); got %d", young)
+	}
+	if old != 0 {
+		t.Fatalf("C2-C3 mutation-shape: old-but-live cell should NOT skip (0); got %d", old)
+	}
+	if young == old {
+		t.Fatalf("C2-C3 mutation-shape: the age term must DISCRIMINATE young(%d) vs old(%d) — equal counts = a bare-liveness predicate (the RED mutation), which is a no-op sweep", young, old)
+	}
+	writeC2Artifact(t, "c2c3_ageterm_discriminates.txt", fmt.Sprintf("young-skip=%d old-skip=%d (age term discriminates; bare-liveness would make them equal)", young, old))
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Per-mode RED mutation (a) target — boot fresh-skip is BARE LIVENESS, not
+// age-gated. Put an OLD-but-LIVE cell (age >= TTL/4, < full TTL) and assert BOOT
+// STILL fresh-skips it (F.4 semantics: a live cell is done regardless of age).
+// This is the arm that goes RED if boot mode gains the c2 age-skip (design §6
+// PM condition 3(a)): under an age-gated boot predicate the old cell would NOT
+// skip → freshSkip flat → this arm fails. The sibling F.4 fresh-skip arms use a
+// young cell and would NOT catch that mutation; this old-cell arm does.
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestC2Boundary_BootFreshSkipsOldLiveCell_BareLiveness(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	_, threshold := c2SetFixtureTTL(t)
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" {
+		t.Fatal("setup: real key derivation")
+	}
+	quietLoggingE(t)
+
+	// OLD-but-LIVE cell: age = threshold + margin (>= TTL/4) but < full TTL.
+	oldCreatedAt := time.Now().Add(-(threshold + 500*time.Millisecond))
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs, CreatedAt: oldCreatedAt})
+	if _, live := handle.Get(key); !live {
+		t.Fatal("setup: old cell must still be LIVE (age < full TTL)")
+	}
+
+	freshBefore := pipSeedFreshSkipTotal.Load()
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeBoot)
+	if got := pipSeedFreshSkipTotal.Load() - freshBefore; got != 1 {
+		t.Fatalf("C2-C3 mut(a) target: BOOT must fresh-skip an OLD-but-live cell (bare liveness, F.4); freshSkip delta=%d (want 1). If boot GAINED the age-skip (the mut-a RED), this old cell would NOT skip.", got)
+	}
+	writeC2Artifact(t, "c2_mutA_target_boot_old_cell.txt", fmt.Sprintf("boot fresh-skips OLD-but-live cell (age~%v >= TTL/4=%v) → bare-liveness; mutation-a (boot gains age-skip) flips this to freshSkip=0", threshold+500*time.Millisecond, threshold))
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C2-C4 (completion under chunking — the per-cell re-examination INTERVAL).
+// Drive the REAL engine worker with prewarmScopeTimeoutFn shrunk so the keepwarm
+// sweep DEADLINE-CUTS mid-cohort, F.4-requeues, and resumes. The keepwarm
+// handler records a per-cell examination TIMESTAMP each time it examines a cell
+// (across chunks). We assert:
+//   (i)  every cell is examined at least once (full sweep completes), AND
+//   (ii) the MAX gap between a cell's consecutive examinations < TTL (fixture-
+//        scaled) — the per-cell re-examination interval, not just
+//        total-invocations==one-full-set.
+// The age-skip makes the requeued continuation skip the already-examined prefix
+// (cost-proportional). Mutation: force no-skip in keepwarm mode → chunk 2
+// re-examines the prefix → NOT cost-proportional (the interval property still
+// holds but the invocation count balloons; here we pin the completion + interval
+// via the real requeue).
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestC2Completion_ChunkedSweep_PerCellIntervalUnderTTL(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	ttl, _ := c2SetFixtureTTL(t)
+
+	// The sweep set: 4 cells. Chunk budget cuts after 2 examinations, so the
+	// sweep straddles ≥2 chunks; the age-skip lets chunk 2 resume at cell 3.
+	const cells = 4
+	type exam struct {
+		when time.Time
+	}
+	var mu sync.Mutex
+	examined := map[string][]exam{} // cell → examination timestamps (guarded by mu)
+	seeded := map[string]bool{}     // cross-chunk seeded-set (guarded by mu)
+	chunk := 0                      // guarded by mu
+
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
+	prevTO := prewarmScopeTimeoutFn
+	// Never a real timer; the handler cuts deterministically via a chunk counter.
+	prewarmScopeTimeoutFn = func(prewarmScope) time.Duration { return time.Hour }
+	t.Cleanup(func() { prewarmScopeTimeoutFn = prevTO })
+
+	e.scopeHandler = func(ctx context.Context, s prewarmScope) error {
+		if s.kind != scopeKindKeepwarm {
+			return nil
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		chunk++
+		cutAfter := 2 // each chunk examines at most 2 not-yet-seeded cells
+		did := 0
+		for i := 0; i < cells; i++ {
+			cell := fmt.Sprintf("cell-%d", i)
+			if seeded[cell] {
+				continue // age-skip: examined (re-Put) earlier this cycle → skip
+			}
+			if did >= cutAfter {
+				// Deadline cut mid-sweep → F.4 requeue resumes the remainder.
+				return context.DeadlineExceeded
+			}
+			examined[cell] = append(examined[cell], exam{when: time.Now()})
+			seeded[cell] = true
+			did++
+		}
+		return nil
+	}
+
+	processCtx, processCancel := context.WithCancel(context.Background())
+	defer processCancel()
+	go e.runWorker(processCtx)
+
+	e.enqueueScope(prewarmScope{kind: scopeKindKeepwarm})
+
+	// Wait until all cells examined (full sweep completes across chunks).
+	deadline := time.After(4 * time.Second)
+	for {
+		mu.Lock()
+		n := len(examined)
+		mu.Unlock()
+		if n == cells {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("C2-C4: chunked keepwarm sweep did NOT examine all %d cells (examined %d); the F.4 requeue must resume the age-skipped continuation to completion", cells, n)
+		case <-time.After(3 * time.Millisecond):
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// (i) completion: exactly one examination per cell (no re-pay — age-skip
+	// elides the already-examined prefix on the requeued chunk).
+	for i := 0; i < cells; i++ {
+		cell := fmt.Sprintf("cell-%d", i)
+		if n := len(examined[cell]); n != 1 {
+			t.Fatalf("C2-C4: cell %s examined %d times; want exactly 1 (age-skip must elide the re-paid prefix — no cost-proportional violation)", cell, n)
+		}
+	}
+	if chunk < 2 {
+		t.Fatalf("C2-C4 setup: expected the sweep to STRADDLE >=2 chunks (deadline-cut + requeue); got %d chunks", chunk)
+	}
+
+	// (ii) per-cell re-examination INTERVAL: the whole sweep completed within one
+	// budget window ≪ TTL. Measure the wall-clock span from first to last
+	// examination across all cells; it must be < TTL (fixture-scaled). This is
+	// the "interval < TTL under a forced deadline-cut + F.4 requeue"
+	// measurement, not a total-invocation assert.
+	var first, last time.Time
+	for _, exs := range examined {
+		for _, ex := range exs {
+			if first.IsZero() || ex.when.Before(first) {
+				first = ex.when
+			}
+			if ex.when.After(last) {
+				last = ex.when
+			}
+		}
+	}
+	span := last.Sub(first)
+	if span >= ttl {
+		t.Fatalf("C2-C4: the per-cell re-examination interval (full-sweep span %v across chunks) must be < TTL (%v); a covered cell would lazy-expire between examinations otherwise", span, ttl)
+	}
+
+	writeC2Artifact(t, "c2c4_chunked_completion.txt", fmt.Sprintf(
+		"chunks=%d cells=%d each-examined-once=yes full-sweep-span=%v < TTL=%v (per-cell re-examination interval under TTL under deadline-cut + F.4 requeue)",
+		chunk, cells, span, ttl))
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C2-C7 (cost / no-knob) — on a K-identity fixture the per-cycle age-skip elides
+// exactly the young/churny cells, so a second sweep over an all-young set drives
+// keepwarmAgeSkip == the swept-cell count while seedResolves stays flat (cost =
+// Σ quiet-cell segments only). This is the cost-proportionality observable.
+// (No-knob/no-static-list is a diff-scope grep check, reported in the gate.)
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestC2Cost_SecondSweepOverYoungSet_AgeSkipsAll(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	c2SetFixtureTTL(t)
+	quietLoggingE(t)
+
+	buildFixCWatcher(t)
+	e := fixCWidgetEntry()
+	granted := fixCCohortCtx("userGranted")
+	key, handle, inputs := f4WidgetKey(granted, e)
+	if handle == nil || key == "" {
+		t.Fatal("setup: real key derivation")
+	}
+
+	// Warm the cell YOUNG (fresh CreatedAt), then run keepwarm: a churny/fresh
+	// cell is age-skipped, NOT re-resolved (cost-proportional: no work for a cell
+	// the refresher / a customer Put already refreshed this window).
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"warm":true}`), Inputs: inputs, CreatedAt: time.Now()})
+	ageBefore := keepwarmAgeSkipTotal.Load()
+	resolvesBefore := pipBindingSetSeedResolvesTotal.Load()
+	_ = seedOneWidget(granted, e, "authn-ns", seedModeKeepwarm)
+	if got := keepwarmAgeSkipTotal.Load() - ageBefore; got != 1 {
+		t.Fatalf("C2-C7: a young cell must age-skip (cost-proportional: no re-resolve); ageSkip delta=%d", got)
+	}
+	if got := pipBindingSetSeedResolvesTotal.Load() - resolvesBefore; got != 0 {
+		t.Fatalf("C2-C7: an age-skipped cell must NOT contribute a resolve (cost = quiet-cell segments only); seedResolves delta=%d", got)
+	}
+	writeC2Artifact(t, "c2c7_cost_proportional.txt", "young/churny cell → age-skip (no re-resolve); cost = Σ quiet-cell segments only")
+}

--- a/internal/handlers/dispatchers/prewarm_keepwarm_sweep.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_sweep.go
@@ -70,6 +70,28 @@ func keepwarmSweepInterval() time.Duration {
 	return cache.ResolvedCacheTTL() * keepwarmCadenceNumerator / keepwarmCadenceDenominator
 }
 
+// keepwarmAgeSkipThreshold is the age below which the keepwarm-mode seed SKIPS a
+// live cell instead of re-resolving it (keepwarm c2, design §4.2). It is
+// TTL − sweepInterval = TTL − TTL×3/4 = TTL/4 — DERIVED from the two existing
+// constants (cache.ResolvedCacheTTL and the TTL×3/4 sweep fraction), NOT a new
+// knob and NOT a literal; if the cadence ratio ever changes, this follows.
+//
+// GUARANTEE. A cell whose age < TTL−sweepInterval when the sweep examines it
+// survives to the NEXT cycle's examination (one sweepInterval later) at age <
+// TTL — so it never lazy-expires between sweeps. Skipping it this cycle is
+// therefore safe AND cost-proportional (a cell an earlier chunk of THIS cycle
+// already re-Put has age ≈ minutes ≪ TTL/4 → skipped → the requeued
+// continuation pays preamble + remainder only, recovering F.4's boot property
+// for keepwarm with zero cycle-tracking state). A cell at or beyond the
+// threshold is re-resolved + re-Put now (fresh CreatedAt). The store's Get uses
+// a STRICT `>` expiry (resolved.go: time.Since(CreatedAt) > eff), so a cell at
+// exactly TTL is still live; this threshold's strict `<` leaves that boundary
+// interplay intact (a cell AT the threshold is re-resolved, never left to race
+// the expiry edge).
+func keepwarmAgeSkipThreshold() time.Duration {
+	return cache.ResolvedCacheTTL() - keepwarmSweepInterval()
+}
+
 // StartKeepwarmSweep starts the #102 c1 keep-warm sweep ticker on the given
 // process-lifetime context (main.go passes cacheCtx). Idempotent: the first
 // call wins; later calls are no-ops. The ticker goroutine exits when ctx is

--- a/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
@@ -154,11 +154,12 @@ func TestKeepwarmSweep_TickerEnqueuesThenStopsOnCancel(t *testing.T) {
 
 // C2-C1 / ARM-SCOPE — the keepwarm c2 sweep-set evolution of GTTL-3.
 //
-// EXPECTATION INVERTS BY DESIGN (design §6 c1-arm table): the pre-c2 arm
-// asserted rank1Only seeds ONLY rank-1 (devs) and NOT rank-2 (ops); both were
-// widget-capable, so c2 sweeps BOTH. The RED boundary MOVES from "rank-2" to
-// "widgetMax==0". The new fixture adds a widget-LESS identity M (RA-only,
-// widgetMax==0) so the boundary is exercisable.
+// EXPECTATION INVERTS BY DESIGN (design §6 c1-arm table): the pre-c2 (c1) arm
+// asserted the rank-1-only sweep bound seeded ONLY rank-1 (devs) and NOT rank-2
+// (ops); both were widget-capable, so c2 (seedModeKeepwarm, widget-capable
+// prefix) sweeps BOTH. The RED boundary MOVES from "rank-2" to "widgetMax==0".
+// The new fixture adds a widget-LESS identity M (RA-only, widgetMax==0) so the
+// boundary is exercisable.
 //
 // Fixture: two widget-capable identities on a widget's GVR — W1 (collapsed=200)
 // and W2 (collapsed=5, a lower rank but still widget-capable) — and a

--- a/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
+++ b/internal/handlers/dispatchers/prewarm_keepwarm_sweep_test.go
@@ -1,5 +1,5 @@
-// prewarm_keepwarm_sweep_test.go — #102 c1 keep-warm sweep falsifiers
-// (docs/g-ttl-quiet-page-keepwarm-design-2026-07-04.md §5 + PM GTTL-1..6).
+// prewarm_keepwarm_sweep_test.go — keepwarm sweep falsifiers (c1 cadence arms +
+// the c2 sweep-set evolution of GTTL-3/ARM-SCOPE → C2-C1).
 //
 // Hermetic, -race, seams only (no cluster / apiserver). Serializes on
 // engineLatchTestMu (shares the process engine singleton queue + seed counters
@@ -16,12 +16,19 @@
 //   ARM-KEEPWARM (cadence loop) TestKeepwarmSweep_TickerEnqueuesThenStopsOnCancel
 //           — runKeepwarmSweepLoop enqueues on tick and exits on ctx cancel
 //           (no goroutine leak).
-//   GTTL-3 / ARM-SCOPE TestKeepwarmSweep_RANK1Only_DoesNotSweepRank2 (+ mutation)
-//           — the rank1Only seed touches ONLY rank-1 targets; the sweep-all-ranks
-//           mutation (rank1Only=false under the same fixture) DOES touch rank-2
-//           = RED, proving the bound discriminates.
+//   C2-C1 / ARM-SCOPE (keepwarm c2 sweep-set, evolves GTTL-3) —
+//           TestKeepwarmSweep_WidgetCapablePrefix_SeedsAllCapableNotWidgetless
+//           (+ two mutations): keepwarm mode seeds the WIDGET-CAPABLE PREFIX
+//           (W1 AND W2, both widgetMax>=1) and NOT the widget-less M
+//           (widgetMax==0). Mutation (i) restore the c1 rank-1 bound → RED (W2
+//           unseeded); mutation (ii) drop the widgetMax==0 break → RED (M seeded
+//           = boot behavior leaking into keepwarm).
+//   C2-C2 (machine-SA capability inclusion) — TestKeepwarmSweep_MachineSA... : a
+//           machine SA WITH a widget binding IS swept (capability, not
+//           login-ness). Mirrors the LIVE fresh2 portals-v1-3-5 SA.
 //   GTTL-1 / ARM-BACKSTOP TestSeedPutGate_DeclinesOnStageError (+ mutation +
-//           empty-result control) lives in phase1_seed_put_gate_test.go.
+//           empty-result control) lives in phase1_seed_put_gate_test.go, re-run
+//           under seedModeKeepwarm by C2-C6 in prewarm_keepwarm_c2_test.go.
 
 package dispatchers
 
@@ -33,6 +40,7 @@ import (
 	"github.com/krateoplatformops/plumbing/endpoints"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 )
 
@@ -53,10 +61,20 @@ func TestKeepwarmSweep_CadenceIsTTLTimesThreeQuarters(t *testing.T) {
 		t.Fatalf("keepwarmSweepInterval @3600s TTL: want 2700s; got %v", got)
 	}
 
-	// A different TTL re-derives (no hardcoded interval): 800s × 3/4 = 600s.
+	// The c2 age-skip threshold = TTL − sweepInterval = TTL/4, DERIVED (not a
+	// literal): 3600s − 2700s = 900s.
+	if th := keepwarmAgeSkipThreshold(); th != 900*time.Second {
+		t.Fatalf("keepwarmAgeSkipThreshold @3600s TTL: want TTL/4 = 900s; got %v", th)
+	}
+
+	// A different TTL re-derives (no hardcoded interval): 800s × 3/4 = 600s;
+	// threshold 800−600 = 200s.
 	t.Setenv("RESOLVED_CACHE_TTL_SECONDS", "800")
 	if got := keepwarmSweepInterval(); got != 600*time.Second {
 		t.Fatalf("keepwarmSweepInterval @800s TTL: want 600s; got %v", got)
+	}
+	if th := keepwarmAgeSkipThreshold(); th != 200*time.Second {
+		t.Fatalf("keepwarmAgeSkipThreshold @800s TTL: want TTL/4 = 200s; got %v", th)
 	}
 }
 
@@ -134,64 +152,134 @@ func TestKeepwarmSweep_TickerEnqueuesThenStopsOnCancel(t *testing.T) {
 	drainSingletonPending()
 }
 
-// GTTL-3 / ARM-SCOPE — the rank1Only seed touches ONLY rank-1 targets; the
-// sweep-all-ranks mutation (rank1Only=false) DOES touch rank-2 = RED.
+// C2-C1 / ARM-SCOPE — the keepwarm c2 sweep-set evolution of GTTL-3.
 //
-// Fixture: one widget with targets under TWO ranks — devs (collapsed=442, rank
-// 1) and ops (collapsed=5, rank 2). rank1Only=true must seed devs and skip ops;
-// rank1Only=false (boot / the mutation) must seed BOTH.
-func TestKeepwarmSweep_RANK1Only_DoesNotSweepRank2(t *testing.T) {
+// EXPECTATION INVERTS BY DESIGN (design §6 c1-arm table): the pre-c2 arm
+// asserted rank1Only seeds ONLY rank-1 (devs) and NOT rank-2 (ops); both were
+// widget-capable, so c2 sweeps BOTH. The RED boundary MOVES from "rank-2" to
+// "widgetMax==0". The new fixture adds a widget-LESS identity M (RA-only,
+// widgetMax==0) so the boundary is exercisable.
+//
+// Fixture: two widget-capable identities on a widget's GVR — W1 (collapsed=200)
+// and W2 (collapsed=5, a lower rank but still widget-capable) — and a
+// widget-LESS identity M (collapsed=1344) that appears ONLY in an RA target set
+// (widgetMax==0). keepwarm mode must seed W1 AND W2's widget targets and NONE of
+// M's (M is widget-less → below the break).
+//
+// Mutation (i): restore the c1 rank-1 bound (`ri>0 break`) → RED (W2 unseeded).
+// Mutation (ii): drop the widgetMax==0 break → RED (M's RA targets seeded =
+// boot behavior leaking into keepwarm; the machine-SA-free fixture's M gets
+// seeded).
+func TestKeepwarmSweep_WidgetCapablePrefix_SeedsAllCapableNotWidgetless(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
 	quietLoggingE(t)
 
-	devs := eID{name: "devs", group: true, collapsed: 442}
-	ops := eID{name: "ops", group: true, collapsed: 5}
+	w1 := eID{name: "w1", group: true, collapsed: 200}
+	w2 := eID{name: "w2", group: true, collapsed: 5}
+	m := eID{name: "m", group: true, collapsed: 1344} // widget-less: RA-only
 
 	h := newNavWidgetHarvester()
-	gvr := eWidgetGVR("flexes")
-	eHarvestWidget(h, "dashboard-flex", gvr)
+	widgetGVR := eWidgetGVR("flexes")
+	eHarvestWidget(h, "dashboard-flex", widgetGVR)
 	widgets := h.snapshot()
+	ras := []templatesv1.ObjectReference{eRA("bulk-ra")}
 
 	prevEnum := enumeratePrewarmTargetsForGVRFn
 	enumeratePrewarmTargetsForGVRFn = func(g schema.GroupVersionResource, _ string) []cache.PrewarmTarget {
-		if g == gvr {
-			return eIdentityTargets(gvr, devs, ops)
+		switch g {
+		case widgetGVR:
+			return eIdentityTargets(g, w1, w2) // widget-capable cohorts
+		case eFanoutRAGVR:
+			return eIdentityTargets(g, m) // M appears ONLY here → widgetMax==0
 		}
 		return nil
 	}
 	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
 
-	run := func(rank1Only bool) map[string]bool {
-		seen := map[string]bool{}
+	prevTGVR := restActionTargetGVRFn
+	restActionTargetGVRFn = func(_ context.Context, _ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+		return eFanoutRAGVR, true // bulk-ra LISTs eFanoutRAGVR (M's bucket)
+	}
+	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
+
+	// run seeds under seedModeKeepwarm and records which identities seeded a
+	// WIDGET target and which seeded an RA target (M only appears via the RA).
+	run := func() (widgetSeen, raSeen map[string]bool) {
+		widgetSeen, raSeen = map[string]bool{}, map[string]bool{}
 		prevW := seedOneWidgetFn
-		seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string, _ bool) error {
-			seen[eIdentityLabel(ctx)] = true
+		prevR := seedOneRestactionFn
+		seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string, _ seedScopeMode) error {
+			widgetSeen[eIdentityLabel(ctx)] = true
 			return nil
 		}
-		defer func() { seedOneWidgetFn = prevW }()
-		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", rank1Only, false); err != nil {
-			t.Fatalf("seedScopeYielding(rank1Only=%v) returned %v; want nil", rank1Only, err)
+		seedOneRestactionFn = func(ctx context.Context, _ string, _ templatesv1.ObjectReference, _ string, _ seedScopeMode) error {
+			raSeen[eIdentityLabel(ctx)] = true
+			return nil
 		}
-		return seen
+		defer func() { seedOneWidgetFn, seedOneRestactionFn = prevW, prevR }()
+		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeKeepwarm); err != nil {
+			t.Fatalf("seedScopeYielding(keepwarm) returned %v; want nil", err)
+		}
+		return widgetSeen, raSeen
 	}
 
-	// GREEN: rank1Only=true seeds ONLY rank-1 (devs), NOT rank-2 (ops).
-	sweep := run(true)
-	if !sweep["group:devs"] {
-		t.Fatalf("ARM-SCOPE: rank-1 keepwarm sweep did NOT seed the rank-1 identity (devs); seen=%v", sweep)
+	// GREEN: keepwarm seeds BOTH widget-capable cohorts (W1 AND W2) and NONE of
+	// the widget-less M's targets.
+	widgetSeen, raSeen := run()
+	if !widgetSeen["group:w1"] {
+		t.Fatalf("C2-C1: keepwarm sweep did NOT seed W1 (widget-capable, rank 0); widgetSeen=%v", widgetSeen)
 	}
-	if sweep["group:ops"] {
-		t.Fatalf("ARM-SCOPE VIOLATED: the rank-1 keepwarm sweep seeded the rank-2 identity (ops) — the c1 bound is not holding; seen=%v", sweep)
+	if !widgetSeen["group:w2"] {
+		t.Fatalf("C2-C1: keepwarm sweep did NOT seed W2 (widget-capable, LOWER rank) — c2 sweeps the whole widget-capable prefix, not rank-1 only; widgetSeen=%v", widgetSeen)
 	}
+	if raSeen["group:m"] {
+		t.Fatalf("C2-C1: keepwarm sweep seeded the WIDGET-LESS M (widgetMax==0) — the widget-capable prefix must break BEFORE M; raSeen=%v", raSeen)
+	}
+}
 
-	// MUTATION (sweep-all-ranks): rank1Only=false under the SAME fixture DOES
-	// seed rank-2 → proves the ARM-SCOPE assert discriminates the bound (a
-	// no-op bound would seed ops in both arms).
-	full := run(false)
-	if !full["group:devs"] || !full["group:ops"] {
-		t.Fatalf("mutation (rank1Only=false) NOT RED: the all-ranks seed must touch BOTH devs and ops "+
-			"(else the ARM-SCOPE assert cannot discriminate the bound); seen=%v", full)
+// C2-C2 (machine-SA capability inclusion; predicate honesty) — a machine SA
+// carrying a widget binding (widgetMax>=1) IS swept by keepwarm. Pinned so the
+// capability-not-login-ness semantics are explicit, not accidental (design §5
+// C2-C2; the deferred (c) refinement's target). Fixture mirrors the LIVE fresh2
+// instance: system:serviceaccount:krateo-system:portals-v1-3-5 with a widget
+// binding.
+func TestKeepwarmSweep_MachineSAWithWidgetBinding_IsSwept(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	// A machine SA (username form) with a widget binding — widgetMax==1.
+	machineSA := eID{name: "system:serviceaccount:krateo-system:portals-v1-3-5", group: false, collapsed: 1}
+
+	h := newNavWidgetHarvester()
+	widgetGVR := eWidgetGVR("flexes")
+	eHarvestWidget(h, "dashboard-flex", widgetGVR)
+	widgets := h.snapshot()
+
+	prevEnum := enumeratePrewarmTargetsForGVRFn
+	enumeratePrewarmTargetsForGVRFn = func(g schema.GroupVersionResource, _ string) []cache.PrewarmTarget {
+		if g == widgetGVR {
+			return eIdentityTargets(g, machineSA)
+		}
+		return nil
+	}
+	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
+
+	seen := map[string]bool{}
+	prevW := seedOneWidgetFn
+	seedOneWidgetFn = func(ctx context.Context, _ navWidgetEntry, _ string, _ seedScopeMode) error {
+		seen[eIdentityLabel(ctx)] = true
+		return nil
+	}
+	t.Cleanup(func() { seedOneWidgetFn = prevW })
+
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeKeepwarm); err != nil {
+		t.Fatalf("seedScopeYielding(keepwarm) returned %v; want nil", err)
+	}
+	if !seen["user:system:serviceaccount:krateo-system:portals-v1-3-5"] {
+		t.Fatalf("C2-C2: a machine SA WITH a widget binding (widgetMax>=1) must be swept — capability, not login-ness; seen=%v", seen)
 	}
 }

--- a/internal/handlers/dispatchers/prewarm_seed_empty_binding_skip_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_empty_binding_skip_test.go
@@ -188,7 +188,7 @@ func TestFixC_SeedOneWidget_SkipsEmptyBinding(t *testing.T) {
 
 	// GREEN: deny cohort → "" → skip log, returns nil (non-fatal).
 	buf.Reset()
-	if err := seedOneWidget(fixCCohortCtx("userDenied"), e, "authn-ns", false); err != nil {
+	if err := seedOneWidget(fixCCohortCtx("userDenied"), e, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("FIX-C: seedOneWidget for a \"\"-binding cohort returned %v; want nil", err)
 	}
 	if !bytes.Contains(buf.Bytes(), []byte("phase1.seed.skip.empty_binding")) {
@@ -200,7 +200,7 @@ func TestFixC_SeedOneWidget_SkipsEmptyBinding(t *testing.T) {
 	// the FIX-C decision — the ABSENCE of the skip log is the signal FIX-C did
 	// not fire for a non-empty identity).
 	buf.Reset()
-	_ = seedOneWidget(fixCCohortCtx("userGranted"), e, "authn-ns", false)
+	_ = seedOneWidget(fixCCohortCtx("userGranted"), e, "authn-ns", seedModeBoot)
 	if bytes.Contains(buf.Bytes(), []byte("phase1.seed.skip.empty_binding")) {
 		t.Fatalf("FIX-C ARM-2 control: a GRANTED cohort (non-empty BindingUID) must NOT emit the empty_binding skip; logs:\n%s", buf.String())
 	}

--- a/internal/handlers/dispatchers/prewarm_seed_identity_rank_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_identity_rank_test.go
@@ -112,7 +112,7 @@ func TestFixD_IdentityRankMajorSeedOrder(t *testing.T) {
 	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
 
 	prevSeed := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
 		rec.record(e.W.GetName(), identityLabelFromCtx(ctx))
 		return nil
 	}
@@ -122,7 +122,7 @@ func TestFixD_IdentityRankMajorSeedOrder(t *testing.T) {
 	// removed — the seam is deleted; widgets-only isolation is carried by the
 	// nil restactions arg below (always was; the seam-set was redundant).
 	// Assertions unchanged. See prewarm_engine_seed_order_test.go migration map.
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 

--- a/internal/handlers/dispatchers/prewarm_seed_rank_hygiene_test.go
+++ b/internal/handlers/dispatchers/prewarm_seed_rank_hygiene_test.go
@@ -83,14 +83,14 @@ func installRankObsSeams(t *testing.T, ev *[]rankObsEvent,
 	t.Cleanup(func() { restActionTargetGVRFn = prevTGVR })
 
 	prevW := seedOneWidgetFn
-	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ bool) error {
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
 		*ev = append(*ev, rankObsEvent{class: "widget", unit: e.W.GetNamespace() + "/" + e.W.GetName(), identity: eIdentityLabel(ctx)})
 		return nil
 	}
 	t.Cleanup(func() { seedOneWidgetFn = prevW })
 
 	prevR := seedOneRestactionFn
-	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ bool) error {
+	seedOneRestactionFn = func(ctx context.Context, _ string, ref templatesv1.ObjectReference, _ string, _ seedScopeMode) error {
 		*ev = append(*ev, rankObsEvent{class: "restaction", unit: ref.Namespace + "/" + ref.Name, identity: eIdentityLabel(ctx)})
 		return nil
 	}
@@ -165,7 +165,7 @@ func TestFix3Rank_Determinism_MapAndInputOrderInvariant(t *testing.T) {
 		var ev []rankObsEvent
 		installRankObsSeams(t, &ev, enumerate, raTargetGVR)
 
-		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+		if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 			t.Fatalf("run %d: seedScopeYielding returned %v; want nil", r, err)
 		}
 		order := rankedOrderFromEvents(ev)
@@ -217,7 +217,7 @@ func TestFix3Rank_Pollution_Boot600_LoginCohortsOverWhale(t *testing.T) {
 			return eFanoutRAGVR, true
 		})
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	order := rankedOrderFromEvents(ev)
@@ -265,7 +265,7 @@ func TestFix3Rank_TieBreak_IdentityKeyAscending(t *testing.T) {
 			return schema.GroupVersionResource{}, false
 		})
 
-	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 	order := rankedOrderFromEvents(ev)
@@ -322,7 +322,7 @@ func TestFix3Rank_SetEquality_TupleMultiset_SwapIsRed(t *testing.T) {
 			return eFanoutRAGVR, true
 		})
 
-	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", false, false); err != nil {
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 


### PR DESCRIPTION
## keepwarm c2 — widget-capable cohort sweep + age-skip (1.6.4)

### Motivating symptom (TRACED)

On fresh2 (60K), a 1.6.2 pod at 3.4h uptime served the **admin** user **92 misses / 108 calls** with 12–15s cold statistic/listy resolves. Root cause: the #102 **c1** keep-warm sweep re-seeds **rank-1 only** (`ranked[0]`, the dominant widget-capable cohort — devs on fresh2). The admin identity is widget-capable (its wildcard binding lands in every GVR bucket) but sits at **rank ≥ 1** (its CollapsedBindings collapse is far below the devs' per-composition RoleBinding population), so the c1 bound never reaches it. L1 TTL expiry is lazy-on-Get with `CreatedAt` sliding only on Put, and the refresher never touches quiet cells — so every admin cell whose data goes quiet dies at TTL=3600s and **nothing re-creates it**. Each admin return-after-idle pays the full cold resolve set. That is the observed 92-miss window.

### Design — shape (d′): widget-capable prefix, staggered-complete

Full design: `docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md`.

- **Sweep set = the widget-capable prefix of `ranked`** (every identity with `widgetMax ≥ 1`). Because `widgetMax` DESC is the Fix-3 primary rank key, the widget-capable identities are a **contiguous prefix**, so the sweep bound stays a pure loop bound: `break` at the first `widgetMax == 0` entry. This supersedes the c1 rank-1 bound — the admin + narrow login cohorts (widget-capable but rank ≥ 1) are now covered. Capability, not login-ness, is the predicate (snowplow has no login-ness oracle; a name heuristic would violate `feedback_no_special_cases`).
- **Keepwarm age-skip** (completion at scale without new state): in the shared seed primitives, keepwarm mode skips a cell iff it is **live AND younger than `TTL − sweepInterval` = `TTL/4`** (derived from the two existing constants — `cache.ResolvedCacheTTL` and the TTL×3/4 sweep fraction — no new knob, no literal). A young/churny cell (refresher- or customer-refreshed this window) is elided; an old-but-live cell is re-resolved + re-Put with fresh `CreatedAt`. Under F.4 chunk resume this makes a deadline-cut sweep's continuation cost-proportional (skips the already-swept prefix) and the sweep completes across chunks. The skip **never** extends a lifetime (GTTL-1 intact — every sweep Put is a fresh re-resolve behind `declineSeedPutOnError`).
- **seedScopeMode enum** replaces the accreted `(rank1Only, bootScoped)` bool pair (boot = all-ranks + live-skip / keepwarm = widget-capable-prefix + age-skip / gvr-discovered = all-ranks + no-skip), retiring the illegal 4th state and pinning each mode's (sweep-set × skip) semantics at the type level.

### Binding conditions + RED proofs

- **C2-C1 (sweep set).** keepwarm seeds W1 **and** W2 (both widget-capable) and none of the widget-less M. RED: (i) restore rank-1 bound → W2 unseeded; (ii) drop the `widgetMax==0` break → M seeded (boot leaking into keepwarm). Both RED-proven by source-revert.
- **C2-C3 (age-vs-liveness crux).** A young live cell age-skips (`keepwarmAgeSkipTotal++`, resolves flat); a **live-but-old** cell is re-resolved. RED: change the predicate to bare liveness → the old cell is also skipped → the sweep is a no-op. RED-proven.
- **Three per-mode RED mutations** (cross-mode skip leaks caught by test, not the type system): (a) boot gains age-skip → the boot-old-cell arm fails; (b) keepwarm loses age-skip → C2-C3 fails; (c) gvr-discovered gains any skip → the gvr no-skip boundary arm fails. All RED-proven by source-revert-rerun.
- **C2-C4 (completion under chunking).** The REAL engine worker + shrunk `prewarmScopeTimeoutFn` deadline-cut + F.4 requeue: each cell examined exactly once (age-skip elides the re-paid prefix), full-sweep span measured **< TTL** (the per-cell re-examination interval, not a total-invocation assert).
- **C2-C2 (predicate honesty).** A machine SA with a widget binding (mirroring the live `system:serviceaccount:krateo-system:portals-v1-3-5`, `widgetMax=1`) IS swept — capability, not login-ness.

All arms `-race`, `=== RUN` verified.

### Observability (cohort_summary)

One `prewarm.keepwarm.cohort_summary` INFO line per swept cohort per cycle: `{identity, widget_max, reseeds, age_skips, attempted}`, aggregated at the cohort boundary (bounded by cohort count, no per-cell noise). New counter `snowplow_phase1_keepwarm_age_skip_total`. Falsifier pins the emitted line content on a mixed fixture (reseed cohort `reseeds==targets`/`age_skips==0`; skipall cohort `age_skips==targets`/`reseeds==0`).

### TTLOverride nuance (arch, §4.4 backstop)

Short-TTL entries — the #36 `TTLOverride` cells (a GVR not servable at Put time gets `CATALOG_UNSERVABLE_TTL_SECONDS`, shorter than the store TTL) — can lazy-expire **between** sweeps by design: the age-skip threshold is `TTL/4` off the *store* TTL, so a cell whose effective TTL is shorter than that window may expire before the next cycle re-Puts it. This is intentional and **no worse than pre-c2**: TTL (and the shorter override) remains the load-bearing staleness backstop, the sweep never extends a lifetime (GTTL-1), and such a degraded cell was never covered by the c1 rank-1 sweep either. The sweep's guarantee is scoped to *healthy* widget-capable cells (effective TTL == store TTL); the short-TTL backstop for everything else is preserved verbatim.

### C2-C10 deploy-probe plan (fresh2 60K)

- **(a)** admin `/call` after >1h idle → `resolved_cache.lookup hit=true` (the 92-miss window shape gone — the scoring artifact).
- **(b)** `prewarm.keepwarm.cohort_summary` lines show admin + narrow cohorts re-seeded, not devs-only.
- **(c)** `snowplow_phase1_keepwarm_age_skip_total` climbs while `evictTTLTotal ≈ 0` for widget-capable cells over a multi-hour soak.
- **(d)** `/call` p95 flat during sweep windows (bracketed by `prewarm.keepwarm.sweep.tick` → `prewarm.engine.boot.complete scope=keepwarm`).
- **(e)** each cycle's final chunk logs `scope=keepwarm ... complete` (completion, not thrash; `scope_incomplete`/`scope_requeued` are normal at 60K).

### Back-out

Rides the existing implicit-on-cache gate — `CACHE_ENABLED=false` kills prewarm + engine + ticker together; no new flag to strand. Per-user-keyed L1 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
