### PR TITLE
feat(dispatch): diagnostic serve_miss slog with servability conjunct snapshot (#130 F1)

### DIFF
--- a/internal/cache/servability_snapshot_test.go
+++ b/internal/cache/servability_snapshot_test.go
@@ -1,0 +1,103 @@
+// servability_snapshot_test.go — Task #130 F1.
+//
+// Diagnostic-only accessor ServabilitySnapshotFor: returns the four
+// servableLocked conjuncts (registered, HasSynced, watchHealthy,
+// typeConfirmed) for a GVR under ONE rw.mu.RLock() so the tuple is
+// internally consistent (no check-then-act gap across four separate
+// public accessors). It carries NO behaviour — it is consumed only by the
+// internal_dispatch.list.serve_miss slog to discriminate WHY the
+// informer-serve branch was not taken on a given boot.
+//
+// This file asserts the accessor returns a consistent 4-tuple that AGREES
+// with the servability predicate (IsServable) in both directions:
+//   - synced + type-confirmed GVR → all four true → IsServable true.
+//   - synced-over-empty post-startup CRD (the S4 shape) → typeConfirmed
+//     false while registered+HasSynced+watchHealthy hold → IsServable
+//     false. This is the exact tuple the serve_miss log must surface so a
+//     boot operator can read typeConfirmed=false directly.
+//
+// Per feedback_no_special_cases.md: a generic customer GVR; the accessor
+// is uniform over every GVR.
+
+package cache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// TestServabilitySnapshotFor_ConsistentTupleAgreesWithIsServable drives a
+// GVR through its lifecycle and asserts the snapshot's 4-tuple is both
+// internally consistent and in lockstep with IsServable.
+func TestServabilitySnapshotFor_ConsistentTupleAgreesWithIsServable(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), servableListKinds())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	// A discovery client that does NOT (yet) serve the test GVR's type —
+	// the post-startup-CRD-not-yet-installed state (the S4 shape).
+	disco := &fakeDiscovery{served: map[string]bool{}}
+	rw.SetDiscoveryClient(disco)
+
+	// Before registration: nothing holds.
+	pre := rw.ServabilitySnapshotFor(servableTestGVR)
+	if pre.Registered || pre.HasSynced || pre.WatchHealthy || pre.TypeConfirmed {
+		t.Fatalf("pre-registration snapshot must be all-false; got %+v", pre)
+	}
+	if rw.IsServable(servableTestGVR) {
+		t.Fatalf("pre-registration IsServable must be false")
+	}
+
+	// Register + sync the informer over the empty fake apiserver.
+	added, syncCh := rw.EnsureResourceType(servableTestGVR)
+	if !added {
+		t.Fatalf("EnsureResourceType: want added=true")
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer did not sync within 5s")
+	}
+	rw.RefreshDiscovery(context.Background()) // conjunct 4 runs; type still unserved.
+
+	// S4 shape: registered + synced + watch-healthy hold, but the resource
+	// type is UNCONFIRMED. This is the tuple the serve_miss log must surface.
+	miss := rw.ServabilitySnapshotFor(servableTestGVR)
+	if !miss.Registered || !miss.HasSynced || !miss.WatchHealthy {
+		t.Fatalf("post-sync snapshot: registered+hasSynced+watchHealthy must all hold; got %+v", miss)
+	}
+	if miss.TypeConfirmed {
+		t.Fatalf("post-sync snapshot: typeConfirmed must be FALSE for the un-served type; got %+v", miss)
+	}
+	// Tuple must AGREE with the predicate: type-unconfirmed → not servable.
+	if rw.IsServable(servableTestGVR) {
+		t.Fatalf("consistency: IsServable must be false when snapshot.TypeConfirmed=false; snapshot=%+v", miss)
+	}
+
+	// Install the type; refresh discovery → conjunct 4 flips true.
+	disco.served[gvString(servableTestGVR)] = true
+	rw.RefreshDiscovery(context.Background())
+
+	hit := rw.ServabilitySnapshotFor(servableTestGVR)
+	if !hit.Registered || !hit.HasSynced || !hit.WatchHealthy || !hit.TypeConfirmed {
+		t.Fatalf("post-confirm snapshot: all four conjuncts must hold; got %+v", hit)
+	}
+	// Tuple must AGREE with the predicate: all four true → servable.
+	if !rw.IsServable(servableTestGVR) {
+		t.Fatalf("consistency: IsServable must be true when all four snapshot conjuncts hold; snapshot=%+v", hit)
+	}
+}

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -1929,6 +1929,44 @@ func (rw *ResourceWatcher) IsServable(gvr schema.GroupVersionResource) bool {
 	return ok
 }
 
+// ServabilitySnapshot is a diagnostic read-only view of the four
+// servableLocked conjuncts for a single GVR, captured under ONE
+// rw.mu.RLock() so the tuple is internally consistent (no check-then-act
+// gap between four separate public accessors). It carries NO behaviour —
+// it is consumed only by the internal_dispatch.list.serve_miss slog to
+// discriminate WHY the informer-serve branch was not taken on a given
+// boot. Task #130 F1.
+type ServabilitySnapshot struct {
+	Registered    bool
+	HasSynced     bool
+	WatchHealthy  bool
+	TypeConfirmed bool
+}
+
+// ServabilitySnapshotFor returns the four servability conjuncts for gvr
+// under a single read lock. Read-only: it inspects the same maps
+// servableLocked reads and mutates nothing. On a nil / passthrough
+// watcher every conjunct is false (the serve branch never engages there).
+//
+// Safe for concurrent use; takes rw.mu in read mode.
+func (rw *ResourceWatcher) ServabilitySnapshotFor(gvr schema.GroupVersionResource) ServabilitySnapshot {
+	if rw == nil || rw.mode == modePassthrough {
+		return ServabilitySnapshot{}
+	}
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+	gi, registered := rw.informers[gvr]
+	snap := ServabilitySnapshot{Registered: registered}
+	if !registered {
+		return snap
+	}
+	snap.HasSynced = gi.Informer().HasSynced()
+	_, broken := rw.watchBroken[gvr]
+	snap.WatchHealthy = !broken
+	snap.TypeConfirmed = rw.resourceTypeConfirmedLocked(gvr)
+	return snap
+}
+
 // servableLocked is the single four-conjunct servability predicate
 // shared by IsServable and ListObjectsServable. Callers MUST hold rw.mu
 // (read or write). Returns the resolved GenericInformer alongside the

--- a/internal/resolvers/restactions/api/internal_dispatch.go
+++ b/internal/resolvers/restactions/api/internal_dispatch.go
@@ -394,6 +394,20 @@ func dispatchViaInternalRESTConfig(ctx context.Context, call httpcall.RequestOpt
 				return served, true, nil
 			}
 		}
+		// Serve branch NOT taken — capture the four servability conjuncts under
+		// one read lock so the boot log discriminates ALL miss reasons (sync
+		// timeout, unregistered, watch-broken, or typeConfirmed=false) before
+		// we fall through to the live paged LIST. Diagnostic only (Task #130 F1);
+		// the dispatch flow below is byte-identical whether or not this fires.
+		snap := rw.ServabilitySnapshotFor(gvr)
+		xcontext.Logger(ctx).Info("internal_dispatch.list.serve_miss",
+			slog.String("subsystem", "cache"),
+			slog.String("gvr", gvr.String()),
+			slog.Bool("registered", snap.Registered),
+			slog.Bool("hasSynced", snap.HasSynced),
+			slog.Bool("watchHealthy", snap.WatchHealthy),
+			slog.Bool("typeConfirmed", snap.TypeConfirmed),
+		)
 		// Fall through to the live paged LIST below (never worse).
 	}
 

--- a/internal/resolvers/restactions/api/internal_dispatch_serve_miss_slog_test.go
+++ b/internal/resolvers/restactions/api/internal_dispatch_serve_miss_slog_test.go
@@ -1,0 +1,166 @@
+// internal_dispatch_serve_miss_slog_test.go — Task #130 F1 diagnostic slog.
+//
+// The internal_dispatch.list.serve_miss slog fires on the serve-branch
+// MISS path — every exit within the ServeWatcherFromContext block that
+// falls through to the live paged LIST — carrying the four servability
+// conjuncts (registered, hasSynced, watchHealthy, typeConfirmed) captured
+// under one read lock. It discriminates ALL miss reasons (sync timeout,
+// unregistered, watch-broken, typeConfirmed=false) so the next boot log
+// reads the fall-through reason directly.
+//
+// Arms:
+//   MISS path emits with all four fields — the C1 never-synced fall-through
+//     (registered=false). RED: revert the emit → no serve_miss line.
+//   HIT path does NOT emit — a servable GVR serves from the informer, and
+//     serve_miss must be absent (the flow returns before the miss emit).
+//
+// Diagnostic-only: neither arm changes the dispatch result (served / raw /
+// error); they only assert the presence/absence of the observability line.
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+// serveMissLine parses the single serve_miss JSON log line out of buf and
+// returns its decoded fields. Fails the test if zero or more than one line
+// is present.
+func serveMissLine(t *testing.T, buf string) map[string]any {
+	t.Helper()
+	var found []map[string]any
+	for _, ln := range strings.Split(strings.TrimSpace(buf), "\n") {
+		if ln == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(ln), &m); err != nil {
+			continue
+		}
+		if m["msg"] == "internal_dispatch.list.serve_miss" {
+			found = append(found, m)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one serve_miss line, got %d; log:\n%s", len(found), buf)
+	}
+	return found[0]
+}
+
+// TestServe1a_ServeMiss_EmitsConjunctSnapshotOnFallThrough is the MISS-path
+// arm: a never-synced GVR forces the serve branch to fall through to the
+// live LIST, and the serve_miss line must fire with all four conjunct
+// fields present (registered=false here — the never-synced/unregistered
+// exit). RED: revert the emit → serveMissLine finds zero lines.
+func TestServe1a_ServeMiss_EmitsConjunctSnapshotOnFallThrough(t *testing.T) {
+	resetInternalClientCacheForTest()
+	t.Cleanup(resetInternalClientCacheForTest)
+
+	// Never-synced watcher → the serve branch misses and falls through.
+	rw := newServe1aWatcher(t, false)
+	if rw.IsServable(serve1aGVR) {
+		t.Fatal("precondition: never-synced GVR must not be servable")
+	}
+
+	const n = 20
+	fixture, caPEM := newServe1aLiveFixture(t, n, int(internalDispatchListPageLimit))
+	rc := &rest.Config{
+		Host:            fixture.server.URL,
+		BearerToken:     "fake-sa-jwt",
+		TLSClientConfig: rest.TLSClientConfig{CAData: caPEM},
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	ctx := cache.WithInternalRESTConfig(context.Background(), rc)
+	ctx = cache.WithServeWatcher(ctx, rw)
+	ctx = withSlogLogger(ctx, logger)
+
+	_, served, err := dispatchViaInternalRESTConfig(ctx, httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: serve1aListPath},
+	})
+	if err != nil {
+		t.Fatalf("fall-through dispatch returned error: %v", err)
+	}
+	if !served {
+		t.Fatal("expected served=true from the live-LIST fall-through")
+	}
+
+	m := serveMissLine(t, logBuf.String())
+	// All four conjunct fields must be present (and JSON bools).
+	for _, f := range []string{"registered", "hasSynced", "watchHealthy", "typeConfirmed"} {
+		v, ok := m[f]
+		if !ok {
+			t.Fatalf("serve_miss line missing field %q; line: %+v", f, m)
+		}
+		if _, isBool := v.(bool); !isBool {
+			t.Fatalf("serve_miss field %q must be a bool, got %T (%v)", f, v, v)
+		}
+	}
+	// The never-synced/unregistered exit → registered=false, the discriminating
+	// signal the boot operator reads.
+	if m["registered"] != false {
+		t.Fatalf("never-synced GVR: serve_miss registered must be false; line: %+v", m)
+	}
+	if m["gvr"] != serve1aGVR.String() {
+		t.Fatalf("serve_miss gvr = %v, want %s", m["gvr"], serve1aGVR.String())
+	}
+}
+
+// TestServe1a_ServeHit_DoesNotEmitServeMiss is the HIT-path arm: a
+// servable, populated GVR serves from the informer and returns BEFORE the
+// miss emit — serve_miss must be absent.
+func TestServe1a_ServeHit_DoesNotEmitServeMiss(t *testing.T) {
+	resetInternalClientCacheForTest()
+	t.Cleanup(resetInternalClientCacheForTest)
+
+	const n = 20
+	items := make([]*unstructured.Unstructured, 0, n)
+	for i := 0; i < n; i++ {
+		items = append(items, serve1aItem(i, "composition-"+itoa(i), "krateo-system"))
+	}
+	rw := newServe1aWatcher(t, true, items...)
+
+	fixture, caPEM := newServe1aLiveFixture(t, n, int(internalDispatchListPageLimit))
+	rc := &rest.Config{
+		Host:            fixture.server.URL,
+		BearerToken:     "fake-sa-jwt",
+		TLSClientConfig: rest.TLSClientConfig{CAData: caPEM},
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	ctx := cache.WithInternalRESTConfig(context.Background(), rc)
+	ctx = cache.WithServeWatcher(ctx, rw)
+	ctx = withSlogLogger(ctx, logger)
+
+	_, served, err := dispatchViaInternalRESTConfig(ctx, httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Path: serve1aListPath},
+	})
+	if err != nil {
+		t.Fatalf("informer-serve dispatch returned error: %v", err)
+	}
+	if !served {
+		t.Fatal("expected served=true from the informer-serve branch")
+	}
+	// HIT served from the informer — the serve_miss line must be absent.
+	if strings.Contains(logBuf.String(), `"msg":"internal_dispatch.list.serve_miss"`) {
+		t.Fatalf("serve_miss fired on the HIT path (should return before the miss emit); log:\n%s", logBuf.String())
+	}
+	// Sanity: it WAS the informer-serve (not a silent live LIST).
+	if !strings.Contains(logBuf.String(), `"msg":"internal_dispatch.list.informer_served"`) {
+		t.Fatalf("expected informer_served on the HIT path; log:\n%s", logBuf.String())
+	}
+}


### PR DESCRIPTION
## What
Diagnostic-only (Diego-authorized, #130 F1 milestone). Emits ONE INFO slog line `internal_dispatch.list.serve_miss` on the #121 1a informer-serve **MISS** path — every exit within the `ServeWatcherFromContext` block that falls through to the live paged LIST — carrying the four `servableLocked` conjuncts so the next boot log discriminates ALL miss reasons directly:

```
internal_dispatch.list.serve_miss
  gvr=<gvr> registered=<bool> hasSynced=<bool> watchHealthy=<bool> typeConfirmed=<bool>
```

Unblocks the #130 F1 confirm-wiring fix: roll on installer-test, read `typeConfirmed=false` directly, build the fix on TRACED ground.

## No behavior change (self-evident from the diff)
- `ServabilitySnapshotFor` is a **read-only** accessor capturing the four conjuncts under **ONE** `rw.mu.RLock()` (no check-then-act gap across four separate public methods); it mutates nothing.
- The emit sits **AFTER** `return served, true, nil` (the HIT path returns before it) and **BEFORE** the unchanged `listStart := time.Now()` live paged LIST. The dispatch flow is byte-identical whether or not the line fires. INFO level (bounded: per-missed-LIST during boot).

## Miss-reason coverage
The single emit covers ALL fall-through exits inside the `haveRW` block: `WaitForGVRSync` timeout (not-synced), unregistered, watch-broken, and `typeConfirmed=false` — each reads directly off the conjunct snapshot.

## Tests (-race, -count=1)
- **cache** `TestServabilitySnapshotFor_ConsistentTupleAgreesWithIsServable`: accessor returns a consistent 4-tuple that agrees with `IsServable` in both directions (S4-shape `typeConfirmed=false` → not servable; all-four-true → servable).
- **api** `TestServe1a_ServeMiss_EmitsConjunctSnapshotOnFallThrough`: MISS path emits the line with all four bool fields present. `TestServe1a_ServeHit_DoesNotEmitServeMiss`: HIT path does NOT emit (returns before the miss emit). Pre-existing 1a byte-parity arms remain green (dispatch unchanged).

## Review
Diagnostic-only → LIGHT review: architect soundness ping on the diff (no full PM gate), per Diego.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1