### PR TITLE
refactor(cache): A1 extract shared effectiveKeyExtras (behavior-preserving) — definitive-arch ship 1/7

### DIFF
--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -1,0 +1,87 @@
+// effective_key_extras_test.go — A1 byte-identical golden for the
+// effectiveKeyExtras extraction (docs/definitive-cache-identity-architecture-2026-07-07.md
+// §8.1-A1). A1 is a pure behavior-preserving refactor: effectiveKeyExtras must
+// return output BYTE-IDENTICAL to the pre-A1 inline fold
+// unionForKey(GetApiRefExtras(cr), GetResourcesRefsExtras(cr), request) at every
+// one of the four routed sites, because the A2 identity-injection slot
+// (declaredIdentityForKey) is INERT in A1 (returns nil). This is the "nothing
+// moved" acceptance gate — no observable behavior is introduced.
+//
+// keyExtrasFor (extras_cache_key_test.go) IS the pre-A1 inline fold, so asserting
+// effectiveKeyExtras == keyExtrasFor over representative corpus shapes is the
+// direct byte-identical proof. The transitive coverage (Falsifier64/67,
+// InlineExtras seed-parity, DedupKeyParity) exercises the four sites end-to-end;
+// this arm pins the extraction's equivalence at the unit boundary + guards A2
+// against silently changing A1 behavior (the injection must stay inert here).
+
+package dispatchers
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold — the A1 nothing-moved
+// golden across the corpus-representative extras shapes: no-extras, apiRef-inline
+// only, rrt-inline only, both inline maps, request-extras only, and inline+request
+// with a COLLISION (request must win — the pre-A1 precedence). At each shape the
+// shared helper must deep-equal the pre-A1 inline fold.
+func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
+	ctx := ctxWithIdentity()
+
+	cases := []struct {
+		name       string
+		apiRefJSON string
+		rrtJSON    string
+		request    map[string]any
+	}{
+		{name: "no-extras (backward-compat empty fold)"},
+		{name: "apiRef-inline only", apiRefJSON: `{"tenant":"acme"}`},
+		{name: "rrt-inline only", rrtJSON: `{"region":"eu"}`},
+		{name: "both inline maps", apiRefJSON: `{"tenant":"acme"}`, rrtJSON: `{"region":"eu"}`},
+		{name: "request-extras only", request: map[string]any{"page": "detail"}},
+		{
+			name:       "inline + request, request wins on collision",
+			apiRefJSON: `{"tenant":"acme","shared":"inline"}`,
+			rrtJSON:    `{"region":"eu"}`,
+			request:    map[string]any{"shared": "request", "q": "x"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := widgetCRWithExtras(t, tc.apiRefJSON, tc.rrtJSON)
+
+			want := keyExtrasFor(cr, tc.request)           // the pre-A1 inline fold
+			got := effectiveKeyExtras(ctx, cr, tc.request) // the A1 shared helper
+
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("A1 NOT byte-identical: effectiveKeyExtras diverged from the pre-A1 unionForKey fold\n  got  = %#v\n  want = %#v", got, want)
+			}
+		})
+	}
+}
+
+// TestA1_DeclaredIdentityForKey_InertInA1 — pins that the A2 injection slot is
+// INERT in A1: declaredIdentityForKey returns nil regardless of ctx/CR, so
+// effectiveKeyExtras adds nothing beyond the union. If A2 wiring lands, THIS test
+// is the one that must be deliberately updated — a guard that A1 shipped with the
+// slot provably off (and that a stray early-wire is caught).
+func TestA1_DeclaredIdentityForKey_InertInA1(t *testing.T) {
+	ctx := ctxWithIdentity()
+	// Even a CR that (in A2) would declare identityContext must yield nil in A1 —
+	// the accessor does not exist yet, so any CR shape returns nil.
+	cr := map[string]any{"spec": map[string]any{
+		"identityContext": []any{"username", "groups"},
+		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
+	}}
+	if got := declaredIdentityForKey(ctx, cr); got != nil {
+		t.Fatalf("A1: declaredIdentityForKey must be INERT (nil) until A2 wires it; got %#v", got)
+	}
+	// And effectiveKeyExtras over that CR equals the pure union (no identity keys).
+	want := keyExtrasFor(cr, nil)
+	got := effectiveKeyExtras(ctx, cr, nil)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("A1: with the injection inert, effectiveKeyExtras must equal the pure union\n  got  = %#v\n  want = %#v", got, want)
+	}
+}

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/handlers/util"
 	"github.com/krateoplatformops/snowplow/internal/objects"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
@@ -334,6 +335,61 @@ func unionForKey(apiRefInline, rrtInline, request map[string]any) map[string]any
 		out[k] = v
 	}
 	return out
+}
+
+// effectiveKeyExtras is the SINGLE shared derivation of the "effective key
+// extras" the definitive cache-identity architecture (§2.2,
+// docs/definitive-cache-identity-architecture-2026-07-07.md) mandates for ALL
+// FOUR key-derivation consumers — dispatch lookup (widgets.go), widgetContent
+// lookup (widgets.go), subscription arming (refresh_subscription.go), and the
+// boot/keepwarm seed (phase1_pip_seed.go). Extracting it here is the A1
+// head-start: a pure behavior-preserving refactor that gives every consumer ONE
+// place to fold extras, so the A2 identity-injection lands at a single site and
+// cannot drift across the four consumers (the #64 shadow-drift lesson, applied
+// preemptively — same principle as the normalizePagination extraction).
+//
+// TODAY (A1) it returns EXACTLY what the four sites computed inline before:
+//
+//	unionForKey(GetApiRefExtras(cr), GetResourcesRefsExtras(cr), requestExtras)
+//
+// ⊎ declaredIdentityForKey(ctx, cr), which is INERT in A1 (returns nil → the
+// union is returned unchanged → byte-identical ResolvedKeyInputs at every site).
+// A2 wires declaredIdentityForKey to read spec.identityContext + materialise the
+// declared subset of xcontext.UserInfo(ctx) with injection-wins precedence; the
+// merge slot is present now so A2 is a one-function change with no new call-site
+// plumbing. The ctx parameter is accepted now (unused in A1) for the same
+// reason — A2 needs it, and threading it now keeps A1↔A2 signature-stable.
+//
+// cr is the widget CR's unstructured object map (the accessors deep-copy, so the
+// result never aliases the shared CR); nil-safe (both accessors return {} on a
+// nil/mismatched map → union degenerates to requestExtras → ComputeKey's len>0
+// guard skips the extras fold on an all-empty result — the no-extras backward-
+// compat path).
+func effectiveKeyExtras(ctx context.Context, cr map[string]any, requestExtras map[string]any) map[string]any {
+	base := unionForKey(
+		widgets.GetApiRefExtras(cr),
+		widgets.GetResourcesRefsExtras(cr),
+		requestExtras,
+	)
+	// A2 injection slot (INERT in A1): server-declared identity wins on
+	// collision. declaredIdentityForKey returns nil today, so this loop is a
+	// no-op and `base` is returned byte-identical to the pre-refactor union.
+	for k, v := range declaredIdentityForKey(ctx, cr) {
+		base[k] = v
+	}
+	return base
+}
+
+// declaredIdentityForKey is the A2 injection point, INERT in A1. Under the
+// contract (§2.2) it will read spec.identityContext off the CR and materialise
+// the declared subset of xcontext.UserInfo(ctx) — the server-trusted identity
+// keys that a DECLARED widget's cell must vary on. In A1 it returns nil so
+// effectiveKeyExtras is provably behavior-preserving (no CR declares yet, and
+// the accessor does not exist until A2). Kept as a named function (not an inline
+// nil) so A2 is a localized change and the injection semantics have a home for
+// the F-ARCH-3 precedence falsifier.
+func declaredIdentityForKey(_ context.Context, _ map[string]any) map[string]any {
+	return nil
 }
 
 // cacheHandle is the narrow interface the dispatchers depend on. The

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -772,11 +772,13 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode s
 	// outside Resolve and must be hand-threaded. Absent both blocks ⇒ {} + {}
 	// ⇒ a fresh empty union ⇒ byte-identical to the pre-inline-extras nil arg
 	// (HG-PIP.3 backward-compat). Falsifier #6 asserts the resulting HIT.
-	seedKeyExtras := unionForKey(
-		widgets.GetApiRefExtras(e.W.Object),
-		widgets.GetResourcesRefsExtras(e.W.Object),
-		nil,
-	)
+	// A1: route through the shared effectiveKeyExtras (definitive-architecture
+	// §2.2) — identical to the pre-A1 unionForKey(apiRefInline, rrtInline, nil)
+	// today (injection slot inert), so the seed key stays byte-identical to the
+	// dispatcher key it must match. A2 wires declaredIdentityForKey; the seed ctx
+	// carries the cohort identity (WithUserInfo) so a declared widget's seed key
+	// will fold the same identity a live request folds.
+	seedKeyExtras := effectiveKeyExtras(ctx, e.W.Object, nil)
 
 	// Ship 0.30.187 D2: the dispatcher-lookup key uses the KEY tuple
 	// (KeyPerPage, KeyPage) — derived from the /call Path the walker

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -38,7 +38,6 @@ import (
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/objects"
-	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -135,11 +134,7 @@ func subscriptionKeyExtras(ctx context.Context, c SubscriptionCoordinates) (map[
 		// same, the log noise is gone.
 		return nil, false
 	}
-	return unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		c.Extras,
-	), true
+	return effectiveKeyExtras(ctx, got.Unstructured.Object, c.Extras), true
 }
 
 // SubscriptionSkipReason classifies WHY a coordinate did not arm — for the

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -149,11 +149,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	// blocks ⇒ both accessors return {} ⇒ keyExtras == request extras ⇒
 	// byte-identical keys (backward-compat). The accessors return deep copies,
 	// so keyExtras never aliases the shared CR.
-	keyExtras := unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		extras,
-	)
+	keyExtras := effectiveKeyExtras(req.Context(), got.Unstructured.Object, extras)
 
 	// Ship G (0.30.16x) — identity-free widget content L1 lookup runs
 	// FIRST. Same gating semantics as the per-user lookup below


### PR DESCRIPTION
## A1 — extract shared `effectiveKeyExtras` (behavior-preserving)

Ship 1/7 of the definitive cache-identity architecture (`docs/definitive-cache-identity-architecture-2026-07-07.md` §8.1). This is the decision-independent head start — a pure behavior-preserving refactor with **zero observable behavior change**.

### What

Extracts the "effective key extras" fold into ONE shared helper and routes all four key-derivation consumers through it:

```
effectiveKeyExtras(ctx, cr, requestExtras) =
    unionForKey(GetApiRefExtras(cr), GetResourcesRefsExtras(cr), requestExtras)
    ⊎ declaredIdentityForKey(ctx, cr)   // A2 injection slot — INERT in A1 (returns nil)
```

- **dispatch lookup + widgetContent** — `widgets.go:152` (one `keyExtras` feeds both key builders)
- **subscription arming** — `refresh_subscription.go:137`
- **boot/keepwarm seed** — `phase1_pip_seed.go:781`

The A2 identity-injection slot is present but inert, so today the helper returns exactly the pre-A1 inline union at every site. Giving A2 a single site to wire injection means it cannot drift across the four consumers (the #64 shadow-drift lesson applied preemptively; same principle as the `normalizePagination` extraction). No `ComputeKey` / hash-shape change.

### Why it's safe (nothing moved)

- New `effective_key_extras_test.go` asserts `effectiveKeyExtras == ` the pre-A1 inline fold byte-identical over 6 corpus shapes (no-extras / apiRef-inline / rrt-inline / both / request-only / collision-request-wins) and pins `declaredIdentityForKey` inert in A1.
- Every existing key-parity golden passes unchanged: the #67 per-class `DeriveSubscriptionKey == ComputeKey` invariant, the #64 pagination pre-hash golden, inline-extras seed parity, dedup key parity, extras cache key.
- Full dispatchers suite green under `-race`.

### Scope

4 prod files (`helpers.go`, `widgets.go`, `refresh_subscription.go`, `phase1_pip_seed.go`) + 1 new test; ~56 LOC prod. A2 (the contract core — `declaredIdentity` + injection + quarantine) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
