### PR TITLE
fix(prewarm): #106 config-vars data-change redrive gate — stop CDC traceparent-churn boot redrives

### DIFF
--- a/docs/configvars-update-datagate-design-2026-07-07.md
+++ b/docs/configvars-update-datagate-design-2026-07-07.md
@@ -1,0 +1,127 @@
+# #106 — Config-vars watcher data-change redrive gate (design memo v2)
+
+Author: architect (archC2d), 2026-07-07. PM gate: ACCEPT (pmC2d, C106-1..4; INFO skip line binding).
+Base: main @ bcd6f286 (1.6.4). Target: 1.6.5. Task #106.
+
+## Symptom mechanism (TRACED)
+
+`UpdateFunc` enqueues unconditionally on ANY object write: `phase1_configvars_watch.go:213-217`
+→ `enqueueBootReDrive` :131-139 → `enqueueScope(scopeKindBoot)` :133. The KrateoFrontend CDC
+re-apply bumps annotations/managedFields (fresh `krateo.io/traceparent` span each reconcile) →
+new ResourceVersion → informer UPDATE → boot scope ~1/min, each paying the full walk (~2.3 min
+at 60K). `config.json` is byte-identical across these events (sha-verified live on fresh2,
+2026-07-07). Keepwarm scopes queue behind the permanent boot stream (observed delaying the
+first c2 sweep).
+
+## Prior-art check
+
+client-go has no built-in data-diff predicate, but the informer `UpdateFunc` already receives
+`(old, new)`. Canonical filter tiers: (1) `old.ResourceVersion == new.ResourceVersion` skip —
+filters only resync replays, useless here (CDC writes genuinely bump RV; our factory runs
+resync=0, :194); (2) content compare of the consumed fields via
+`apiequality.Semantic.DeepEqual` — the standard controller pattern for ConfigMap-driven reload
+(GenerationChangedPredicate does not apply: ConfigMaps have no spec/generation; Helm's
+checksum/config pattern hashes full Data for the same reason). We take tier 2.
+
+## Design — stateless Data-equality predicate in UpdateFunc (C106-1..3)
+
+**Placement.** One function `configVarsDataChanged(oldObj, newObj any) bool` in
+`phase1_configvars_watch.go` beside `matchesConfigVars` (:113), called from `UpdateFunc` after
+the name guard. Casts both to `*corev1.ConfigMap`; returns
+`!apiequality.Semantic.DeepEqual(old.Data, new.Data) || !apiequality.Semantic.DeepEqual(old.BinaryData, new.BinaryData)`.
+If EITHER cast fails → return true (fail OPEN = pre-fix behavior; never suppress on doubt).
+The hook stays O(1)-ish (map compare over a 1-key CM) and non-blocking — the
+HOOK-MUST-NOT-BLOCK contract (:30-33) holds. NOTE: the current UpdateFunc is
+`func(_, newObj interface{})` and discards `old` — wiring `old` in is part of the change.
+
+**Scope: FULL Data + BinaryData (superset), never narrower than consumed.** The walker consumes
+ONLY `Data["config.json"]` (`frontendConfigDataKey`, phase1_roots.go:75; read :248 — TRACED).
+Key-only would be tightest but fails SILENT-STALE if a future walker change consumes a sibling
+key and the gate isn't widened in lockstep — a suppressed genuine redrive is the exact
+cold-first-nav class this watcher exists to kill, and it fails quietly. Full-Data fails only
+with an occasional redundant coalesced walk on a frontend deploy touching a sibling key —
+self-limiting and arguably desirable. Matches Helm checksum/config prior-art. NO parse in the
+hook (no parse-error path; the only failure mode is the type-cast, which fails OPEN). Add a
+pointer comment at `frontendConfigDataKey` (phase1_roots.go:73-75) noting the gate so the
+coupling is discoverable.
+
+**No stored hash; the staleness dilemma dissolves (C106-2c).** Semantics = compare against
+LAST-SEEN, implemented via the informer's own delivered `(old, new)` pair: client-go guarantees
+each UpdateFunc `old` is the previously delivered state, and `enqueueScope` never drops
+(workqueue.Add, prewarm_engine.go:344-346 — TRACED), so last-seen ≡ last-redriven with no
+divergence window. The REJECTED trap (fixed boot-baseline hash missing a revert-to-baseline
+change) is structurally absent — nothing captured at boot, nothing persisted. Flap A→B→A as two
+updates: event 1 (old=A,new=B) differs → redrive; event 2 (old=B,new=A) differs → redrive.
+Both fire BY CONSTRUCTION.
+
+**AddFunc UNGATED (C106-3a).** Verbatim unchanged (:206-210) — first appearance / initial-LIST
+replay always redrives; it is the boot-race self-heal trigger itself; there is no prior state
+to diff. A design that gates the ADD path is wrong.
+
+**DELETE semantics.** Keep NO DeleteFunc (unchanged :218-219). A deleted config-vars CM has
+nothing to walk; delete→recreate is covered by the unconditional AddFunc (recreate = ADD).
+Stateless dividend: a stored last-hash would survive the delete and could suppress the recreate
+under a naive compare — no such state exists.
+
+**Coalescing + F.4 (C106-3b): NO behavior change.** The gate sits BEFORE `enqueueScope` inside
+the hook; the boot dedup key (:335-341), the engine worker, and the F.4 engine-owned requeue
+(post-dequeue, prewarm_engine.go:541) are untouched. Net effect on c2: keepwarm scopes stop
+queueing behind a permanent 1/min boot stream. Two rapid data changes may coalesce to ONE walk
+run — correct: the walk reads the LIVE ConfigMap at run time (readFrontendConfig,
+phase1_roots.go:235+), so the single run observes the final state; later events re-enqueue if
+anything changed after dequeue. Converges to last-written state.
+
+## Observability (C106-4 — PM ruling: BOTH, INFO binding)
+
+- Expvar counter `configVarsSkippedTotal` + `ConfigVarsSkippedTotal()` accessor + expvar
+  `snowplow_phase1_configvars_skipped_total`, exact mirror of the enqueued counter
+  (phase1_configvars_watch.go:91-95). Steady-state rate = the churn rate — proves the gate is
+  actively firing (distinguishes gate-working from informer-dead/churn-stopped).
+- Skip line at INFO: `prewarm.configvars.redrive_skipped` with
+  reason="data_unchanged_metadata_only" + CM name + effect string, greppable under
+  PRETTY_LOG:false. Volume bounded by the CDC cadence (~1/min on fresh2) — that IS the live
+  evidence stream for the C106-1(ii) ledger row, and it disappears if the CDC churn is ever
+  fixed upstream.
+- Enqueue reason string split: "configmap_added" / "configmap_data_changed".
+
+## Falsifier spec (C106-1(i), C106-2)
+
+Substrate: the existing real-informer-over-fake-clientset harness
+(phase1_boot_race_selfheal_falsifier_test.go pattern, SetConfigVarsWatchClientForTest), reading
+ConfigVarsEnqueuedTotal / ConfigVarsSkippedTotal.
+
+- **ARM-1 annotation-only (crux), paired in ONE test with ARM-2:** Update changing ONLY a
+  traceparent-shaped annotation → EnqueuedTotal FLAT + no boot_redrive_enqueued + SkippedTotal
+  +1; then Update changing Data["config.json"] → EnqueuedTotal +1,
+  reason="configmap_data_changed". Discriminator = the data-diff (gate-less build passes the
+  data arm but fails the annotation arm; gate-everything build fails the data arm).
+- **ARM-3 flap:** A→B→A two updates → EnqueuedTotal +2 (pins per-event-delta semantics).
+- **ARM-4 add-always:** existing TestBootRace_ConfigVarsInformerDrivesReWalk stays GREEN
+  unchanged (ADD path ungated); first ADD redrives regardless of data.
+- **ARM-5 delete→recreate:** Delete then Create same Data → +1 via ADD.
+- **RED mutation (source-revert, byte-clean restore):** drop the predicate (UpdateFunc calls
+  enqueueBootReDrive unconditionally, the pre-fix :213-217 form) → ARM-1 annotation arm goes
+  RED (counter increments).
+
+## On-cluster ledger row (C106-1(ii), post-deploy)
+
+Fresh2 60K, ≥15 min under CDC churn: `boot_redrive_enqueued` delta 0 (pre-fix ~15) while the
+CM's traceparent keeps changing (resourceVersion bumping) + `snowplow_phase1_configvars_skipped_total`
+climbing ~1/min + `prewarm.configvars.redrive_skipped` INFO lines at the churn cadence; then
+ONE live config.json edit → exactly one redrive + a completed walk; c2 keepwarm cohort_summary
+lines appear on cadence (no boot-scope queue delay).
+
+## Touched surface (~28 LOC)
+
+`phase1_configvars_watch.go`: predicate helper (~12), UpdateFunc wiring (~3),
+counter+accessor+expvar (~7), INFO line (~4), reason split (~2). Plus ONE comment-only pointer
+line at phase1_roots.go:73-75. NO env knob (unconditional-on; pure correctness fix), NO
+engine/queue/F.4 change, NO stored state, no new apiserver reads.
+
+## Option surfaced and rejected
+
+(B) stored sha256-of-Data compared against last-REDRIVEN hash — needed only to gate the ADD
+path too (suppress the redundant boot redrive when a restart replays an unchanged CM).
+Rejected: ADD-always is load-bearing for the boot race; stored state reintroduces the
+drift/delete-staleness holes the stateless design closes. Revisit only if ADD-path noise is
+ever observed (it isn't — ADD fires once per process).

--- a/internal/handlers/dispatchers/phase1_configvars_datagate_test.go
+++ b/internal/handlers/dispatchers/phase1_configvars_datagate_test.go
@@ -1,0 +1,227 @@
+// phase1_configvars_datagate_test.go — #106 config-vars data-change redrive gate
+// falsifiers (docs/configvars-update-datagate-design-2026-07-07.md §Falsifier spec).
+//
+// Substrate: the SAME real-informer-over-fake-clientset harness as
+// phase1_boot_race_selfheal_falsifier_test.go (SetConfigVarsWatchClientForTest +
+// kfake + a REAL SharedInformerFactory ConfigMap informer). A real
+// ConfigMaps().Update() fires the REAL UpdateFunc → the REAL configVarsDataChanged
+// gate → (enqueueBootReDrive | configVarsSkippedTotal++). We read
+// ConfigVarsEnqueuedTotal / ConfigVarsSkippedTotal. Serializes on bootRaceTestMu
+// (shared singleton queue + package-level configVars* counters). No ./internal/rbac.
+//
+// ARM MAP (design §Falsifier spec):
+//   ARM-1+2 (paired, TestConfigVarsGate_AnnotationOnlySkips_DataChangeRedrives):
+//     annotation-only Update → Enqueued FLAT + Skipped +1; then a
+//     Data["config.json"] Update → Enqueued +1 (reason configmap_data_changed).
+//     Discriminator = the data-diff.
+//   ARM-3 (TestConfigVarsGate_FlapRedrivesBothEvents): A→B→A two Data updates →
+//     Enqueued +2 (per-event-delta semantics, stateless last-seen).
+//   ARM-4: TestBootRace_ConfigVarsInformerDrivesReWalk (ADD path) stays GREEN
+//     unchanged — not re-implemented here.
+//   ARM-5 (TestConfigVarsGate_DeleteRecreateRedrivesViaAdd): Delete then Create
+//     same Data → +1 via the ungated ADD path.
+//
+// RED mutation (source-revert, byte-clean restore): drop the gate (UpdateFunc
+// calls enqueueBootReDrive unconditionally) → ARM-1 annotation arm goes RED
+// (Enqueued increments on the metadata-only write). Captured to /tmp/c106/.
+
+package dispatchers
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// waitForCount polls until getter() reaches want (or the deadline), returning
+// the final value. Lets the REAL informer deliver the event asynchronously.
+func waitForCount(getter func() uint64, want uint64, d time.Duration) uint64 {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if getter() >= want {
+			return getter()
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return getter()
+}
+
+func writeC106Artifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/c106", 0o755)
+	_ = os.WriteFile("/tmp/c106/"+name, []byte(body), 0o644)
+}
+
+// cvGateCM builds a config-vars ConfigMap with the given config.json value and
+// an optional traceparent-shaped annotation (models the CDC re-apply churn).
+func cvGateCM(configJSON, traceparent string) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootRaceConfigMapName,
+			Namespace: bootRaceNamespace,
+		},
+		Data: map[string]string{"config.json": configJSON},
+	}
+	if traceparent != "" {
+		cm.ObjectMeta.Annotations = map[string]string{"krateo.io/traceparent": traceparent}
+	}
+	return cm
+}
+
+// startCVGateInformer starts the REAL config-vars informer over a fake clientset
+// pre-seeded with an initial config-vars CM (so the ADD/initial-list has already
+// fired and settled before the arm drives UPDATEs). Returns the clientset.
+func startCVGateInformer(t *testing.T, initial *corev1.ConfigMap) *kfake.Clientset {
+	t.Helper()
+	resetBootRaceState()
+	t.Cleanup(resetBootRaceState)
+	t.Setenv(frontendConfigConfigMapEnv, bootRaceConfigMapName)
+
+	kc := kfake.NewSimpleClientset(initial)
+	restore := SetConfigVarsWatchClientForTest(kc)
+	t.Cleanup(restore)
+
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+	t.Cleanup(watchCancel)
+	StartConfigVarsWatch(watchCtx, nil, bootRaceNamespace)
+
+	// Wait for the initial ADD (ungated) to fire so Enqueued==1 before UPDATEs.
+	if got := waitForCount(ConfigVarsEnqueuedTotal, 1, 5*time.Second); got != 1 {
+		t.Fatalf("setup: initial config-vars ADD did not fire exactly once (Enqueued=%d)", got)
+	}
+	return kc
+}
+
+// TestConfigVarsGate_AnnotationOnlySkips_DataChangeRedrives — ARM-1 (crux) +
+// ARM-2, paired. The gate suppresses a metadata-only UPDATE and passes a genuine
+// Data change. This ONE test is the discriminator: a gate-less build passes the
+// data arm but FAILS the annotation arm (Enqueued climbs); a gate-everything
+// build FAILS the data arm.
+func TestConfigVarsGate_AnnotationOnlySkips_DataChangeRedrives(t *testing.T) {
+	bootRaceTestMu.Lock()
+	defer bootRaceTestMu.Unlock()
+
+	const cfgA = `{"api":{"INIT":"/call?resource=navmenus&name=a"}}`
+	const cfgB = `{"api":{"INIT":"/call?resource=navmenus&name=b"}}`
+	kc := startCVGateInformer(t, cvGateCM(cfgA, "00-aaaaaaaa-1111-01"))
+
+	enqAfterAdd := ConfigVarsEnqueuedTotal() // == 1
+	skipBefore := ConfigVarsSkippedTotal()
+
+	// ── ARM-1 (crux): annotation-only UPDATE (fresh traceparent, SAME Data).
+	// The CDC re-apply shape. Must be SKIPPED: Enqueued FLAT, Skipped +1.
+	if _, err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Update(
+		context.Background(), cvGateCM(cfgA, "00-bbbbbbbb-2222-01"), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("annotation-only update: %v", err)
+	}
+	if got := waitForCount(ConfigVarsSkippedTotal, skipBefore+1, 5*time.Second); got != skipBefore+1 {
+		t.Fatalf("ARM-1: annotation-only UPDATE must be SKIPPED (Skipped %d -> want %d); the data-change gate did not fire",
+			skipBefore, skipBefore+1)
+	}
+	// Give any (erroneous) enqueue a beat to show up, then assert Enqueued FLAT.
+	time.Sleep(300 * time.Millisecond)
+	if got := ConfigVarsEnqueuedTotal(); got != enqAfterAdd {
+		t.Fatalf("ARM-1 (crux) RED-shape: annotation-only UPDATE drove a boot re-enqueue (Enqueued %d -> %d) — "+
+			"the metadata-only CDC churn is NOT gated (this is the pre-#106 defect / the RED mutation)", enqAfterAdd, got)
+	}
+
+	// ── ARM-2: a genuine Data["config.json"] change MUST redrive.
+	if _, err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Update(
+		context.Background(), cvGateCM(cfgB, "00-cccccccc-3333-01"), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("data-change update: %v", err)
+	}
+	if got := waitForCount(ConfigVarsEnqueuedTotal, enqAfterAdd+1, 5*time.Second); got != enqAfterAdd+1 {
+		t.Fatalf("ARM-2: a genuine config.json change must REDRIVE (Enqueued %d -> want %d); the gate over-suppressed a real change",
+			enqAfterAdd, enqAfterAdd+1)
+	}
+	// The skip counter must NOT have moved on the data change.
+	if got := ConfigVarsSkippedTotal(); got != skipBefore+1 {
+		t.Fatalf("ARM-2: the data change must NOT be counted as a skip (Skipped=%d, want %d)", got, skipBefore+1)
+	}
+
+	writeC106Artifact(t, "arm1_2_annotation_skip_data_redrive.txt",
+		"ARM-1 annotation-only UPDATE: Enqueued FLAT + Skipped+1 (gated).\n"+
+			"ARM-2 config.json change: Enqueued+1 (redrive), Skipped flat.\n"+
+			"Discriminator = configVarsDataChanged; RED mutation (unconditional enqueue) flips ARM-1.")
+}
+
+// TestConfigVarsGate_FlapRedrivesBothEvents — ARM-3. A→B→A as two Data updates
+// each differ from the previously-delivered state → Enqueued +2. Pins the
+// stateless per-event-delta semantics (no stored baseline hash that a
+// revert-to-A could match and wrongly suppress).
+func TestConfigVarsGate_FlapRedrivesBothEvents(t *testing.T) {
+	bootRaceTestMu.Lock()
+	defer bootRaceTestMu.Unlock()
+
+	const cfgA = `{"api":{"INIT":"/call?resource=navmenus&name=a"}}`
+	const cfgB = `{"api":{"INIT":"/call?resource=navmenus&name=b"}}`
+	kc := startCVGateInformer(t, cvGateCM(cfgA, "00-aaaaaaaa-1111-01"))
+
+	enqStart := ConfigVarsEnqueuedTotal() // == 1 (initial ADD)
+
+	// A→B (differs → redrive).
+	if _, err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Update(
+		context.Background(), cvGateCM(cfgB, ""), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("flap A->B: %v", err)
+	}
+	if got := waitForCount(ConfigVarsEnqueuedTotal, enqStart+1, 5*time.Second); got != enqStart+1 {
+		t.Fatalf("ARM-3: A->B must redrive (Enqueued %d -> want %d)", enqStart, enqStart+1)
+	}
+
+	// B→A (differs from the previously-delivered B → redrive AGAIN). A stored
+	// boot-baseline hash of A would wrongly suppress this; the stateless
+	// last-seen (old=B) does not.
+	if _, err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Update(
+		context.Background(), cvGateCM(cfgA, ""), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("flap B->A: %v", err)
+	}
+	if got := waitForCount(ConfigVarsEnqueuedTotal, enqStart+2, 5*time.Second); got != enqStart+2 {
+		t.Fatalf("ARM-3: B->A (revert-to-baseline) must ALSO redrive (Enqueued %d -> want %d) — "+
+			"a stored-baseline-hash design would wrongly suppress it; the stateless last-seen must fire", enqStart, enqStart+2)
+	}
+
+	writeC106Artifact(t, "arm3_flap.txt",
+		"A->B->A two Data updates → Enqueued +2 (per-event-delta, stateless last-seen; no baseline-hash suppression).")
+}
+
+// TestConfigVarsGate_DeleteRecreateRedrivesViaAdd — ARM-5. Delete then Create
+// the SAME Data → +1 via the ungated ADD path (recreate == ADD). The stateless
+// design has no stored last-hash to survive the delete and wrongly suppress the
+// recreate.
+func TestConfigVarsGate_DeleteRecreateRedrivesViaAdd(t *testing.T) {
+	bootRaceTestMu.Lock()
+	defer bootRaceTestMu.Unlock()
+
+	const cfg = `{"api":{"INIT":"/call?resource=navmenus&name=a"}}`
+	kc := startCVGateInformer(t, cvGateCM(cfg, ""))
+
+	enqStart := ConfigVarsEnqueuedTotal() // == 1 (initial ADD)
+
+	// Delete (no DeleteFunc → no enqueue, no skip).
+	if err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Delete(
+		context.Background(), bootRaceConfigMapName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := ConfigVarsEnqueuedTotal(); got != enqStart {
+		t.Fatalf("ARM-5: DELETE must not enqueue (Enqueued %d -> %d); there is no DeleteFunc", enqStart, got)
+	}
+
+	// Recreate SAME Data → ADD fires → +1 (ungated ADD, no data-diff on recreate).
+	if _, err := kc.CoreV1().ConfigMaps(bootRaceNamespace).Create(
+		context.Background(), cvGateCM(cfg, ""), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("recreate: %v", err)
+	}
+	if got := waitForCount(ConfigVarsEnqueuedTotal, enqStart+1, 5*time.Second); got != enqStart+1 {
+		t.Fatalf("ARM-5: delete->recreate (same Data) must REDRIVE via the ungated ADD (Enqueued %d -> want %d) — "+
+			"a stored last-hash would wrongly suppress the recreate", enqStart, enqStart+1)
+	}
+
+	writeC106Artifact(t, "arm5_delete_recreate.txt",
+		"Delete (no enqueue) then Create same Data → +1 via ungated ADD (recreate==ADD; no stored-hash suppression).")
+}

--- a/internal/handlers/dispatchers/phase1_configvars_watch.go
+++ b/internal/handlers/dispatchers/phase1_configvars_watch.go
@@ -43,6 +43,7 @@ import (
 	"log/slog"
 	"sync/atomic"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
@@ -94,6 +95,21 @@ var configVarsEnqueuedTotal atomic.Uint64
 // count (falsifier + telemetry).
 func ConfigVarsEnqueuedTotal() uint64 { return configVarsEnqueuedTotal.Load() }
 
+// configVarsSkippedTotal counts config-vars UPDATE events the data-change gate
+// (#106, configVarsDataChanged) SUPPRESSED because Data + BinaryData were
+// byte-identical to the previously-delivered state — i.e. a metadata-only write
+// (the KrateoFrontend CDC re-apply bumps annotations/managedFields with a fresh
+// krateo.io/traceparent span each reconcile, ~1/min on fresh2). Steady-state
+// rate == the CDC churn rate, so a climbing value PROVES the gate is actively
+// firing (distinguishes gate-working from informer-dead / churn-stopped).
+// Exact mirror of the enqueued-counter shape above; exposed via expvar
+// snowplow_phase1_configvars_skipped_total (phase1_pip_metrics.go).
+var configVarsSkippedTotal atomic.Uint64
+
+// ConfigVarsSkippedTotal exposes the count of UPDATE events suppressed by the
+// data-change gate (falsifier + telemetry).
+func ConfigVarsSkippedTotal() uint64 { return configVarsSkippedTotal.Load() }
+
 // buildConfigVarsWatchClient builds the typed clientset the informer uses —
 // the injected fake in tests, else kubernetes.NewForConfig(rc). Mirrors
 // cache.buildSecretsClient.
@@ -118,6 +134,40 @@ func matchesConfigVars(obj interface{}, cmName string) bool {
 		return false
 	}
 	return cm.Name == cmName
+}
+
+// configVarsDataChanged reports whether the config-vars ConfigMap's CONSUMED
+// content changed between the informer's previously-delivered state (oldObj) and
+// the new one (newObj) — #106 data-change redrive gate (design
+// docs/configvars-update-datagate-design-2026-07-07.md).
+//
+// WHY. UpdateFunc used to enqueue a full boot re-walk on ANY object write. The
+// KrateoFrontend CDC re-apply bumps annotations/managedFields (a fresh
+// krateo.io/traceparent span each reconcile) → new ResourceVersion → informer
+// UPDATE ~1/min, each paying the ~2.3-min walk at 60K while config.json is
+// byte-identical. This predicate gates the enqueue on the actual consumed
+// content so metadata-only churn stops driving the walk.
+//
+// SCOPE = FULL Data + BinaryData (superset of the single consumed key
+// Data["config.json"], phase1_roots.go frontendConfigDataKey), never narrower
+// than consumed: a future walker reading a sibling key must NOT silently go
+// stale, and a redundant coalesced walk on a real frontend deploy touching a
+// sibling key is self-limiting. Matches the Helm checksum/config prior-art.
+//
+// FAIL-OPEN. If EITHER object is not a *corev1.ConfigMap (unexpected type /
+// tombstone) the function returns true (== the pre-#106 unconditional-enqueue
+// behavior) — never suppress a redrive on doubt (a suppressed genuine redrive is
+// the cold-first-nav class this watcher exists to kill, and it fails silent).
+// O(1)-ish map compare over a 1-key ConfigMap; the HOOK-MUST-NOT-BLOCK contract
+// holds (no parse, no apiserver read).
+func configVarsDataChanged(oldObj, newObj interface{}) bool {
+	oldCM, oldOK := oldObj.(*corev1.ConfigMap)
+	newCM, newOK := newObj.(*corev1.ConfigMap)
+	if !oldOK || !newOK {
+		return true // fail OPEN — pre-#106 behavior; never suppress on doubt
+	}
+	return !apiequality.Semantic.DeepEqual(oldCM.Data, newCM.Data) ||
+		!apiequality.Semantic.DeepEqual(oldCM.BinaryData, newCM.BinaryData)
 }
 
 // enqueueBootReDrive is the AddFunc/UpdateFunc body: it ONLY calls the
@@ -202,21 +252,43 @@ func StartConfigVarsWatch(ctx context.Context, rc *rest.Config, authnNS string) 
 
 	if _, err := inf.AddEventHandler(clientcache.ResourceEventHandlerFuncs{
 		// AddFunc: config-vars appeared (or the initial-list replay when it
-		// is already present at boot). Drives the boot re-walk.
+		// is already present at boot). Drives the boot re-walk. UNGATED
+		// (#106 C106-3a): first appearance / initial-LIST replay always
+		// redrives — it is the boot-race self-heal trigger itself and has no
+		// prior state to diff.
 		AddFunc: func(obj interface{}) {
 			if matchesConfigVars(obj, cmName) {
 				enqueueBootReDrive("configmap_added")
 			}
 		},
-		// UpdateFunc: config.json changed (e.g. the frontend rewrote its
-		// INIT/ROUTES_LOADER entry points). Re-drives so the new roots warm.
-		UpdateFunc: func(_, newObj interface{}) {
-			if matchesConfigVars(newObj, cmName) {
-				enqueueBootReDrive("configmap_updated")
+		// UpdateFunc: re-drives ONLY when the consumed content actually changed
+		// (#106 data-change gate). The KrateoFrontend CDC re-apply bumps
+		// annotations/managedFields (fresh traceparent span each reconcile) →
+		// UPDATE ~1/min with byte-identical config.json; without the gate each
+		// paid a full ~2.3-min boot re-walk and starved the keepwarm sweep. The
+		// gate compares the informer's own delivered (old,new) pair — last-seen
+		// ≡ last-redriven, no stored hash, so a flap A→B→A redrives on BOTH
+		// events by construction (design §"No stored hash").
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if !matchesConfigVars(newObj, cmName) {
+				return
 			}
+			if !configVarsDataChanged(oldObj, newObj) {
+				configVarsSkippedTotal.Add(1)
+				slog.Info("prewarm.configvars.redrive_skipped",
+					slog.String("subsystem", "cache"),
+					slog.String("reason", "data_unchanged_metadata_only"),
+					slog.String("configmap", cmName),
+					slog.String("effect", "config-vars UPDATE was metadata-only (Data+BinaryData byte-identical); "+
+						"boot re-walk SUPPRESSED (#106 CDC-churn gate) — the walk reads the live CM, nothing to re-warm"),
+				)
+				return
+			}
+			enqueueBootReDrive("configmap_data_changed")
 		},
 		// No DeleteFunc: a deleted config-vars ConfigMap has no roots to
-		// re-walk — nothing to enqueue.
+		// re-walk — nothing to enqueue. delete→recreate is covered by the
+		// unconditional AddFunc (recreate == ADD).
 	}); err != nil {
 		log.Warn("prewarm.configvars.add_event_handler_failed",
 			slog.String("subsystem", "cache"),

--- a/internal/handlers/dispatchers/phase1_pip_metrics.go
+++ b/internal/handlers/dispatchers/phase1_pip_metrics.go
@@ -257,6 +257,14 @@ func registerPIPMetrics() {
 			return keepwarmAgeSkipTotal.Load()
 		}))
 
+		// #106 — config-vars UPDATE events suppressed by the data-change gate
+		// (metadata-only CDC churn; Data+BinaryData byte-identical). Steady-state
+		// rate == the CDC churn rate, so a climbing value proves the gate is
+		// actively firing (gate-working vs informer-dead/churn-stopped).
+		expvar.Publish("snowplow_phase1_configvars_skipped_total", expvar.Func(func() any {
+			return configVarsSkippedTotal.Load()
+		}))
+
 		// Ship 0.30.187 D1 — per-(cohort, target) seed-failure maps so
 		// operators see WHICH widget/restaction broke WHICH cohort.
 		// Composite key shape: "cohort|name|gvr" (widgets) /

--- a/internal/handlers/dispatchers/phase1_roots.go
+++ b/internal/handlers/dispatchers/phase1_roots.go
@@ -72,6 +72,14 @@ const frontendConfigConfigMapDefault = "frontend-config-vars"
 
 // frontendConfigDataKey is the single key inside the ConfigMap whose
 // value is the `config.json` JSON string.
+//
+// #106 COUPLING: the config-vars UPDATE redrive gate (configVarsDataChanged,
+// phase1_configvars_watch.go) compares the FULL Data + BinaryData maps — a
+// superset of this one consumed key — so if a future walker change starts
+// consuming a SIBLING key here, the gate already covers it (no silent-stale
+// hole). Narrowing the gate to only this key would require widening it in
+// lockstep with any such change; the full-Data compare deliberately avoids that
+// coupling. See docs/configvars-update-datagate-design-2026-07-07.md §Scope.
 const frontendConfigDataKey = "config.json"
 
 // configMapGVR is the GVR for core/v1 ConfigMap — the meta object Phase 1


### PR DESCRIPTION
## #106 — config-vars data-change redrive gate

### Symptom (TRACED, fresh2 60K @1.6.4, 2026-07-07)

The KrateoFrontend CDC reconcile re-applies the `frontend-config-vars` ConfigMap every ~60s, stamping only a fresh `krateo.io/traceparent` span annotation — `config.json` (`Data`) is byte-identical across reads (sha256-verified). Each re-apply bumps `resourceVersion` → informer UPDATE → `phase1_configvars_watch.go`'s `UpdateFunc` enqueued a `scopeKindBoot` re-drive unconditionally → the engine walked the full nav tree (~2.3 min/pass at 60K), near-permanently, ~1/min. Keepwarm scopes queued behind that permanent boot stream (observed delaying the first c2 keepwarm sweep's `cohort_summary` emissions).

### Fix — stateless (old,new) Data-equality gate in UpdateFunc

`UpdateFunc` now gates the enqueue on a stateless `configVarsDataChanged(old, new)` predicate:
`!apiequality.Semantic.DeepEqual(old.Data, new.Data) || !DeepEqual(old.BinaryData, new.BinaryData)`.

- **No stored state.** The comparison is against the informer's own delivered `old` (the previously-delivered state), which client-go guarantees, and `enqueueScope` never drops — so last-seen ≡ last-redriven with no divergence window. A flap A→B→A redrives on BOTH events by construction; delete→recreate is covered by the ungated `AddFunc` (recreate == ADD). A stored baseline hash would stale-match and wrongly suppress both cases — the stateless design closes those holes. (Same content-change intent as the /refreshes publish semantics, without persisting a hash.)
- **Full `Data` + `BinaryData`** (superset of the single consumed `Data["config.json"]` key), so a future walker consuming a sibling key can't silently go stale; a redundant coalesced walk on a real frontend deploy touching a sibling key is self-limiting.
- **Fail-OPEN.** If either object is not a `*corev1.ConfigMap` (unexpected type / tombstone) the predicate returns `true` (== pre-#106 unconditional behavior) — never suppress a redrive on doubt (a suppressed genuine redrive is the cold-first-nav class this watcher exists to kill).
- **AddFunc UNGATED** (verbatim): first appearance / initial-LIST replay always redrives — it is the boot-race self-heal trigger and has no prior state to diff. **No DeleteFunc.** Engine/queue/F.4 untouched. **No env knob** (unconditional correctness fix). The hook stays O(1)-ish and non-blocking (no parse, no apiserver read).

### Observability

- INFO `prewarm.configvars.redrive_skipped` (`reason="data_unchanged_metadata_only"` + CM name) — greppable under `PRETTY_LOG:false`; volume bounded by the CDC cadence (~1/min).
- expvar `snowplow_phase1_configvars_skipped_total` (mirror of the enqueued-counter shape) — steady-state rate == the CDC churn rate, so a climbing value proves the gate is actively firing (distinguishes gate-working from informer-dead / churn-stopped).
- Enqueue reason split: `configmap_added` / `configmap_data_changed`.

### Falsifiers (5 arms + RED proof)

Real-informer-over-fake-clientset harness (`SetConfigVarsWatchClientForTest` + a real `SharedInformerFactory` ConfigMap informer). All `-race`, `=== RUN` verified; full dispatchers package `-race -count=1` green ×3.

- **ARM-1+2 (paired, crux):** annotation-only UPDATE (fresh traceparent, same Data) → EnqueuedTotal FLAT + SkippedTotal +1; then a `Data["config.json"]` UPDATE → EnqueuedTotal +1 (reason `configmap_data_changed`). The data-diff is the discriminator.
- **ARM-3 (flap):** A→B→A → EnqueuedTotal +2 (stateless per-event-delta; a baseline-hash design would wrongly suppress B→A).
- **ARM-4 (add-always):** the existing `TestBootRace_ConfigVarsInformerDrivesReWalk` stays green unchanged (ADD path ungated).
- **ARM-5 (delete→recreate):** Delete (no enqueue, no DeleteFunc) then Create same Data → +1 via the ungated ADD.
- **RED mutation** (source-revert, byte-clean restore): drop the gate (UpdateFunc calls `enqueueBootReDrive` unconditionally, the pre-#106 form) → the ARM-1 annotation arm goes RED (a metadata-only write drives a boot re-enqueue). ARM-2 stays green under the mutation, confirming ARM-1 is the discriminator.

### On-cluster ledger row (C106-1(ii), post-deploy)

Fresh2 60K, ≥15 min under CDC churn: `boot_redrive_enqueued` delta **0** (pre-fix ~15) while the CM's traceparent keeps changing (resourceVersion bumping), `snowplow_phase1_configvars_skipped_total` climbing ~1/min, `prewarm.configvars.redrive_skipped` INFO lines at the churn cadence; then ONE live `config.json` edit → exactly one redrive + a completed walk; c2 keepwarm `cohort_summary` lines appear on cadence (no boot-scope queue delay).

### Design reference

`docs/configvars-update-datagate-design-2026-07-07.md` (PM-accepted memo v2; the §"No stored hash" rationale + §Falsifier spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
