### PR TITLE
feat(cache): A2 contract core — author-declared identity injection + quarantine — definitive-arch ship 2/7

### DIFF
--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -62,26 +62,46 @@ func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
 	}
 }
 
-// TestA1_DeclaredIdentityForKey_InertInA1 — pins that the A2 injection slot is
-// INERT in A1: declaredIdentityForKey returns nil regardless of ctx/CR, so
-// effectiveKeyExtras adds nothing beyond the union. If A2 wiring lands, THIS test
-// is the one that must be deliberately updated — a guard that A1 shipped with the
-// slot provably off (and that a stray early-wire is caught).
-func TestA1_DeclaredIdentityForKey_InertInA1(t *testing.T) {
-	ctx := ctxWithIdentity()
-	// Even a CR that (in A2) would declare identityContext must yield nil in A1 —
-	// the accessor does not exist yet, so any CR shape returns nil.
-	cr := map[string]any{"spec": map[string]any{
+// TestA2_DeclaredIdentityForKey_WiresInjection — the A1 inert-slot guard,
+// deliberately FLIPPED for A2 (the stray-early-wire guard becomes the wiring
+// proof — per the definitive-arch A2 brief, converted not deleted). In A1 this
+// asserted declaredIdentityForKey returns nil for a CR declaring identityContext;
+// A2 WIRES the injection, so a declared CR under an identity-carrying ctx now
+// materialises the declared subset of the principal, and effectiveKeyExtras folds
+// it into the key (which the pure pre-A2 union does NOT). The inert half survives
+// as the undeclared control (still nil → still byte-identical to pre-A2).
+func TestA2_DeclaredIdentityForKey_WiresInjection(t *testing.T) {
+	ctx := ctxWithIdentity() // cyberjoker / [devs]
+
+	// DECLARED: spec.identityContext:[username,groups] → injection now materialises
+	// {username: cyberjoker, groups: [devs]} from the ctx JWT (A2 wired).
+	declaredCR := map[string]any{"spec": map[string]any{
 		"identityContext": []any{"username", "groups"},
 		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
 	}}
-	if got := declaredIdentityForKey(ctx, cr); got != nil {
-		t.Fatalf("A1: declaredIdentityForKey must be INERT (nil) until A2 wires it; got %#v", got)
-	}
-	// And effectiveKeyExtras over that CR equals the pure union (no identity keys).
-	want := keyExtrasFor(cr, nil)
-	got := effectiveKeyExtras(ctx, cr, nil)
+	got := declaredIdentityForKey(ctx, declaredCR)
+	want := map[string]any{"username": "cyberjoker", "groups": []string{"devs"}}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("A1: with the injection inert, effectiveKeyExtras must equal the pure union\n  got  = %#v\n  want = %#v", got, want)
+		t.Fatalf("A2: declaredIdentityForKey must materialise the declared identity subset from ctx; got %#v want %#v", got, want)
+	}
+	// effectiveKeyExtras folds the identity into the key (differs from the pure union).
+	eff := effectiveKeyExtras(ctx, declaredCR, nil)
+	if eff["username"] != "cyberjoker" {
+		t.Fatalf("A2: effectiveKeyExtras must fold the declared username into the key; got %#v", eff)
+	}
+	if pure := keyExtrasFor(declaredCR, nil); reflect.DeepEqual(eff, pure) {
+		t.Fatalf("A2: a DECLARED widget's key must DIFFER from the pure pre-A2 union (identity folded); both = %#v", eff)
+	}
+
+	// UNDECLARED control: no identityContext → still nil → key byte-identical to
+	// the pure union (the prod-inert acceptance for the ~99% corpus survives).
+	undeclaredCR := map[string]any{"spec": map[string]any{
+		"apiRef": map[string]any{"extras": map[string]any{"k": "v"}},
+	}}
+	if got := declaredIdentityForKey(ctx, undeclaredCR); got != nil {
+		t.Fatalf("A2: an UNDECLARED widget must inject nothing (nil); got %#v", got)
+	}
+	if eff, pure := effectiveKeyExtras(ctx, undeclaredCR, nil), keyExtrasFor(undeclaredCR, nil); !reflect.DeepEqual(eff, pure) {
+		t.Fatalf("A2: an UNDECLARED widget's key must equal the pure union (prod-inert)\n  got  = %#v\n  want = %#v", eff, pure)
 	}
 }

--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -80,7 +80,12 @@ func TestA2_DeclaredIdentityForKey_WiresInjection(t *testing.T) {
 		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
 	}}
 	got := declaredIdentityForKey(ctx, declaredCR)
-	want := map[string]any{"username": "cyberjoker", "groups": []string{"devs"}}
+	// groups is JSON-native []any (NOT []string) — the A2 fix: identity extras
+	// must be deep-copy-safe for the resolve-input path (mergeRequestWins →
+	// plumbing DeepCopyJSON panics on []string). Key-parity byte-identical
+	// (json.Marshal treats []string and []any the same), proven by the A1
+	// byte-identical goldens above.
+	want := map[string]any{"username": "cyberjoker", "groups": []any{"devs"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("A2: declaredIdentityForKey must materialise the declared identity subset from ctx; got %#v want %#v", got, want)
 	}

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -1,0 +1,255 @@
+// farch_identity_contract_test.go — A2 contract-core falsifiers F-ARCH-2/3/5/6
+// (definitive-cache-identity-architecture §6). All arms drive the REAL derivation
+// (effectiveKeyExtras → cache.ComputeKey / widgets.DeclaredIdentity) over real CR
+// shapes and assert PRE-HASH ResolvedKeyInputs field-equality on the identity
+// dimension (feedback_key_parity_golden_real_inputs_prehash_diff), never a
+// hand-fed digest. RED mutations are expressed as discriminating observables +
+// captured to /tmp/a2/ (revert the prod fold → the discriminant collapses).
+//
+// GATE AUTHN-1: identity flows ONLY from xcontext.UserInfo (the JWT); these arms
+// build the principal via WithUserInfo, never a store.
+
+package dispatchers
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// ctxAs builds a request ctx carrying a specific authenticated principal (the
+// only identity source under GATE AUTHN-1).
+func ctxAsIdentity(username string, groups ...string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: groups}))
+}
+
+// widgetCRDeclaring builds a widget CR declaring spec.identityContext = keys
+// (plus an apiRef.extras block so the CR is a realistic shape). Reuses the same
+// unstructured shape widgetCRWithExtras produces.
+func widgetCRDeclaring(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{
+		"identityContext": anyKeys,
+		"apiRef":          map[string]any{"name": "some-ra", "namespace": "demo-system"},
+	}}
+}
+
+// widgetCRInlineParent builds a CR with a static inline+GET resourcesRefs child
+// (hasInlineGETRef==true) but NO identityContext of its own — the F-ARCH-5 shape.
+func widgetCRInlineParent() map[string]any {
+	return map[string]any{"spec": map[string]any{
+		"resourcesRefs": map[string]any{"items": []any{
+			map[string]any{
+				"inline":     true,
+				"verb":       "get",
+				"resource":   "configmaps",
+				"apiVersion": "v1",
+				"name":       "child-cm",
+				"namespace":  "demo-system",
+			},
+		}},
+	}}
+}
+
+func writeA2Artifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/a2", 0o755)
+	_ = os.WriteFile("/tmp/a2/"+name, []byte(body), 0o644)
+}
+
+// keyFor computes the production key for a widget cell under a given identity ctx
+// via the REAL derivation: effectiveKeyExtras → the per-cohort ResolvedKeyInputs
+// → cache.ComputeKey. Identity enters ONLY via the extras fold (§2.1). BindingUID
+// is left "" (no watcher wired), IDENTICAL for both users, so the ONLY key
+// discriminant these arms probe is the identity-in-extras dimension — exactly the
+// per-binding-≠-per-user crux (K=1 binding, M=2 users).
+func keyFor(t *testing.T, ctx context.Context, cr map[string]any, request map[string]any) (string, map[string]any) {
+	t.Helper()
+	eff := effectiveKeyExtras(ctx, cr, request)
+	inputs := cache.ResolvedKeyInputs{
+		CacheEntryClass: "widgets",
+		Group:           "widgets.templates.krateo.io",
+		Version:         "v1beta1",
+		Resource:        "buttons",
+		Namespace:       "demo-system",
+		Name:            "w1",
+		// BindingUID "" — SAME for both users (the shared-binding equivalence class).
+		PerPage: -1,
+		Page:    -1,
+		Extras:  eff,
+	}
+	return cache.ComputeKey(inputs), eff
+}
+
+// F-ARCH-2 — cross-user leak. A DECLARED widget under two users u1≠u2 in the SAME
+// binding: the effective key extras carry each user's identity → the keys DIFFER →
+// u2's serve after u1's Put is a MISS (never u1's bytes). RED mutation (drop the
+// identity fold from effectiveKeyExtras) → both users fold identical extras → same
+// key → u2 reads u1's cell (the leak). Pre-hash field-equality: assert the Extras
+// maps differ on the identity keys, not just the digest.
+func TestFARCH2_DeclaredWidget_CrossUserKeysDiffer(t *testing.T) {
+	cr := widgetCRDeclaring("username", "groups")
+	u1 := ctxAsIdentity("alice", "devs")
+	u2 := ctxAsIdentity("bob", "devs") // SAME binding-shape (same groups), DIFFERENT user
+
+	k1, e1 := keyFor(t, u1, cr, nil)
+	k2, e2 := keyFor(t, u2, cr, nil)
+
+	// Pre-hash: the identity dimension must differ (alice vs bob).
+	if e1["username"] != "alice" || e2["username"] != "bob" {
+		t.Fatalf("F-ARCH-2 pre-hash: effective extras must carry each user's server-derived username; e1=%#v e2=%#v", e1, e2)
+	}
+	if reflect.DeepEqual(e1, e2) {
+		t.Fatalf("F-ARCH-2: a DECLARED widget's effective extras must DIFFER across users (identity folded); both=%#v — the RED mutation (drop the fold) makes them equal → cross-user leak", e1)
+	}
+	// Digest consequence: distinct keys → u2 is a MISS on u1's cell.
+	if k1 == k2 {
+		t.Fatalf("F-ARCH-2: declared-widget keys must differ across users (u1=%s u2=%s); identical key = u2 serves u1's per-user body (leak)", k1, k2)
+	}
+	writeA2Artifact(t, "farch2_crossuser.txt",
+		"declared[username,groups]: alice-key != bob-key (identity folded); RED=drop fold → equal → leak.\ne1="+
+			mapStr(e1)+"\ne2="+mapStr(e2))
+}
+
+// F-ARCH-3 — declared/undeclared boundary + spoof quarantine.
+//
+//	(a) UNDECLARED + old-frontend request (client identity extras) → folded as-is
+//	    (passive compat, per-user, no strip).
+//	(b) UNDECLARED + new-frontend request (no extras) → per-binding shared key ==
+//	    the seed key (empty extras).
+//	(c) DECLARED + a request trying to SPOOF extras.username=someone-else → server
+//	    injection WINS: the effective extras carry the JWT's OWN username, not the
+//	    spoofed value. RED mutation (injection loses precedence) → the spoofed value
+//	    survives → arm fails.
+func TestFARCH3_Boundary_And_SpoofQuarantine(t *testing.T) {
+	ctx := ctxAsIdentity("alice", "devs")
+
+	// (a) undeclared + client identity extras → folded (passive compat).
+	undeclared := map[string]any{"spec": map[string]any{}}
+	_, aExtras := keyFor(t, ctx, undeclared, map[string]any{"username": "client-supplied"})
+	if aExtras["username"] != "client-supplied" {
+		t.Fatalf("F-ARCH-3(a): an UNDECLARED widget must fold client-supplied extras verbatim (passive compat); got %#v", aExtras)
+	}
+
+	// (b) undeclared + no request extras → empty effective extras (== seed key).
+	_, bExtras := keyFor(t, ctx, undeclared, nil)
+	if len(bExtras) != 0 {
+		t.Fatalf("F-ARCH-3(b): an UNDECLARED widget with no request extras must have EMPTY effective extras (per-binding == seed key); got %#v", bExtras)
+	}
+
+	// (c) declared[username] + a SPOOF attempt in the request → injection wins.
+	declared := widgetCRDeclaring("username")
+	_, cExtras := keyFor(t, ctx, declared, map[string]any{"username": "SOMEONE-ELSE"})
+	if cExtras["username"] != "alice" {
+		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE: server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
+	}
+	writeA2Artifact(t, "farch3_boundary_spoof.txt",
+		"(a) undeclared folds client extras=client-supplied; (b) undeclared+no-extras empty; "+
+			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins → alice. RED=injection loses → SOMEONE-ELSE survives.")
+}
+
+// F-ARCH-5 — inline-variance union (arch ruling option (d)). An inline-embedding
+// parent (hasInlineGETRef) that declares NO identityContext of its own is keyed
+// per-USER (full-identity marker) so an embedded child's identity-varying rendered
+// body cannot leak across users sharing one binding. Two users → keys DIFFER. RED
+// mutation (drop inlineParentIdentityForKey) → same key → u2 served u1's embedded
+// child body.
+func TestFARCH5_InlineParent_PerUserKey(t *testing.T) {
+	parent := widgetCRInlineParent() // hasInlineGETRef==true, NO identityContext
+	u1 := ctxAsIdentity("alice", "devs")
+	u2 := ctxAsIdentity("bob", "devs") // same binding-shape
+
+	// Sanity: the parent declares NO identity of its own — without the inline
+	// marker this would be per-binding (the leak). declaredIdentityForKey is nil.
+	if di := declaredIdentityForKey(u1, parent); di != nil {
+		t.Fatalf("F-ARCH-5 setup: the inline parent must declare NO identityContext of its own; got %#v", di)
+	}
+
+	k1, e1 := keyFor(t, u1, parent, nil)
+	k2, e2 := keyFor(t, u2, parent, nil)
+
+	if e1["username"] != "alice" || e2["username"] != "bob" {
+		t.Fatalf("F-ARCH-5 pre-hash: an inline parent's effective extras must carry the FULL per-user identity marker; e1=%#v e2=%#v", e1, e2)
+	}
+	if reflect.DeepEqual(e1, e2) || k1 == k2 {
+		t.Fatalf("F-ARCH-5: an inline-embedding parent must be keyed PER-USER (full-identity marker); e1=%#v e2=%#v k1=%s k2=%s — the RED mutation (drop inlineParentIdentityForKey) makes them equal → embedded child body leaks cross-user", e1, e2, k1, k2)
+	}
+
+	// BOUNDARY: a NON-inline undeclared widget stays per-binding (no marker) —
+	// proves the marker is scoped to inline parents, not blanket per-user.
+	nonInline := map[string]any{"spec": map[string]any{}}
+	_, en1 := keyFor(t, u1, nonInline, nil)
+	_, en2 := keyFor(t, u2, nonInline, nil)
+	if !reflect.DeepEqual(en1, en2) {
+		t.Fatalf("F-ARCH-5 BOUNDARY: a NON-inline undeclared widget must stay per-binding (empty extras, shared); en1=%#v en2=%#v — the inline marker must not leak into non-inline widgets", en1, en2)
+	}
+	writeA2Artifact(t, "farch5_inline_peruser.txt",
+		"inline parent (no own identityContext): alice-key != bob-key (full-identity marker); "+
+			"non-inline undeclared: shared key (marker scoped to inline). RED=drop marker → inline keys equal → child leak.")
+}
+
+// F-ARCH-6 — cache-off transparency. The A2 identity injection is part of the
+// widget INPUT contract, not a cache feature: widgets.DeclaredIdentity (the
+// resolve-input injection source) yields the SAME identity map regardless of
+// cache state, and it is the SAME derivation the key path folds
+// (declaredIdentityForKey). So a declared widget's resolve input for a given JWT
+// is identical whether the cache is on or off. We assert the derivation is
+// cache-state-independent (it reads only ctx + CR, never the cache) and that the
+// key-path and resolve-path identity maps are byte-identical (single derivation).
+func TestFARCH6_CacheOffTransparency_SingleDerivation(t *testing.T) {
+	cr := widgetCRDeclaring("username", "groups")
+	ctx := ctxAsIdentity("alice", "devs")
+
+	// The resolve-input injection source (widgets.DeclaredIdentity) and the
+	// key-path source (declaredIdentityForKey → widgets.DeclaredIdentity) are the
+	// SAME function → byte-identical identity material, cache-state-independent.
+	keyPathID := declaredIdentityForKey(ctx, cr)
+	// Simulate cache-off vs cache-on by calling the derivation twice — it reads
+	// ONLY ctx + CR (no cache handle), so the result cannot depend on cache state.
+	resolveInputID1 := declaredIdentityForKey(ctx, cr)
+	if !reflect.DeepEqual(keyPathID, resolveInputID1) {
+		t.Fatalf("F-ARCH-6: the key-path and resolve-input identity derivations must be byte-identical (single derivation, cache-state-independent); key=%#v resolve=%#v", keyPathID, resolveInputID1)
+	}
+	if keyPathID["username"] != "alice" {
+		t.Fatalf("F-ARCH-6: declared identity must materialise from the JWT (alice) for the resolve input, cache on or off; got %#v", keyPathID)
+	}
+	writeA2Artifact(t, "farch6_cacheoff.txt",
+		"declared[username,groups]: key-path identity == resolve-input identity (single derivation, reads only ctx+CR, no cache handle) → cache-off byte-identical to cache-on for the same JWT.")
+}
+
+// mapStr renders a map for artifact transcripts deterministically-enough.
+func mapStr(m map[string]any) string {
+	b := ""
+	for k, v := range m {
+		b += k + "=" + valStr(v) + " "
+	}
+	return b
+}
+
+func valStr(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []string:
+		s := "["
+		for i, e := range t {
+			if i > 0 {
+				s += ","
+			}
+			s += e
+		}
+		return s + "]"
+	default:
+		return "?"
+	}
+}

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -312,6 +312,60 @@ func TestFARCH6_CacheOffTransparency_ResolvedOutputIdentical(t *testing.T) {
 		"declared[username] echoing .username → status.widgetData.echoedUser: driven through REAL widgets.Resolve under CACHE_ENABLED=true (cold) AND CACHE_ENABLED=false — both render echoedUser=alice (JWT identity in the resolve input) AND are byte-identical. Injection is an INPUT-contract property, transparent to the cache toggle.")
 }
 
+// TestFARCH3_GroupsResolveOutput_GroupScopedOnly — the SECOND-DIMENSION arm for a
+// declared[groups] widget (the A2-fix falsifier AND the A4 seed-safety resolve-output
+// closure; §4.4.6 group-shared cell). Two properties in one arm:
+//
+//  1. JSON-NATIVE FIX GUARD: a declared[groups] widget must resolve through the REAL
+//     widgets.Resolve WITHOUT PANIC. Pre-fix, DeclaredIdentity emitted groups as a Go
+//     []string, which mergeRequestWins → plumbing DeepCopyJSON panicked on ("cannot
+//     deep copy []string"). The fix emits JSON-native []any. RED (i): revert the fix
+//     (DeclaredIdentity groups → []string) → this arm's own driver PANICS. No A2/A4
+//     key-side arm drives Resolve with [groups], so this is the FIRST arm to exercise
+//     that path — the gap both re-gaters proved (whole A4 battery stayed green under
+//     the []string panic AND under the content-spoof).
+//
+//  2. RESOLVE-OUTPUT SCOPE (the content dimension a key-side arm is blind to): the
+//     seeded group-shared cell's rendered body must carry ONLY the group, NEVER the
+//     cohort representative's per-user username. Drive Resolve under a group-only-rep
+//     ctx that ALSO carries a NON-EMPTY username ("rep-admin"); the widget declares
+//     [groups] only, so DeclaredIdentity (the SAME function that scopes the key)
+//     injects only {groups} into the resolve input → the body echoes the groups and
+//     NOT rep-admin. RED (ii): a content-spoof that folds the rep username into the
+//     resolve input while the KEY stays group-only → echoedUser=rep-admin here while
+//     the key-side case-3 stays GREEN — the invisible-to-key-arms leak.
+//
+// Since seedOneWidget calls widgets.Resolve with NO Extras (phase1_pip_seed.go), the
+// seed's resolve-input identity IS this same A2 injection, so this serve-path arm IS
+// the seed-safety guard for the group-shared cell — A4 needs no separate seed-ctx variant.
+func TestFARCH3_GroupsResolveOutput_GroupScopedOnly(t *testing.T) {
+	// declared[groups] echo CR: echoes BOTH .groups and .username into the rendered
+	// body so we assert groups-present AND rep-username-ABSENT.
+	cr := map[string]any{"spec": map[string]any{
+		"identityContext": []any{"groups"},
+		"widgetData":      map[string]any{},
+		"widgetDataTemplate": []any{
+			map[string]any{"forPath": ".echoedGroups", "expression": "${ .groups }"},
+			map[string]any{"forPath": ".echoedUser", "expression": "${ .username }"},
+		},
+	}}
+	// Cohort representative ctx: a group (devs) AND a non-empty username — the
+	// User-kind representative shape. resolveRenderedWidgetData drives the REAL
+	// widgets.Resolve; pre-fix this PANICS on the []string groups deep-copy (RED i).
+	rendered := resolveRenderedWidgetData(t, ctxAsIdentity("rep-admin", "devs"), cr, nil)
+
+	// (1) group-scoped content present.
+	if rendered["echoedGroups"] == nil {
+		t.Fatalf("F-ARCH-3 groups resolve-output: a declared[groups] widget's rendered body must carry the group-scoped identity; got %#v", rendered)
+	}
+	// (2) the rep's per-user username must NOT reach the resolve input / body.
+	if got := rendered["echoedUser"]; got == "rep-admin" {
+		t.Fatalf("F-ARCH-3 groups resolve-output LEAK: the group-shared body carries the cohort representative's username %q — every devs member would be served rep-admin's identity. declared[groups] must inject ONLY groups. RED(ii) = content-spoof folds the rep username into the resolve input while the key stays group-only.", got)
+	}
+	writeA2Artifact(t, "farch3_groups_resolve_output.txt",
+		"declared[groups] echoing .groups + .username, driven through REAL widgets.Resolve under a group-only-rep ctx (rep-admin/devs): echoedGroups=[devs] present, echoedUser ABSENT (not rep-admin) — group-shared body is group-scoped only, no per-user leak; and Resolve does NOT panic (JSON-native []any groups fix). RED(i)=revert to []string → panic; RED(ii)=content-spoof rep username into resolve input → echoedUser=rep-admin while key-side stays green.")
+}
+
 // mapStr renders a map for artifact transcripts deterministically-enough.
 func mapStr(m map[string]any) string {
 	b := ""

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/krateoplatformops/plumbing/jwtutil"
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ctxAs builds a request ctx carrying a specific authenticated principal (the
@@ -42,6 +44,51 @@ func widgetCRDeclaring(keys ...string) map[string]any {
 		"identityContext": anyKeys,
 		"apiRef":          map[string]any{"name": "some-ra", "namespace": "demo-system"},
 	}}
+}
+
+// widgetCRDeclaringWithEcho builds a widget CR declaring spec.identityContext =
+// keys AND a widgetDataTemplate that echoes .username into
+// status.widgetData.echoedUser via jq. It has NO apiRef (so widgets.Resolve's
+// apiRef fetch short-circuits with an empty dict — hermetic, no apiserver), and
+// a spec.widgetData base map for the template to write into. Driving
+// widgets.Resolve over this CR exercises the REAL resolve-input injection merge
+// (resolve.go:64-73) → mergeExtras into the data source → widgetDataTemplate jq,
+// so the rendered echoedUser IS the value that reached the resolve INPUT.
+func widgetCRDeclaringWithEcho(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{
+		"identityContext": anyKeys,
+		"widgetData":      map[string]any{},
+		"widgetDataTemplate": []any{
+			map[string]any{"forPath": ".echoedUser", "expression": "${ .username }"},
+		},
+	}}
+}
+
+// resolveRenderedWidgetData drives the REAL widgets.Resolve over a no-apiRef CR
+// and returns status.widgetData — the RESOLVED OUTPUT / resolve INPUT the widget
+// templates evaluated against. widgets.Resolve populates status.widgetData
+// (resolve.go:141) BEFORE its final crdschema.ValidateObjectStatus step, which
+// needs an apiserver and therefore returns a (benign, expected) error in this
+// hermetic harness; the rendered widgetData is already set on opts.In.Object at
+// that point, so we read it regardless of the tail validate error. This is a
+// genuine drive of the injection merge + mergeExtras + widgetDataTemplate jq —
+// NOT a key-side proxy.
+func resolveRenderedWidgetData(t *testing.T, ctx context.Context, cr map[string]any, requestExtras map[string]any) map[string]any {
+	t.Helper()
+	in := &unstructured.Unstructured{Object: cr}
+	obj, _ := widgets.Resolve(ctx, widgets.ResolveOptions{
+		In:     in,
+		Extras: requestExtras,
+	})
+	wd, _, err := unstructured.NestedMap(obj.Object, "status", "widgetData")
+	if err != nil {
+		t.Fatalf("resolveRenderedWidgetData: reading status.widgetData: %v", err)
+	}
+	return wd
 }
 
 // widgetCRInlineParent builds a CR with a static inline+GET resourcesRefs child
@@ -147,15 +194,38 @@ func TestFARCH3_Boundary_And_SpoofQuarantine(t *testing.T) {
 		t.Fatalf("F-ARCH-3(b): an UNDECLARED widget with no request extras must have EMPTY effective extras (per-binding == seed key); got %#v", bExtras)
 	}
 
-	// (c) declared[username] + a SPOOF attempt in the request → injection wins.
+	// (c) declared[username] + a SPOOF attempt in the request → injection wins
+	// ON THE KEY SIDE (the effective key extras carry alice, not the spoof).
 	declared := widgetCRDeclaring("username")
 	_, cExtras := keyFor(t, ctx, declared, map[string]any{"username": "SOMEONE-ELSE"})
 	if cExtras["username"] != "alice" {
-		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE: server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
+		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE (key side): server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
 	}
+
+	// (c2) SPOOF QUARANTINE on the RESOLVED OUTPUT (the second conjunct §4.4.6(b)
+	// requires and (c) alone was missing). Drive the REAL widgets.Resolve with the
+	// SAME spoof: a request carrying extras.username="SOMEONE-ELSE", a JWT ctx whose
+	// username is alice, a CR declaring identityContext:[username]. The rendered
+	// output (status.widgetData.echoedUser, echoing .username through the resolve
+	// path's widgetDataTemplate jq) MUST carry alice — proving the INJECTION also
+	// wins in the resolve INPUT, not just in the key. This is the §4.4.6(b)-
+	// impossible state made observable: it goes RED under the exact mutation arch
+	// found (reverse the precedence in resolve.go:64-73's injection merge so the
+	// client-supplied value wins), which the KEY-only (c) arm cannot see.
+	echoCR := widgetCRDeclaringWithEcho("username")
+	rendered := resolveRenderedWidgetData(t, ctx, echoCR, map[string]any{"username": "SOMEONE-ELSE"})
+	if got := rendered["echoedUser"]; got != "alice" {
+		t.Fatalf("F-ARCH-3(c2) SPOOF QUARANTINE (resolved output): the resolve INPUT must carry the JWT username (alice), NOT the client spoof; status.widgetData.echoedUser=%#v — the RED mutation (resolve.go injection loses precedence) leaves SOMEONE-ELSE in the rendered body", got)
+	}
+	if got := rendered["echoedUser"]; got == "SOMEONE-ELSE" {
+		t.Fatalf("F-ARCH-3(c2): the SPOOFED value must NOT survive into the rendered body; got %#v", got)
+	}
+
 	writeA2Artifact(t, "farch3_boundary_spoof.txt",
 		"(a) undeclared folds client extras=client-supplied; (b) undeclared+no-extras empty; "+
-			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins → alice. RED=injection loses → SOMEONE-ELSE survives.")
+			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins on KEY → alice; "+
+			"(c2) SAME spoof driven through REAL widgets.Resolve → rendered echoedUser=alice (resolve-input injection wins, NOT SOMEONE-ELSE). "+
+			"RED=reverse resolve.go injection precedence → (c2) rendered=SOMEONE-ELSE (key-only (c) unaffected).")
 }
 
 // F-ARCH-5 — inline-variance union (arch ruling option (d)). An inline-embedding
@@ -198,33 +268,48 @@ func TestFARCH5_InlineParent_PerUserKey(t *testing.T) {
 			"non-inline undeclared: shared key (marker scoped to inline). RED=drop marker → inline keys equal → child leak.")
 }
 
-// F-ARCH-6 — cache-off transparency. The A2 identity injection is part of the
-// widget INPUT contract, not a cache feature: widgets.DeclaredIdentity (the
-// resolve-input injection source) yields the SAME identity map regardless of
-// cache state, and it is the SAME derivation the key path folds
-// (declaredIdentityForKey). So a declared widget's resolve input for a given JWT
-// is identical whether the cache is on or off. We assert the derivation is
-// cache-state-independent (it reads only ctx + CR, never the cache) and that the
-// key-path and resolve-path identity maps are byte-identical (single derivation).
-func TestFARCH6_CacheOffTransparency_SingleDerivation(t *testing.T) {
-	cr := widgetCRDeclaring("username", "groups")
+// F-ARCH-6 — cache-off transparency, driven through the REAL widgets.Resolve.
+// The A2 identity injection is part of the widget INPUT contract, not a cache
+// feature: it runs in widgets.Resolve whether or not the cache is on, so a
+// declared widget's rendered output for a given JWT is identical cache-on vs
+// cache-off. This arm DRIVES the resolve path in BOTH modes (CACHE_ENABLED=true
+// cold vs CACHE_ENABLED=false) over the SAME declared CR + JWT ctx and asserts
+// the RESOLVED OUTPUT is byte-identical AND carries the injected JWT identity in
+// BOTH modes — no more twice-call-DeepEqual-with-self. (widgets.Resolve consults
+// no cache handle, so byte-identity is the substantive property: the injection
+// is transparent to the cache toggle.)
+func TestFARCH6_CacheOffTransparency_ResolvedOutputIdentical(t *testing.T) {
+	echoCR := widgetCRDeclaringWithEcho("username")
 	ctx := ctxAsIdentity("alice", "devs")
 
-	// The resolve-input injection source (widgets.DeclaredIdentity) and the
-	// key-path source (declaredIdentityForKey → widgets.DeclaredIdentity) are the
-	// SAME function → byte-identical identity material, cache-state-independent.
-	keyPathID := declaredIdentityForKey(ctx, cr)
-	// Simulate cache-off vs cache-on by calling the derivation twice — it reads
-	// ONLY ctx + CR (no cache handle), so the result cannot depend on cache state.
-	resolveInputID1 := declaredIdentityForKey(ctx, cr)
-	if !reflect.DeepEqual(keyPathID, resolveInputID1) {
-		t.Fatalf("F-ARCH-6: the key-path and resolve-input identity derivations must be byte-identical (single derivation, cache-state-independent); key=%#v resolve=%#v", keyPathID, resolveInputID1)
+	// Cache ON (cold): drive the real resolve path with CACHE_ENABLED truthy.
+	t.Setenv("CACHE_ENABLED", "true")
+	if cache.Disabled() {
+		t.Fatalf("F-ARCH-6 setup: CACHE_ENABLED=true must report cache enabled")
 	}
-	if keyPathID["username"] != "alice" {
-		t.Fatalf("F-ARCH-6: declared identity must materialise from the JWT (alice) for the resolve input, cache on or off; got %#v", keyPathID)
+	cacheOn := resolveRenderedWidgetData(t, ctx, widgetCRDeclaringWithEcho("username"), nil)
+
+	// Cache OFF: drive the SAME resolve path with CACHE_ENABLED=false semantics.
+	t.Setenv("CACHE_ENABLED", "false")
+	if !cache.Disabled() {
+		t.Fatalf("F-ARCH-6 setup: CACHE_ENABLED=false must report cache disabled")
+	}
+	cacheOff := resolveRenderedWidgetData(t, ctx, echoCR, nil)
+
+	// The injected JWT identity must materialise in the resolve INPUT in BOTH modes.
+	if cacheOn["echoedUser"] != "alice" {
+		t.Fatalf("F-ARCH-6 (cache ON): the declared JWT identity must reach the resolve input (echoedUser=alice); got %#v", cacheOn)
+	}
+	if cacheOff["echoedUser"] != "alice" {
+		t.Fatalf("F-ARCH-6 (cache OFF): the declared JWT identity must reach the resolve input (echoedUser=alice); got %#v", cacheOff)
+	}
+	// And the resolved output must be byte-identical across the cache toggle —
+	// the injection is part of the INPUT contract, invariant to cache state.
+	if !reflect.DeepEqual(cacheOn, cacheOff) {
+		t.Fatalf("F-ARCH-6: declared-widget resolved output must be byte-identical cache-on vs cache-off for the same JWT; on=%#v off=%#v", cacheOn, cacheOff)
 	}
 	writeA2Artifact(t, "farch6_cacheoff.txt",
-		"declared[username,groups]: key-path identity == resolve-input identity (single derivation, reads only ctx+CR, no cache handle) → cache-off byte-identical to cache-on for the same JWT.")
+		"declared[username] echoing .username → status.widgetData.echoedUser: driven through REAL widgets.Resolve under CACHE_ENABLED=true (cold) AND CACHE_ENABLED=false — both render echoedUser=alice (JWT identity in the resolve input) AND are byte-identical. Injection is an INPUT-contract property, transparent to the cache toggle.")
 }
 
 // mapStr renders a map for artifact transcripts deterministically-enough.

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -438,7 +438,16 @@ func inlineParentIdentityForKey(ctx context.Context, cr map[string]any) map[stri
 		out["username"] = ui.Username
 	}
 	if len(ui.Groups) > 0 {
-		out["groups"] = append([]string(nil), ui.Groups...)
+		// JSON-native []any (NOT []string) — key-only here, so this doesn't hit
+		// the resolve-input DeepCopyJSON panic today, but mirror DeclaredIdentity
+		// so ALL identity-extras are JSON-native by construction (shape
+		// uniformity, feedback_no_special_cases). Key-parity byte-identical:
+		// json.Marshal treats []string and []any identically.
+		g := make([]any, len(ui.Groups))
+		for i, v := range ui.Groups {
+			g[i] = v
+		}
+		out["groups"] = g
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -371,25 +371,79 @@ func effectiveKeyExtras(ctx context.Context, cr map[string]any, requestExtras ma
 		widgets.GetResourcesRefsExtras(cr),
 		requestExtras,
 	)
-	// A2 injection slot (INERT in A1): server-declared identity wins on
-	// collision. declaredIdentityForKey returns nil today, so this loop is a
-	// no-op and `base` is returned byte-identical to the pre-refactor union.
+	// A2 identity injection (§2.2): server-declared identity wins on collision.
+	// declaredIdentityForKey → widgets.DeclaredIdentity reads the parent CR's OWN
+	// spec.identityContext; nil for an undeclared widget → no-op → byte-identical
+	// to pre-A2 for the identity-free corpus.
 	for k, v := range declaredIdentityForKey(ctx, cr) {
+		base[k] = v
+	}
+	// A2 inline-variance union (§4.3, F-ARCH-5) — arch ruling option (d): an
+	// inline-embedding parent (hasInlineGETRef) embeds children rendered UNDER the
+	// requesting user's identity (widgets_inline.go), so its cell must be per-USER
+	// even if the PARENT declares no identityContext and even if the embedded
+	// child is a template-expanded ref not enumerable pre-resolve. Fold the FULL
+	// request identity ({username, groups}) into the KEY as a conservative marker
+	// = treat the inline parent as effectively declaring identityContext:[username,
+	// groups]. This is a SUPERSET of any child's declared identity (own ∪ children
+	// ⊆ full), so the effective-union rule is satisfied by over-approximation with
+	// ZERO child-fetch on the hot key path (O(1), C-INLINE-2 triviality) and NO
+	// template-surface hole. KEY-ONLY: it does NOT enter the resolve input (the
+	// parent's own jq gets only its declared identity via widgets.Resolve) — the
+	// child render varies by identity through ResolveNestedCall's per-user ctx.
+	// INERT for the ~99% corpus: inline is opt-in + default-off, and a non-inline
+	// widget returns nil here → byte-identical to pre-A2.
+	for k, v := range inlineParentIdentityForKey(ctx, cr) {
 		base[k] = v
 	}
 	return base
 }
 
-// declaredIdentityForKey is the A2 injection point, INERT in A1. Under the
-// contract (§2.2) it will read spec.identityContext off the CR and materialise
-// the declared subset of xcontext.UserInfo(ctx) — the server-trusted identity
-// keys that a DECLARED widget's cell must vary on. In A1 it returns nil so
-// effectiveKeyExtras is provably behavior-preserving (no CR declares yet, and
-// the accessor does not exist until A2). Kept as a named function (not an inline
-// nil) so A2 is a localized change and the injection semantics have a home for
-// the F-ARCH-3 precedence falsifier.
-func declaredIdentityForKey(_ context.Context, _ map[string]any) map[string]any {
-	return nil
+// declaredIdentityForKey is the KEY-side injection point for the A2 contract
+// (definitive-cache-identity-architecture §2.2). It delegates to the SINGLE
+// shared derivation widgets.DeclaredIdentity(ctx, cr) — the SAME function the
+// resolve-input path calls (widgets.Resolve) — so a declared widget's key fold
+// and its rendered body see byte-identical identity material and cannot desync
+// (the #64 anti-drift principle at the identity dimension). Returns nil for an
+// undeclared widget or an identity-less ctx → the effectiveKeyExtras merge is a
+// no-op → byte-identical to pre-A2 for the ~99% identity-free corpus (the
+// prod-inert acceptance). GATE AUTHN-1: the only identity source is
+// xcontext.UserInfo (inside DeclaredIdentity) — zero store reads.
+func declaredIdentityForKey(ctx context.Context, cr map[string]any) map[string]any {
+	return widgets.DeclaredIdentity(ctx, cr)
+}
+
+// inlineParentIdentityForKey is the KEY-side inline-variance marker (A2 §4.3,
+// F-ARCH-5, arch ruling option (d)). It returns the FULL request identity
+// ({username, groups} from xcontext.UserInfo) as key extras iff the widget CR is
+// an inline-embedding parent (hasInlineGETRef) — making the parent cell per-USER
+// so an embedded child's identity-varying rendered body cannot leak across users
+// sharing one binding. Conservative by construction: the full identity is a
+// superset of any child's declared identityContext, so it closes the leak for
+// BOTH static AND template-expanded inline children WITHOUT fetching any child CR
+// at key time (O(1), no hot-path fan-out). Returns nil for a non-inline widget
+// (byte-identical to pre-A2) or an identity-less ctx (fail-safe: the request
+// already fail-closes to the ""-BindingUID MISS path in dispatchCacheLookupKey).
+// KEY-ONLY — never injected into the resolve input.
+func inlineParentIdentityForKey(ctx context.Context, cr map[string]any) map[string]any {
+	if !hasInlineGETRef(cr) {
+		return nil
+	}
+	ui, err := xcontext.UserInfo(ctx)
+	if err != nil {
+		return nil
+	}
+	out := map[string]any{}
+	if ui.Username != "" {
+		out["username"] = ui.Username
+	}
+	if len(ui.Groups) > 0 {
+		out["groups"] = append([]string(nil), ui.Groups...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // cacheHandle is the narrow interface the dispatchers depend on. The

--- a/internal/resolvers/widgets/resolve.go
+++ b/internal/resolvers/widgets/resolve.go
@@ -45,6 +45,33 @@ type ResolveOptions struct {
 func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	log := xcontext.Logger(ctx).With(loggerAttr(opts.In.Object))
 
+	// A2 contract: server-trusted identity injection into the RESOLVE INPUT
+	// (definitive-cache-identity-architecture §1.3 + §2.4). For a widget whose CR
+	// declares spec.identityContext, fold the declared subset of the
+	// authenticated principal (DeclaredIdentity — the SAME derivation the cache
+	// key path uses via effectiveKeyExtras) into opts.Extras, so the declared
+	// identity reaches BOTH the widgetDataTemplate/resourcesRefsTemplate jq
+	// (mergeExtras(ds, opts.Extras) below) AND the apiRef fetch (resolveApiRef).
+	// INJECTION WINS over any client-supplied value for the declared keys — this
+	// is the quarantine that closes the spoofability hole (§1.3, F-ARCH-3): a
+	// request carrying extras.username=SOMEONE_ELSE is overwritten by the JWT's
+	// own username. CACHE-OFF TRANSPARENT (§2.4, F-ARCH-6): this is part of the
+	// widget's INPUT contract, not a cache feature — it runs here in the resolve
+	// path whether or not the cache is on, so declared-widget output is identical
+	// cache-on vs cache-off for the same JWT. INERT for the ~99% identity-free
+	// corpus: DeclaredIdentity returns nil when no identityContext is declared →
+	// opts.Extras is untouched → byte-identical to pre-A2.
+	if inj := DeclaredIdentity(ctx, opts.In.Object); len(inj) > 0 {
+		merged := make(map[string]any, len(opts.Extras)+len(inj))
+		for k, v := range opts.Extras {
+			merged[k] = v
+		}
+		for k, v := range inj { // injection wins on collision (quarantine)
+			merged[k] = v
+		}
+		opts.Extras = merged
+	}
+
 	// Ship 0.30.193 Checkpoint 1 — widget-resolve phase wall-clocks.
 	// Captured per-phase so seedOneWidget's deferred log can attribute
 	// total widget-resolve cost across apiref / widgetData / resrefs /

--- a/internal/resolvers/widgets/resourcesrefstemplate/resolve_test.go
+++ b/internal/resolvers/widgets/resourcesrefstemplate/resolve_test.go
@@ -146,3 +146,50 @@ func TestResolve_EmptyWindowYieldsNoRefs(t *testing.T) {
 		t.Fatalf("empty post-chokepoint ds fanned %d refs; want 0", len(refs))
 	}
 }
+
+// TestFARCH_InlineNeverPropagatesFromTemplate — A2 F-ARCH-5 guard-completeness
+// invariant (definitive-cache-identity-architecture §4.4.6 + §8.1). The
+// inline-parent per-USER key marker (dispatchers inlineParentIdentityForKey →
+// hasInlineGETRef) statically scans a widget's DECLARED spec.resourcesRefs for
+// inline:true. That static scan is SOUND only because createResourceRef here
+// NEVER copies Template.Inline into the expanded ref (it copies only
+// ID/Verb/APIVersion/Name/Namespace/Resource — resolve.go:75-81): a
+// template-expanded ref cannot silently become inline post-scan.
+//
+// This arm PINS that non-propagation directly: a ResourceRefTemplate whose
+// Template.Inline is TRUE must expand to refs with Inline UNSET (false). If a
+// later change adds `out.Inline = in.Template.Inline` to createResourceRef,
+// this arm goes RED — catching the leak BEFORE the F-ARCH-5 static scan silently
+// under-approximates (a template-expanded inline child would then bypass the
+// per-user marker, embed identity-varying content under a per-binding-shared
+// key, and reopen the cross-user leak §4.4.6 closes). Cheap, hermetic, no cluster.
+func TestFARCH_InlineNeverPropagatesFromTemplate(t *testing.T) {
+	items := []templatesv1.ResourceRefTemplate{{
+		Iterator: ptr.To("${.items}"),
+		Template: templatesv1.ResourceRef{
+			Inline:     true, // author sets Inline on the TEMPLATE
+			Verb:       "get",
+			Resource:   "configmaps",
+			APIVersion: "v1",
+			Name:       "${ .name }",
+			Namespace:  "demo-system",
+		},
+	}}
+	ds := map[string]any{"items": []any{
+		map[string]any{"name": "cm-a"},
+		map[string]any{"name": "cm-b"},
+	}}
+
+	refs, err := Resolve(context.Background(), items, ds)
+	if err != nil {
+		t.Fatalf("Resolve errored: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 expanded refs (one per ds item); got %d", len(refs))
+	}
+	for i, r := range refs {
+		if r.Inline {
+			t.Fatalf("F-ARCH inline-completeness: expanded ref[%d] carries Inline=true — createResourceRef must NOT propagate Template.Inline (resolve.go:75-81 copies only ID/Verb/APIVersion/Name/Namespace/Resource). A template-expanded inline child would bypass the F-ARCH-5 static hasInlineGETRef scan and reopen the §4.4.6 cross-user leak. RED = someone added out.Inline = in.Template.Inline.", i)
+		}
+	}
+}

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -125,7 +125,21 @@ func DeclaredIdentity(ctx context.Context, obj map[string]any) map[string]any {
 			}
 		case identityContextEnumGroups:
 			if len(ui.Groups) > 0 {
-				out[identityContextEnumGroups] = append([]string(nil), ui.Groups...)
+				// JSON-native []any (NOT []string): this identity map is folded
+				// into opts.Extras (resolve.go:64-73) and threaded through
+				// resolveApiRef → mergeRequestWins → plumbing/maps.DeepCopyJSON,
+				// which PANICS on a Go []string ("cannot deep copy []string" — it
+				// only handles the json.Unmarshal-produced []any). A fresh []any
+				// keeps the value deep-copy-safe AND non-aliasing
+				// (feedback_shared_vs_copy_is_a_concurrency_change), and is
+				// key-parity byte-identical: json.Marshal([]string{"devs"}) ==
+				// json.Marshal([]any{"devs"}) == ["devs"], so canonicaliseExtras
+				// hashes it identically (the A1 prod-inert goldens stay green).
+				g := make([]any, len(ui.Groups))
+				for i, v := range ui.Groups {
+					g[i] = v
+				}
+				out[identityContextEnumGroups] = g
 			}
 		}
 	}

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -1,10 +1,12 @@
 package widgets
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 
+	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/maps"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 )
@@ -23,7 +25,115 @@ const (
 	// (resourcesRefsTemplateKey, below) stays byte-identical and existing
 	// blueprints are untouched (the PM-endorsed non-breaking shape).
 	resourcesRefsTemplateExtrasKey = "resourcesRefsTemplateExtras"
+
+	// identityContextKey — the A2 author-declared identity-dependence field
+	// (definitive-cache-identity-architecture §1.1): spec.identityContext is an
+	// OPTIONAL []string enumerating which authenticated-principal keys the
+	// widget's rendered output depends on. Absent/empty = identity-free (the
+	// default; per-binding-shareable + seedable). Read off the unstructured spec
+	// (same absence-tolerant pattern as the extras accessors).
+	identityContextKey = "identityContext"
 )
+
+// identityContextEnumUsername / identityContextEnumGroups are the ONLY enum
+// values the Phase A contract honors — exactly jwtutil.UserInfo (username,
+// groups). D1 (Diego 2026-07-07): displayName is FORECLOSED from the enum (it is
+// not a JWT claim for any strategy, §1.3), so the accessor FILTERS to these two
+// IN CODE — an out-of-enum value (a stale/typo'd/displayName declaration) is
+// dropped, never injected. This is the code-side twin of the CRD enum bound: the
+// server never injects a key the principal does not carry.
+const (
+	identityContextEnumUsername = "username"
+	identityContextEnumGroups   = "groups"
+)
+
+// GetIdentityContext reads spec.identityContext off the unstructured widget CR
+// and returns the DECLARED identity keys FILTERED to the Phase A enum
+// ({username, groups}) — the A2 declaration accessor
+// (definitive-cache-identity-architecture §1.1). Absence-tolerant: absent /
+// wrong-type / empty ⇒ nil (identity-free default, byte-identical to pre-A2).
+// Out-of-enum entries (e.g. displayName, a typo) are DROPPED in code (D1
+// foreclosure) — never a silent inject of a key the principal lacks. Order is
+// preserved and duplicates are collapsed so the derived identity map is
+// deterministic. Reads the raw slice via maps.NestedSlice (deep copy → no CR
+// aliasing), mirroring GetResourcesRefsExtras.
+func GetIdentityContext(obj map[string]any) []string {
+	raw, ok, err := maps.NestedSlice(obj, "spec", identityContextKey)
+	if !ok || err != nil {
+		return nil
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, v := range raw {
+		s, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		// D1 enum filter IN CODE: honor only username/groups.
+		if s != identityContextEnumUsername && s != identityContextEnumGroups {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// DeclaredIdentity is the SINGLE derivation of a declared widget's
+// server-trusted identity map (definitive-cache-identity-architecture §1.3 +
+// §2.2). It is the ONE place identity ever meets the resolve input / key fold,
+// called from BOTH the key path (dispatchers effectiveKeyExtras via
+// declaredIdentityForKey) and the resolve-input path (widgets Resolve) — so the
+// key and the body cannot desync (the #64 anti-drift principle at the identity
+// dimension).
+//
+// It reads the widget's declared identityContext (GetIdentityContext, already
+// enum-filtered) and materialises ONLY those keys from the authenticated
+// principal on ctx (xcontext.UserInfo — the JWT the authn middleware minted).
+//
+// GATE AUTHN-1 (Diego binding constraint): the ONLY source is
+// xcontext.UserInfo(ctx). ZERO user-store reads — no User CR, no IdP call, no
+// LDAP query, no apiserver fetch — so it is STRATEGY-AGNOSTIC by construction
+// (basic / OIDC / LDAP / serviceaccount all mint the same JWT tuple). displayName
+// is not derivable here (not in the JWT); the enum forecloses declaring it.
+//
+// Returns nil when: no declaration (identity-free widget — the ~99% corpus
+// path), or no/invalid UserInfo on ctx (fail-safe: absent identity yields no
+// injection, never a spurious key). A nil return makes the caller's fold a
+// no-op → byte-identical to pre-A2 for every undeclared widget (the prod-inert
+// acceptance). Values: username → ui.Username; groups → a fresh copy of
+// ui.Groups (never aliases the ctx slice). Only NON-EMPTY values are injected —
+// an empty username is not a key (jq `// empty` semantics apply downstream).
+func DeclaredIdentity(ctx context.Context, obj map[string]any) map[string]any {
+	declared := GetIdentityContext(obj)
+	if len(declared) == 0 {
+		return nil // identity-free widget — no injection (prod-inert default)
+	}
+	ui, err := xcontext.UserInfo(ctx)
+	if err != nil {
+		return nil // no authenticated principal → inject nothing (fail-safe)
+	}
+	out := map[string]any{}
+	for _, key := range declared {
+		switch key {
+		case identityContextEnumUsername:
+			if ui.Username != "" {
+				out[identityContextEnumUsername] = ui.Username
+			}
+		case identityContextEnumGroups:
+			if len(ui.Groups) > 0 {
+				out[identityContextEnumGroups] = append([]string(nil), ui.Groups...)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
 
 func GetAPIVersion(obj map[string]any) string {
 	val, err := maps.NestedString(obj, "apiVersion")


### PR DESCRIPTION
## A2 contract core — author-declared identity injection + quarantine

Second ship of the definitive cache-identity architecture (docs/definitive-cache-identity-architecture-2026-07-07.md §8.1 A2 + §4.4.6). **STACKS on A1 (PR #89, fix/A1-effectivekeyextras).** This PR is based on the A1 branch so its diff shows only the A2 delta; it will be batch-merged with A1/A3/A4 as ONE snowplow cut at the A4 gate.

### What it does

- **Server-trusted identity injection for declared widgets.** A widget CR may declare `spec.identityContext` (an optional `[]string` enum, `{username, groups}`). For a declared widget, the server folds the declared subset of the authenticated principal into BOTH the cache key (`effectiveKeyExtras` → `declaredIdentityForKey`) and the resolve input (`widgets.Resolve` → `DeclaredIdentity`).
- **GATE AUTHN-1:** identity flows ONLY from `xcontext.UserInfo` (the JWT the authn middleware minted) — zero user-store reads, strategy-agnostic by construction. `displayName` is foreclosed from the enum (not a JWT claim) and filtered in code.
- **Injection-wins spoof quarantine (§4.4.6b):** a request carrying `extras.username=SOMEONE-ELSE` is overwritten by the JWT's own username on both the key side and the resolve input — content cannot be spoofed while the key stays honest.
- **Single derivation feeds key + resolve.** `widgets.DeclaredIdentity` is the ONE place identity meets the fold, called from both the key path and the resolve-input path, so key and body cannot desync (the #64 anti-drift principle at the identity dimension).
- **Inline option-(d) marker (§4.3, F-ARCH-5):** an inline-embedding parent (`hasInlineGETRef`) is keyed per-USER via a conservative full-identity marker (superset of any child's declared identity), closing the cross-user leak for embedded children with O(1) key-time cost and no child fetch. KEY-only — never enters the resolve input.
- **Prod-inert until a CR declares:** `DeclaredIdentity` returns nil for the ~99% identity-free corpus → every key is byte-identical to pre-A2 (A1 goldens still green).

### Falsifier coverage (definitive-arch §6)

- **F-ARCH-2** cross-user leak: declared widget under u1≠u2 (same binding) → keys differ.
- **F-ARCH-3(c)** spoof quarantine on the KEY side; **F-ARCH-3(c2)** spoof quarantine on the RESOLVED OUTPUT — drives the REAL `widgets.Resolve` and asserts the rendered body carries the JWT value, not the spoof (§4.4.6b second conjunct).
- **F-ARCH-5** inline parent per-user key + non-inline boundary.
- **F-ARCH-6** cache-off transparency: drives `widgets.Resolve` under `CACHE_ENABLED=true` vs `=false`, asserts JWT identity in both AND byte-identical output.
- **inline-completeness arm** pins `createResourceRef` never propagates `Template.Inline` — guards the F-ARCH-5 static scan against a future regression.

All arms `=== RUN` + green under `-race -count=1`; four RED mutations each flip only their intended arm(s) (drop identity fold / key-side precedence loss / drop inline marker / resolve-side precedence reversal).

### Rollout

Off by default (no CR declares `identityContext` → no behavior change). No north-star delta until a widget opts in. Backend-only — no frontend-doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1