### PR TITLE
test(cache): A4 seed parity — permanent F-ARCH-1 #107 arm + declared-seed-safety pin — definitive-arch ship 4/7

### DIFF
--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -1,0 +1,87 @@
+// effective_key_extras_test.go — A1 byte-identical golden for the
+// effectiveKeyExtras extraction (docs/definitive-cache-identity-architecture-2026-07-07.md
+// §8.1-A1). A1 is a pure behavior-preserving refactor: effectiveKeyExtras must
+// return output BYTE-IDENTICAL to the pre-A1 inline fold
+// unionForKey(GetApiRefExtras(cr), GetResourcesRefsExtras(cr), request) at every
+// one of the four routed sites, because the A2 identity-injection slot
+// (declaredIdentityForKey) is INERT in A1 (returns nil). This is the "nothing
+// moved" acceptance gate — no observable behavior is introduced.
+//
+// keyExtrasFor (extras_cache_key_test.go) IS the pre-A1 inline fold, so asserting
+// effectiveKeyExtras == keyExtrasFor over representative corpus shapes is the
+// direct byte-identical proof. The transitive coverage (Falsifier64/67,
+// InlineExtras seed-parity, DedupKeyParity) exercises the four sites end-to-end;
+// this arm pins the extraction's equivalence at the unit boundary + guards A2
+// against silently changing A1 behavior (the injection must stay inert here).
+
+package dispatchers
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold — the A1 nothing-moved
+// golden across the corpus-representative extras shapes: no-extras, apiRef-inline
+// only, rrt-inline only, both inline maps, request-extras only, and inline+request
+// with a COLLISION (request must win — the pre-A1 precedence). At each shape the
+// shared helper must deep-equal the pre-A1 inline fold.
+func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
+	ctx := ctxWithIdentity()
+
+	cases := []struct {
+		name       string
+		apiRefJSON string
+		rrtJSON    string
+		request    map[string]any
+	}{
+		{name: "no-extras (backward-compat empty fold)"},
+		{name: "apiRef-inline only", apiRefJSON: `{"tenant":"acme"}`},
+		{name: "rrt-inline only", rrtJSON: `{"region":"eu"}`},
+		{name: "both inline maps", apiRefJSON: `{"tenant":"acme"}`, rrtJSON: `{"region":"eu"}`},
+		{name: "request-extras only", request: map[string]any{"page": "detail"}},
+		{
+			name:       "inline + request, request wins on collision",
+			apiRefJSON: `{"tenant":"acme","shared":"inline"}`,
+			rrtJSON:    `{"region":"eu"}`,
+			request:    map[string]any{"shared": "request", "q": "x"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := widgetCRWithExtras(t, tc.apiRefJSON, tc.rrtJSON)
+
+			want := keyExtrasFor(cr, tc.request)           // the pre-A1 inline fold
+			got := effectiveKeyExtras(ctx, cr, tc.request) // the A1 shared helper
+
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("A1 NOT byte-identical: effectiveKeyExtras diverged from the pre-A1 unionForKey fold\n  got  = %#v\n  want = %#v", got, want)
+			}
+		})
+	}
+}
+
+// TestA1_DeclaredIdentityForKey_InertInA1 — pins that the A2 injection slot is
+// INERT in A1: declaredIdentityForKey returns nil regardless of ctx/CR, so
+// effectiveKeyExtras adds nothing beyond the union. If A2 wiring lands, THIS test
+// is the one that must be deliberately updated — a guard that A1 shipped with the
+// slot provably off (and that a stray early-wire is caught).
+func TestA1_DeclaredIdentityForKey_InertInA1(t *testing.T) {
+	ctx := ctxWithIdentity()
+	// Even a CR that (in A2) would declare identityContext must yield nil in A1 —
+	// the accessor does not exist yet, so any CR shape returns nil.
+	cr := map[string]any{"spec": map[string]any{
+		"identityContext": []any{"username", "groups"},
+		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
+	}}
+	if got := declaredIdentityForKey(ctx, cr); got != nil {
+		t.Fatalf("A1: declaredIdentityForKey must be INERT (nil) until A2 wires it; got %#v", got)
+	}
+	// And effectiveKeyExtras over that CR equals the pure union (no identity keys).
+	want := keyExtrasFor(cr, nil)
+	got := effectiveKeyExtras(ctx, cr, nil)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("A1: with the injection inert, effectiveKeyExtras must equal the pure union\n  got  = %#v\n  want = %#v", got, want)
+	}
+}

--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -62,26 +62,46 @@ func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
 	}
 }
 
-// TestA1_DeclaredIdentityForKey_InertInA1 — pins that the A2 injection slot is
-// INERT in A1: declaredIdentityForKey returns nil regardless of ctx/CR, so
-// effectiveKeyExtras adds nothing beyond the union. If A2 wiring lands, THIS test
-// is the one that must be deliberately updated — a guard that A1 shipped with the
-// slot provably off (and that a stray early-wire is caught).
-func TestA1_DeclaredIdentityForKey_InertInA1(t *testing.T) {
-	ctx := ctxWithIdentity()
-	// Even a CR that (in A2) would declare identityContext must yield nil in A1 —
-	// the accessor does not exist yet, so any CR shape returns nil.
-	cr := map[string]any{"spec": map[string]any{
+// TestA2_DeclaredIdentityForKey_WiresInjection — the A1 inert-slot guard,
+// deliberately FLIPPED for A2 (the stray-early-wire guard becomes the wiring
+// proof — per the definitive-arch A2 brief, converted not deleted). In A1 this
+// asserted declaredIdentityForKey returns nil for a CR declaring identityContext;
+// A2 WIRES the injection, so a declared CR under an identity-carrying ctx now
+// materialises the declared subset of the principal, and effectiveKeyExtras folds
+// it into the key (which the pure pre-A2 union does NOT). The inert half survives
+// as the undeclared control (still nil → still byte-identical to pre-A2).
+func TestA2_DeclaredIdentityForKey_WiresInjection(t *testing.T) {
+	ctx := ctxWithIdentity() // cyberjoker / [devs]
+
+	// DECLARED: spec.identityContext:[username,groups] → injection now materialises
+	// {username: cyberjoker, groups: [devs]} from the ctx JWT (A2 wired).
+	declaredCR := map[string]any{"spec": map[string]any{
 		"identityContext": []any{"username", "groups"},
 		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
 	}}
-	if got := declaredIdentityForKey(ctx, cr); got != nil {
-		t.Fatalf("A1: declaredIdentityForKey must be INERT (nil) until A2 wires it; got %#v", got)
-	}
-	// And effectiveKeyExtras over that CR equals the pure union (no identity keys).
-	want := keyExtrasFor(cr, nil)
-	got := effectiveKeyExtras(ctx, cr, nil)
+	got := declaredIdentityForKey(ctx, declaredCR)
+	want := map[string]any{"username": "cyberjoker", "groups": []string{"devs"}}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("A1: with the injection inert, effectiveKeyExtras must equal the pure union\n  got  = %#v\n  want = %#v", got, want)
+		t.Fatalf("A2: declaredIdentityForKey must materialise the declared identity subset from ctx; got %#v want %#v", got, want)
+	}
+	// effectiveKeyExtras folds the identity into the key (differs from the pure union).
+	eff := effectiveKeyExtras(ctx, declaredCR, nil)
+	if eff["username"] != "cyberjoker" {
+		t.Fatalf("A2: effectiveKeyExtras must fold the declared username into the key; got %#v", eff)
+	}
+	if pure := keyExtrasFor(declaredCR, nil); reflect.DeepEqual(eff, pure) {
+		t.Fatalf("A2: a DECLARED widget's key must DIFFER from the pure pre-A2 union (identity folded); both = %#v", eff)
+	}
+
+	// UNDECLARED control: no identityContext → still nil → key byte-identical to
+	// the pure union (the prod-inert acceptance for the ~99% corpus survives).
+	undeclaredCR := map[string]any{"spec": map[string]any{
+		"apiRef": map[string]any{"extras": map[string]any{"k": "v"}},
+	}}
+	if got := declaredIdentityForKey(ctx, undeclaredCR); got != nil {
+		t.Fatalf("A2: an UNDECLARED widget must inject nothing (nil); got %#v", got)
+	}
+	if eff, pure := effectiveKeyExtras(ctx, undeclaredCR, nil), keyExtrasFor(undeclaredCR, nil); !reflect.DeepEqual(eff, pure) {
+		t.Fatalf("A2: an UNDECLARED widget's key must equal the pure union (prod-inert)\n  got  = %#v\n  want = %#v", eff, pure)
 	}
 }

--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -80,7 +80,12 @@ func TestA2_DeclaredIdentityForKey_WiresInjection(t *testing.T) {
 		"apiRef":          map[string]any{"extras": map[string]any{"k": "v"}},
 	}}
 	got := declaredIdentityForKey(ctx, declaredCR)
-	want := map[string]any{"username": "cyberjoker", "groups": []string{"devs"}}
+	// groups is JSON-native []any (NOT []string) — the A2 fix: identity extras
+	// must be deep-copy-safe for the resolve-input path (mergeRequestWins →
+	// plumbing DeepCopyJSON panics on []string). Key-parity byte-identical
+	// (json.Marshal treats []string and []any the same), proven by the A1
+	// byte-identical goldens above.
+	want := map[string]any{"username": "cyberjoker", "groups": []any{"devs"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("A2: declaredIdentityForKey must materialise the declared identity subset from ctx; got %#v want %#v", got, want)
 	}

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -1,0 +1,255 @@
+// farch_identity_contract_test.go — A2 contract-core falsifiers F-ARCH-2/3/5/6
+// (definitive-cache-identity-architecture §6). All arms drive the REAL derivation
+// (effectiveKeyExtras → cache.ComputeKey / widgets.DeclaredIdentity) over real CR
+// shapes and assert PRE-HASH ResolvedKeyInputs field-equality on the identity
+// dimension (feedback_key_parity_golden_real_inputs_prehash_diff), never a
+// hand-fed digest. RED mutations are expressed as discriminating observables +
+// captured to /tmp/a2/ (revert the prod fold → the discriminant collapses).
+//
+// GATE AUTHN-1: identity flows ONLY from xcontext.UserInfo (the JWT); these arms
+// build the principal via WithUserInfo, never a store.
+
+package dispatchers
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// ctxAs builds a request ctx carrying a specific authenticated principal (the
+// only identity source under GATE AUTHN-1).
+func ctxAsIdentity(username string, groups ...string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: groups}))
+}
+
+// widgetCRDeclaring builds a widget CR declaring spec.identityContext = keys
+// (plus an apiRef.extras block so the CR is a realistic shape). Reuses the same
+// unstructured shape widgetCRWithExtras produces.
+func widgetCRDeclaring(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{
+		"identityContext": anyKeys,
+		"apiRef":          map[string]any{"name": "some-ra", "namespace": "demo-system"},
+	}}
+}
+
+// widgetCRInlineParent builds a CR with a static inline+GET resourcesRefs child
+// (hasInlineGETRef==true) but NO identityContext of its own — the F-ARCH-5 shape.
+func widgetCRInlineParent() map[string]any {
+	return map[string]any{"spec": map[string]any{
+		"resourcesRefs": map[string]any{"items": []any{
+			map[string]any{
+				"inline":     true,
+				"verb":       "get",
+				"resource":   "configmaps",
+				"apiVersion": "v1",
+				"name":       "child-cm",
+				"namespace":  "demo-system",
+			},
+		}},
+	}}
+}
+
+func writeA2Artifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/a2", 0o755)
+	_ = os.WriteFile("/tmp/a2/"+name, []byte(body), 0o644)
+}
+
+// keyFor computes the production key for a widget cell under a given identity ctx
+// via the REAL derivation: effectiveKeyExtras → the per-cohort ResolvedKeyInputs
+// → cache.ComputeKey. Identity enters ONLY via the extras fold (§2.1). BindingUID
+// is left "" (no watcher wired), IDENTICAL for both users, so the ONLY key
+// discriminant these arms probe is the identity-in-extras dimension — exactly the
+// per-binding-≠-per-user crux (K=1 binding, M=2 users).
+func keyFor(t *testing.T, ctx context.Context, cr map[string]any, request map[string]any) (string, map[string]any) {
+	t.Helper()
+	eff := effectiveKeyExtras(ctx, cr, request)
+	inputs := cache.ResolvedKeyInputs{
+		CacheEntryClass: "widgets",
+		Group:           "widgets.templates.krateo.io",
+		Version:         "v1beta1",
+		Resource:        "buttons",
+		Namespace:       "demo-system",
+		Name:            "w1",
+		// BindingUID "" — SAME for both users (the shared-binding equivalence class).
+		PerPage: -1,
+		Page:    -1,
+		Extras:  eff,
+	}
+	return cache.ComputeKey(inputs), eff
+}
+
+// F-ARCH-2 — cross-user leak. A DECLARED widget under two users u1≠u2 in the SAME
+// binding: the effective key extras carry each user's identity → the keys DIFFER →
+// u2's serve after u1's Put is a MISS (never u1's bytes). RED mutation (drop the
+// identity fold from effectiveKeyExtras) → both users fold identical extras → same
+// key → u2 reads u1's cell (the leak). Pre-hash field-equality: assert the Extras
+// maps differ on the identity keys, not just the digest.
+func TestFARCH2_DeclaredWidget_CrossUserKeysDiffer(t *testing.T) {
+	cr := widgetCRDeclaring("username", "groups")
+	u1 := ctxAsIdentity("alice", "devs")
+	u2 := ctxAsIdentity("bob", "devs") // SAME binding-shape (same groups), DIFFERENT user
+
+	k1, e1 := keyFor(t, u1, cr, nil)
+	k2, e2 := keyFor(t, u2, cr, nil)
+
+	// Pre-hash: the identity dimension must differ (alice vs bob).
+	if e1["username"] != "alice" || e2["username"] != "bob" {
+		t.Fatalf("F-ARCH-2 pre-hash: effective extras must carry each user's server-derived username; e1=%#v e2=%#v", e1, e2)
+	}
+	if reflect.DeepEqual(e1, e2) {
+		t.Fatalf("F-ARCH-2: a DECLARED widget's effective extras must DIFFER across users (identity folded); both=%#v — the RED mutation (drop the fold) makes them equal → cross-user leak", e1)
+	}
+	// Digest consequence: distinct keys → u2 is a MISS on u1's cell.
+	if k1 == k2 {
+		t.Fatalf("F-ARCH-2: declared-widget keys must differ across users (u1=%s u2=%s); identical key = u2 serves u1's per-user body (leak)", k1, k2)
+	}
+	writeA2Artifact(t, "farch2_crossuser.txt",
+		"declared[username,groups]: alice-key != bob-key (identity folded); RED=drop fold → equal → leak.\ne1="+
+			mapStr(e1)+"\ne2="+mapStr(e2))
+}
+
+// F-ARCH-3 — declared/undeclared boundary + spoof quarantine.
+//
+//	(a) UNDECLARED + old-frontend request (client identity extras) → folded as-is
+//	    (passive compat, per-user, no strip).
+//	(b) UNDECLARED + new-frontend request (no extras) → per-binding shared key ==
+//	    the seed key (empty extras).
+//	(c) DECLARED + a request trying to SPOOF extras.username=someone-else → server
+//	    injection WINS: the effective extras carry the JWT's OWN username, not the
+//	    spoofed value. RED mutation (injection loses precedence) → the spoofed value
+//	    survives → arm fails.
+func TestFARCH3_Boundary_And_SpoofQuarantine(t *testing.T) {
+	ctx := ctxAsIdentity("alice", "devs")
+
+	// (a) undeclared + client identity extras → folded (passive compat).
+	undeclared := map[string]any{"spec": map[string]any{}}
+	_, aExtras := keyFor(t, ctx, undeclared, map[string]any{"username": "client-supplied"})
+	if aExtras["username"] != "client-supplied" {
+		t.Fatalf("F-ARCH-3(a): an UNDECLARED widget must fold client-supplied extras verbatim (passive compat); got %#v", aExtras)
+	}
+
+	// (b) undeclared + no request extras → empty effective extras (== seed key).
+	_, bExtras := keyFor(t, ctx, undeclared, nil)
+	if len(bExtras) != 0 {
+		t.Fatalf("F-ARCH-3(b): an UNDECLARED widget with no request extras must have EMPTY effective extras (per-binding == seed key); got %#v", bExtras)
+	}
+
+	// (c) declared[username] + a SPOOF attempt in the request → injection wins.
+	declared := widgetCRDeclaring("username")
+	_, cExtras := keyFor(t, ctx, declared, map[string]any{"username": "SOMEONE-ELSE"})
+	if cExtras["username"] != "alice" {
+		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE: server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
+	}
+	writeA2Artifact(t, "farch3_boundary_spoof.txt",
+		"(a) undeclared folds client extras=client-supplied; (b) undeclared+no-extras empty; "+
+			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins → alice. RED=injection loses → SOMEONE-ELSE survives.")
+}
+
+// F-ARCH-5 — inline-variance union (arch ruling option (d)). An inline-embedding
+// parent (hasInlineGETRef) that declares NO identityContext of its own is keyed
+// per-USER (full-identity marker) so an embedded child's identity-varying rendered
+// body cannot leak across users sharing one binding. Two users → keys DIFFER. RED
+// mutation (drop inlineParentIdentityForKey) → same key → u2 served u1's embedded
+// child body.
+func TestFARCH5_InlineParent_PerUserKey(t *testing.T) {
+	parent := widgetCRInlineParent() // hasInlineGETRef==true, NO identityContext
+	u1 := ctxAsIdentity("alice", "devs")
+	u2 := ctxAsIdentity("bob", "devs") // same binding-shape
+
+	// Sanity: the parent declares NO identity of its own — without the inline
+	// marker this would be per-binding (the leak). declaredIdentityForKey is nil.
+	if di := declaredIdentityForKey(u1, parent); di != nil {
+		t.Fatalf("F-ARCH-5 setup: the inline parent must declare NO identityContext of its own; got %#v", di)
+	}
+
+	k1, e1 := keyFor(t, u1, parent, nil)
+	k2, e2 := keyFor(t, u2, parent, nil)
+
+	if e1["username"] != "alice" || e2["username"] != "bob" {
+		t.Fatalf("F-ARCH-5 pre-hash: an inline parent's effective extras must carry the FULL per-user identity marker; e1=%#v e2=%#v", e1, e2)
+	}
+	if reflect.DeepEqual(e1, e2) || k1 == k2 {
+		t.Fatalf("F-ARCH-5: an inline-embedding parent must be keyed PER-USER (full-identity marker); e1=%#v e2=%#v k1=%s k2=%s — the RED mutation (drop inlineParentIdentityForKey) makes them equal → embedded child body leaks cross-user", e1, e2, k1, k2)
+	}
+
+	// BOUNDARY: a NON-inline undeclared widget stays per-binding (no marker) —
+	// proves the marker is scoped to inline parents, not blanket per-user.
+	nonInline := map[string]any{"spec": map[string]any{}}
+	_, en1 := keyFor(t, u1, nonInline, nil)
+	_, en2 := keyFor(t, u2, nonInline, nil)
+	if !reflect.DeepEqual(en1, en2) {
+		t.Fatalf("F-ARCH-5 BOUNDARY: a NON-inline undeclared widget must stay per-binding (empty extras, shared); en1=%#v en2=%#v — the inline marker must not leak into non-inline widgets", en1, en2)
+	}
+	writeA2Artifact(t, "farch5_inline_peruser.txt",
+		"inline parent (no own identityContext): alice-key != bob-key (full-identity marker); "+
+			"non-inline undeclared: shared key (marker scoped to inline). RED=drop marker → inline keys equal → child leak.")
+}
+
+// F-ARCH-6 — cache-off transparency. The A2 identity injection is part of the
+// widget INPUT contract, not a cache feature: widgets.DeclaredIdentity (the
+// resolve-input injection source) yields the SAME identity map regardless of
+// cache state, and it is the SAME derivation the key path folds
+// (declaredIdentityForKey). So a declared widget's resolve input for a given JWT
+// is identical whether the cache is on or off. We assert the derivation is
+// cache-state-independent (it reads only ctx + CR, never the cache) and that the
+// key-path and resolve-path identity maps are byte-identical (single derivation).
+func TestFARCH6_CacheOffTransparency_SingleDerivation(t *testing.T) {
+	cr := widgetCRDeclaring("username", "groups")
+	ctx := ctxAsIdentity("alice", "devs")
+
+	// The resolve-input injection source (widgets.DeclaredIdentity) and the
+	// key-path source (declaredIdentityForKey → widgets.DeclaredIdentity) are the
+	// SAME function → byte-identical identity material, cache-state-independent.
+	keyPathID := declaredIdentityForKey(ctx, cr)
+	// Simulate cache-off vs cache-on by calling the derivation twice — it reads
+	// ONLY ctx + CR (no cache handle), so the result cannot depend on cache state.
+	resolveInputID1 := declaredIdentityForKey(ctx, cr)
+	if !reflect.DeepEqual(keyPathID, resolveInputID1) {
+		t.Fatalf("F-ARCH-6: the key-path and resolve-input identity derivations must be byte-identical (single derivation, cache-state-independent); key=%#v resolve=%#v", keyPathID, resolveInputID1)
+	}
+	if keyPathID["username"] != "alice" {
+		t.Fatalf("F-ARCH-6: declared identity must materialise from the JWT (alice) for the resolve input, cache on or off; got %#v", keyPathID)
+	}
+	writeA2Artifact(t, "farch6_cacheoff.txt",
+		"declared[username,groups]: key-path identity == resolve-input identity (single derivation, reads only ctx+CR, no cache handle) → cache-off byte-identical to cache-on for the same JWT.")
+}
+
+// mapStr renders a map for artifact transcripts deterministically-enough.
+func mapStr(m map[string]any) string {
+	b := ""
+	for k, v := range m {
+		b += k + "=" + valStr(v) + " "
+	}
+	return b
+}
+
+func valStr(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []string:
+		s := "["
+		for i, e := range t {
+			if i > 0 {
+				s += ","
+			}
+			s += e
+		}
+		return s + "]"
+	default:
+		return "?"
+	}
+}

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -312,6 +312,60 @@ func TestFARCH6_CacheOffTransparency_ResolvedOutputIdentical(t *testing.T) {
 		"declared[username] echoing .username → status.widgetData.echoedUser: driven through REAL widgets.Resolve under CACHE_ENABLED=true (cold) AND CACHE_ENABLED=false — both render echoedUser=alice (JWT identity in the resolve input) AND are byte-identical. Injection is an INPUT-contract property, transparent to the cache toggle.")
 }
 
+// TestFARCH3_GroupsResolveOutput_GroupScopedOnly — the SECOND-DIMENSION arm for a
+// declared[groups] widget (the A2-fix falsifier AND the A4 seed-safety resolve-output
+// closure; §4.4.6 group-shared cell). Two properties in one arm:
+//
+//  1. JSON-NATIVE FIX GUARD: a declared[groups] widget must resolve through the REAL
+//     widgets.Resolve WITHOUT PANIC. Pre-fix, DeclaredIdentity emitted groups as a Go
+//     []string, which mergeRequestWins → plumbing DeepCopyJSON panicked on ("cannot
+//     deep copy []string"). The fix emits JSON-native []any. RED (i): revert the fix
+//     (DeclaredIdentity groups → []string) → this arm's own driver PANICS. No A2/A4
+//     key-side arm drives Resolve with [groups], so this is the FIRST arm to exercise
+//     that path — the gap both re-gaters proved (whole A4 battery stayed green under
+//     the []string panic AND under the content-spoof).
+//
+//  2. RESOLVE-OUTPUT SCOPE (the content dimension a key-side arm is blind to): the
+//     seeded group-shared cell's rendered body must carry ONLY the group, NEVER the
+//     cohort representative's per-user username. Drive Resolve under a group-only-rep
+//     ctx that ALSO carries a NON-EMPTY username ("rep-admin"); the widget declares
+//     [groups] only, so DeclaredIdentity (the SAME function that scopes the key)
+//     injects only {groups} into the resolve input → the body echoes the groups and
+//     NOT rep-admin. RED (ii): a content-spoof that folds the rep username into the
+//     resolve input while the KEY stays group-only → echoedUser=rep-admin here while
+//     the key-side case-3 stays GREEN — the invisible-to-key-arms leak.
+//
+// Since seedOneWidget calls widgets.Resolve with NO Extras (phase1_pip_seed.go), the
+// seed's resolve-input identity IS this same A2 injection, so this serve-path arm IS
+// the seed-safety guard for the group-shared cell — A4 needs no separate seed-ctx variant.
+func TestFARCH3_GroupsResolveOutput_GroupScopedOnly(t *testing.T) {
+	// declared[groups] echo CR: echoes BOTH .groups and .username into the rendered
+	// body so we assert groups-present AND rep-username-ABSENT.
+	cr := map[string]any{"spec": map[string]any{
+		"identityContext": []any{"groups"},
+		"widgetData":      map[string]any{},
+		"widgetDataTemplate": []any{
+			map[string]any{"forPath": ".echoedGroups", "expression": "${ .groups }"},
+			map[string]any{"forPath": ".echoedUser", "expression": "${ .username }"},
+		},
+	}}
+	// Cohort representative ctx: a group (devs) AND a non-empty username — the
+	// User-kind representative shape. resolveRenderedWidgetData drives the REAL
+	// widgets.Resolve; pre-fix this PANICS on the []string groups deep-copy (RED i).
+	rendered := resolveRenderedWidgetData(t, ctxAsIdentity("rep-admin", "devs"), cr, nil)
+
+	// (1) group-scoped content present.
+	if rendered["echoedGroups"] == nil {
+		t.Fatalf("F-ARCH-3 groups resolve-output: a declared[groups] widget's rendered body must carry the group-scoped identity; got %#v", rendered)
+	}
+	// (2) the rep's per-user username must NOT reach the resolve input / body.
+	if got := rendered["echoedUser"]; got == "rep-admin" {
+		t.Fatalf("F-ARCH-3 groups resolve-output LEAK: the group-shared body carries the cohort representative's username %q — every devs member would be served rep-admin's identity. declared[groups] must inject ONLY groups. RED(ii) = content-spoof folds the rep username into the resolve input while the key stays group-only.", got)
+	}
+	writeA2Artifact(t, "farch3_groups_resolve_output.txt",
+		"declared[groups] echoing .groups + .username, driven through REAL widgets.Resolve under a group-only-rep ctx (rep-admin/devs): echoedGroups=[devs] present, echoedUser ABSENT (not rep-admin) — group-shared body is group-scoped only, no per-user leak; and Resolve does NOT panic (JSON-native []any groups fix). RED(i)=revert to []string → panic; RED(ii)=content-spoof rep username into resolve input → echoedUser=rep-admin while key-side stays green.")
+}
+
 // mapStr renders a map for artifact transcripts deterministically-enough.
 func mapStr(m map[string]any) string {
 	b := ""

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/krateoplatformops/plumbing/jwtutil"
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ctxAs builds a request ctx carrying a specific authenticated principal (the
@@ -42,6 +44,51 @@ func widgetCRDeclaring(keys ...string) map[string]any {
 		"identityContext": anyKeys,
 		"apiRef":          map[string]any{"name": "some-ra", "namespace": "demo-system"},
 	}}
+}
+
+// widgetCRDeclaringWithEcho builds a widget CR declaring spec.identityContext =
+// keys AND a widgetDataTemplate that echoes .username into
+// status.widgetData.echoedUser via jq. It has NO apiRef (so widgets.Resolve's
+// apiRef fetch short-circuits with an empty dict — hermetic, no apiserver), and
+// a spec.widgetData base map for the template to write into. Driving
+// widgets.Resolve over this CR exercises the REAL resolve-input injection merge
+// (resolve.go:64-73) → mergeExtras into the data source → widgetDataTemplate jq,
+// so the rendered echoedUser IS the value that reached the resolve INPUT.
+func widgetCRDeclaringWithEcho(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{
+		"identityContext": anyKeys,
+		"widgetData":      map[string]any{},
+		"widgetDataTemplate": []any{
+			map[string]any{"forPath": ".echoedUser", "expression": "${ .username }"},
+		},
+	}}
+}
+
+// resolveRenderedWidgetData drives the REAL widgets.Resolve over a no-apiRef CR
+// and returns status.widgetData — the RESOLVED OUTPUT / resolve INPUT the widget
+// templates evaluated against. widgets.Resolve populates status.widgetData
+// (resolve.go:141) BEFORE its final crdschema.ValidateObjectStatus step, which
+// needs an apiserver and therefore returns a (benign, expected) error in this
+// hermetic harness; the rendered widgetData is already set on opts.In.Object at
+// that point, so we read it regardless of the tail validate error. This is a
+// genuine drive of the injection merge + mergeExtras + widgetDataTemplate jq —
+// NOT a key-side proxy.
+func resolveRenderedWidgetData(t *testing.T, ctx context.Context, cr map[string]any, requestExtras map[string]any) map[string]any {
+	t.Helper()
+	in := &unstructured.Unstructured{Object: cr}
+	obj, _ := widgets.Resolve(ctx, widgets.ResolveOptions{
+		In:     in,
+		Extras: requestExtras,
+	})
+	wd, _, err := unstructured.NestedMap(obj.Object, "status", "widgetData")
+	if err != nil {
+		t.Fatalf("resolveRenderedWidgetData: reading status.widgetData: %v", err)
+	}
+	return wd
 }
 
 // widgetCRInlineParent builds a CR with a static inline+GET resourcesRefs child
@@ -147,15 +194,38 @@ func TestFARCH3_Boundary_And_SpoofQuarantine(t *testing.T) {
 		t.Fatalf("F-ARCH-3(b): an UNDECLARED widget with no request extras must have EMPTY effective extras (per-binding == seed key); got %#v", bExtras)
 	}
 
-	// (c) declared[username] + a SPOOF attempt in the request → injection wins.
+	// (c) declared[username] + a SPOOF attempt in the request → injection wins
+	// ON THE KEY SIDE (the effective key extras carry alice, not the spoof).
 	declared := widgetCRDeclaring("username")
 	_, cExtras := keyFor(t, ctx, declared, map[string]any{"username": "SOMEONE-ELSE"})
 	if cExtras["username"] != "alice" {
-		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE: server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
+		t.Fatalf("F-ARCH-3(c) SPOOF QUARANTINE (key side): server injection must WIN over a client-supplied extras.username (JWT=alice); got %#v — the RED mutation (injection loses precedence) leaves the spoofed value here", cExtras)
 	}
+
+	// (c2) SPOOF QUARANTINE on the RESOLVED OUTPUT (the second conjunct §4.4.6(b)
+	// requires and (c) alone was missing). Drive the REAL widgets.Resolve with the
+	// SAME spoof: a request carrying extras.username="SOMEONE-ELSE", a JWT ctx whose
+	// username is alice, a CR declaring identityContext:[username]. The rendered
+	// output (status.widgetData.echoedUser, echoing .username through the resolve
+	// path's widgetDataTemplate jq) MUST carry alice — proving the INJECTION also
+	// wins in the resolve INPUT, not just in the key. This is the §4.4.6(b)-
+	// impossible state made observable: it goes RED under the exact mutation arch
+	// found (reverse the precedence in resolve.go:64-73's injection merge so the
+	// client-supplied value wins), which the KEY-only (c) arm cannot see.
+	echoCR := widgetCRDeclaringWithEcho("username")
+	rendered := resolveRenderedWidgetData(t, ctx, echoCR, map[string]any{"username": "SOMEONE-ELSE"})
+	if got := rendered["echoedUser"]; got != "alice" {
+		t.Fatalf("F-ARCH-3(c2) SPOOF QUARANTINE (resolved output): the resolve INPUT must carry the JWT username (alice), NOT the client spoof; status.widgetData.echoedUser=%#v — the RED mutation (resolve.go injection loses precedence) leaves SOMEONE-ELSE in the rendered body", got)
+	}
+	if got := rendered["echoedUser"]; got == "SOMEONE-ELSE" {
+		t.Fatalf("F-ARCH-3(c2): the SPOOFED value must NOT survive into the rendered body; got %#v", got)
+	}
+
 	writeA2Artifact(t, "farch3_boundary_spoof.txt",
 		"(a) undeclared folds client extras=client-supplied; (b) undeclared+no-extras empty; "+
-			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins → alice. RED=injection loses → SOMEONE-ELSE survives.")
+			"(c) declared[username] + spoof SOMEONE-ELSE → injection wins on KEY → alice; "+
+			"(c2) SAME spoof driven through REAL widgets.Resolve → rendered echoedUser=alice (resolve-input injection wins, NOT SOMEONE-ELSE). "+
+			"RED=reverse resolve.go injection precedence → (c2) rendered=SOMEONE-ELSE (key-only (c) unaffected).")
 }
 
 // F-ARCH-5 — inline-variance union (arch ruling option (d)). An inline-embedding
@@ -198,33 +268,48 @@ func TestFARCH5_InlineParent_PerUserKey(t *testing.T) {
 			"non-inline undeclared: shared key (marker scoped to inline). RED=drop marker → inline keys equal → child leak.")
 }
 
-// F-ARCH-6 — cache-off transparency. The A2 identity injection is part of the
-// widget INPUT contract, not a cache feature: widgets.DeclaredIdentity (the
-// resolve-input injection source) yields the SAME identity map regardless of
-// cache state, and it is the SAME derivation the key path folds
-// (declaredIdentityForKey). So a declared widget's resolve input for a given JWT
-// is identical whether the cache is on or off. We assert the derivation is
-// cache-state-independent (it reads only ctx + CR, never the cache) and that the
-// key-path and resolve-path identity maps are byte-identical (single derivation).
-func TestFARCH6_CacheOffTransparency_SingleDerivation(t *testing.T) {
-	cr := widgetCRDeclaring("username", "groups")
+// F-ARCH-6 — cache-off transparency, driven through the REAL widgets.Resolve.
+// The A2 identity injection is part of the widget INPUT contract, not a cache
+// feature: it runs in widgets.Resolve whether or not the cache is on, so a
+// declared widget's rendered output for a given JWT is identical cache-on vs
+// cache-off. This arm DRIVES the resolve path in BOTH modes (CACHE_ENABLED=true
+// cold vs CACHE_ENABLED=false) over the SAME declared CR + JWT ctx and asserts
+// the RESOLVED OUTPUT is byte-identical AND carries the injected JWT identity in
+// BOTH modes — no more twice-call-DeepEqual-with-self. (widgets.Resolve consults
+// no cache handle, so byte-identity is the substantive property: the injection
+// is transparent to the cache toggle.)
+func TestFARCH6_CacheOffTransparency_ResolvedOutputIdentical(t *testing.T) {
+	echoCR := widgetCRDeclaringWithEcho("username")
 	ctx := ctxAsIdentity("alice", "devs")
 
-	// The resolve-input injection source (widgets.DeclaredIdentity) and the
-	// key-path source (declaredIdentityForKey → widgets.DeclaredIdentity) are the
-	// SAME function → byte-identical identity material, cache-state-independent.
-	keyPathID := declaredIdentityForKey(ctx, cr)
-	// Simulate cache-off vs cache-on by calling the derivation twice — it reads
-	// ONLY ctx + CR (no cache handle), so the result cannot depend on cache state.
-	resolveInputID1 := declaredIdentityForKey(ctx, cr)
-	if !reflect.DeepEqual(keyPathID, resolveInputID1) {
-		t.Fatalf("F-ARCH-6: the key-path and resolve-input identity derivations must be byte-identical (single derivation, cache-state-independent); key=%#v resolve=%#v", keyPathID, resolveInputID1)
+	// Cache ON (cold): drive the real resolve path with CACHE_ENABLED truthy.
+	t.Setenv("CACHE_ENABLED", "true")
+	if cache.Disabled() {
+		t.Fatalf("F-ARCH-6 setup: CACHE_ENABLED=true must report cache enabled")
 	}
-	if keyPathID["username"] != "alice" {
-		t.Fatalf("F-ARCH-6: declared identity must materialise from the JWT (alice) for the resolve input, cache on or off; got %#v", keyPathID)
+	cacheOn := resolveRenderedWidgetData(t, ctx, widgetCRDeclaringWithEcho("username"), nil)
+
+	// Cache OFF: drive the SAME resolve path with CACHE_ENABLED=false semantics.
+	t.Setenv("CACHE_ENABLED", "false")
+	if !cache.Disabled() {
+		t.Fatalf("F-ARCH-6 setup: CACHE_ENABLED=false must report cache disabled")
+	}
+	cacheOff := resolveRenderedWidgetData(t, ctx, echoCR, nil)
+
+	// The injected JWT identity must materialise in the resolve INPUT in BOTH modes.
+	if cacheOn["echoedUser"] != "alice" {
+		t.Fatalf("F-ARCH-6 (cache ON): the declared JWT identity must reach the resolve input (echoedUser=alice); got %#v", cacheOn)
+	}
+	if cacheOff["echoedUser"] != "alice" {
+		t.Fatalf("F-ARCH-6 (cache OFF): the declared JWT identity must reach the resolve input (echoedUser=alice); got %#v", cacheOff)
+	}
+	// And the resolved output must be byte-identical across the cache toggle —
+	// the injection is part of the INPUT contract, invariant to cache state.
+	if !reflect.DeepEqual(cacheOn, cacheOff) {
+		t.Fatalf("F-ARCH-6: declared-widget resolved output must be byte-identical cache-on vs cache-off for the same JWT; on=%#v off=%#v", cacheOn, cacheOff)
 	}
 	writeA2Artifact(t, "farch6_cacheoff.txt",
-		"declared[username,groups]: key-path identity == resolve-input identity (single derivation, reads only ctx+CR, no cache handle) → cache-off byte-identical to cache-on for the same JWT.")
+		"declared[username] echoing .username → status.widgetData.echoedUser: driven through REAL widgets.Resolve under CACHE_ENABLED=true (cold) AND CACHE_ENABLED=false — both render echoedUser=alice (JWT identity in the resolve input) AND are byte-identical. Injection is an INPUT-contract property, transparent to the cache toggle.")
 }
 
 // mapStr renders a map for artifact transcripts deterministically-enough.

--- a/internal/handlers/dispatchers/farch_seed_parity_test.go
+++ b/internal/handlers/dispatchers/farch_seed_parity_test.go
@@ -1,0 +1,235 @@
+// farch_seed_parity_test.go — A4 seed parity falsifiers (definitive-cache-identity-
+// architecture-2026-07-07.md §8.1 A4 + §6 F-ARCH-1). A4 is TEST-ONLY: the seed path
+// (phase1_pip_seed.go:781) already routes through the shared effectiveKeyExtras (A1),
+// so for a NON-declared widget the seed emits the identity-free shared cell that a
+// post-contract (buildExtrasParam) browser request keys to — seed parity by
+// construction (§1 "per-binding shared cells and seed parity BY CONSTRUCTION"). For a
+// DECLARED widget the seed folds only the identity dimensions the cohort representative
+// actually carries, and — proven by the arch trace on this branch — never creates a
+// leakable mis-keyed shared cell (the two-dimension BindingUID × declared-identity-in-
+// Extras key + DeclaredIdentity injecting only NON-EMPTY values makes every declared
+// case SAFE). No prod change needed or made.
+//
+// F-ARCH-1 (the permanent #107 arm): portal-shaped request exactly as post-contract
+// buildExtrasParam emits (dashboard: NO identity extras) vs a cell seeded by the REAL
+// seed key fold → pre-hash ResolvedKeyInputs field-equality + L1 HIT. RED arm: re-add
+// the unconditional identity extras (the shipped 1.6.5 / old-frontend defect) → the
+// serve key diverges → MISS (reproduces the 0/N key-match divergence #107 documented).
+//
+// Declared-seed-safety pin: the three declared-widget cases the arch trace enumerated,
+// driven through the REAL effectiveKeyExtras → ComputeKey (never hand-fed keys;
+// feedback_key_parity_golden_real_inputs_prehash_diff), asserting the two-dimension
+// property (Extras dimension, not just BindingUID; feedback_spoof_quarantine_needs_
+// both_key_and_resolved_output_arms).
+package dispatchers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// portalDashboardRequest is the extras a post-contract buildExtrasParam
+// (useWidgetQuery.ts:72-85 with SNOWPLOW_IDENTITY_INJECTION set) emits for a
+// DASHBOARD widget: NO identity keys, NO route params → an EMPTY extras map. This
+// is the exact wire shape F-ARCH-1 pins the seed against.
+func portalDashboardRequest() map[string]any { return map[string]any{} }
+
+// oldFrontendRequest is the PRE-contract buildExtrasParam shape (the shipped 1.6.5
+// defect / flag-absent legacy): unconditional identity merges → username+groups on
+// the wire. F-ARCH-1's RED arm uses this to reproduce the #107 seed-miss divergence.
+func oldFrontendRequest() map[string]any {
+	return map[string]any{"username": "cyberjoker", "groups": []any{"devs"}}
+}
+
+// TestFARCH1_SeedParity_NonDeclaredWidget_PortalShapedHIT — the permanent #107
+// invariant. A NON-declared widget's cell seeded under the REAL seed key fold (the
+// seed has NO request extras → effectiveKeyExtras(ctx, cr, nil)) is HIT by a
+// post-contract portal request (empty extras) — pre-hash ResolvedKeyInputs
+// field-equality + a real Put-under-seed / Get-under-serve HIT with zero resolver
+// invocations. This is the warmth vehicle that fixes #107: seed cell == browser key.
+func TestFARCH1_SeedParity_NonDeclaredWidget_PortalShapedHIT(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity() // cyberjoker / [devs] — the requesting principal
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-107"
+		perPage, page     = 10, 1
+	)
+	// A NON-declared widget (no spec.identityContext), no inline extras — the ~99%
+	// corpus shape. Its key folds NO identity on either side under the contract.
+	cr := map[string]any{"spec": map[string]any{}}
+
+	// SEED key: the REAL seed fold — effectiveKeyExtras(ctx, cr, nil) (no request).
+	seedExtras := effectiveKeyExtras(ctx, cr, nil)
+	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, seedExtras)
+	if seedHandle == nil || seedKey == "" {
+		t.Fatal("F-ARCH-1: expected a live per-cohort cache handle + key under the seed ctx")
+	}
+	body := []byte(`{"status":{"widgetData":{"label":"warm"}}}`)
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: body, Inputs: seedInputs})
+
+	// SERVE key: the REAL dispatcher fold under a POST-CONTRACT portal request
+	// (empty extras) — effectiveKeyExtras(ctx, cr, portalDashboardRequest()).
+	serveExtras := effectiveKeyExtras(ctx, cr, portalDashboardRequest())
+	serveKey, serveHandle, serveInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, serveExtras)
+	if serveHandle == nil || serveKey == "" {
+		t.Fatal("F-ARCH-1: expected a live per-cohort cache handle + key under the serve ctx")
+	}
+
+	// Pre-hash: both sides fold EMPTY effective extras (no identity, no request) for
+	// a non-declared widget under the contract.
+	if len(seedExtras) != 0 || len(serveExtras) != 0 {
+		t.Fatalf("F-ARCH-1 pre-hash: a non-declared widget under the contract must fold EMPTY extras on BOTH sides; seed=%#v serve=%#v", seedExtras, serveExtras)
+	}
+	if !reflect.DeepEqual(seedInputs.Extras, serveInputs.Extras) {
+		t.Fatalf("F-ARCH-1 pre-hash: seed vs serve ResolvedKeyInputs.Extras differ; seed=%#v serve=%#v", seedInputs.Extras, serveInputs.Extras)
+	}
+	if seedKey != serveKey {
+		t.Fatalf("F-ARCH-1 INVARIANT: seed key %q != portal-shaped serve key %q — the seeded cell is not browser-reachable (the #107 seed-miss class)", seedKey, serveKey)
+	}
+	// L1 HIT with zero resolver invocations (the Get is a pure cache read).
+	got, hit := serveHandle.Get(serveKey)
+	if !hit {
+		t.Fatal("F-ARCH-1: portal-shaped serve MISSED the seeded cell — #107 not fixed")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("F-ARCH-1: served the wrong body; got %q want %q", got.RawJSON, body)
+	}
+}
+
+// TestFARCH1_RED_OldFrontendRequest_Misses — the F-ARCH-1 RED arm. Re-adding the
+// unconditional identity extras to the SERVE request (the old-frontend / shipped
+// 1.6.5 wire shape) makes the serve key fold {username,groups} while the seed key
+// (identity-free) folds nothing → the keys DIVERGE → the seeded cell is MISSED. This
+// documents exactly what the pre-contract wire shape did (the #107 0/N divergence):
+// this arm is GREEN (asserts the MISS) precisely because the defect shape must miss.
+func TestFARCH1_RED_OldFrontendRequest_Misses(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-107-red"
+		perPage, page     = 10, 1
+	)
+	cr := map[string]any{"spec": map[string]any{}} // non-declared
+
+	seedExtras := effectiveKeyExtras(ctx, cr, nil)
+	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, seedExtras)
+	if seedHandle == nil || seedKey == "" {
+		t.Fatal("F-ARCH-1 RED: expected a live seed handle + key")
+	}
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: []byte(`{"x":1}`), Inputs: seedInputs})
+
+	// OLD-FRONTEND serve request: unconditional identity extras on the wire.
+	serveExtras := effectiveKeyExtras(ctx, cr, oldFrontendRequest())
+	serveKey, serveHandle, _ := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, serveExtras)
+	if serveHandle == nil || serveKey == "" {
+		t.Fatal("F-ARCH-1 RED: expected a live serve handle + key")
+	}
+
+	// The old-frontend request folds identity extras (a non-declared widget passes
+	// them through, passive compat) → the serve key MUST diverge from the seed key.
+	if serveExtras["username"] != "cyberjoker" {
+		t.Fatalf("F-ARCH-1 RED setup: the old-frontend request must fold identity extras (passive compat); got %#v", serveExtras)
+	}
+	if seedKey == serveKey {
+		t.Fatalf("F-ARCH-1 RED: seed key == old-frontend serve key %q — the arm is not discriminating; the old wire shape MUST miss the identity-free seed cell (the #107 divergence)", serveKey)
+	}
+	if _, hit := serveHandle.Get(serveKey); hit {
+		t.Fatal("F-ARCH-1 RED: old-frontend serve unexpectedly HIT the seed cell — the #107 seed-miss should reproduce here")
+	}
+}
+
+// --- Declared-seed-safety pin (arch trace: SAFE across all 3 cases) ---
+
+// declaredCR builds a widget CR declaring spec.identityContext=keys (no apiRef).
+func declaredCR(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{"identityContext": anyKeys}}
+}
+
+// seedCtxRealUser / seedCtxGroupOnly model the cohort representative the seed ctx
+// carries (withCohortSeedContext installs WithUserInfo from pickRepresentativeFrom-
+// Subjects): a real single user, or a group-only representative (empty username).
+func seedCtxRealUser(username string, groups ...string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: groups}))
+}
+func seedCtxGroupOnly(groups ...string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "", Groups: groups})) // group-only rep
+}
+
+// TestFARCH_A4_DeclaredSeedSafety pins the arch trace's three cases through the REAL
+// effectiveKeyExtras → ComputeKey. It proves the seed never creates a leakable
+// mis-keyed shared cell for a declared widget:
+//
+//	Case 1: representative = real user → declared[username] folds THAT user's name;
+//	        another real user folds a DIFFERENT name → distinct Extras → distinct key.
+//	Case 2: representative = group-only + declared[username] → DeclaredIdentity returns
+//	        nil (empty username not injected) → seed folds EMPTY extras; a real member's
+//	        request folds {username:<name>} → distinct key → the seed cell is an
+//	        UNREACHABLE orphan (no leak, benign warmth-miss).
+//	Case 3: representative = group-only + declared[groups] → seed folds {groups:[devs]};
+//	        a real member also folds {groups:[devs]} → SAME extras → SAME key → intended
+//	        per-group-shared HIT.
+func TestFARCH_A4_DeclaredSeedSafety(t *testing.T) {
+	// Case 1 — real-user representative, declared[username]: per-user distinct keys.
+	t.Run("case1_real_user_distinct", func(t *testing.T) {
+		cr := declaredCR("username")
+		seedExtras := effectiveKeyExtras(seedCtxRealUser("admin"), cr, nil)
+		otherExtras := effectiveKeyExtras(seedCtxRealUser("bob"), cr, nil)
+		if seedExtras["username"] != "admin" {
+			t.Fatalf("case1: seed under real user must fold that username; got %#v", seedExtras)
+		}
+		if reflect.DeepEqual(seedExtras, otherExtras) {
+			t.Fatalf("case1: a declared[username] cell must differ across users (admin vs bob); both=%#v — the seed cell is per-user, never cross-user reachable", seedExtras)
+		}
+	})
+
+	// Case 2 — group-only representative, declared[username]: seed folds EMPTY extras
+	// (no username to inject) → unreachable orphan vs any real member's request.
+	t.Run("case2_group_only_username_orphan", func(t *testing.T) {
+		cr := declaredCR("username")
+		seedExtras := effectiveKeyExtras(seedCtxGroupOnly("devs"), cr, nil)
+		if len(seedExtras) != 0 {
+			t.Fatalf("case2: a group-only representative (empty username) declaring [username] must inject NOTHING → EMPTY seed extras (DeclaredIdentity returns nil on empty username); got %#v", seedExtras)
+		}
+		// A real devs member folds their own username → distinct extras → the seed
+		// orphan is UNREACHABLE (no real principal can re-derive the empty-extras key).
+		realExtras := effectiveKeyExtras(seedCtxRealUser("carol", "devs"), cr, nil)
+		if realExtras["username"] != "carol" {
+			t.Fatalf("case2: a real devs member declaring [username] must fold their own name; got %#v", realExtras)
+		}
+		if reflect.DeepEqual(seedExtras, realExtras) {
+			t.Fatalf("case2 LEAK GUARD: the empty-extras seed cell must be UNREACHABLE by a real member (whose extras carry a username); seed=%#v real=%#v — equality would mean a real request keys onto the group-only orphan (leak)", seedExtras, realExtras)
+		}
+	})
+
+	// Case 3 — group-only representative, declared[groups]: seed == real member →
+	// intended per-group-shared HIT (body scoped to the group, not a user).
+	t.Run("case3_group_only_groups_shared_hit", func(t *testing.T) {
+		cr := declaredCR("groups")
+		seedExtras := effectiveKeyExtras(seedCtxGroupOnly("devs"), cr, nil)
+		// groups is JSON-native []any (the A2 fix — deep-copy-safe for the
+		// resolve-input path; key-parity byte-identical to the prior []string).
+		if !reflect.DeepEqual(seedExtras["groups"], []any{"devs"}) {
+			t.Fatalf("case3: a group-only representative declaring [groups] must fold {groups:[devs]}; got %#v", seedExtras)
+		}
+		realExtras := effectiveKeyExtras(seedCtxRealUser("carol", "devs"), cr, nil)
+		// carol declares [groups] only → username NOT folded; groups match the seed.
+		if !reflect.DeepEqual(seedExtras, realExtras) {
+			t.Fatalf("case3: a declared[groups] cell must be per-group-shared — seed (group-only rep) and a real member's extras must be IDENTICAL; seed=%#v real=%#v", seedExtras, realExtras)
+		}
+	})
+}

--- a/internal/handlers/dispatchers/farch_subscription_parity_test.go
+++ b/internal/handlers/dispatchers/farch_subscription_parity_test.go
@@ -1,0 +1,278 @@
+// farch_subscription_parity_test.go — A3 subscription parity falsifiers F-ARCH-4
+// (definitive-cache-identity-architecture-2026-07-07.md §8.1 A3). A3 is TEST-ONLY:
+// the subscription arming path (subscriptionKeyExtras, refresh_subscription.go:137)
+// ALREADY routes through the shared effectiveKeyExtras (extracted in A1), which A2
+// wired to fold declaredIdentityForKey → widgets.DeclaredIdentity. So the /refreshes
+// arming key inherits A2's declared-identity injection AUTOMATICALLY, and the EMIT
+// path (widgets.go:152 dispatch → effectiveKeyExtras) folds the SAME material through
+// the SAME helper. Arming↔serve identity parity for declared widgets therefore holds
+// BY CONSTRUCTION — these arms PIN it so it can never regress silently (the #64/#67
+// permanent-invariant discipline, extended to the declared-identity dimension).
+//
+// F-ARCH-4: for a DECLARED widget, DeriveSubscriptionKey(coords, JWT-identity) ==
+// ComputeKey(the /call emit that renders it), per subscribable class, with REAL
+// derivation + pre-hash ResolvedKeyInputs field-equality (never a hand-fed digest;
+// feedback_key_parity_golden_real_inputs_prehash_diff). This is the arming↔serve
+// key-parity that keeps /refreshes forgery-proof for declared widgets.
+//
+// u2-cannot-arm-u1: user u2's subscription derivation for a DECLARED widget yields a
+// DIFFERENT key than u1's cell → u2 cannot arm/receive u1's refreshes. RED mutation:
+// drop the declaredIdentity fold from the shared effectiveKeyExtras (the same helper
+// the subscription path calls) → u1 and u2 derive the same key → u2 arms u1's key.
+//
+// GATE AUTHN-1: identity flows ONLY from the connection ctx's xcontext.UserInfo (the
+// JWT), never the SubscriptionCoordinates wire — the forgery-proof property.
+package dispatchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// buildDeclaredWidgetParityWatcher seeds a widget CR that DECLARES
+// spec.identityContext=declaredKeys (the A2 identity-dependence field) in ns demo,
+// and grants BOTH userA and userB get/list on the widget GVR (so the u2 forgery arm
+// can drive DeriveSubscriptionKey under each identity — both can GET the CR, the
+// key difference is purely the folded identity, not an RBAC skip). Reuses the
+// widgetParityGVR shape from refresh_subscription_key_parity_test.go.
+//
+// sharedBinding controls the RBAC shape: when true, userA and userB are subjects of
+// ONE ClusterRoleBinding → they share a BindingUID → the declared-identity fold is
+// the SOLE key discriminant (so the forgery arm's key-collapse under the fold-drop
+// mutation is provable). When false, each user has its own binding (distinct
+// BindingUID) — the realistic per-tenant shape used by the parity arm.
+func buildDeclaredWidgetParityWatcher(t *testing.T, sharedBinding bool, declaredKeys ...string) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		widgetParityGVR: "PanelList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"widgets.templates.krateo.io"}, Resources: []string{"panels"}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "panel-reader"}, Rules: rule},
+	}
+	if sharedBinding {
+		// ONE binding lists BOTH users → identical BindingUID → the ONLY key
+		// discriminant is the declared-identity fold (the forgery-arm shape).
+		seed = append(seed, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "ab-bind", UID: types.UID("uid-AB")},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "userA"}, {Kind: "User", Name: "userB"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+		})
+	} else {
+		// Two DISTINCT bindings (distinct UIDs) → distinct BindingUID folds.
+		seed = append(seed,
+			&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "a-bind", UID: types.UID("uid-A")},
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "userA"}},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+			},
+			&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-bind", UID: types.UID("uid-B")},
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "userB"}},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+			},
+		)
+	}
+	declared := make([]any, len(declaredKeys))
+	for i, k := range declaredKeys {
+		declared[i] = k
+	}
+	w := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata":   map[string]any{"name": "panel-1", "namespace": "demo"},
+		"spec":       map[string]any{"identityContext": declared},
+	}}
+	seed = append(seed, w)
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(widgetParityGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+func ctxUserB() context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "userB"}))
+}
+
+// declaredPanelCoords is panelCoords for a DECLARED widget under the two
+// subscribable widget classes; identity is NOT in coords (forgery-proof: it
+// comes from the connection ctx).
+func declaredPanelCoords(class string) SubscriptionCoordinates {
+	return panelCoords(class, map[string]any{"name": "demo-vpc"})
+}
+
+// emitInputsDeclared computes the EMIT-side ResolvedKeyInputs the /call dispatcher
+// would Put for a DECLARED widget under ctx's identity, driving the SAME production
+// derivation the dispatch emit path uses: effectiveKeyExtras (which folds the
+// declaredIdentity via A2) → dispatch*Key. This is the emit half of the arming↔serve
+// parity — reconstructed through the real helper, not hand-built extras.
+func emitInputsDeclared(t *testing.T, ctx context.Context, class string, coords SubscriptionCoordinates) *cache.ResolvedKeyInputs {
+	t.Helper()
+	got := objects.Get(ctx, templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: coords.Name, Namespace: coords.Namespace},
+		APIVersion: coords.Group + "/" + coords.Version,
+		Resource:   coords.Resource,
+	})
+	if got.Err != nil || got.Unstructured == nil {
+		t.Fatalf("emit setup: objects.Get(%s/%s) failed: %v", coords.Namespace, coords.Name, got.Err)
+	}
+	// The REAL emit key extras: the SAME effectiveKeyExtras the widgets.go
+	// genuine-Put folds (widgets.go:152), which under A2 injects the declared
+	// identity from ctx. Pass it through dispatch*Key exactly as emit does.
+	emitExtras := effectiveKeyExtras(ctx, got.Unstructured.Object, coords.Extras)
+	pp, pg := normalizePagination(coords.PerPage, coords.Page)
+	if class == cache.CacheEntryClassWidgetContent {
+		_, _, inputs := dispatchWidgetContentKey(ctx,
+			coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, emitExtras)
+		return inputs
+	}
+	_, _, inputs := dispatchCacheLookupKey(ctx, class,
+		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name, pp, pg, emitExtras)
+	return inputs
+}
+
+// TestFARCH4_DeclaredWidget_SubscriptionEmitParity — the A3 arming↔serve invariant
+// for a DECLARED widget, per subscribable class. For a widget declaring
+// identityContext:[username,groups], the SUBSCRIPTION key (production
+// DeriveSubscriptionKey under userA's JWT) MUST equal the EMIT key (production
+// effectiveKeyExtras → dispatch*Key under the same JWT), with field-by-field
+// pre-hash equality as the BindingUID-independent proof. This is the parity that
+// keeps declared-widget /refreshes forgery-proof; it holds because both sides fold
+// the declared identity through the SAME effectiveKeyExtras (A2). RED mutation: drop
+// the declaredIdentity fold from effectiveKeyExtras → the emit key stops folding the
+// declared identity while the sub key derivation is the same call, so the parity
+// itself does NOT break here (both sides move together) — the DISCRIMINATING arm for
+// the fold-drop is the u2-forgery arm below. This arm guards against a FUTURE change
+// that folds identity on ONE side only (the #64 desync class at the identity dimension).
+func TestFARCH4_DeclaredWidget_SubscriptionEmitParity(t *testing.T) {
+	classes := []string{classWidgets, cache.CacheEntryClassWidgetContent}
+	for _, class := range classes {
+		class := class
+		t.Run(class, func(t *testing.T) {
+			buildDeclaredWidgetParityWatcher(t, false, "username", "groups")
+			ctx := ctxUserA()
+			coords := declaredPanelCoords(class)
+
+			subKey, ok := DeriveSubscriptionKey(ctx, coords)
+			if !ok || subKey == "" {
+				t.Fatalf("%s: DeriveSubscriptionKey failed (ok=%v key=%q)", class, ok, subKey)
+			}
+			subIn, okIn := deriveSubscriptionKeyInputsForTest(ctx, coords)
+			if !okIn || subIn == nil {
+				t.Fatalf("%s: sub inputs failed", class)
+			}
+			emitIn := emitInputsDeclared(t, ctx, class, coords)
+			if emitIn == nil {
+				t.Fatalf("%s: emit inputs nil", class)
+			}
+
+			// Pre-hash: the declared identity (userA) must be folded into the key
+			// extras on BOTH sides — this is the load-bearing dimension A3 adds.
+			if subIn.Extras["username"] != "userA" {
+				t.Fatalf("%s F-ARCH-4 pre-hash: subscription key extras must carry the declared JWT username (userA); got %#v", class, subIn.Extras)
+			}
+			if emitIn.Extras["username"] != "userA" {
+				t.Fatalf("%s F-ARCH-4 pre-hash: emit key extras must carry the declared JWT username (userA); got %#v", class, emitIn.Extras)
+			}
+
+			// THE INVARIANT: digest equality (what the broadcaster matches on).
+			if got := cache.ComputeKey(*emitIn); subKey != got {
+				t.Fatalf("%s F-ARCH-4 INVARIANT BROKEN: DeriveSubscriptionKey %q != emit ComputeKey %q — the declared-widget "+
+					"armed key would never match the published key (arming↔serve identity desync).", class, subKey, got)
+			}
+			assertKeyInputsFieldEqual(t, "farch4/"+class, subIn, emitIn)
+		})
+	}
+}
+
+// TestFARCH4_U2CannotArmU1_DeclaredWidget — the forgery arm. For a DECLARED widget
+// where u1 and u2 SHARE ONE binding (identical BindingUID, so the declared-identity
+// fold is the SOLE key discriminant), user u2's subscription derivation yields a
+// DIFFERENT key than u1's → u2 cannot arm (and thus cannot receive) u1's refreshes.
+// RED mutation: drop the declaredIdentity fold from the shared effectiveKeyExtras →
+// u1 and u2 key extras lose the username → with the shared binding the keys COLLAPSE
+// to equal → u2 arms u1's key (the cross-user leak on the arming path). This arm
+// goes RED under that mutation on BOTH the pre-hash extras assertion AND the
+// key-collapse assertion (the shared binding is what makes the collapse observable).
+func TestFARCH4_U2CannotArmU1_DeclaredWidget(t *testing.T) {
+	classes := []string{classWidgets, cache.CacheEntryClassWidgetContent}
+	for _, class := range classes {
+		class := class
+		t.Run(class, func(t *testing.T) {
+			buildDeclaredWidgetParityWatcher(t, true, "username", "groups") // SHARED binding
+			coords := declaredPanelCoords(class)
+
+			k1, ok1 := DeriveSubscriptionKey(ctxUserA(), coords)
+			k2, ok2 := DeriveSubscriptionKey(ctxUserB(), coords)
+			if !ok1 || !ok2 || k1 == "" || k2 == "" {
+				t.Fatalf("%s: DeriveSubscriptionKey failed (u1 ok=%v key=%q; u2 ok=%v key=%q)", class, ok1, k1, ok2, k2)
+			}
+
+			in1, _ := deriveSubscriptionKeyInputsForTest(ctxUserA(), coords)
+			in2, _ := deriveSubscriptionKeyInputsForTest(ctxUserB(), coords)
+			if in1 == nil || in2 == nil {
+				t.Fatalf("%s: sub inputs nil (in1=%v in2=%v)", class, in1, in2)
+			}
+			// Pre-hash: each user's folded identity must be their OWN username — the
+			// declared-identity dimension is what the forgery guard hinges on.
+			if in1.Extras["username"] != "userA" || in2.Extras["username"] != "userB" {
+				t.Fatalf("%s FORGERY pre-hash: each subscription's folded identity must be its own JWT username; "+
+					"u1=%#v u2=%#v — the RED mutation (drop the declaredIdentity fold from effectiveKeyExtras) makes both empty", class, in1.Extras, in2.Extras)
+			}
+
+			// THE FORGERY GUARD: distinct keys → u2 cannot arm u1's cell.
+			if k1 == k2 {
+				t.Fatalf("%s FORGERY: u2's declared-widget subscription key %q == u1's %q — u2 could arm/receive u1's "+
+					"per-user refreshes (cross-user leak on the arming path). RED mutation (drop declaredIdentity fold) collapses them.", class, k2, k1)
+			}
+		})
+	}
+}

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -438,7 +438,16 @@ func inlineParentIdentityForKey(ctx context.Context, cr map[string]any) map[stri
 		out["username"] = ui.Username
 	}
 	if len(ui.Groups) > 0 {
-		out["groups"] = append([]string(nil), ui.Groups...)
+		// JSON-native []any (NOT []string) — key-only here, so this doesn't hit
+		// the resolve-input DeepCopyJSON panic today, but mirror DeclaredIdentity
+		// so ALL identity-extras are JSON-native by construction (shape
+		// uniformity, feedback_no_special_cases). Key-parity byte-identical:
+		// json.Marshal treats []string and []any identically.
+		g := make([]any, len(ui.Groups))
+		for i, v := range ui.Groups {
+			g[i] = v
+		}
+		out["groups"] = g
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/handlers/util"
 	"github.com/krateoplatformops/snowplow/internal/objects"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
@@ -334,6 +335,61 @@ func unionForKey(apiRefInline, rrtInline, request map[string]any) map[string]any
 		out[k] = v
 	}
 	return out
+}
+
+// effectiveKeyExtras is the SINGLE shared derivation of the "effective key
+// extras" the definitive cache-identity architecture (§2.2,
+// docs/definitive-cache-identity-architecture-2026-07-07.md) mandates for ALL
+// FOUR key-derivation consumers — dispatch lookup (widgets.go), widgetContent
+// lookup (widgets.go), subscription arming (refresh_subscription.go), and the
+// boot/keepwarm seed (phase1_pip_seed.go). Extracting it here is the A1
+// head-start: a pure behavior-preserving refactor that gives every consumer ONE
+// place to fold extras, so the A2 identity-injection lands at a single site and
+// cannot drift across the four consumers (the #64 shadow-drift lesson, applied
+// preemptively — same principle as the normalizePagination extraction).
+//
+// TODAY (A1) it returns EXACTLY what the four sites computed inline before:
+//
+//	unionForKey(GetApiRefExtras(cr), GetResourcesRefsExtras(cr), requestExtras)
+//
+// ⊎ declaredIdentityForKey(ctx, cr), which is INERT in A1 (returns nil → the
+// union is returned unchanged → byte-identical ResolvedKeyInputs at every site).
+// A2 wires declaredIdentityForKey to read spec.identityContext + materialise the
+// declared subset of xcontext.UserInfo(ctx) with injection-wins precedence; the
+// merge slot is present now so A2 is a one-function change with no new call-site
+// plumbing. The ctx parameter is accepted now (unused in A1) for the same
+// reason — A2 needs it, and threading it now keeps A1↔A2 signature-stable.
+//
+// cr is the widget CR's unstructured object map (the accessors deep-copy, so the
+// result never aliases the shared CR); nil-safe (both accessors return {} on a
+// nil/mismatched map → union degenerates to requestExtras → ComputeKey's len>0
+// guard skips the extras fold on an all-empty result — the no-extras backward-
+// compat path).
+func effectiveKeyExtras(ctx context.Context, cr map[string]any, requestExtras map[string]any) map[string]any {
+	base := unionForKey(
+		widgets.GetApiRefExtras(cr),
+		widgets.GetResourcesRefsExtras(cr),
+		requestExtras,
+	)
+	// A2 injection slot (INERT in A1): server-declared identity wins on
+	// collision. declaredIdentityForKey returns nil today, so this loop is a
+	// no-op and `base` is returned byte-identical to the pre-refactor union.
+	for k, v := range declaredIdentityForKey(ctx, cr) {
+		base[k] = v
+	}
+	return base
+}
+
+// declaredIdentityForKey is the A2 injection point, INERT in A1. Under the
+// contract (§2.2) it will read spec.identityContext off the CR and materialise
+// the declared subset of xcontext.UserInfo(ctx) — the server-trusted identity
+// keys that a DECLARED widget's cell must vary on. In A1 it returns nil so
+// effectiveKeyExtras is provably behavior-preserving (no CR declares yet, and
+// the accessor does not exist until A2). Kept as a named function (not an inline
+// nil) so A2 is a localized change and the injection semantics have a home for
+// the F-ARCH-3 precedence falsifier.
+func declaredIdentityForKey(_ context.Context, _ map[string]any) map[string]any {
+	return nil
 }
 
 // cacheHandle is the narrow interface the dispatchers depend on. The

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -371,25 +371,79 @@ func effectiveKeyExtras(ctx context.Context, cr map[string]any, requestExtras ma
 		widgets.GetResourcesRefsExtras(cr),
 		requestExtras,
 	)
-	// A2 injection slot (INERT in A1): server-declared identity wins on
-	// collision. declaredIdentityForKey returns nil today, so this loop is a
-	// no-op and `base` is returned byte-identical to the pre-refactor union.
+	// A2 identity injection (§2.2): server-declared identity wins on collision.
+	// declaredIdentityForKey → widgets.DeclaredIdentity reads the parent CR's OWN
+	// spec.identityContext; nil for an undeclared widget → no-op → byte-identical
+	// to pre-A2 for the identity-free corpus.
 	for k, v := range declaredIdentityForKey(ctx, cr) {
+		base[k] = v
+	}
+	// A2 inline-variance union (§4.3, F-ARCH-5) — arch ruling option (d): an
+	// inline-embedding parent (hasInlineGETRef) embeds children rendered UNDER the
+	// requesting user's identity (widgets_inline.go), so its cell must be per-USER
+	// even if the PARENT declares no identityContext and even if the embedded
+	// child is a template-expanded ref not enumerable pre-resolve. Fold the FULL
+	// request identity ({username, groups}) into the KEY as a conservative marker
+	// = treat the inline parent as effectively declaring identityContext:[username,
+	// groups]. This is a SUPERSET of any child's declared identity (own ∪ children
+	// ⊆ full), so the effective-union rule is satisfied by over-approximation with
+	// ZERO child-fetch on the hot key path (O(1), C-INLINE-2 triviality) and NO
+	// template-surface hole. KEY-ONLY: it does NOT enter the resolve input (the
+	// parent's own jq gets only its declared identity via widgets.Resolve) — the
+	// child render varies by identity through ResolveNestedCall's per-user ctx.
+	// INERT for the ~99% corpus: inline is opt-in + default-off, and a non-inline
+	// widget returns nil here → byte-identical to pre-A2.
+	for k, v := range inlineParentIdentityForKey(ctx, cr) {
 		base[k] = v
 	}
 	return base
 }
 
-// declaredIdentityForKey is the A2 injection point, INERT in A1. Under the
-// contract (§2.2) it will read spec.identityContext off the CR and materialise
-// the declared subset of xcontext.UserInfo(ctx) — the server-trusted identity
-// keys that a DECLARED widget's cell must vary on. In A1 it returns nil so
-// effectiveKeyExtras is provably behavior-preserving (no CR declares yet, and
-// the accessor does not exist until A2). Kept as a named function (not an inline
-// nil) so A2 is a localized change and the injection semantics have a home for
-// the F-ARCH-3 precedence falsifier.
-func declaredIdentityForKey(_ context.Context, _ map[string]any) map[string]any {
-	return nil
+// declaredIdentityForKey is the KEY-side injection point for the A2 contract
+// (definitive-cache-identity-architecture §2.2). It delegates to the SINGLE
+// shared derivation widgets.DeclaredIdentity(ctx, cr) — the SAME function the
+// resolve-input path calls (widgets.Resolve) — so a declared widget's key fold
+// and its rendered body see byte-identical identity material and cannot desync
+// (the #64 anti-drift principle at the identity dimension). Returns nil for an
+// undeclared widget or an identity-less ctx → the effectiveKeyExtras merge is a
+// no-op → byte-identical to pre-A2 for the ~99% identity-free corpus (the
+// prod-inert acceptance). GATE AUTHN-1: the only identity source is
+// xcontext.UserInfo (inside DeclaredIdentity) — zero store reads.
+func declaredIdentityForKey(ctx context.Context, cr map[string]any) map[string]any {
+	return widgets.DeclaredIdentity(ctx, cr)
+}
+
+// inlineParentIdentityForKey is the KEY-side inline-variance marker (A2 §4.3,
+// F-ARCH-5, arch ruling option (d)). It returns the FULL request identity
+// ({username, groups} from xcontext.UserInfo) as key extras iff the widget CR is
+// an inline-embedding parent (hasInlineGETRef) — making the parent cell per-USER
+// so an embedded child's identity-varying rendered body cannot leak across users
+// sharing one binding. Conservative by construction: the full identity is a
+// superset of any child's declared identityContext, so it closes the leak for
+// BOTH static AND template-expanded inline children WITHOUT fetching any child CR
+// at key time (O(1), no hot-path fan-out). Returns nil for a non-inline widget
+// (byte-identical to pre-A2) or an identity-less ctx (fail-safe: the request
+// already fail-closes to the ""-BindingUID MISS path in dispatchCacheLookupKey).
+// KEY-ONLY — never injected into the resolve input.
+func inlineParentIdentityForKey(ctx context.Context, cr map[string]any) map[string]any {
+	if !hasInlineGETRef(cr) {
+		return nil
+	}
+	ui, err := xcontext.UserInfo(ctx)
+	if err != nil {
+		return nil
+	}
+	out := map[string]any{}
+	if ui.Username != "" {
+		out["username"] = ui.Username
+	}
+	if len(ui.Groups) > 0 {
+		out["groups"] = append([]string(nil), ui.Groups...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // cacheHandle is the narrow interface the dispatchers depend on. The

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -772,11 +772,13 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode s
 	// outside Resolve and must be hand-threaded. Absent both blocks ⇒ {} + {}
 	// ⇒ a fresh empty union ⇒ byte-identical to the pre-inline-extras nil arg
 	// (HG-PIP.3 backward-compat). Falsifier #6 asserts the resulting HIT.
-	seedKeyExtras := unionForKey(
-		widgets.GetApiRefExtras(e.W.Object),
-		widgets.GetResourcesRefsExtras(e.W.Object),
-		nil,
-	)
+	// A1: route through the shared effectiveKeyExtras (definitive-architecture
+	// §2.2) — identical to the pre-A1 unionForKey(apiRefInline, rrtInline, nil)
+	// today (injection slot inert), so the seed key stays byte-identical to the
+	// dispatcher key it must match. A2 wires declaredIdentityForKey; the seed ctx
+	// carries the cohort identity (WithUserInfo) so a declared widget's seed key
+	// will fold the same identity a live request folds.
+	seedKeyExtras := effectiveKeyExtras(ctx, e.W.Object, nil)
 
 	// Ship 0.30.187 D2: the dispatcher-lookup key uses the KEY tuple
 	// (KeyPerPage, KeyPage) — derived from the /call Path the walker

--- a/internal/handlers/dispatchers/refresh_subscription.go
+++ b/internal/handlers/dispatchers/refresh_subscription.go
@@ -38,7 +38,6 @@ import (
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/objects"
-	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -135,11 +134,7 @@ func subscriptionKeyExtras(ctx context.Context, c SubscriptionCoordinates) (map[
 		// same, the log noise is gone.
 		return nil, false
 	}
-	return unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		c.Extras,
-	), true
+	return effectiveKeyExtras(ctx, got.Unstructured.Object, c.Extras), true
 }
 
 // SubscriptionSkipReason classifies WHY a coordinate did not arm — for the

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -149,11 +149,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	// blocks ⇒ both accessors return {} ⇒ keyExtras == request extras ⇒
 	// byte-identical keys (backward-compat). The accessors return deep copies,
 	// so keyExtras never aliases the shared CR.
-	keyExtras := unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		extras,
-	)
+	keyExtras := effectiveKeyExtras(req.Context(), got.Unstructured.Object, extras)
 
 	// Ship G (0.30.16x) — identity-free widget content L1 lookup runs
 	// FIRST. Same gating semantics as the per-user lookup below

--- a/internal/resolvers/widgets/resolve.go
+++ b/internal/resolvers/widgets/resolve.go
@@ -45,6 +45,33 @@ type ResolveOptions struct {
 func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	log := xcontext.Logger(ctx).With(loggerAttr(opts.In.Object))
 
+	// A2 contract: server-trusted identity injection into the RESOLVE INPUT
+	// (definitive-cache-identity-architecture §1.3 + §2.4). For a widget whose CR
+	// declares spec.identityContext, fold the declared subset of the
+	// authenticated principal (DeclaredIdentity — the SAME derivation the cache
+	// key path uses via effectiveKeyExtras) into opts.Extras, so the declared
+	// identity reaches BOTH the widgetDataTemplate/resourcesRefsTemplate jq
+	// (mergeExtras(ds, opts.Extras) below) AND the apiRef fetch (resolveApiRef).
+	// INJECTION WINS over any client-supplied value for the declared keys — this
+	// is the quarantine that closes the spoofability hole (§1.3, F-ARCH-3): a
+	// request carrying extras.username=SOMEONE_ELSE is overwritten by the JWT's
+	// own username. CACHE-OFF TRANSPARENT (§2.4, F-ARCH-6): this is part of the
+	// widget's INPUT contract, not a cache feature — it runs here in the resolve
+	// path whether or not the cache is on, so declared-widget output is identical
+	// cache-on vs cache-off for the same JWT. INERT for the ~99% identity-free
+	// corpus: DeclaredIdentity returns nil when no identityContext is declared →
+	// opts.Extras is untouched → byte-identical to pre-A2.
+	if inj := DeclaredIdentity(ctx, opts.In.Object); len(inj) > 0 {
+		merged := make(map[string]any, len(opts.Extras)+len(inj))
+		for k, v := range opts.Extras {
+			merged[k] = v
+		}
+		for k, v := range inj { // injection wins on collision (quarantine)
+			merged[k] = v
+		}
+		opts.Extras = merged
+	}
+
 	// Ship 0.30.193 Checkpoint 1 — widget-resolve phase wall-clocks.
 	// Captured per-phase so seedOneWidget's deferred log can attribute
 	// total widget-resolve cost across apiref / widgetData / resrefs /

--- a/internal/resolvers/widgets/resourcesrefstemplate/resolve_test.go
+++ b/internal/resolvers/widgets/resourcesrefstemplate/resolve_test.go
@@ -146,3 +146,50 @@ func TestResolve_EmptyWindowYieldsNoRefs(t *testing.T) {
 		t.Fatalf("empty post-chokepoint ds fanned %d refs; want 0", len(refs))
 	}
 }
+
+// TestFARCH_InlineNeverPropagatesFromTemplate — A2 F-ARCH-5 guard-completeness
+// invariant (definitive-cache-identity-architecture §4.4.6 + §8.1). The
+// inline-parent per-USER key marker (dispatchers inlineParentIdentityForKey →
+// hasInlineGETRef) statically scans a widget's DECLARED spec.resourcesRefs for
+// inline:true. That static scan is SOUND only because createResourceRef here
+// NEVER copies Template.Inline into the expanded ref (it copies only
+// ID/Verb/APIVersion/Name/Namespace/Resource — resolve.go:75-81): a
+// template-expanded ref cannot silently become inline post-scan.
+//
+// This arm PINS that non-propagation directly: a ResourceRefTemplate whose
+// Template.Inline is TRUE must expand to refs with Inline UNSET (false). If a
+// later change adds `out.Inline = in.Template.Inline` to createResourceRef,
+// this arm goes RED — catching the leak BEFORE the F-ARCH-5 static scan silently
+// under-approximates (a template-expanded inline child would then bypass the
+// per-user marker, embed identity-varying content under a per-binding-shared
+// key, and reopen the cross-user leak §4.4.6 closes). Cheap, hermetic, no cluster.
+func TestFARCH_InlineNeverPropagatesFromTemplate(t *testing.T) {
+	items := []templatesv1.ResourceRefTemplate{{
+		Iterator: ptr.To("${.items}"),
+		Template: templatesv1.ResourceRef{
+			Inline:     true, // author sets Inline on the TEMPLATE
+			Verb:       "get",
+			Resource:   "configmaps",
+			APIVersion: "v1",
+			Name:       "${ .name }",
+			Namespace:  "demo-system",
+		},
+	}}
+	ds := map[string]any{"items": []any{
+		map[string]any{"name": "cm-a"},
+		map[string]any{"name": "cm-b"},
+	}}
+
+	refs, err := Resolve(context.Background(), items, ds)
+	if err != nil {
+		t.Fatalf("Resolve errored: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 expanded refs (one per ds item); got %d", len(refs))
+	}
+	for i, r := range refs {
+		if r.Inline {
+			t.Fatalf("F-ARCH inline-completeness: expanded ref[%d] carries Inline=true — createResourceRef must NOT propagate Template.Inline (resolve.go:75-81 copies only ID/Verb/APIVersion/Name/Namespace/Resource). A template-expanded inline child would bypass the F-ARCH-5 static hasInlineGETRef scan and reopen the §4.4.6 cross-user leak. RED = someone added out.Inline = in.Template.Inline.", i)
+		}
+	}
+}

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -125,7 +125,21 @@ func DeclaredIdentity(ctx context.Context, obj map[string]any) map[string]any {
 			}
 		case identityContextEnumGroups:
 			if len(ui.Groups) > 0 {
-				out[identityContextEnumGroups] = append([]string(nil), ui.Groups...)
+				// JSON-native []any (NOT []string): this identity map is folded
+				// into opts.Extras (resolve.go:64-73) and threaded through
+				// resolveApiRef → mergeRequestWins → plumbing/maps.DeepCopyJSON,
+				// which PANICS on a Go []string ("cannot deep copy []string" — it
+				// only handles the json.Unmarshal-produced []any). A fresh []any
+				// keeps the value deep-copy-safe AND non-aliasing
+				// (feedback_shared_vs_copy_is_a_concurrency_change), and is
+				// key-parity byte-identical: json.Marshal([]string{"devs"}) ==
+				// json.Marshal([]any{"devs"}) == ["devs"], so canonicaliseExtras
+				// hashes it identically (the A1 prod-inert goldens stay green).
+				g := make([]any, len(ui.Groups))
+				for i, v := range ui.Groups {
+					g[i] = v
+				}
+				out[identityContextEnumGroups] = g
 			}
 		}
 	}

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -1,10 +1,12 @@
 package widgets
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 
+	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/maps"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 )
@@ -23,7 +25,115 @@ const (
 	// (resourcesRefsTemplateKey, below) stays byte-identical and existing
 	// blueprints are untouched (the PM-endorsed non-breaking shape).
 	resourcesRefsTemplateExtrasKey = "resourcesRefsTemplateExtras"
+
+	// identityContextKey — the A2 author-declared identity-dependence field
+	// (definitive-cache-identity-architecture §1.1): spec.identityContext is an
+	// OPTIONAL []string enumerating which authenticated-principal keys the
+	// widget's rendered output depends on. Absent/empty = identity-free (the
+	// default; per-binding-shareable + seedable). Read off the unstructured spec
+	// (same absence-tolerant pattern as the extras accessors).
+	identityContextKey = "identityContext"
 )
+
+// identityContextEnumUsername / identityContextEnumGroups are the ONLY enum
+// values the Phase A contract honors — exactly jwtutil.UserInfo (username,
+// groups). D1 (Diego 2026-07-07): displayName is FORECLOSED from the enum (it is
+// not a JWT claim for any strategy, §1.3), so the accessor FILTERS to these two
+// IN CODE — an out-of-enum value (a stale/typo'd/displayName declaration) is
+// dropped, never injected. This is the code-side twin of the CRD enum bound: the
+// server never injects a key the principal does not carry.
+const (
+	identityContextEnumUsername = "username"
+	identityContextEnumGroups   = "groups"
+)
+
+// GetIdentityContext reads spec.identityContext off the unstructured widget CR
+// and returns the DECLARED identity keys FILTERED to the Phase A enum
+// ({username, groups}) — the A2 declaration accessor
+// (definitive-cache-identity-architecture §1.1). Absence-tolerant: absent /
+// wrong-type / empty ⇒ nil (identity-free default, byte-identical to pre-A2).
+// Out-of-enum entries (e.g. displayName, a typo) are DROPPED in code (D1
+// foreclosure) — never a silent inject of a key the principal lacks. Order is
+// preserved and duplicates are collapsed so the derived identity map is
+// deterministic. Reads the raw slice via maps.NestedSlice (deep copy → no CR
+// aliasing), mirroring GetResourcesRefsExtras.
+func GetIdentityContext(obj map[string]any) []string {
+	raw, ok, err := maps.NestedSlice(obj, "spec", identityContextKey)
+	if !ok || err != nil {
+		return nil
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, v := range raw {
+		s, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		// D1 enum filter IN CODE: honor only username/groups.
+		if s != identityContextEnumUsername && s != identityContextEnumGroups {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// DeclaredIdentity is the SINGLE derivation of a declared widget's
+// server-trusted identity map (definitive-cache-identity-architecture §1.3 +
+// §2.2). It is the ONE place identity ever meets the resolve input / key fold,
+// called from BOTH the key path (dispatchers effectiveKeyExtras via
+// declaredIdentityForKey) and the resolve-input path (widgets Resolve) — so the
+// key and the body cannot desync (the #64 anti-drift principle at the identity
+// dimension).
+//
+// It reads the widget's declared identityContext (GetIdentityContext, already
+// enum-filtered) and materialises ONLY those keys from the authenticated
+// principal on ctx (xcontext.UserInfo — the JWT the authn middleware minted).
+//
+// GATE AUTHN-1 (Diego binding constraint): the ONLY source is
+// xcontext.UserInfo(ctx). ZERO user-store reads — no User CR, no IdP call, no
+// LDAP query, no apiserver fetch — so it is STRATEGY-AGNOSTIC by construction
+// (basic / OIDC / LDAP / serviceaccount all mint the same JWT tuple). displayName
+// is not derivable here (not in the JWT); the enum forecloses declaring it.
+//
+// Returns nil when: no declaration (identity-free widget — the ~99% corpus
+// path), or no/invalid UserInfo on ctx (fail-safe: absent identity yields no
+// injection, never a spurious key). A nil return makes the caller's fold a
+// no-op → byte-identical to pre-A2 for every undeclared widget (the prod-inert
+// acceptance). Values: username → ui.Username; groups → a fresh copy of
+// ui.Groups (never aliases the ctx slice). Only NON-EMPTY values are injected —
+// an empty username is not a key (jq `// empty` semantics apply downstream).
+func DeclaredIdentity(ctx context.Context, obj map[string]any) map[string]any {
+	declared := GetIdentityContext(obj)
+	if len(declared) == 0 {
+		return nil // identity-free widget — no injection (prod-inert default)
+	}
+	ui, err := xcontext.UserInfo(ctx)
+	if err != nil {
+		return nil // no authenticated principal → inject nothing (fail-safe)
+	}
+	out := map[string]any{}
+	for _, key := range declared {
+		switch key {
+		case identityContextEnumUsername:
+			if ui.Username != "" {
+				out[identityContextEnumUsername] = ui.Username
+			}
+		case identityContextEnumGroups:
+			if len(ui.Groups) > 0 {
+				out[identityContextEnumGroups] = append([]string(nil), ui.Groups...)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
 
 func GetAPIVersion(obj map[string]any) string {
 	val, err := maps.NestedString(obj, "apiVersion")


### PR DESCRIPTION
## A4 seed parity — permanent F-ARCH-1 (#107) arm + declared-seed-safety pin

Fourth and final ship of the definitive cache-identity architecture (docs/definitive-cache-identity-architecture-2026-07-07.md §8.1 A4 + §6 F-ARCH-1). **STACKS on A3 (PR #92) ← A2 (PR #91) ← A1 (PR #89).** Batch-merges as ONE snowplow cut for Diego's single merge+tag decision.

### TEST-ONLY — zero prod change

The seed path (phase1_pip_seed.go:781) already routes through the shared `effectiveKeyExtras` (A1), so a NON-declared widget's seed cell equals the post-contract browser's identity-free key — seed parity by construction. For a DECLARED widget the cache-architect trace proved the seed never creates a leakable mis-keyed shared cell (two-dimension `BindingUID × declared-identity-in-Extras` key + `DeclaredIdentity` injecting only non-empty values). No prod change needed or made in this ship.

### Falsifier arms (definitive-arch §6, F-ARCH-1)

- **TestFARCH1_SeedParity_NonDeclaredWidget_PortalShapedHIT** — the permanent #107 warmth vehicle: a non-declared widget's cell seeded under the real seed fold is HIT by a post-contract portal request (empty extras), with pre-hash `ResolvedKeyInputs` field-equality + a real L1 HIT and zero resolver invocations.
- **TestFARCH1_RED_OldFrontendRequest_Misses** — documents the pre-contract defect wire shape (unconditional identity extras → MISS of the identity-free seed cell).
- **TestFARCH_A4_DeclaredSeedSafety** {case1 per-user distinct, case2 group-only orphan unreachable, case3 per-group shared HIT} — the three arch-traced declared-widget cases via real `effectiveKeyExtras` → `ComputeKey`.

### Rebase note

Rebased forward onto the A2 fix tip (455055c). The A2 fix emits `groups` as JSON-native `[]any` (not `[]string`); A4's case3 assertion was updated `[]string{"devs"}` → `[]any{"devs"}` to match — the only content delta vs the pre-rebase A4 (the test's intent is unchanged). The resolve-output second-dimension coverage lives in the A2 test surface (`TestFARCH3_GroupsResolveOutput_GroupScopedOnly`), so A4 keeps its four key-side arms as-is.

All arms `=== RUN` + green under `-race -count=1`; full dispatchers package green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1