### PR TITLE
feat(cache): #130 F1 — prime conjunct-4 confirm on the discovery-walk register path [PARKED — Diego merge]

### DIFF
--- a/internal/cache/prewarm.go
+++ b/internal/cache/prewarm.go
@@ -74,6 +74,7 @@ import (
 	"log/slog"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -139,6 +140,14 @@ func (rw *ResourceWatcher) PrewarmRegisterFromNavigation(ctx context.Context, dy
 		return 0, 0, walkErr
 	}
 
+	// Fix #130 F1: collect the GVRs this walk newly registers so we can
+	// prime ONE scoped conjunct-4 confirm over exactly that set after the
+	// loop (below). Without the prime, a walk-registered GVR latches
+	// typeConfirmed:false until the next discoveryRefreshInterval (30s)
+	// ticker tick — the 1.7.3 serve_miss readout showed conjunct 4 was the
+	// sole universal blocker of informer-serve at boot for every walk GVR.
+	walkRegistered := make([]schema.GroupVersionResource, 0, len(inv))
+
 	for _, gvr := range inv {
 		if ctx.Err() != nil {
 			// Boot context cancelled — stop early. Whatever we did not
@@ -160,18 +169,39 @@ func (rw *ResourceWatcher) PrewarmRegisterFromNavigation(ctx context.Context, dy
 		added, _ := rw.EnsureResourceType(gvr)
 		if added {
 			registered++
+			walkRegistered = append(walkRegistered, gvr)
 		} else {
 			alreadyPresent++
 		}
 	}
+
+	// Fix #130 F1: prime conjunct-4 (typeConfirmed) for the GVRs this walk
+	// registered, in ONE scoped pass. ConfirmResourceTypes reuses
+	// RefreshDiscovery's exact per-GV-deduped confirm body (no forked
+	// predicate) — one ServerResourcesForGroupVersion per distinct
+	// group/version, bounded by ctx, run off the lock. This lands well
+	// before the walk's informers issue their first LIST (~seconds), so the
+	// FIRST post-walk dispatch of these GVRs can take the informer-serve
+	// branch instead of the live paged LIST fall-through.
+	//
+	// Scope is exactly the walk-registered set — the RBAC bootstrap GVRs are
+	// already confirmed by StartDiscoveryRefresher's startup prime, and
+	// already-present GVRs (added==false) were confirmed on their original
+	// registration path. Offline (disco==nil) degrades to conjunct-4 true
+	// per resourceTypeConfirmedLocked — ConfirmResourceTypes leaves
+	// rw.confirmed untouched, so the degraded-true path is preserved.
+	confirmStart := time.Now()
+	rw.ConfirmResourceTypes(ctx, walkRegistered)
 
 	slog.Info("cache.prewarm.completed",
 		slog.String("subsystem", "cache"),
 		slog.Int("inventory_size", len(inv)),
 		slog.Int("registered", registered),
 		slog.Int("already_present", alreadyPresent),
+		slog.Int("confirm_primed", len(walkRegistered)),
+		slog.Int64("confirm_ms", time.Since(confirmStart).Milliseconds()),
 		slog.Int64("walk_ms", time.Since(start).Milliseconds()),
-		slog.String("mode", "fire-and-forget — informers sync asynchronously; boot not blocked"),
+		slog.String("mode", "fire-and-forget informers; conjunct-4 primed synchronously — informer-serve alive at boot"),
 	)
 	return registered, alreadyPresent, nil
 }

--- a/internal/cache/prewarm_test.go
+++ b/internal/cache/prewarm_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
@@ -107,6 +108,123 @@ func TestPrewarmRegisterFromNavigation_RegistersInventoryGVRs(t *testing.T) {
 			t.Fatalf("informer for %s did not sync within 5s", gvr)
 		}
 	}
+}
+
+// TestPrewarmRegisterFromNavigation_PrimesConfirm is the #130 F1 end-to-end
+// wiring falsifier: the walk must leave every GVR it registers CONFIRMED
+// (conjunct 4) so the FIRST post-walk dispatch can take the informer-serve
+// branch instead of a live paged LIST — WITHOUT waiting a discovery-refresh
+// ticker tick.
+//
+// A discovery client that serves the navigation GVRs' types is wired before
+// the walk. After the walk returns (and the informers sync), every
+// walk-registered GVR must be IsServable — all four conjuncts true. Pre-F1
+// (no confirm prime in the walk) these GVRs would be registered+synced but
+// typeConfirmed:false → NOT servable until the 30s ticker — the exact 1.7.3
+// serve_miss state this fix eliminates.
+func TestPrewarmRegisterFromNavigation_PrimesConfirm(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		buildSchemeWithRestActions(),
+		inventoryListKinds(),
+		makeRestAction("ra-confirm", "demo",
+			"/api/v1/namespaces",
+			"/apis/apps/v1/deployments",
+		),
+	)
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	navGVRs := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "namespaces"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	// Wire a discovery client that serves the navigation GVRs' types. This
+	// is what StartDiscoveryRefresher would use in production; here we drive
+	// the walk directly, so the walk's own confirm prime is the ONLY thing
+	// that can confirm these GVRs (no ticker runs in this test).
+	rw.SetDiscoveryClient(f1WalkPrimeDiscovery(navGVRs))
+
+	// Generous ctx: ConfirmResourceTypes correctly honors ctx cancellation
+	// (early-return before the apply-loop if the deadline trips). A tight
+	// deadline under CPU starvation could early-return the confirm and
+	// produce a TypeConfirmed:false snapshot that MASQUERADES as the 1.7.3
+	// symptom — a false-RED. 60s is far beyond a few in-process discovery
+	// round-trips; the explicit ctx.Err() guard below makes any deadline
+	// trip fail loud as "ctx expired" rather than impersonate the bug.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	registered, _, walkErr := rw.PrewarmRegisterFromNavigation(ctx, dyn)
+	if walkErr != nil {
+		t.Fatalf("PrewarmRegisterFromNavigation: %v", walkErr)
+	}
+	// Guard against a ctx-timeout false-RED: if the boot ctx expired, the
+	// confirm may have early-returned and the servability assertion below
+	// would fail with the exact 1.7.3 snapshot for the WRONG reason. Fail
+	// loud here instead so the flake is unambiguous.
+	if ctx.Err() != nil {
+		t.Fatalf("walk ctx expired (%v) — confirm may have early-returned; "+
+			"this is a harness-timeout, NOT the F1 symptom", ctx.Err())
+	}
+	if registered != 2 {
+		t.Fatalf("walk: want registered=2, got %d", registered)
+	}
+
+	// The walk is fire-and-forget on SYNC — wait for the informers to sync
+	// so conjunct 2 (HasSynced) holds. Conjunct 4 (typeConfirmed) must
+	// already have been primed by the walk itself.
+	for _, gvr := range navGVRs {
+		if !rw.WaitForGVRSync(ctx, gvr, 5*time.Second) {
+			t.Fatalf("informer for %s did not sync within 5s", gvr)
+		}
+	}
+
+	// F1 acceptance: every walk-registered GVR is servable with NO ticker
+	// tick — the walk primed conjunct 4.
+	for _, gvr := range navGVRs {
+		if !rw.IsServable(gvr) {
+			t.Fatalf("F1: walk-registered GVR %s must be servable after the walk "+
+				"(conjunct 4 primed by the walk, no ticker); got servable=false snap=%+v",
+				gvr, rw.ServabilitySnapshotFor(gvr))
+		}
+	}
+}
+
+// gvrSetDiscovery is a discovery double that serves EXACTLY the resource
+// types (group/version → resource names) it is constructed with, so the
+// walk's confirm can match arbitrary real k8s plurals (namespaces,
+// deployments) rather than the alphas/betas/gammas of countingDiscovery.
+type gvrSetDiscovery struct {
+	byGV map[string][]metav1.APIResource
+}
+
+func (d *gvrSetDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	rs := d.byGV[groupVersion]
+	return &metav1.APIResourceList{GroupVersion: groupVersion, APIResources: rs}, nil
+}
+
+// f1WalkPrimeDiscovery returns a discovery double that serves the resource
+// types of the given GVRs (grouped by group/version) and reports empty for
+// anything else.
+func f1WalkPrimeDiscovery(gvrs []schema.GroupVersionResource) *gvrSetDiscovery {
+	byGV := map[string][]metav1.APIResource{}
+	for _, gvr := range gvrs {
+		gv := gvr.Version
+		if gvr.Group != "" {
+			gv = gvr.Group + "/" + gvr.Version
+		}
+		byGV[gv] = append(byGV[gv], metav1.APIResource{Name: gvr.Resource, Namespaced: true})
+	}
+	return &gvrSetDiscovery{byGV: byGV}
 }
 
 // TestPrewarmRegisterFromNavigation_FireAndForget asserts the walk does

--- a/internal/cache/servable.go
+++ b/internal/cache/servable.go
@@ -400,6 +400,84 @@ func (rw *ResourceWatcher) ConfirmResourceType(ctx context.Context, gvr schema.G
 	rw.applyConfirmLocked(gvr, curGI, disco != nil, typeServed)
 }
 
+// ConfirmResourceTypes runs the scoped conjunct-3/4 confirmation pass over a
+// caller-supplied SET of GVRs in one shot, reusing RefreshDiscovery's exact
+// per-GV dedup + applyConfirmLocked body (it does NOT fork a parallel
+// predicate). It is ConfirmResourceType's plural sibling: same confirm/recover
+// semantics, but it issues ONE ServerResourcesForGroupVersion per distinct
+// group/version across the whole set rather than one-per-GVR — so a walk that
+// registers many GVRs sharing a group/version (e.g. several CompositionDefinition
+// versions) costs one discovery round-trip per GV, not per GVR.
+//
+// Fix #130 F1: primed by the discovery-walk registration path
+// (PrewarmRegisterFromNavigation, prewarm.go) so a GVR the walk lazily
+// registers becomes conjunct-4 typeConfirmed within one discovery round-trip
+// instead of waiting a full discoveryRefreshInterval (30s) ticker tick. The
+// 1.7.3 serve_miss readout showed EVERY walk-registered GVR latched
+// typeConfirmed:false (registered/hasSynced/watchHealthy all true) until the
+// ticker — conjunct 4 was the sole universal blocker of informer-serve at boot.
+//
+// Only the SUBSET of gvrs currently registered is confirmed — an unregistered
+// gvr in the set is a cheap no-op (nothing to confirm; the walk's
+// EnsureResourceType runs first, so a walk-registered GVR is registered by the
+// time this runs). Idempotent + re-runnable: confirming an already-confirmed
+// GVR is a map write of an existing key. Discovery calls run OFF the lock and
+// are bounded by ctx.
+//
+// Concurrency: writes rw.confirmed / rw.watchBroken / rw.lastSyncRV under
+// rw.mu.Lock() — the SAME maps + lock the discovery-refresh ticker and the
+// scoped ConfirmResourceType use, so all three are serialised. Informer handles
+// are re-read under the write lock (N2), not captured under the earlier RLock,
+// to survive a delete+recreate interleave.
+//
+// Nil-receiver / passthrough safe. Empty / nil set = no-op.
+func (rw *ResourceWatcher) ConfirmResourceTypes(ctx context.Context, gvrs []schema.GroupVersionResource) {
+	if rw == nil || rw.mode == modePassthrough || len(gvrs) == 0 {
+		return
+	}
+
+	rw.mu.RLock()
+	disco := rw.disco
+	rw.mu.RUnlock()
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+
+	// Resolve resource-type existence per group/version, deduped — identical
+	// to RefreshDiscovery's dedup loop, run OFF the lock. One discovery call
+	// per distinct gv across the whole set (the cost bound), not per GVR.
+	served := map[string]bool{}
+	if disco != nil {
+		queried := map[string]struct{}{}
+		for _, gvr := range gvrs {
+			if ctx != nil && ctx.Err() != nil {
+				return
+			}
+			gv := groupVersionString(gvr)
+			if _, done := queried[gv]; done {
+				continue
+			}
+			queried[gv] = struct{}{}
+			served[gv] = resourceTypeServed(disco, gvr)
+		}
+	}
+
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+	rw.ensureConfirmMapsLocked()
+	for _, gvr := range gvrs {
+		// Re-read the informer under the write lock (N2): only confirm a GVR
+		// that is CURRENTLY registered. A GVR unregistered between the walk's
+		// EnsureResourceType and here (CRD-DELETE teardown) is skipped, so we
+		// never resurrect a stale rw.confirmed entry.
+		curGI, stillRegistered := rw.informers[gvr]
+		if !stillRegistered {
+			continue
+		}
+		rw.applyConfirmLocked(gvr, curGI, disco != nil, served[groupVersionString(gvr)])
+	}
+}
+
 // ServableGVRStatus is a read-only per-GVR servability snapshot row,
 // surfaced by the /debug/servable diagnostic. It exposes the four
 // servability conjuncts so an operator can see WHY a GVR is (not) servable

--- a/internal/cache/walk_confirm_prime_f1_test.go
+++ b/internal/cache/walk_confirm_prime_f1_test.go
@@ -1,0 +1,345 @@
+// walk_confirm_prime_f1_test.go — #130 F1 falsifiers.
+//
+// FIX under test: the discovery-walk registration path
+// (PrewarmRegisterFromNavigation, prewarm.go) now primes ONE scoped
+// conjunct-4 confirm (ConfirmResourceTypes) over exactly the GVRs the walk
+// newly registers, so a walk-registered GVR becomes IsServable (all four
+// conjuncts true) within one discovery round-trip instead of waiting a full
+// discoveryRefreshInterval (30s) ticker tick.
+//
+// Root cause (1.7.3 serve_miss readout): every walk-registered GVR latched
+// registered:true hasSynced:true watchHealthy:true typeConfirmed:FALSE —
+// conjunct 4 was the sole universal blocker until the ticker.
+//
+// Falsifiers here (run -race -count=1, 3×):
+//
+//   - TestF1Walk_ConfirmPrimed_ServableWithoutTicker (F-confirm-primed):
+//     after ConfirmResourceTypes, a walk-registered synced GVR is IsServable.
+//     RED control: WITHOUT the confirm prime the same GVR is NOT servable
+//     (typeConfirmed false) even though registered+synced hold — that is the
+//     bug reproduced. A single RefreshDiscovery pass (the ticker) also flips
+//     it true, proving the prime just brings that flip forward, not fakes it.
+//
+//   - TestF1Walk_ConfirmResourceTypes_DedupsPerGV (cost bound): two GVRs
+//     sharing one group/version cost exactly ONE
+//     ServerResourcesForGroupVersion call, not two.
+//
+//   - TestF1Walk_ConfirmResourceTypes_Idempotent (F-idempotent/no-regress):
+//     a second ConfirmResourceTypes over the same set does not re-storm and
+//     leaves the GVR confirmed; an unregistered GVR in the set is a no-op.
+//
+//   - TestF1Walk_ConfirmResourceTypes_OfflineDegrade (F-offline-degrade):
+//     with no discovery client wired, ConfirmResourceTypes issues ZERO
+//     discovery calls and IsServable stays degraded-true (conjunct 4 falls
+//     back to HasSynced-only) — the degraded path is not broken.
+//
+// Per feedback_no_special_cases.md: every GVR is a generic customer-style
+// CRD GVR; the confirm is uniform, no per-GVR carve-out.
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// Two customer-style CRD GVRs that SHARE one group/version — the dedup
+// dimension. A third GVR in a distinct group/version proves multi-GV.
+var (
+	f1WalkGVRa = schema.GroupVersionResource{Group: "walk.example", Version: "v1", Resource: "alphas"}
+	f1WalkGVRb = schema.GroupVersionResource{Group: "walk.example", Version: "v1", Resource: "betas"}
+	f1WalkGVRc = schema.GroupVersionResource{Group: "other.example", Version: "v1", Resource: "gammas"}
+)
+
+func f1WalkScheme() *k8sruntime.Scheme {
+	// Reuse the RBAC-registered scheme so the bootstrap RBAC informers
+	// (registered by NewResourceWatcher) can decode their initial LISTs.
+	return newTestScheme()
+}
+
+func f1WalkListKinds() map[schema.GroupVersionResource]string {
+	// Merge the RBAC bootstrap List kinds — NewResourceWatcher registers the
+	// four RBAC GVRs, whose informers LIST at startup and panic without them.
+	m := rbacListKinds()
+	m[f1WalkGVRa] = "AlphaList"
+	m[f1WalkGVRb] = "BetaList"
+	m[f1WalkGVRc] = "GammaList"
+	return m
+}
+
+// countingDiscovery is a discovery double that COUNTS
+// ServerResourcesForGroupVersion calls per group/version so the dedup
+// falsifier can assert one-call-per-GV. `served` toggles which
+// group/versions the fake apiserver reports as serving their type.
+type countingDiscovery struct {
+	mu     sync.Mutex
+	served map[string]bool // groupVersion -> served
+	calls  map[string]int  // groupVersion -> call count
+}
+
+func newCountingDiscovery(served map[string]bool) *countingDiscovery {
+	return &countingDiscovery{served: served, calls: map[string]int{}}
+}
+
+func (d *countingDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	d.mu.Lock()
+	d.calls[groupVersion]++
+	served := d.served[groupVersion]
+	d.mu.Unlock()
+	if !served {
+		return &metav1.APIResourceList{GroupVersion: groupVersion}, nil
+	}
+	// Report every resource this GV could serve — the confirm only checks
+	// the Resource name appears, so list all three plurals; harmless.
+	return &metav1.APIResourceList{
+		GroupVersion: groupVersion,
+		APIResources: []metav1.APIResource{
+			{Name: "alphas", Kind: "Alpha", Namespaced: true},
+			{Name: "betas", Kind: "Beta", Namespaced: true},
+			{Name: "gammas", Kind: "Gamma", Namespaced: true},
+		},
+	}, nil
+}
+
+func (d *countingDiscovery) callCount(gv string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls[gv]
+}
+
+func newF1WalkWatcher(t *testing.T) *cache.ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		f1WalkScheme(), f1WalkListKinds())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	if rw == nil {
+		t.Fatalf("expected non-nil watcher under CACHE_ENABLED=true")
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	return rw
+}
+
+// registerAndSync registers gvr via the same EnsureResourceType the walk
+// uses and blocks until its informer's initial LIST reconciles (HasSynced).
+func registerAndSync(t *testing.T, rw *cache.ResourceWatcher, gvr schema.GroupVersionResource) {
+	t.Helper()
+	added, syncCh := rw.EnsureResourceType(gvr)
+	if !added {
+		t.Fatalf("EnsureResourceType(%s): want added=true", gvr)
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer for %s did not sync within 5s", gvr)
+	}
+}
+
+// TestF1Walk_ConfirmPrimed_ServableWithoutTicker is the primary F1
+// falsifier + its RED control. A walk-registered, synced GVR:
+//
+//	RED (no confirm prime): IsServable == false — conjunct 4 (typeConfirmed)
+//	  is the blocker even though registered+synced hold. This is the bug.
+//	GREEN (ConfirmResourceTypes): IsServable == true within one discovery
+//	  round-trip — NO ticker wait.
+//
+// A subsequent RefreshDiscovery (the ticker) also yields true, proving the
+// prime brings the SAME flip forward rather than fabricating servability.
+func TestF1Walk_ConfirmPrimed_ServableWithoutTicker(t *testing.T) {
+	rw := newF1WalkWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
+	rw.SetDiscoveryClient(disco)
+
+	registerAndSync(t, rw, f1WalkGVRa)
+
+	// RED control: BEFORE any confirm, the GVR is registered + synced but
+	// NOT confirmed → not servable. This is exactly the 1.7.3 readout state.
+	if rw.IsServable(f1WalkGVRa) {
+		t.Fatalf("RED control invalid: a walk-registered synced GVR must NOT be servable "+
+			"before the confirm prime (conjunct 4 typeConfirmed=false); got servable=true")
+	}
+	snap := rw.ServabilitySnapshotFor(f1WalkGVRa)
+	if !snap.Registered || !snap.HasSynced || !snap.WatchHealthy {
+		t.Fatalf("RED control setup wrong: want registered+synced+watchHealthy; got %+v", snap)
+	}
+	if snap.TypeConfirmed {
+		t.Fatalf("RED control invalid: typeConfirmed must be false pre-prime; got %+v", snap)
+	}
+
+	// GREEN: the F1 fix — prime the scoped confirm over the walk set.
+	rw.ConfirmResourceTypes(context.Background(), []schema.GroupVersionResource{f1WalkGVRa})
+
+	if !rw.IsServable(f1WalkGVRa) {
+		t.Fatalf("F1: after ConfirmResourceTypes the walk-registered GVR MUST be servable "+
+			"without a ticker wait; got servable=false (snap=%+v)", rw.ServabilitySnapshotFor(f1WalkGVRa))
+	}
+
+	// Sanity: the ticker path reaches the same verdict — the prime is not a
+	// shortcut around real discovery, it is the same confirm brought forward.
+	rw.RefreshDiscovery(context.Background())
+	if !rw.IsServable(f1WalkGVRa) {
+		t.Fatalf("F1: RefreshDiscovery (ticker path) disagrees with the prime; got servable=false")
+	}
+}
+
+// TestF1Walk_ConfirmResourceTypes_DedupsPerGV asserts the cost bound: two
+// GVRs sharing one group/version cost exactly ONE discovery round-trip for
+// that GV, and a GVR in a second GV costs exactly one more.
+func TestF1Walk_ConfirmResourceTypes_DedupsPerGV(t *testing.T) {
+	rw := newF1WalkWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{
+		"walk.example/v1":  true,
+		"other.example/v1": true,
+	})
+	rw.SetDiscoveryClient(disco)
+
+	registerAndSync(t, rw, f1WalkGVRa)
+	registerAndSync(t, rw, f1WalkGVRb)
+	registerAndSync(t, rw, f1WalkGVRc)
+
+	rw.ConfirmResourceTypes(context.Background(), []schema.GroupVersionResource{
+		f1WalkGVRa, f1WalkGVRb, f1WalkGVRc,
+	})
+
+	if got := disco.callCount("walk.example/v1"); got != 1 {
+		t.Fatalf("cost bound: want exactly 1 discovery call for shared GV walk.example/v1, got %d", got)
+	}
+	if got := disco.callCount("other.example/v1"); got != 1 {
+		t.Fatalf("cost bound: want exactly 1 discovery call for other.example/v1, got %d", got)
+	}
+	// All three confirmed → all three servable.
+	for _, gvr := range []schema.GroupVersionResource{f1WalkGVRa, f1WalkGVRb, f1WalkGVRc} {
+		if !rw.IsServable(gvr) {
+			t.Fatalf("want %s servable after per-GV-deduped confirm; got false", gvr)
+		}
+	}
+}
+
+// TestF1Walk_ConfirmResourceTypes_Idempotent asserts no re-storm on a second
+// pass and that an UNregistered GVR in the set is a cheap no-op (no panic, no
+// spurious confirm).
+func TestF1Walk_ConfirmResourceTypes_Idempotent(t *testing.T) {
+	rw := newF1WalkWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
+	rw.SetDiscoveryClient(disco)
+
+	registerAndSync(t, rw, f1WalkGVRa)
+
+	set := []schema.GroupVersionResource{f1WalkGVRa, f1WalkGVRb /* NOT registered */}
+	rw.ConfirmResourceTypes(context.Background(), set)
+	afterFirst := disco.callCount("walk.example/v1")
+
+	rw.ConfirmResourceTypes(context.Background(), set)
+	afterSecond := disco.callCount("walk.example/v1")
+
+	// A second pass DOES query discovery again (it must re-verify a possibly-
+	// retracted type) but it is ONE call per GV per pass — not a storm.
+	if afterSecond-afterFirst != 1 {
+		t.Fatalf("idempotent: second pass should add exactly 1 discovery call for the GV, "+
+			"got delta=%d (first=%d second=%d)", afterSecond-afterFirst, afterFirst, afterSecond)
+	}
+	// The registered GVR stays servable; the unregistered one never becomes
+	// servable (no informer to serve from) — no spurious confirm resurrected.
+	if !rw.IsServable(f1WalkGVRa) {
+		t.Fatalf("idempotent: registered GVR must stay servable across double-confirm")
+	}
+	if rw.IsServable(f1WalkGVRb) {
+		t.Fatalf("idempotent: unregistered GVR must NOT be servable (no informer); got true")
+	}
+}
+
+// TestF1Walk_ConfirmResourceTypes_Race is the concurrency falsifier. The
+// walk's ConfirmResourceTypes writes rw.confirmed / rw.watchBroken /
+// rw.lastSyncRV under rw.mu — the SAME maps the discovery-refresh ticker
+// (RefreshDiscovery) and the scoped ConfirmResourceType write. This drives
+// all three concurrently against a shared GVR set (K>1 confirmers × the
+// ticker × concurrent registration) so -race flags any unsynchronised map
+// access. Degenerate single-goroutine shapes would not exercise the
+// map-under-lock contention this fix introduces.
+func TestF1Walk_ConfirmResourceTypes_Race(t *testing.T) {
+	rw := newF1WalkWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{
+		"walk.example/v1":  true,
+		"other.example/v1": true,
+	})
+	rw.SetDiscoveryClient(disco)
+
+	gvrs := []schema.GroupVersionResource{f1WalkGVRa, f1WalkGVRb, f1WalkGVRc}
+	for _, gvr := range gvrs {
+		registerAndSync(t, rw, gvr)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	// K>1 concurrent walk-confirmers over the shared set.
+	for k := 0; k < 4; k++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				rw.ConfirmResourceTypes(ctx, gvrs)
+			}
+		}()
+	}
+	// The ticker path, racing the same maps.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 25; i++ {
+			rw.RefreshDiscovery(ctx)
+		}
+	}()
+	// The scoped single-GVR confirm, racing the same maps.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 25; i++ {
+			rw.ConfirmResourceType(ctx, f1WalkGVRa)
+		}
+	}()
+	wg.Wait()
+
+	// Convergent verdict: all three GVRs confirmed → servable.
+	for _, gvr := range gvrs {
+		if !rw.IsServable(gvr) {
+			t.Fatalf("post-race: %s must be servable; got false (snap=%+v)", gvr, rw.ServabilitySnapshotFor(gvr))
+		}
+	}
+}
+
+// TestF1Walk_ConfirmResourceTypes_OfflineDegrade asserts the degraded path:
+// with NO discovery client wired, ConfirmResourceTypes issues zero discovery
+// calls and conjunct 4 degrades to true (HasSynced-only), so the GVR is
+// servable — the pre-0.30.98 behaviour is preserved, not broken.
+func TestF1Walk_ConfirmResourceTypes_OfflineDegrade(t *testing.T) {
+	rw := newF1WalkWatcher(t)
+	// NO SetDiscoveryClient — disco stays nil (offline).
+
+	registerAndSync(t, rw, f1WalkGVRa)
+
+	// Should not panic and should be a no-op w.r.t. discovery.
+	rw.ConfirmResourceTypes(context.Background(), []schema.GroupVersionResource{f1WalkGVRa})
+
+	// Degraded-true: conjunct 4 returns true when disco==nil, so a
+	// registered+synced GVR is servable.
+	if !rw.IsServable(f1WalkGVRa) {
+		t.Fatalf("offline degrade: registered+synced GVR must be servable with no discovery client "+
+			"(conjunct 4 degraded-true); got false (snap=%+v)", rw.ServabilitySnapshotFor(f1WalkGVRa))
+	}
+}


### PR DESCRIPTION
## #130 F1 — informer-serve alive at boot for discovery-walk GVRs

**PARKED: Diego-reserved merge. Do not merge without Diego's call.**

Reviewer checkout recipe (avoid diffing stale local siblings):
```
git fetch origin feat/130-f1-walk-confirm-prime && git checkout FETCH_HEAD
```

### Root cause (TRACED, 1.7.3 serve_miss, pod snowplow-69bb955946-q8t9f)
Every serve_miss across ~30 walk-registered GVRs showed `registered:true hasSynced:true watchHealthy:true typeConfirmed:FALSE` — conjunct 4 was the sole universal blocker. Walk-registered GVRs waited a full 30s discovery-refresh ticker to become servable, so the first LIST fell through to a live paged LIST instead of the informer-serve branch. `informer_served:8` later in boot proved serve works once confirmed.

### Fix (wiring change)
The discovery-walk register path (`PrewarmRegisterFromNavigation`) never primed conjunct-4. After the register loop, it now primes ONE scoped confirm over exactly the walk-registered set via new `ConfirmResourceTypes` — the plural sibling of the #50 1b scoped `ConfirmResourceType`, reusing `RefreshDiscovery`'s exact `applyConfirmLocked` body (no forked predicate) with **per-GV dedup** (one `ServerResourcesForGroupVersion` per distinct group/version, off the lock, ctx-bounded). Mirrors the `informer_dispatch` Gate-6 prime, at the walk boundary.

- No special-cases; uniform over the walk-registered set (RBAC bootstrap already confirmed by the startup prime).
- Offline (`disco==nil`) degrade preserved.
- Idempotent; N2 informer re-read under the write lock.

### Scope
F1 = the walk's confirm-wiring ONLY. **NOT in this PR** (separate F2): `withContentPrewarmSAContext` lacks the serve-watcher ctx, so content.prewarm LISTs can't take the serve branch even when confirmed.

### Falsifiers (-race -count=1, 3x green; full internal/cache suite 3x green)
- `TestPrewarmRegisterFromNavigation_PrimesConfirm` — end-to-end wiring. **RED** (wiring disabled) reproduces the exact 1.7.3 state `{Registered:true HasSynced:true WatchHealthy:true TypeConfirmed:false}` → not servable; **GREEN** with the prime. Hardened (architect N1): 60s ctx + `ctx.Err()` guard so a starvation-timeout fails loud rather than impersonating the symptom.
- `TestF1Walk_ConfirmPrimed_ServableWithoutTicker` (+embedded RED control), `_DedupsPerGV` (cost bound), `_Idempotent` (no storm; unregistered=no-op), `_OfflineDegrade`, `_Race` (K=4 confirmers × ticker × scoped confirm, -race clean).

Falsifier artifact: `/tmp/snowplow-runs/130-f1/falsifier-RED-GREEN.txt`

### Dual review gate (frozen SHA)
- **Architect: SOUND-WITH-NOTES** — batch approach ruled sound and PREFERRED over the literal per-GVR shape (which would break the cost bound); all secondary checks pass (sync-timing, no-special-cases, offline-degrade, N2, F2-untouched). N1 (falsifier ctx fragility) applied.
- **PM: PASS** — reproduced the RED independently (exact 1.7.3 snapshot); all 6 falsifiers ran; admissible servability-gate assertions.

### On-deploy falsifier (TESTER, post-merge — not in this PR)
`paged_list.completed` benchapps 4→0, `informer_served` >> 8, serve_miss typeConfirmed lines vanish for walk GVRs, content.prewarm elapsed drops from ~90s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1