### PR TITLE
#130 F1b — confirm-prime on the lazy-register production seam + PREWARM_REGISTER implicit-on (1.7.5) [PARKED — Diego-reserved merge]

### DIFF
--- a/internal/cache/lazy_register_confirm_prime_f1b_test.go
+++ b/internal/cache/lazy_register_confirm_prime_f1b_test.go
@@ -1,0 +1,330 @@
+// lazy_register_confirm_prime_f1b_test.go — #130 F1b falsifiers.
+//
+// FIX under test: the LAZY-REGISTER production seam — EnsureResourceType /
+// EnsureResourceTypeMetadataOnly (watcher.go) — now primes ONE scoped
+// conjunct-4 confirm (ConfirmResourceType, async, off the register lock) for
+// every GVR it lazily registers, so the GVR becomes IsServable (all four
+// conjuncts true) within one discovery round-trip instead of latching
+// typeConfirmed:false and falling through to a live LIST.
+//
+// # Why F1b (the REACHABILITY close — the twice-learned lesson)
+//
+// F1 (1.7.4) wired the approved confirm-prime onto the discovery-walk register
+// path (PrewarmRegisterFromNavigation), gated behind PREWARM_REGISTER_ENABLED
+// (default OFF). Under the DEPLOYED default config that walk never runs, so
+// F1's on-deploy deltas were all zero — the mechanism was runtime-INERT. The
+// registration path the default binary ACTUALLY runs is lazy registration via
+// EnsureResourceType, reached from the dispatch seams with NO env flag on the
+// chain. F1b primes confirm THERE.
+//
+// # THE headline arm: F-reachable
+//
+// TestF1b_LazyRegister_PrimesConfirm_NoFlagNoDirectCall drives the
+// default-config entry path end-to-end: EnsureResourceType (the exact call the
+// dispatch seams make) with NO env flags set and NO direct call to any Confirm*
+// function → asserts typeConfirmed flips true and the GVR becomes servable. The
+// RED control (unwire the two primeConfirmAsyncLocked call sites in
+// watcher.go's EnsureResourceType success paths) makes this SAME flow show the
+// conjunct-4 snapshot {Registered:true HasSynced:true WatchHealthy:true
+// TypeConfirmed:FALSE} — reproduced-and-caught by the assertion below. The RED
+// was captured before ship (see docs falsifier artifact).
+//
+// # Other arms
+//
+//   - F-skip-guard: same-GV sibling registrations after a confirmed GV do not
+//     re-storm discovery beyond one call per distinct GVR-first-registration;
+//     a re-EnsureResourceType of an already-confirmed GVR issues ZERO calls.
+//   - F-no-stall (-race, K>1): concurrent EnsureResourceType + dispatch-style
+//     reads + the ticker over a shared GVR set stay -race clean and never
+//     deadlock/serialise on the discovery call (the prime is async, off-lock).
+//   - F-offline-degrade: with no discovery client, lazy register issues ZERO
+//     discovery calls and IsServable stays degraded-true — offline preserved.
+//
+// Per feedback_no_special_cases.md: every GVR is a generic customer-style CRD
+// GVR; the prime is uniform, no per-GVR carve-out.
+//
+// All -race -count=1, 3×.
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// f1b GVRs reuse the walk.example / other.example scheme kinds registered by
+// f1WalkListKinds (walk_confirm_prime_f1_test.go, same package) so the fake
+// dynamic client can decode the informer initial LISTs.
+var (
+	f1bGVRa = f1WalkGVRa // walk.example/v1 alphas
+	f1bGVRb = f1WalkGVRb // walk.example/v1 betas  (SAME GV as a — sibling)
+	f1bGVRc = f1WalkGVRc // other.example/v1 gammas (distinct GV)
+)
+
+func newF1bWatcher(t *testing.T) *cache.ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		f1WalkScheme(), f1WalkListKinds())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	if rw == nil {
+		t.Fatalf("expected non-nil watcher under CACHE_ENABLED=true")
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	return rw
+}
+
+// ensureAndSync registers gvr via EnsureResourceType (the EXACT call the
+// dispatch seams make — no flag, no direct Confirm* call) and blocks until its
+// informer's initial LIST reconciles (HasSynced).
+func ensureAndSync(t *testing.T, rw *cache.ResourceWatcher, gvr schema.GroupVersionResource) {
+	t.Helper()
+	added, syncCh := rw.EnsureResourceType(gvr)
+	if !added {
+		t.Fatalf("EnsureResourceType(%s): want added=true (first lazy register)", gvr)
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("informer for %s did not sync within 5s", gvr)
+	}
+}
+
+// waitServable polls IsServable until true or timeout — the async confirm prime
+// lands on a watcher goroutine after EnsureResourceType returns, so servability
+// is eventually-consistent (bounded by one discovery round-trip). A timeout
+// here IS the RED signal: the GVR latched typeConfirmed:false.
+func waitServable(t *testing.T, rw *cache.ResourceWatcher, gvr schema.GroupVersionResource, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if rw.IsServable(gvr) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return rw.IsServable(gvr)
+}
+
+// TestF1b_LazyRegister_PrimesConfirm_NoFlagNoDirectCall is THE reachability
+// falsifier. It drives ONLY the default-config lazy-register call —
+// EnsureResourceType — with NO env flags and NO direct Confirm* call, and
+// asserts the GVR becomes servable (conjunct 4 typeConfirmed flips true).
+//
+// RED control (documented + captured pre-ship): comment out the two
+// rw.primeConfirmAsyncLocked(gvr) call sites in EnsureResourceType's success
+// paths → this test fails with the exact latched snapshot
+// {Registered:true HasSynced:true WatchHealthy:true TypeConfirmed:false} and a
+// servability timeout — the 1.7.3/1.7.4 boot readout reproduced.
+func TestF1b_LazyRegister_PrimesConfirm_NoFlagNoDirectCall(t *testing.T) {
+	rw := newF1bWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
+	rw.SetDiscoveryClient(disco)
+
+	// The ONLY registration action — the default-config seam. No flag, no
+	// PrewarmRegisterFromNavigation, no direct ConfirmResourceType(s) call.
+	ensureAndSync(t, rw, f1bGVRa)
+
+	// The async prime lands within one discovery round-trip. Poll for it.
+	if !waitServable(t, rw, f1bGVRa, 3*time.Second) {
+		snap := rw.ServabilitySnapshotFor(f1bGVRa)
+		t.Fatalf("F-reachable: a lazily-registered synced GVR MUST become servable via the "+
+			"auto-prime with NO flag and NO direct Confirm* call; it did not — this is the "+
+			"1.7.3/1.7.4 latched-false readout reproduced. snap=%+v "+
+			"(RED control: this is exactly what unwiring primeConfirmAsyncLocked yields)", snap)
+	}
+
+	// Prove the conjunct that moved is conjunct 4 (typeConfirmed), and the
+	// other three held all along (so the fix addressed the SOLE blocker).
+	snap := rw.ServabilitySnapshotFor(f1bGVRa)
+	if !snap.Registered || !snap.HasSynced || !snap.WatchHealthy || !snap.TypeConfirmed {
+		t.Fatalf("F-reachable: want all four conjuncts true after auto-prime; got %+v", snap)
+	}
+
+	// Exactly one discovery call for the GV — the prime is a single round-trip,
+	// not a storm.
+	if got := disco.callCount("walk.example/v1"); got != 1 {
+		t.Fatalf("F-reachable cost: want exactly 1 discovery round-trip for the auto-prime; got %d", got)
+	}
+}
+
+// TestF1b_LazyRegister_MetadataOnlyPath_PrimesConfirm asserts the SAME
+// auto-prime fires on the metadata-only registration success path
+// (EnsureResourceTypeMetadataOnly). Reachability must hold on BOTH lazy-register
+// success branches, not just the full-unstructured one.
+func TestF1b_LazyRegister_MetadataOnlyPath_PrimesConfirm(t *testing.T) {
+	rw := newF1bWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
+	rw.SetDiscoveryClient(disco)
+
+	added, syncCh := rw.EnsureResourceTypeMetadataOnly(f1bGVRa)
+	if !added {
+		// No metadata client wired in this harness → the metadata-only entry
+		// returns (false,nil) by contract; skip rather than assert a false
+		// negative. The full-unstructured arm above is the load-bearing one;
+		// this arm documents the wiring exists on the metadata branch too and
+		// runs meaningfully once a metaClient is present.
+		t.Skip("metadata-only entry returned added=false (no metaClient wired in this harness); " +
+			"full-unstructured reachability arm covers the prime")
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("metadata-only informer for %s did not sync within 5s", f1bGVRa)
+	}
+	if !waitServable(t, rw, f1bGVRa, 3*time.Second) {
+		t.Fatalf("F-reachable (metadata-only): lazily-registered synced GVR must become servable "+
+			"via the auto-prime; snap=%+v", rw.ServabilitySnapshotFor(f1bGVRa))
+	}
+}
+
+// TestF1b_SkipGuard_ReEnsureConfirmedGVR_ZeroDiscovery asserts the
+// skip-if-already-confirmed guard: once a GVR is confirmed, a repeat
+// EnsureResourceType (dispatch singleflight hit) issues ZERO additional
+// discovery calls. It also shows a same-GV SIBLING (betas, same walk.example/v1
+// as alphas) costs its own single first-register discovery call — the guard is
+// per-GVR-lifetime, bounding lazy-register confirm cost.
+func TestF1b_SkipGuard_ReEnsureConfirmedGVR_ZeroDiscovery(t *testing.T) {
+	rw := newF1bWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
+	rw.SetDiscoveryClient(disco)
+
+	// First register + confirm alphas.
+	ensureAndSync(t, rw, f1bGVRa)
+	if !waitServable(t, rw, f1bGVRa, 3*time.Second) {
+		t.Fatalf("setup: alphas must be servable after first register auto-prime; snap=%+v",
+			rw.ServabilitySnapshotFor(f1bGVRa))
+	}
+	afterA := disco.callCount("walk.example/v1")
+	if afterA != 1 {
+		t.Fatalf("setup: want exactly 1 discovery call after alphas first register; got %d", afterA)
+	}
+
+	// Re-EnsureResourceType(alphas) — a dispatch singleflight HIT (added=false).
+	// The prime is on the added=true success path only; a hit never reaches
+	// primeConfirmAsyncLocked. Belt-and-suspenders: even if it did, the
+	// skip-if-already-confirmed guard would short-circuit before any discovery
+	// call. Assert ZERO additional calls either way.
+	for i := 0; i < 5; i++ {
+		added, _ := rw.EnsureResourceType(f1bGVRa)
+		if added {
+			t.Fatalf("re-EnsureResourceType(alphas): want added=false (singleflight hit); got true")
+		}
+	}
+	// Give any (erroneous) async prime a chance to fire, then assert no growth.
+	time.Sleep(200 * time.Millisecond)
+	if got := disco.callCount("walk.example/v1"); got != afterA {
+		t.Fatalf("F-skip-guard: re-registering an already-confirmed GVR must issue ZERO additional "+
+			"discovery calls; grew %d -> %d", afterA, got)
+	}
+
+	// A same-GV SIBLING first-registration (betas) is a distinct GVR-lifetime:
+	// it pays its own single discovery round-trip (the guard is per-GVR, and the
+	// bound is one round-trip per distinct first-register).
+	ensureAndSync(t, rw, f1bGVRb)
+	if !waitServable(t, rw, f1bGVRb, 3*time.Second) {
+		t.Fatalf("betas must be servable after its first register auto-prime; snap=%+v",
+			rw.ServabilitySnapshotFor(f1bGVRb))
+	}
+	if got := disco.callCount("walk.example/v1"); got != afterA+1 {
+		t.Fatalf("F-skip-guard sibling: betas first-register should add exactly 1 discovery call; "+
+			"got %d (was %d)", got, afterA)
+	}
+}
+
+// TestF1b_LazyRegister_Race is the -race / no-stall / no-deadlock falsifier.
+// It drives K>1 concurrent lazy registrations (distinct GVRs) racing the ticker
+// (RefreshDiscovery) and dispatch-style servability reads over the shared
+// confirm maps. The prime is ASYNC + off the register lock, so a concurrent
+// register must never block on another register's discovery call, and the maps
+// (rw.confirmed / rw.watchBroken / rw.lastSyncRV) must stay -race clean.
+//
+// K>1 and M>1 (feedback_falsifier_shape_must_discriminate): 4 concurrent
+// registrants × repeated ticker/reads over a multi-GVR, multi-GV set. A
+// degenerate K=1 shape would not exercise the register-vs-register + register-
+// vs-ticker map contention this fix introduces.
+func TestF1b_LazyRegister_Race(t *testing.T) {
+	rw := newF1bWatcher(t)
+	disco := newCountingDiscovery(map[string]bool{
+		"walk.example/v1":  true,
+		"other.example/v1": true,
+	})
+	rw.SetDiscoveryClient(disco)
+
+	gvrs := []schema.GroupVersionResource{f1bGVRa, f1bGVRb, f1bGVRc}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	// K>1 concurrent registrants each hammering EnsureResourceType over the
+	// shared set — the first per-GVR wins added=true and spawns the async prime;
+	// the rest are singleflight hits. No registrant may stall on another's prime.
+	for k := 0; k < 4; k++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				for _, gvr := range gvrs {
+					rw.EnsureResourceType(gvr)
+				}
+			}
+		}()
+	}
+	// Ticker path racing the same confirm maps.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 25; i++ {
+			rw.RefreshDiscovery(ctx)
+		}
+	}()
+	// Dispatch-style servability reads racing the writers.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			for _, gvr := range gvrs {
+				_ = rw.IsServable(gvr)
+			}
+		}
+	}()
+	wg.Wait()
+
+	// Convergent verdict: every GVR ends up servable (registered+synced+confirmed).
+	for _, gvr := range gvrs {
+		if !waitServable(t, rw, gvr, 3*time.Second) {
+			t.Fatalf("post-race: %s must be servable; snap=%+v", gvr, rw.ServabilitySnapshotFor(gvr))
+		}
+	}
+}
+
+// TestF1b_LazyRegister_OfflineDegrade asserts the degraded path: with NO
+// discovery client wired, lazy register issues ZERO discovery calls (the prime
+// short-circuits on disco==nil) and conjunct 4 degrades to true, so the GVR is
+// servable — the offline behaviour is preserved, not broken.
+func TestF1b_LazyRegister_OfflineDegrade(t *testing.T) {
+	rw := newF1bWatcher(t)
+	// NO SetDiscoveryClient — disco stays nil (offline).
+
+	ensureAndSync(t, rw, f1bGVRa)
+
+	// Degraded-true: conjunct 4 returns true when disco==nil, so a
+	// registered+synced GVR is servable with no prime work at all.
+	if !waitServable(t, rw, f1bGVRa, 2*time.Second) {
+		t.Fatalf("offline degrade: registered+synced GVR must be servable with no discovery client "+
+			"(conjunct 4 degraded-true); snap=%+v", rw.ServabilitySnapshotFor(f1bGVRa))
+	}
+}

--- a/internal/cache/prewarm.go
+++ b/internal/cache/prewarm.go
@@ -25,47 +25,44 @@
 // place (the same anchor the inventory walker already uses) — that is
 // the bare meta-query seed, not a per-resource policy.
 //
-// GATED DEFAULT-OFF — PREWARM_REGISTER_ENABLED (main.go). This walk does
-// NOT run unless PREWARM_REGISTER_ENABLED=true. The gate exists because
-// a startup GVR-walk RE-ARMS multiple documented regressions while the
-// pivot consumer is off:
+// IMPLICIT-ON under CACHE_ENABLED (#130 1.7.5) — resolved by
+// resolvePrewarmRegisterDefault (main.go): the walk runs by default
+// whenever the cache subsystem is on; only an explicit
+// PREWARM_REGISTER_ENABLED=false opts out. This inverts the pre-1.7.5
+// default-OFF gate. The inversion is safe because the historical
+// default-OFF rationale was TRACED to be inaccurate:
 //
-//   - No-consumer apiserver pressure (0.30.6 / 0.30.61). When the
-//     resolver pivot is inactive (historically RESOLVER_USE_INFORMER OFF;
-//     post-#57 the pivot is implicit-on-cache, so "inactive" == cache
-//     off) the resolver pivot does not read from these informers. Each
-//     EnsureResourceType the walk fires
-//     lands in the post-Start late-registration branch and immediately
-//     spawns a LIST+WATCH against the apiserver — N informers nobody
-//     reads. The 0.30.61 feature-journal entry recorded exactly this:
-//     "no consumer reads from the eagerly-registered informers ...
-//     eager-register = pure apiserver overhead", and that is why
-//     EAGER_REGISTER_ENABLED was reverted to default-OFF.
+//   - The walk registers ONLY the STATIC (non-JQ-templated) inventory
+//     GVR subset. CollectResourceTypesFromRestActions derives GVRs from
+//     spec.api[*].path via ParseAPIServerPathToGVR, which REJECTS any
+//     path carrying an unresolved `${...}` JQ template (inventory.go:171).
+//     Every composition.krateo.io path is JQ-templated, so the walk
+//     CANNOT register composition GVRs — the walk's set is the trivial
+//     static/CRD-meta class, NOT the "same 58 GVRs" earlier comments
+//     claimed. (The lazy dispatch path evaluates the JQ and derives the
+//     composition GVR at request time; the eager walk cannot.)
 //
-//   - OOM-at-50K (0.30.8 rev 104, 0.30.92), UNMITIGATED. Composition
-//     GVRs (~50K objects at production scale) take the FULL-Unstructured
-//     informer, not the §0.30.93 metadata-only PartialObjectMetadata
-//     path: `metadataOnlyGVRSeed` is empty (`[]gvrPattern{}`) and
-//     customer core-provider CRDs are not annotated
-//     `krateo.io/cache-mode: metadata`, so `shouldUseMetadataOnly`
-//     returns false for them. A startup walk that registers those GVRs
-//     up front incurs the same RSS burst the OOM post-mortems recorded.
+//   - OOM-at-50K is NOT re-armed by this flag. The composition informers
+//     (the OOM-relevant mass) are registered LAZILY via the resolver
+//     inner-call DiscoverGroupResources / EnsureResourceType hook
+//     (resolve.go) REGARDLESS of PREWARM_REGISTER_ENABLED. Flipping this
+//     flag neither adds nor removes composition informers, so it does not
+//     touch the 0.30.8/0.30.92 RSS surface at all.
+//
+//   - The 0.30.6/0.30.61 "no consumer reads the eagerly-registered
+//     informers = pure apiserver overhead" note is OBSOLETE. Consumers
+//     now exist: the #130 F1 confirm-prime batch (below) makes the
+//     walk-registered GVRs conjunct-4 servable, the informer-serve branch
+//     reads them, and the Phase 1 seed replays navigation against them
+//     (#57: the pivot is implicit-on-cache; there is no separate
+//     RESOLVER_USE_INFORMER flag).
 //
 // FIRE-AND-FORGET (the distinction from EagerRegisterAll): the walk
 // calls EnsureResourceType per GVR and returns immediately — it does NOT
 // WaitForCacheSync over the inventory. Each informer's initial LIST runs
 // asynchronously on its own goroutine (the standard EnsureResourceType
-// late-registration branch). So the walk does not add the blocking
-// bulk-sync startup-latency burst EagerRegisterAll has — but
-// fire-and-forget removes ONLY the blocking-sync mode; it does NOT
-// remove the no-consumer apiserver-QPS or the OOM modes above. That is
-// why the gate, not fire-and-forget alone, is the safety mechanism.
-//
-// Promotion to default-ON requires a PREWARM_REGISTER_ENABLED=true bench
-// at 50K scale measuring apiserver QPS + RSS-under-load, run with the
-// cache subsystem on (CACHE_ENABLED=true) so the resolver pivot consumer
-// is actually present (#57: the pivot is implicit-on-cache — there is no
-// longer a separate RESOLVER_USE_INFORMER flag to set).
+// late-registration branch), so the walk adds no blocking bulk-sync
+// startup-latency burst.
 
 package cache
 

--- a/internal/cache/stale_delete_heal_dep_falsifier_test.go
+++ b/internal/cache/stale_delete_heal_dep_falsifier_test.go
@@ -283,14 +283,20 @@ func TestFalsifierHealB_PreFixControl_NotServableNoEviction(t *testing.T) {
 		rw.Stop()
 		time.Sleep(50 * time.Millisecond)
 	})
-	rw.SetDiscoveryClient(healBDiscovery{})
-
+	// #130 F1b: register BEFORE wiring the discovery client so the
+	// lazy-register auto-prime short-circuits (disco==nil guard) and the
+	// "registered + synced but UNCONFIRMED" pre-fix control below is
+	// establishable by hand. This arm NEVER calls ConfirmResourceType — its
+	// whole point is that the latch persists without a confirm — so the
+	// auto-prime, which would confirm it, must be prevented from running by the
+	// disco==nil-at-register condition.
 	_, syncCh := rw.EnsureResourceType(healBSecretsGVR)
 	select {
 	case <-syncCh:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("informer did not sync within 5s")
 	}
+	rw.SetDiscoveryClient(healBDiscovery{})
 
 	// PRE-FIX: do NOT call ConfirmResourceType. The GVR is registered +
 	// synced but UNCONFIRMED → not-servable (the latched state).

--- a/internal/cache/stale_delete_heal_falsifier_test.go
+++ b/internal/cache/stale_delete_heal_falsifier_test.go
@@ -125,9 +125,17 @@ func TestFalsifierHealA_ScopedConfirmMatchesRefreshDiscovery(t *testing.T) {
 	// type ("apps/v1"). A scoped confirm of secrets must confirm secrets
 	// and leave deployments unconfirmed.
 	disco := &fakeDiscovery{served: map[string]bool{"v1": true}}
-	rw.SetDiscoveryClient(disco)
 
-	// Register + sync both informers.
+	// #130 F1b: register the informers with NO discovery client wired so the
+	// lazy-register auto-prime (primeConfirmAsyncLocked) short-circuits on its
+	// disco==nil guard — this test needs to establish the "registered + synced
+	// but UNCONFIRMED" latched pre-state by hand, which the auto-prime would
+	// otherwise dissolve. The discovery client is wired AFTER registration so
+	// the SCOPED ConfirmResourceType this test exercises is the ONLY confirm
+	// path that runs. (feedback_no_shortcuts_or_workarounds: this is not a
+	// bypass of the fix — it is the correct way to set up a negative control
+	// for a helper the fix now also auto-invokes; the fix's own reachability is
+	// proven in lazy_register_confirm_prime_f1b_test.go.)
 	for _, gvr := range []schema.GroupVersionResource{servableTestGVR, healSecondGVR} {
 		added, syncCh := rw.EnsureResourceType(gvr)
 		if !added {
@@ -139,6 +147,7 @@ func TestFalsifierHealA_ScopedConfirmMatchesRefreshDiscovery(t *testing.T) {
 			t.Fatalf("EnsureResourceType(%s): informer did not sync within 5s", gvr)
 		}
 	}
+	rw.SetDiscoveryClient(disco)
 
 	// PRE: neither GVR is confirmed yet (no RefreshDiscovery pass run), so
 	// both are not-servable — the latched state the content cache shields.
@@ -353,8 +362,12 @@ func TestFalsifierHealC_LatchedNotServableHealsOnConfirm(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	})
 	disco := &fakeDiscovery{served: map[string]bool{"v1": true}}
-	rw.SetDiscoveryClient(disco)
 
+	// #130 F1b: register with NO discovery client wired so the lazy-register
+	// auto-prime short-circuits (disco==nil guard) and this test can establish
+	// the "registered + synced but UNCONFIRMED" latched control by hand; wire
+	// the discovery client AFTER register so the scoped ConfirmResourceType
+	// below is the only confirm that runs.
 	added, syncCh := rw.EnsureResourceType(servableTestGVR)
 	if !added {
 		t.Fatalf("EnsureResourceType: want added=true")
@@ -364,6 +377,7 @@ func TestFalsifierHealC_LatchedNotServableHealsOnConfirm(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("informer did not sync within 5s")
 	}
+	rw.SetDiscoveryClient(disco)
 
 	// BEFORE: registered + synced but unconfirmed -> not-servable. This is
 	// the exact latch the content cache shields permanently pre-fix.

--- a/internal/cache/walk_confirm_prime_f1_test.go
+++ b/internal/cache/walk_confirm_prime_f1_test.go
@@ -162,9 +162,17 @@ func registerAndSync(t *testing.T, rw *cache.ResourceWatcher, gvr schema.GroupVe
 func TestF1Walk_ConfirmPrimed_ServableWithoutTicker(t *testing.T) {
 	rw := newF1WalkWatcher(t)
 	disco := newCountingDiscovery(map[string]bool{"walk.example/v1": true})
-	rw.SetDiscoveryClient(disco)
 
+	// #130 F1b: register with NO discovery client wired so the lazy-register
+	// auto-prime short-circuits (disco==nil guard) — this test's negative
+	// control is "registered+synced but UNCONFIRMED ⇒ not-servable", which the
+	// auto-prime would otherwise dissolve. Wire discovery AFTER register so the
+	// walk-path ConfirmResourceTypes below is the ONLY confirm that runs. (The
+	// F1b auto-prime's own reachability is proven in
+	// lazy_register_confirm_prime_f1b_test.go; this arm still guards F1's
+	// walk-path batch confirm.)
 	registerAndSync(t, rw, f1WalkGVRa)
+	rw.SetDiscoveryClient(disco)
 
 	// RED control: BEFORE any confirm, the GVR is registered + synced but
 	// NOT confirmed → not servable. This is exactly the 1.7.3 readout state.
@@ -205,11 +213,23 @@ func TestF1Walk_ConfirmResourceTypes_DedupsPerGV(t *testing.T) {
 		"walk.example/v1":  true,
 		"other.example/v1": true,
 	})
-	rw.SetDiscoveryClient(disco)
 
+	// #130 F1b: register the three GVRs with NO discovery client wired so the
+	// lazy-register auto-prime short-circuits (disco==nil guard) and issues
+	// ZERO discovery calls. This isolates the per-GV dedup contract of the
+	// walk-path ConfirmResourceTypes BATCH — the property this test exists to
+	// prove — from the per-GVR auto-prime (which has no per-GV dedup and would
+	// otherwise add same-GV calls, the got==3 the pre-rework test saw). Wire
+	// discovery AFTER register, then the batch below is the ONLY discovery
+	// caller, so its per-GV dedup is asserted cleanly: a==b share
+	// walk.example/v1 ⇒ exactly ONE call for that GV; c is other.example/v1 ⇒
+	// exactly one more. (NOT a papering of the count to 3 — the batch really
+	// does dedup to 1/GV; the auto-prime's per-GVR cost is asserted separately
+	// in TestF1b_SkipGuard_ReEnsureConfirmedGVR_ZeroDiscovery.)
 	registerAndSync(t, rw, f1WalkGVRa)
 	registerAndSync(t, rw, f1WalkGVRb)
 	registerAndSync(t, rw, f1WalkGVRc)
+	rw.SetDiscoveryClient(disco)
 
 	rw.ConfirmResourceTypes(context.Background(), []schema.GroupVersionResource{
 		f1WalkGVRa, f1WalkGVRb, f1WalkGVRc,

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -677,6 +677,11 @@ func (rw *ResourceWatcher) EnsureResourceType(gvr schema.GroupVersionResource) (
 			slog.String("reason", metadataOnlyReason(gvr)),
 			slog.String("hint", "PartialObjectMetadata informer — ~10x smaller than full Unstructured; DepTracker preserved"),
 		)
+		// Fix #130 F1b: prime conjunct-4 (typeConfirmed) for the GVR this call
+		// just lazily registered so the NEXT dispatch serves from the informer
+		// rather than falling through to a live LIST. Async + skip-guarded; runs
+		// after this critical section releases rw.mu. See primeConfirmAsyncLocked.
+		rw.primeConfirmAsyncLocked(gvr)
 		return true, ch
 	}
 	// Soft-fail observability: if the predicate WOULD have routed
@@ -711,6 +716,14 @@ func (rw *ResourceWatcher) EnsureResourceType(gvr schema.GroupVersionResource) (
 		slog.String("path", "full-unstructured"),
 		slog.String("hint", "first resolver touch — informer registered + dep-tracker handlers wired"),
 	)
+
+	// Fix #130 F1b: prime conjunct-4 (typeConfirmed) for the GVR this call just
+	// lazily registered so the NEXT dispatch serves from the informer rather
+	// than falling through to a live LIST (the 23s benchapps 60K-item boot-walk
+	// fall-through the 1.7.3/1.7.4 serve_miss readout showed). Async +
+	// skip-guarded; runs after this critical section releases rw.mu. See
+	// primeConfirmAsyncLocked.
+	rw.primeConfirmAsyncLocked(gvr)
 
 	return true, ch
 }
@@ -898,6 +911,103 @@ func (rw *ResourceWatcher) addResourceTypeMetadataOnlyLocked(gvr schema.GroupVer
 		defer rw.goroutineWG.Done()
 		waitInformerSync(hasSynced, ch, stop)
 	}(gi.Informer().HasSynced)
+}
+
+// primeConfirmAsyncLocked schedules a one-shot conjunct-4 (typeConfirmed)
+// confirm-prime for a GVR that was JUST lazily registered by
+// EnsureResourceType / EnsureResourceTypeMetadataOnly. Callers MUST hold
+// rw.mu.Lock() (both EnsureResourceType success paths do, via their deferred
+// unlock).
+//
+// # Why this exists (Fix #130 F1b — the REACHABILITY close)
+//
+// F1 (1.7.4) wired the approved confirm-prime (ConfirmResourceTypes) onto the
+// discovery-walk register path (PrewarmRegisterFromNavigation) — but that walk
+// is gated behind PREWARM_REGISTER_ENABLED, default OFF, so under the DEPLOYED
+// default config it never runs and F1's on-deploy deltas were all zero. The
+// registration path the default binary ACTUALLY runs is lazy registration:
+// EnsureResourceType, reached from the dispatch seams (informer_dispatch.go,
+// internal_dispatch.go via the walk-era GVRs). The 1.7.3/1.7.4 boot logs showed
+// every lazily-registered GVR (incl. benchapps) latch
+// {Registered:true HasSynced:true WatchHealthy:true TypeConfirmed:false} and
+// fall through to the 23s live 60K LIST — conjunct 4 (typeConfirmed) was the
+// sole universal blocker of informer-serve at boot. Priming confirm HERE, at
+// the lazy-register success path, makes the F1 mechanism runtime-reachable with
+// NO env flag on the call chain. Precedent: the Gate-6 dispatch path already
+// primes ConfirmResourceType on ITS register (informer_dispatch.go, added &&
+// name==""); this generalises that prime to the register site itself so it is
+// independent of the dispatch's added/name gating.
+//
+// # Async, not sync (deadlock + no-stall — architect-settled)
+//
+// ConfirmResourceType issues a blocking discovery round-trip
+// (ServerResourcesForGroupVersion) and then RE-ACQUIRES rw.mu to write
+// rw.confirmed. Calling it inline here would (a) DEADLOCK — the caller holds
+// rw.mu.Lock() — and (b) even if the lock were re-entrant, serialise every
+// other dispatch behind a ~10ms network call held under the writer lock
+// (F-no-stall). So the prime is dispatched on a watcher-owned goroutine that
+// runs AFTER this critical section releases the lock. It uses a background
+// context (independent of the registering caller's request ctx, which may be
+// cancelled the instant the dispatch falls through) bounded by rw.stopCh so it
+// cannot outlive Stop().
+//
+// # Skip-if-already-confirmed guard (cost bound)
+//
+// The prime is skipped when gvr is ALREADY confirmed (rw.confirmed has the key)
+// — a re-registration of a confirmed GVR pays zero discovery calls. It is also
+// a no-op when no discovery client is wired (rw.disco == nil): conjunct 4 is
+// degraded-true in that mode (resourceTypeConfirmedLocked returns true), so
+// there is nothing to fetch — the offline degrade is preserved byte-identically.
+// Net cost bound: at most ONE discovery round-trip per GVR over the process
+// lifetime of lazy registration (a GVR registers-lazily once; a re-register
+// after CRD delete+recreate is the intended re-confirm, not waste).
+//
+// The FIRST dispatch after a lazy register is exactly the one we want to serve;
+// ~10ms of async discovery beats a 23s live-LIST fall-through, and because the
+// confirm runs off the register path's lock it never stalls unrelated
+// dispatches.
+func (rw *ResourceWatcher) primeConfirmAsyncLocked(gvr schema.GroupVersionResource) {
+	// Skip-guard 1 — offline degrade preserved: with no discovery client,
+	// conjunct 4 is degraded-true and there is nothing to confirm. Bail before
+	// spawning a goroutine that would immediately no-op inside ConfirmResourceType.
+	if rw.disco == nil {
+		return
+	}
+	// Skip-guard 2 — already confirmed: a re-registration of a GVR that is
+	// already conjunct-4 confirmed pays no discovery call. rw.confirmed may be
+	// nil (never allocated) — a nil-map read is a safe miss.
+	if _, ok := rw.confirmed[gvr]; ok {
+		return
+	}
+	// Respect shutdown ordering (Task #85): the stopRequestedLocked() check
+	// under rw.mu keeps goroutineWG.Add ordered before Stop's Wait, so we never
+	// Add after Stop has begun draining.
+	if rw.stopRequestedLocked() {
+		return
+	}
+	rw.goroutineWG.Add(1)
+	go func() {
+		defer rw.goroutineWG.Done()
+		// Background context: the registering caller's request ctx may be
+		// cancelled the moment its dispatch falls through, but the prime must
+		// still land so the NEXT dispatch of this GVR serves from the informer.
+		// ConfirmResourceType is itself ctx-cancel and passthrough/nil safe; it
+		// does the discovery call OFF rw.mu then re-locks to write rw.confirmed.
+		bgCtx := context.Background()
+		// Bound teardown: if Stop() has closed stopCh, abandon the prime rather
+		// than issue a discovery call against a client that may be tearing down.
+		select {
+		case <-rw.stopCh:
+			return
+		default:
+		}
+		rw.ConfirmResourceType(bgCtx, gvr)
+		slog.Info("cache.lazy_register.confirm_primed",
+			slog.String("subsystem", "cache"),
+			slog.String("gvr", gvr.String()),
+			slog.String("hint", "Fix #130 F1b — primed conjunct-4 typeConfirmed at the default-config lazy-register seam so the next dispatch serves from the informer instead of a live LIST fall-through"),
+		)
+	}()
 }
 
 // EnsureResourceTypeMetadataOnly is the explicit, signature-preserving

--- a/main.go
+++ b/main.go
@@ -666,45 +666,45 @@ func main() {
 						// gate in watcher.AddResourceType).
 						w.MarkEagerSet([]schema.GroupVersionResource{})
 
-						// 0.30.99 Tag B — startup navigation GVR-walk,
-						// gated behind PREWARM_REGISTER_ENABLED (default
-						// OFF, mirrors EAGER_REGISTER_ENABLED). Not in the
-						// chart configmap — absent ⇒ OFF, so Tag B is
-						// chart-change-free and behavior-neutral for
-						// production.
+						// 0.30.99 Tag B — startup navigation GVR-walk.
 						//
-						// Why default OFF (architect REJECT of default-on,
-						// adjudicated): when the resolver pivot is inactive
-						// (historically RESOLVER_USE_INFORMER OFF; post-#57
-						// the pivot is implicit-on-cache, so "inactive" ==
-						// cache off) the resolver pivot does NOT consume the
-						// informers a startup walk would register. A walk
-						// would register N informers nobody reads — each
-						// EnsureResourceType lands in the post-Start branch
-						// and immediately spawns a LIST+WATCH against
-						// apiserver. That is the exact "pure apiserver
-						// pressure, no consumer" regression the 0.30.6 /
-						// 0.30.61 post-mortems reverted (feature journal
-						// 0.30.61: "no consumer reads from the eagerly-
-						// registered informers ... eager-register = pure
-						// apiserver overhead"). The 0.30.8 (rev 104) and
-						// 0.30.92 OOM-at-50K modes are also unmitigated:
-						// composition GVRs route to the FULL-Unstructured
-						// informer because metadataOnlyGVRSeed is empty and
-						// customer core-provider CRDs are not annotated
-						// krateo.io/cache-mode: metadata.
+						// #130 1.7.5 — IMPLICIT-ON under CACHE_ENABLED. We are
+						// inside the !cache.Disabled() branch, so the cache
+						// subsystem is on and the walk now runs by DEFAULT here;
+						// only an explicit PREWARM_REGISTER_ENABLED=false opts
+						// out (emergency lever). This INVERTS the pre-1.7.5
+						// default-OFF gate. resolvePrewarmRegisterDefault encodes
+						// the contract (unset/"true"/other => ON, "false" => OFF)
+						// and is unit-tested. Not in the chart configmap: absent
+						// now means ON (was OFF).
 						//
-						// Promotion to ON-by-default requires a
-						// PREWARM_REGISTER_ENABLED=true bench at 50K
-						// measuring apiserver QPS + RSS-under-load, with the
-						// cache subsystem on (CACHE_ENABLED=true) so the
-						// pivot consumer is actually present (#57: the pivot
-						// is implicit-on-cache; no separate
-						// RESOLVER_USE_INFORMER flag to set).
-						if os.Getenv("PREWARM_REGISTER_ENABLED") == "true" {
-							log.Info("prewarm-register: enabled via PREWARM_REGISTER_ENABLED=true",
+						// Why implicit-on is safe (TRACED — supersedes the
+						// obsolete default-OFF "no-consumer QPS / OOM" rationale,
+						// which was falsified; the walk is NOT the "same 58 GVRs"):
+						//
+						//   - The walk registers ONLY the STATIC (non-JQ-templated)
+						//     inventory GVR subset. Every composition.krateo.io path
+						//     is JQ-templated and is REJECTED by the ${-guard in
+						//     ParseAPIServerPathToGVR (inventory.go:171) — so the
+						//     walk CANNOT register composition GVRs. Its incremental
+						//     footprint is the trivial static/CRD-meta GVR class.
+						//   - The composition informers (the OOM-relevant mass at
+						//     50K) are registered LAZILY via the
+						//     DiscoverGroupResources / EnsureResourceType hook on the
+						//     resolver inner-call path (resolve.go) REGARDLESS of
+						//     this flag. Flipping it neither adds nor removes them,
+						//     so it does not touch the 0.30.8/0.30.92 OOM surface.
+						//   - A consumer now EXISTS for the walk-registered
+						//     informers: the #130 F1 confirm-prime + the
+						//     informer-serve branch + the Phase 1 seed read them.
+						//     The 0.30.61 "no consumer reads the eagerly-registered
+						//     informers" regression the default-OFF gate guarded
+						//     against no longer applies (pivot is implicit-on-cache,
+						//     #57).
+						if resolvePrewarmRegisterDefault(os.Getenv("PREWARM_REGISTER_ENABLED")) {
+							log.Info("prewarm-register: enabled (implicit-on under CACHE_ENABLED; set PREWARM_REGISTER_ENABLED=false to opt out)",
 								slog.String("subsystem", "cache"),
-								slog.String("hint", "startup navigation GVR-walk active; opt-in only — costs apiserver QPS when the resolver pivot is inactive (cache off, #57)"),
+								slog.String("hint", "startup navigation GVR-walk active; registers the STATIC (non-${-templated) inventory GVR subset only — composition GVRs arrive lazily via the resolver DiscoverGroupResources hook regardless of this flag"),
 							)
 							// Soft failure: a LIST error is logged +
 							// ignored — the lazy register-on-navigation
@@ -725,9 +725,9 @@ func main() {
 									slog.Int("already_present", present))
 							}
 						} else {
-							log.Info("prewarm-register: disabled (default); set PREWARM_REGISTER_ENABLED=true to opt-in",
+							log.Info("prewarm-register: disabled via explicit PREWARM_REGISTER_ENABLED=false opt-out",
 								slog.String("subsystem", "cache"),
-								slog.String("rationale", "startup walk registers informers the pivot does not consume when the pivot is inactive (cache off, #57) — re-arms the 0.30.61 no-consumer apiserver-QPS regression + the unmitigated 0.30.8/0.30.92 OOM modes"),
+								slog.String("rationale", "explicit emergency opt-out (PREWARM_REGISTER_ENABLED=false); the walk registers only the static non-${-templated inventory GVR subset — composition informers still arrive lazily via the resolver DiscoverGroupResources hook, so this opt-out does NOT change the composition-informer footprint"),
 							)
 						}
 
@@ -1161,6 +1161,39 @@ func main() {
 // input → empty slice (subsystem-defined behavior: the per-
 // namespace Deployment + Endpoints watches stay inert; cluster-
 // scoped webhook watches still run).
+// resolvePrewarmRegisterDefault decides whether the startup navigation
+// GVR-walk (PrewarmRegisterFromNavigation) runs, from the raw
+// PREWARM_REGISTER_ENABLED env value.
+//
+// #130 1.7.5 — IMPLICIT-ON under CACHE_ENABLED. The walk is now enabled by
+// default whenever the cache subsystem is on; only an EXPLICIT
+// PREWARM_REGISTER_ENABLED=false opts out (emergency lever). This is the
+// inverse of the pre-1.7.5 default-OFF gate (== "true" to enable). Rationale
+// (TRACED, supersedes the obsolete "no-consumer QPS" note that justified
+// default-OFF):
+//
+//   - The walk registers ONLY the STATIC (non-JQ-templated) inventory GVR
+//     subset. JQ-templated apiserver paths — every composition.krateo.io path
+//     is one — are rejected by the `${`-guard in ParseAPIServerPathToGVR
+//     (inventory.go:171), so the walk CANNOT register composition GVRs. Its
+//     incremental footprint is bounded to the trivial static/CRD-meta class.
+//   - The composition informers (the OOM-relevant mass at 50K) are registered
+//     lazily via the DiscoverGroupResources / EnsureResourceType hook on the
+//     resolver inner-call path (resolve.go) REGARDLESS of this flag — flipping
+//     it neither adds nor removes them.
+//   - A consumer now DOES exist for the walk-registered informers: the #130 F1
+//     confirm-prime + the informer-serve branch + the Phase 1 seed all read
+//     them. The "walk registers informers nobody reads" regression the
+//     default-OFF gate guarded against no longer applies.
+//
+// Contract: only the exact string "false" disables. Empty (unset), "true", and
+// any other value all enable — an implicit-on lever with a single explicit
+// opt-out. CACHE-off unreachability is enforced by the CALLER (this resolves
+// only inside the !cache.Disabled() branch), not here.
+func resolvePrewarmRegisterDefault(raw string) bool {
+	return raw != "false"
+}
+
 func splitCommaList(s string) []string {
 	if s == "" {
 		return nil

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"net/http"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
 )
 
 // TestWriteTimeoutGuard locks the http.Server WriteTimeout at 300s.
@@ -36,5 +39,80 @@ func TestWriteTimeoutGuard(t *testing.T) {
 	srv := &http.Server{WriteTimeout: writeTimeout}
 	if srv.WriteTimeout != want {
 		t.Fatalf("http.Server.WriteTimeout = %v, want %v", srv.WriteTimeout, want)
+	}
+}
+
+// TestResolvePrewarmRegisterDefault pins the #130 1.7.5 implicit-on contract of
+// the PREWARM_REGISTER_ENABLED resolution: the startup navigation GVR-walk runs
+// by default; ONLY the exact string "false" opts out.
+//
+// This is the helper-level half of the C5 reachability gate. The composed
+// default-wiring arm (with cache.Disabled folded in) is
+// TestPrewarmWalkReachable_DefaultConfig below.
+func TestResolvePrewarmRegisterDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"unset (deployed default) => ON", "", true},
+		{"explicit false => OFF (emergency opt-out)", "false", false},
+		{"explicit true => ON", "true", true},
+		{"any other value => ON (implicit-on)", "1", true},
+		{"garbage => ON (only \"false\" disables)", "no", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolvePrewarmRegisterDefault(tc.raw); got != tc.want {
+				t.Fatalf("resolvePrewarmRegisterDefault(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrewarmWalkReachable_DefaultConfig is the C5 reachability arm — the one
+// that would have caught 1.7.4's inert F1. It reproduces main's EXACT composed
+// gate for the startup navigation GVR-walk:
+//
+//	if !cache.Disabled() {              // deployed default: CACHE_ENABLED=true
+//	    ...
+//	    if resolvePrewarmRegisterDefault(os.Getenv("PREWARM_REGISTER_ENABLED")) {
+//	        w.PrewarmRegisterFromNavigation(...)   // the walk (F1 batch confirm)
+//	    }
+//	}
+//
+// under the DEPLOYED DEFAULT environment (CACHE_ENABLED=true, no
+// PREWARM_REGISTER_ENABLED key set) and asserts the walk IS reached. The
+// pre-1.7.4 gate (`== "true"`) with no key set made this expression FALSE — the
+// F1 walk-batch confirm never ran on-deploy, the "inert F1" the ledger row is
+// still open on. This arm fails (RED) if the gate ever regresses to require an
+// explicit opt-in, i.e. it protects the reachability the whole 1.7.5 change
+// exists to establish.
+func TestPrewarmWalkReachable_DefaultConfig(t *testing.T) {
+	// Deployed default env: cache on, prewarm-register key ABSENT.
+	t.Setenv("CACHE_ENABLED", "true")
+	os.Unsetenv("PREWARM_REGISTER_ENABLED")
+
+	// main's outer guard: the walk lives inside the !cache.Disabled() branch.
+	if cache.Disabled() {
+		t.Fatalf("setup: CACHE_ENABLED=true must make cache.Disabled()==false (the walk's outer guard)")
+	}
+
+	// main's inner gate — the EXACT expression at main.go's walk site.
+	reached := !cache.Disabled() &&
+		resolvePrewarmRegisterDefault(os.Getenv("PREWARM_REGISTER_ENABLED"))
+
+	if !reached {
+		t.Fatalf("C5 reachability: under the DEPLOYED DEFAULT config (CACHE_ENABLED=true, " +
+			"PREWARM_REGISTER_ENABLED unset) main's composed gate MUST reach " +
+			"PrewarmRegisterFromNavigation — this is exactly the wiring 1.7.4 got wrong " +
+			"(gate was `== \"true\"`, key unset => walk never ran => F1 inert). Gate regressed.")
+	}
+
+	// Belt-and-suspenders: the explicit emergency opt-out still works and is the
+	// ONLY thing that suppresses the walk under cache-on.
+	t.Setenv("PREWARM_REGISTER_ENABLED", "false")
+	if !cache.Disabled() && resolvePrewarmRegisterDefault(os.Getenv("PREWARM_REGISTER_ENABLED")) {
+		t.Fatalf("C5: explicit PREWARM_REGISTER_ENABLED=false must suppress the walk even with cache on")
 	}
 }


### PR DESCRIPTION
**PARKED — Diego-reserved merge.** Frozen SHA `8b5163a`. Dual pre-commit gate (arch + PM) on this SHA; on-deploy falsifier + ledger close post-merge.

Gater checkout recipe (never a bare SHA):
```
git fetch origin f1b-lazy-register-confirm-prime && git checkout FETCH_HEAD
```

## What this closes
F1 (1.7.4) shipped the approved confirm-prime but wired it ONLY on `PrewarmRegisterFromNavigation`, gated behind `PREWARM_REGISTER_ENABLED` (default OFF) → the walk never ran on the deployed default config → F1 was runtime-INERT (on-deploy deltas all zero, F1 ledger row still open). The 1.7.3/1.7.4 boot logs show every lazily-registered GVR (incl. benchapps) latch `{Registered:true HasSynced:true WatchHealthy:true TypeConfirmed:false}` → 23s live 60K LIST fall-through. Conjunct 4 was the sole universal blocker.

## The change (disjoint file sets)
**F1b (`internal/cache/watcher.go`)** — `primeConfirmAsyncLocked`, called under `rw.mu.Lock()` from BOTH `EnsureResourceType` success paths. ASYNC (background ctx + goroutineWG + stopCh): inline would deadlock (ConfirmResourceType re-acquires rw.mu after a blocking discovery call) and stall unrelated dispatches under the writer lock. Skip-guards: `disco==nil` (offline degrade preserved), already-confirmed (re-register = 0 discovery), stopRequested. Cost: ≤1 discovery round-trip per distinct GVR over lazy-register lifetime.

**1.7.5 flag (`main.go` + `prewarm.go` docs)** — `PREWARM_REGISTER_ENABLED` is now IMPLICIT-ON under CACHE_ENABLED (`resolvePrewarmRegisterDefault`: only explicit `"false"` opts out), inverting the wiring that made 1.7.4 inert. Falsified default-OFF rationale replaced with TRACED mechanism (C1).

## REACHABILITY CALL-CHAIN (explicit gate item for BOTH gaters)
Deployed default binary → dispatcher → `informer_dispatch.go:359` `rw.EnsureResourceType(gvr)` (called unconditionally when `!IsSynced`; `RESOLVER_SYNC_WAIT_MS` gates only the sync-wait AFTER register, not the register) → `watcher.go` EnsureResourceType success path → `rw.primeConfirmAsyncLocked(gvr)`. NO env/flag on this chain. `ServeWatcherFromContext` gates only the internal_dispatch informer-SERVE branch, NOT the register/prime. Also reached (all unguarded): `objects/get.go:113`, `deps_extract.go:156`, `apistage.go:585`, `resolve.go:1719`, `crd_discovery_side_effect.go:611`. The ONLY `PREWARM_REGISTER_ENABLED`-gated caller is the F1 walk (`main.go`, sole `PrewarmRegisterFromNavigation` call site) — and 1.7.5 flips its default to on-under-cache.

## Falsifiers (all -race, 3×)
- **F-reachable (headline):** `TestF1b_LazyRegister_PrimesConfirm_NoFlagNoDirectCall` — drives ONLY EnsureResourceType, no flag, no direct Confirm*, asserts typeConfirmed flips true + servable + 1 round-trip. **RED captured** (unwire both prime sites): `--- FAIL ... snap={Registered:true HasSynced:true WatchHealthy:true TypeConfirmed:false}` — the 1.7.3/1.7.4 readout reproduced. Restored GREEN 3×.
- **F-skip-guard / F-no-stall (K=4 -race) / F-offline-degrade** — all PASS 3×.
- **C5 reachability:** `TestPrewarmWalkReachable_DefaultConfig` reproduces main's composed gate under deployed default env → walk reached (the arm that would have caught 1.7.4's inert F1); `TestResolvePrewarmRegisterDefault` arms (unset/false/true/other).
- **Reworked (NOT deleted)** the 5 tests whose unconfirmed-pre-state control the auto-prime dissolved (HealA/B/C + 2 F1Walk): register under `disco==nil` (prime short-circuits) then wire discovery. Discrimination verified: disco-before-register → negative control fails loudly.
- Full `internal/cache` 3× -race GREEN; resolvers/objects/handlers GREEN; vet clean.

## PM conditions status
- **C1 (doc rewrite to TRACED mechanism):** DONE — main.go + prewarm.go doc-blocks rewritten; `${`-guard (inventory.go:171) verified rejects composition paths; no "same-58" / no-consumer-QPS claims survive.
- **C5 (reachability as pre-ship test):** DONE — helper arms + main-wiring arm above.
- **C-1 (RED artifact + 3× green):** DONE — see F-reachable above; artifact `/tmp/f1b-falsifiers/RED-reachability-unwired.txt`.

## Staged for tester (post-merge, on-deploy — CLOSES the F1 ledger row)
- **C2 bench arm A re-scope:** walk registers ONLY the static (non-`${`) inventory set (< 58, ZERO composition.krateo.io); compositions still arrive via `cache.discovery.gvr_registered` at the same offset.
- **C3 per-GVR attribution:** each of the 4 paged_list + 39 serve_miss events attributed to its GVR — the composition ones (benchapps!) are cleared by **F1b's lazy-seam prime**, NOT the walk/F1 batch. Artifact must show which mechanism cleared which event.
- **Acceptance thresholds (PM):** benchapps paged_list 4→0; `serve_miss typeConfirmed:false`→0 steady-state; `cache.lazy_register.confirm_primed` slog present once-per-GVR; `informer_served` climbs; narrow-RBAC (cyberjoker) CONTENT row-parity vs the live LIST it replaces.
- **C4 ledger wording:** "walk pre-warms static/widget-adjacent GVRs only; composition informers remain lazy-discovery-driven — their conjunct-4 fix is F1b's register-seam prime; F1 walk-batch reachable. NOT warm-at-Ready (F2/F3 remain)."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1