### PR TITLE
#130 F3 — login-cohort seed coverage (SA-exclusion + reachable-rank + all-cohort latch + seed attribution) [PARKED — Diego-reserved merge]

### DIFF
--- a/docs/f3-login-cohort-seed-coverage-design-2026-07-11.md
+++ b/docs/f3-login-cohort-seed-coverage-design-2026-07-11.md
@@ -1,0 +1,391 @@
+# F3 — Login-cohort seed coverage (Fix #130 F3)
+
+Date: 2026-07-11
+Author: cache architect
+Repo state: main @ 8b5163a (measured build 1.7.6)
+Evidence: /tmp/f2-deploy/admin-hit-count/{admin-hit-ledger.txt, boot-t0.log, nav-full.log, pass2-full.log}
+
+## TL;DR
+
+Admin first-nav is 56.8% (76 cold cacheable widgets), 0 hits seed-attributable. The
+admins cohort is NOT under-enumerated — it appears in EVERY widget target set (all
+537 widget entries carry `targets:16` including `\x1fadmins`). It is
+**enumerated-but-starved**: the rank-major seed (FIX-E) seeds ALL of rank-0 (devs,
+widget_max 1293) first, and the serial per-widget resolve is so slow that the seed
+processed only 169 widget targets before its deadline — never reaching admins at
+rank 2. The `/readyz` first-nav latch (FIX-F) fires on the DEVS segment only, so the
+pod goes Ready with admins' cells cold. attribution=0 is a coverage gap, NOT a
+key-divergence bug (the 76 miss widgets are identity-UNDECLARED → their key does not
+fold username → a completed admins seed WOULD hit). Fix: a UNIFORM login-cohort-first
+rank discriminator + a first-nav latch that waits for EVERY login cohort's first-nav
+segment, not just rank-0's.
+
+## 1. TRACE — admins enumeration (Q1): enumerated-but-starved, NOT under-enumerated
+
+### The dedup + rank mechanism (file:line)
+- `EnumeratePrewarmTargetsForGVR` (internal/cache/prewarm_enumeration.go:128) collects
+  every binding for a GVR (per-GVR bucket ∪ wildcard), then DEDUPS by representative
+  identity: key = `rep.Username + \x1f + join(sorted rep.Groups)` (:190). For a
+  GROUP-only cohort (admins granted via a ClusterRoleBinding to `Group=admins`),
+  `pickRepresentativeFromSubjectKeys` (:249) picks the group subject → rep =
+  {Username:"", Groups:["admins"]} → key `\x1fadmins`. `CollapsedBindings` counts how
+  many raw bindings fold into that representative (:195/:207).
+- The engine ranks identities over BOTH classes' target sets by
+  (widgetMax DESC, allMax DESC, key ASC), where widgetMax/allMax are MAX-FOLDS of
+  `CollapsedBindings` (prewarm_engine_boot.go:718-758). widgetMax = the collapsed
+  count observed in some WIDGET target set.
+
+### Why admins = widget_max 1 (TRACED, and why it is CORRECT)
+`widget_max=1` for `\x1fadmins` means: admins is represented by ONE collapsed binding
+(one CRB to Group=admins) and appears in widget target sets with CollapsedBindings=1.
+devs = widget_max 1293 because the 1000-user + per-user-RoleBinding topology folds
+1293 raw bindings into the single `\x1fdevs` representative. **widget_max is the RANK
+METRIC (binding multiplicity), NOT the count of widgets the cohort can render.**
+
+The decisive evidence that admins is fully enumerated (NOT blind to CRB-only cohorts):
+- `prewarm.engine.seed.widget_targets`: 537 lines, EVERY ONE `"targets":16`
+  (boot-t0.log). Every widget's per-binding target set has 16 representative
+  identities — and `\x1fadmins` is one of them (it is rank 2 = present).
+- `prewarm.enumerate.dedup`: every widget GVR shows `bindings:1308 identities:16`.
+  admins is one of those 16 for EVERY widget GVR.
+
+So the binding→widget mapping is NOT blind to the cluster-scoped/CRB-only admins
+cohort. Admins is a first-class rank-2 identity across all 537 widgets. **Verdict:
+enumerated-but-STARVED by rank + deadline, not under-enumerated.** (This falsifies the
+"binding→widget mapping blind to CRB-only cohorts" hypothesis in the brief — the
+enumeration is correct; the SCHEDULING starves it.)
+
+### The starvation (TRACED, boot-t0.log timeline)
+The seed is RANK-MAJOR (prewarm_engine_boot.go:970-1018): the outer loop walks
+`ranked` in order; each rank's inner loops iterate all widget/RA seeds but only
+process targets whose `identityKey(c)==rankKey`. So it seeds devs (rank 0: all its
+widget targets + RAs), THEN portals (rank 1), THEN admins (rank 2).
+- 14:20:54 Phase-1 warmup starts.
+- 14:24:47 ranks emitted (devs r0, portals r1, admins r2, then 222 system-SA ranks).
+- 14:25:54 `phase1.seed.sync_incomplete` err="context deadline exceeded"
+  elapsed_ms=150746 → readiness flips as backstop.
+- `prewarm.seed.abort phase=widgets targets_processed=169 elapsed_ms=396033` (14:31:23)
+  — the widgets phase processed only **169** targets before the ctx cancelled.
+  rank-0 devs alone is 537 widget targets; the seed never finished devs, so **admins
+  (rank 2) was never reached.** The abort repeats (14:39:40 tp=227, 14:47:44 tp=264)
+  — the boot re-walk re-enqueues and re-aborts, never converging.
+
+### Why it is so slow (TRACED)
+Each widget seed is a full nested resolve under `WithPrewarmIterSerial`
+(withCohortSeedContext, phase1_pip_seed.go:440) — one resolve in flight, no
+parallelism. `phase1.seed.widget.phase.timing` shows per-widget apiref_ms up to 669ms
+(list-activity-events), and the discovery re-walk itself is 84-327s
+(`prewarm.engine.boot.rewalk_complete`). 169 targets / 396s ≈ 2.3s/target. A
+`marketplace-detail` operational_failure (null-jq, #128-class) at 14:45:50 triggers a
+coalesced re-walk (prewarm_engine_boot.go:548-551) that resets progress — the seed
+never converges past the early ranks.
+
+## 2. TRACE — the 150.7s deadline (Q2)
+
+There are TWO distinct bounds, and the "150.7s" is the pipSeed return, NOT
+pipGlobalTimeout:
+- `pipCohortTimeout = 120s` (phase1_pip_seed.go:132) — per-target-cohort ctx
+  (seedOneTarget, prewarm_engine_boot.go:591).
+- `pipGlobalTimeout = 8min = 480s` (phase1_pip_seed.go:141) — the seedCtx budget the
+  SYNC seed runs under (phase1_walk.go:826).
+- `PHASE1_TIMEOUT_SECONDS` — the outer Phase-1 backstop (p1Ctx, cache/phase1.go:323).
+
+The `sync_incomplete` WARN (phase1_walk.go:831) fires when `pipSeed(seedCtx)` returns
+a non-nil err — here `context deadline exceeded` at elapsed 150746ms. This is a CHILD
+ctx cancel, not pipGlobalTimeout (480s) — the seed's parent Phase1Warmup ctx
+(bounded by PHASE1_TIMEOUT_SECONDS) cancelled at ~150s. **Config-drift finding: the
+deployed pod's PHASE1_TIMEOUT is ~150s, well short of the 8-min pipGlobalTimeout the
+seed budget assumes** (chart default has historically been 180/300; this pod ran
+~150s — the exact env is not dumped in the boot log; the developer must read the
+live pod env at build time). The seed budget (480s) is dead because its PARENT
+(PHASE1_TIMEOUT) cancels first.
+
+What work was cut: the entire rank-1+ tail — portals, admins, and all system SAs.
+The MarkPhase1Done backstop (phase1_walk.go:811 defer) fires on the cancel, flipping
+Ready-degraded. **Did even the 1 admin widget land? NO** — the seed never reached
+rank 2; admins got 0 widget cells (confirmed by attribution=0 + all 76 admin widgets
+cold). The "1" in widget_max is a binding count, not a seeded-widget count.
+
+**Q4 answer — intended best-effort or bug?** The "first /call per affected cohort
+falls back to per-user resolve" fallback is the INTENDED C2 liveness backstop
+(never-not-Ready-forever, phase1_walk.go:792-799). It is doing its job. But the
+DESIGN INTENT that made it acceptable — that the first-nav segment for the served
+cohort is warm before Ready — holds ONLY for rank-0 (devs). For every OTHER login
+cohort the backstop degenerates to "always cold on first nav." So it is a
+best-effort fallback that has become the DEFAULT path for admins = a coverage
+defect, not a code bug in the fallback itself.
+
+## 3. TRACE — attribution=0 sanity (Q3): NOT key-divergence; it is coverage
+
+The seed cohort identity for admins is Username="" + Groups=["admins"]
+(withCohortSeedContext sets `WithUserInfo{Username: cohort.Username, Groups:
+cohort.Groups}`, phase1_pip_seed.go:432-435; cohort.Username="" for the group-rep).
+The real admin browser is `{name:"admin", groups:"admins"}` (nav-full.log
+resolved_cache.lookup `user:{name:"admin",groups:"admins"}`). These differ in
+Username.
+
+**But the key does not fold Username for the 76 miss widgets.** `DeclaredIdentity`
+(internal/resolvers/widgets/widgets.go:110) returns nil unless the widget declares an
+`identityContext` — the ~99% corpus path (:103-113). It is the SINGLE identity fold
+site for both the key path (`effectiveKeyExtras` → `declaredIdentityForKey`) and the
+resolve-input path. For an UNDECLARED widget the fold is a no-op → the cache key is
+identity-INVARIANT (BindingUID "" — the A2/#95 mechanism) → seed key (Username="")
+== browser key (Username="admin"). The 76 misses are all
+statistics/cards/flexes/tags/buttons/listies/selects/layouts/images/menus/
+paragraphs/linecharts/tables (ledger MISS breakdown) — none of which declare
+identity. So a COMPLETED admins seed WOULD produce browser-hittable cells.
+
+Therefore attribution=0 is fully explained by "the seed never ran for admins," NOT by
+the A7 key-divergence class. The A7 definitive-arch cure holds for the admins shape:
+undeclared widgets are group/user-invariant, so the group-rep seed key matches the
+real admin key. (This must still be PROVEN by falsifier — see §7 arm (c) — because a
+key-parity claim on the admins shape must be verified through REAL derivation on both
+sides, per feedback_consultation_mutation_is_not_key_correctness.)
+
+CAVEAT (identity-declared widgets): IF any first-nav admin widget declares
+`identityContext:[username]`, its key DOES fold username → the group-rep seed
+(Username="") would write a key the admin (Username="admin") cannot hit. The design
+below handles this uniformly (§4 note) — the seed must resolve each cohort under a
+representative that carries the key-folded identity dimensions, OR such widgets are
+knowingly per-user and out of cohort-seed scope. Empirically the 76 misses are
+undeclared, so this caveat is not the current gap — but the falsifier must include a
+declared-widget arm to prevent a future regression.
+
+## 4. DESIGN F3
+
+Two levers, both uniform, no static lists, no "if admins":
+
+### Lever 1 — LOGIN-COHORT-FIRST rank discriminator (the root fix)
+Today rank = (widgetMax DESC, allMax DESC, key ASC). widgetMax is binding
+multiplicity, so devs (1293 bindings) outranks admins (1 binding) — but BOTH are
+login cohorts that render the dashboard, and the 222 system SAs that never touch the
+frontend are interleaved by binding count too. The milestone ("ANY user first-nav =
+100%") needs EVERY login cohort's first-nav segment warmed before the
+non-frontend-reachable tail.
+
+Add a PRIMARY rank key: **is this identity frontend-reachable?** = does it have ≥1
+RootIndex==0 (first-nav) widget target? This is already computed for the latch
+(prewarm_engine_boot.go:894-920). Promote it to a rank tier:
+
+    sort by (isFirstNavReachable DESC, widgetMax DESC, allMax DESC, key ASC)
+
+- UNIFORM discriminator: "cohort with a frontend-reachable first-nav nav segment,"
+  derived from the SAME RootIndex==0 widget-target data the latch uses — not a
+  hardcoded cohort list (satisfies feedback_no_special_cases +
+  feedback_dynamic_cohort_prewarm_no_static_no_cold_fill).
+- Effect: devs, portals(if reachable), admins, system:masters — every cohort that
+  renders the dashboard — sort ABOVE the ~222 system SAs. The PURE-ORDERING invariant
+  (FIX-E) is preserved: the seeded (unit×identity) SET is unchanged; only the SEQUENCE
+  changes. No caps, no skips.
+- Within the reachable tier, keep widgetMax DESC (devs first — the largest cohort is
+  still highest-value), so this does not regress the devs-first property that made the
+  95%-narrow mix fast.
+
+Lever 1 ALONE is insufficient at this cluster because even the reachable tier
+(devs+portals+admins+masters) exceeds the ~150s deadline at 2.3s/target serial. So:
+
+### Lever 2 — first-nav latch waits for EVERY reachable cohort's first-nav segment
+Today FIX-F fires `/readyz` the instant the FIRST reachable identity's (segKey at
+segRank) RootIndex==0 segment completes (prewarm_engine_boot.go:1000-1005). Post-Lever-1
+that is still just devs. Change the latch to require ALL first-nav-reachable
+identities' RootIndex==0 segments to complete before firing — i.e. arm
+`firstNavRemaining` as the SUM over every reachable cohort's RootIndex==0 targets, and
+fire when it reaches 0 (or the PHASE1_TIMEOUT/pipGlobalTimeout backstop, unchanged).
+
+- This makes readiness mean "every login cohort's dashboard is warm," which IS the
+  milestone. Combined with Lever 1's ordering, the reachable cohorts seed FIRST and
+  the pod does not go Ready until they are all warm.
+- Backstop preserved: MarkPhase1Done still fires regardless on
+  PHASE1_TIMEOUT/pipGlobalTimeout expiry (C2 liveness) — so a pathological cohort
+  cannot hang readiness forever; it just goes Ready-degraded for that cohort (today's
+  behavior, but now the exception not the rule).
+- The reachable-cohort segment count is small: 16 identities × ~179 first-nav widgets
+  is the ceiling, but only the ~4 reachable cohorts × ~76 RootIndex==0 widgets ≈ 300
+  targets matter. That is the readiness-gating work.
+
+### Ordering / boot-budget interaction (MANDATORY — the deadline is real)
+Lever 1+2 reorder work but do not make it faster. At 2.3s/target serial, ~300
+reachable-cohort first-nav targets ≈ 690s — OVER the ~150s PHASE1_TIMEOUT AND the
+480s pipGlobalTimeout. Two required companions (NOT new mechanisms — existing knobs):
+1. **Raise PHASE1_TIMEOUT so pipGlobalTimeout (480s) is actually the seed's bound**
+   (Q2 config-drift). The seed budget was designed as 480s; the parent cancelling at
+   ~150s is the drift. This is a CHART VALUE change, not code (route to the chart
+   session). Without it the seed budget is dead.
+2. **The serial per-target cost is the structural ceiling** (this is #123 — "seed is
+   the next boot-budget ceiling, ~339s of 480s at 50K"). F3 does NOT solve #123; it
+   makes the reachable cohorts WIN the budget they have. If even the reachable tier
+   overruns the raised budget, the residual is bounded per-cohort (Lever-2 latch fires
+   at backstop with whatever seeded) and the remaining cohorts fall back to per-user
+   resolve — strictly better than today (devs-only). A follow-up (bounded seed
+   PARALLELISM for the reachable tier, or a per-cohort budget slice) is the #123 lever;
+   flag it, do not fold it into F3.
+
+### The marketplace-detail re-walk churn (contributing, route separately)
+The operational_failure (null-jq, #128) re-enqueues the boot re-walk
+(prewarm_engine_boot.go:548-551), resetting seed progress and burning budget. This is
+the #128 portal-RA null-jq issue, already tracked. Note it as a budget amplifier that
+F3's reordering does not fix; #128's resolution removes the re-walk thrash.
+
+## 5. Seed-attribution observable (brief requirement)
+
+Add a counter/log tag so this measurement stops needing forensics. At the resolved
+serve-hit site (resolved_cache.lookup), when `hit==true`, compare the hit entry's
+provenance: stamp a `seeded_at_boot bool` on the ResolvedEntry at seed Put time
+(seedOneWidget/seedOneRestaction Put) and surface it in the lookup log as
+`hit_source:"seed"|"traffic"`. Aggregate a `resolved_cache.hits_seed_attributable`
+expvar. This is leak-safe (boolean provenance, no per-user data) and directly answers
+"did the seed warm this cell." Place the stamp at the two seed Put primitives (single
+insertion each, feedback_no_special_cases). LOC ~15.
+
+## 6. Budget analysis (50K, #123)
+
+At this cluster (~5K deployments, 60K benchapps) the reachable-tier first-nav seed is
+~300 targets × 2.3s ≈ 690s serial. At the canonical 50K/1.3M-object scale the per-
+target resolve cost rises (larger LISTs, more RBAC bindings → 1293→higher collapsed
+counts, more per-cohort fan-out). #123 already pins seed at ~339s of a 480s budget at
+50K with the CURRENT devs-only-effective seeding. F3 does NOT increase the seeded SET
+(pure reorder), so aggregate seed cost is unchanged — but the READINESS-GATING subset
+grows from "devs first-nav segment" to "all reachable cohorts' first-nav segments."
+That raises the time-to-Ready. Mitigations in priority order:
+1. Raise PHASE1_TIMEOUT to ≥ pipGlobalTimeout (chart) — reclaims the dead 330s.
+2. Bounded reachable-tier parallelism (the #123 lever; NOT F3) if the raised budget
+   still overruns. Must respect the #46 SEED_FOOTPRINT_BUDGET_BYTES aggregate bound
+   (feedback_bounding_mechanism_discipline: cost-proportional, after cache-hit,
+   >cap concurrency in the falsifier).
+State clearly: F3 targets the 0.05 admin mix + every non-devs login cohort; it trades
+a longer time-to-Ready for correct first-nav coverage. If Diego prefers time-to-Ready
+over admin-cohort coverage, Lever-2 can be scoped to "reachable cohorts up to a budget
+fraction" — a strategic call (§8).
+
+## 7. Falsifiers (PM gate)
+
+- **(a) Hermetic RED — rank discriminator (K>1 cohorts × M>1 widgets).** Build a
+  binding index with ≥2 login cohorts (devs 1000-binding, admins 1-binding CRB) + ≥2
+  system SAs, ≥2 first-nav widgets. Assert post-Lever-1 rank order places BOTH login
+  cohorts above BOTH system SAs, regardless of widgetMax. RED arm = pre-fix rank
+  (widgetMax DESC only) interleaves a system SA above admins. Degenerate K=1/M=1 is
+  inadmissible (feedback_falsifier_shape_must_discriminate).
+- **(b) Hermetic RED — latch waits for all reachable cohorts.** ≥2 reachable cohorts;
+  assert the latch does NOT fire until BOTH cohorts' RootIndex==0 segments complete.
+  RED = pre-fix latch fires on the first cohort (segRank) with the second still cold.
+- **(c) Key-parity through REAL derivation (attribution proof, no hand-fed keys).**
+  Drive an UNDECLARED first-nav widget through the REAL seed derivation (cohort
+  Username="", Groups=["admins"]) AND the REAL browser derivation (Username="admin",
+  Groups=["admins"]); assert the pre-hash ResolvedKeyInputs are FIELD-equal (BindingUID
+  "" both sides), then that ComputeKey digests match. PLUS a DECLARED-widget arm
+  (identityContext:[username]) proving the keys DIVERGE (guards the §4 caveat).
+  curl probes INADMISSIBLE (feedback_curl_probes_inadmissible_for_seed_hit_acceptance);
+  both sides must be real derivation (feedback_key_parity_golden_real_inputs_prehash_diff).
+- **(d) Acceptance — repeat the exact reboot+counted admin first-nav.** Fresh boot,
+  real Chrome admin session, per-/call resolved_cache.lookup counted, first-touch per
+  key_hash. REQUIRE: `hits_seed_attributable > 0` (the new observable) AND admin
+  first-nav hit-rate ≥ **85%** (justification below). Contamination control: the
+  ledger notes prior admin traffic inflated the HIT side; run from a genuinely cold
+  boot with NO prior admin session.
+
+### Achievable target justification (the 85%)
+100% first-nav is the milestone aspiration but not guaranteed on the FIRST reboot at
+this cluster because (i) the marketplace-detail null-jq re-walk (#128) still burns
+budget until fixed, and (ii) a few first-nav widgets resolve external/ClickHouse data
+(#129) that the seed cannot warm identically. 85% is the floor that PROVES the fix
+works: it requires the admins cohort seed to have RUN (attribution>0) and covered the
+bulk of the 76 currently-cold widgets. Steady-state stays ~97.7% (measured). If
+PHASE1_TIMEOUT is raised AND #128 lands, 100% is reachable — set 85% as the F3 gate,
+100% as the milestone-close target after #128/#129.
+
+## 8. Options with recommendation (strategic — surface to Diego/TL)
+
+- **Option A (recommended): Lever 1 + Lever 2 + PHASE1_TIMEOUT raise.** Correct
+  milestone semantics (Ready = every login cohort warm). Cost: longer time-to-Ready.
+- **Option B: Lever 1 only (reorder, keep devs-only latch).** Admins seeds sooner
+  (before system SAs) but readiness still flips on devs; admins may still be cold if
+  the budget cuts before rank-2 completes. Weaker, but zero time-to-Ready regression.
+- **Option C: Lever 1+2 but Lever-2 bounded to a budget fraction.** Ready when
+  reachable cohorts up to X% of budget are warm; residual cohorts fall back. Balances
+  coverage vs time-to-Ready.
+Recommend A (the milestone is explicit: "ANY user first-nav = 100%"), with the
+PHASE1_TIMEOUT raise as a hard prerequisite and #128 as a fast-follow.
+
+## 9. REACHABILITY (the F1 lesson — prove the deployed binary reaches the new code)
+
+- The seed engine ran on the measured 1.7.6 boot: `prewarm.engine.seed.rank` (225
+  lines), `prewarm.seed.abort`, `prewarm.first_nav.latch reason=segment-complete
+  segment_identity=\x1fdevs` all present in boot-t0.log. So the deployed binary
+  reaches the rank sort (prewarm_engine_boot.go:750) and the latch arming (:894-920,
+  :1000-1005) on every boot — both Lever-1 and Lever-2 sit on the unconditional seed
+  path, no flag gates them.
+- Lever 1 changes the existing `sort.SliceStable(ranked, ...)` comparator (:750) — the
+  same call that emitted the 225 rank lines. Lever 2 changes the existing
+  `firstNavRemaining` arming (:894-920) + fire condition (:1000-1005) — the same code
+  that fired the observed segment-complete latch.
+- Production call chain: main boot → Phase1Warmup → phase1WarmupWith Step 7.6 →
+  pipSeed(seedCtx) → seedScopeYielding → the rank sort (Lever 1) + the rank-major loop
+  + latch (Lever 2). No env gate.
+- Falsifier (d)'s on-boot `hits_seed_attributable > 0` is the deployed-binary reach
+  proof: a non-zero seed-attributable admin hit on a real reboot proves the reordered
+  seed reached admins and wrote a browser-hittable cell.
+- The seed-attribution observable (§5) is itself the standing reachability probe —
+  every future boot reports whether the seed warmed admin cells, so this never needs
+  forensics again.
+
+---
+
+## 10. AMENDMENT (2026-07-11, Diego directive) — SA-cohort seed EXCLUSION
+
+Diego amended the F3 scope mid-build: rather than only RE-RANKING ServiceAccount
+cohorts below login cohorts (Lever 1's "system SAs sort last" half), **exclude
+ServiceAccount-subject cohorts from the seed target set entirely.** They are
+machine/controller cohorts that never render the frontend, and seeding them
+starved the login cohorts out of the boot budget.
+
+### Discriminator (arch-reviewed, C-F3-6 paths corrected)
+- Implemented in `EnumeratePrewarmTargetsForGVR`
+  (**internal/cache/prewarm_enumeration.go**) via `allSubjectsAreServiceAccountKind`:
+  a binding is excluded iff its projected subject SET is non-empty and contains
+  ZERO User and ZERO Group subjects (every subject is `rbacv1.ServiceAccountKind`).
+- **SET predicate, NOT the picked representative's kind (arch-caught latent bug):**
+  `pickRepresentativeFromSubjects` (match_subject.go) is first-non-empty-BY-SLICE-ORDER,
+  not kind-priority — a MIXED `[SA-first, Group-second]` binding would pick the SA
+  as representative. Gating on the winner's kind would WRONGLY drop that
+  login-cohort binding. The set predicate keeps any binding with a User/Group
+  subject. Falsifier `TestF3SAExclusion_MixedSubjects` is the RED-catcher (the
+  naive winner-kind gate drops the mixed binding — verified RED).
+- **Subject KIND, not a name allowlist:** `system:masters` is a GROUP subject and
+  is KEPT despite the `system:` name (feedback_no_special_cases). A `system:`
+  name-prefix filter would wrongly exclude that login cohort.
+
+### portals-SA safety (safety-check #2 — CLOSED)
+`system:serviceaccount:krateo-system:portals-v1-5-1` has widget_max=1 (it renders
+a widget) and is now excluded. CLOSED as safe: it is a CDC/loopback mechanism SA,
+not a browser login identity — no human session depends on its seeded cell. If it
+issues a real /call its cell cold-fills as a TRAFFIC entry (never-worse arm
+`TestF3SAExclusion_NeverWorse_SATrafficStillServes`). The #57 snowplow loopback SA
+is a seed MECHANISM identity (it RUNS the seed), never itself a seed TARGET in the
+index, so the exclusion does not touch it.
+
+### Interaction with Levers 1+2
+- The exclusion SUPERSEDES the "system SAs sort last" half of Lever 1: SAs are gone
+  from the seed set, so there is no SA tail to sort below. Lever 1's
+  `firstNavReachable` primary rank tier STILL applies — it now orders the surviving
+  LOGIN cohorts (a login cohort with a first-nav widget above one with only
+  non-first-nav widgets).
+- Lever 2 (latch waits ALL reachable cohorts) is unchanged — the reachable set is
+  now login cohorts only.
+
+## 11. C-F3-6 path corrections (applied)
+- `prewarm_engine_boot.go`, `phase1_pip_seed.go` — **internal/handlers/dispatchers/**.
+- `prewarm_enumeration.go` — **internal/cache/**.
+- `DeclaredIdentity` — **internal/resolvers/widgets/widgets.go**.
+
+## 12. Seed-budget mechanism (Q2 finalized) — the chart companion is a RE-RAISE
+TRACED on the 1.7.6 boot: the Step-7.6 seed runs under
+`seedCtx = context.WithTimeout(phase1Ctx, pipGlobalTimeout=480s)`
+(phase1_walk.go:826) — it INHERITS the phase-1 deadline. Effective seed budget =
+`min(PHASE1_TIMEOUT − preSeedElapsed, 480s)`. Pre-seed phases (roots-walk ~150s +
+content-prewarm ~11s + discovery re-walk ~100s) consumed ~251s before the seed
+started. So at PHASE1_TIMEOUT=300 the seed got ~49s (starved). Chart companion:
+PHASE1_TIMEOUT_SECONDS 180→900 (snowplow-chart values.yaml) so 900−251=649 > 480 →
+the seed's own 480s cap is the real bound. Re-measure preSeedElapsed at 50K and
+re-raise if 900−preSeed < 480. Trade (Option A): longer worst-case time-to-Ready;
+the Lever-2 latch flips Ready at min(all-reachable-warm, backstop) so the common
+case is unaffected.

--- a/internal/cache/prewarm_enumeration.go
+++ b/internal/cache/prewarm_enumeration.go
@@ -171,6 +171,38 @@ func EnumeratePrewarmTargetsForGVR(gvr schema.GroupVersionResource, verb string)
 		// match_subject.go (the SOT for binding-identity primitives);
 		// it picks the first non-empty User/Group/SA subject.
 		//
+		// #130 F3 (Diego directive 2026-07-11) — EXCLUDE ServiceAccount-only
+		// bindings from the seed target set. A binding whose subject set contains
+		// ZERO User and ZERO Group subjects (i.e. every subject is a
+		// ServiceAccount) is a machine/controller cohort that never renders the
+		// frontend; seeding it starved the login cohorts (admins) out of the boot
+		// budget. Skipping it here removes it from EVERY seed class (widgets, RAs,
+		// proactive_ra_seed) in ONE insertion.
+		//
+		// PREDICATE = the whole SUBJECT SET, NOT the picked representative's kind.
+		// pickRepresentativeFromSubjectKeys is first-non-empty-by-slice-order (NOT
+		// kind-priority), so a MIXED binding [SA-first, Group-second] would pick
+		// the SA as representative even though a Group subject exists — gating on
+		// the winner's kind would WRONGLY drop that login-cohort binding (arch-
+		// caught latent bug). allSubjectsAreServiceAccountKind is independent of
+		// pickRepresentative: it excludes ONLY when no User/Group subject exists
+		// at all, so a mixed binding is always KEPT.
+		//
+		// Subject-KIND discriminator (subjectKey.Kind from subjectsFromRBAC), not
+		// a name allowlist: `system:masters` is a GROUP subject and is correctly
+		// KEPT despite the system: name (feedback_no_special_cases).
+		//
+		// NEVER-WORSE (serve unaffected): this touches ONLY the boot SEED target
+		// set. An excluded SA that issues a real /call (loopback, controllers,
+		// portals SA) still resolves per-user through the normal dispatch +
+		// EvaluateRBAC path and its cell cold-fills on first request
+		// (hit_source:"traffic"). The #57 snowplow loopback SA is a seed MECHANISM
+		// identity (it runs the seed), never itself a seed TARGET in this index, so
+		// this exclusion does not touch it.
+		if allSubjectsAreServiceAccountKind(entry.subjects) {
+			continue
+		}
+
 		// The bindingEntry's subjects slice was projected at enrol
 		// time (subjectsFromRBAC) to a []subjectKey; reconstitute a
 		// minimal rbacv1.Subject slice so we can re-use the SOT helper
@@ -259,4 +291,33 @@ func pickRepresentativeFromSubjectKeys(subjects []subjectKey) SubjectIdentity {
 		})
 	}
 	return pickRepresentativeFromSubjects(retyped)
+}
+
+// allSubjectsAreServiceAccountKind reports whether a binding's projected
+// subject set is NON-EMPTY and consists ENTIRELY of ServiceAccount-kind
+// subjects — i.e. it has zero User and zero Group subjects. This is the #130 F3
+// seed-exclusion predicate (Diego directive 2026-07-11): such a binding is a
+// machine/controller cohort that never renders the frontend, so it is dropped
+// from the boot seed target set.
+//
+// It is deliberately a SET predicate (not "the representative's kind"):
+// pickRepresentativeFromSubjects is first-non-empty-by-slice-order, so a mixed
+// [SA, Group] binding would pick the SA as representative — but it MUST still be
+// seeded (it grants a Group login cohort). Returning false whenever ANY User or
+// Group subject is present guarantees a mixed binding is never excluded.
+//
+// Empty set → false (nothing to exclude on; the caller's rep would be the empty
+// identity anyway). subjectsFromRBAC only projects User/Group/SA kinds, so an
+// unknown-kind-only binding projects to an empty set → false → kept (harmless;
+// it dedups to the empty representative as today).
+func allSubjectsAreServiceAccountKind(subjects []subjectKey) bool {
+	if len(subjects) == 0 {
+		return false
+	}
+	for _, s := range subjects {
+		if s.Kind != rbacv1.ServiceAccountKind {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cache/prewarm_enumeration_dedup_test.go
+++ b/internal/cache/prewarm_enumeration_dedup_test.go
@@ -95,14 +95,22 @@ func TestPrewarmDedup_ARM_DISTINCT_OneTargetPerIdentity(t *testing.T) {
 	BuildBindingsByGVRIndex([]schema.GroupVersionResource{g})
 
 	targets := EnumeratePrewarmTargetsForGVR(g, "list")
-	if len(targets) != 3 {
-		t.Fatalf("ARM-DISTINCT: expected 3 deduped targets (devs, alice, sa) from 6 bindings, got %d: %+v", len(targets), targets)
+	// #130 F3 (Diego directive 2026-07-11): the SA-only binding (installer) is now
+	// EXCLUDED from the seed target set — it is a machine cohort that never renders
+	// the frontend. So the 6 bindings dedup to EXACTLY 2 login-cohort targets
+	// (devs, alice); the SA is gone. (Pre-F3 this asserted 3 incl. the SA. The
+	// dedup contract for the login cohorts is unchanged — this arm now doubles as
+	// the "login cohorts survive, SA excluded" check; the dedicated exclusion arms
+	// live in prewarm_sa_exclusion_f3_test.go.)
+	if len(targets) != 2 {
+		t.Fatalf("ARM-DISTINCT (F3): expected 2 deduped login-cohort targets (devs, alice) from 6 bindings "+
+			"with the SA-only binding excluded, got %d: %+v", len(targets), targets)
 	}
 	got := subjectSetOf(targets)
-	want := []string{"group:devs", "user:alice", "user:system:serviceaccount:krateo-system:installer"}
+	want := []string{"group:devs", "user:alice"}
 	sort.Strings(want)
 	if !equalSorted(got, want) {
-		t.Fatalf("ARM-DISTINCT: Subject set = %v; want %v (each distinct identity must survive dedup)", got, want)
+		t.Fatalf("ARM-DISTINCT (F3): Subject set = %v; want %v (login cohorts survive dedup; SA-only binding excluded)", got, want)
 	}
 }
 

--- a/internal/cache/prewarm_sa_exclusion_f3_test.go
+++ b/internal/cache/prewarm_sa_exclusion_f3_test.go
@@ -1,0 +1,198 @@
+// prewarm_sa_exclusion_f3_test.go — #130 F3 (Diego directive 2026-07-11):
+// ServiceAccount-subject cohorts are EXCLUDED from the boot seed target set.
+//
+// EnumeratePrewarmTargetsForGVR now drops any binding whose subject set is
+// entirely ServiceAccount-kind (zero User, zero Group subjects) — a machine/
+// controller cohort that never renders the frontend and was starving the login
+// cohorts (admins) out of the boot budget. The discriminator is subject KIND
+// (subjectKey.Kind), NOT a name allowlist.
+//
+// ARMS (architect-mandated set — the match_subject_test.go gap that would have
+// let the winning-rep-kind bug ship silently):
+//
+//   - ARM-ALLSA-EXCLUDED: a binding with ONLY SA subjects → target ABSENT.
+//   - ARM-MIXED-KEPT (the RED-catcher): a binding with [SA-first, Group-second]
+//     → target KEPT. RED = the naive "picked representative is SA-kind" gate
+//     (pickRepresentativeFromSubjects is first-wins-by-slice-order, so it picks
+//     the SA) would WRONGLY drop this login-cohort binding. The set-predicate
+//     allSubjectsAreServiceAccountKind keeps it because a Group subject exists.
+//   - ARM-GROUP-KEPT: all-Group binding, incl. `system:masters` (a GROUP subject
+//     whose name looks system-ish) → KEPT. Proves the discriminator is KIND, not
+//     a `system:` name-prefix (which would wrongly exclude a login cohort).
+//   - ARM-USER-KEPT: a User-subject binding → KEPT.
+//
+// Pure unit — synthetic RBAC snapshots via buildSnap; never touches the rbac
+// package's destructive TestMain.
+
+package cache
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// crbMultiSubject builds a ClusterRoleBinding carrying a MULTI-subject set (the
+// mixed-binding shape crbRuleUID's single-subject signature cannot express) + a
+// matching ClusterRole granting the rules. Subject ORDER is preserved so the
+// [SA-first, Group-second] ordering the RED arm needs is exact.
+func crbMultiSubject(name, uid string, subs []rbacv1.Subject, rules []rbacv1.PolicyRule) (*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRole) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "-role"},
+		Rules:      rules,
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(uid)},
+		Subjects:   subs,
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: name + "-role"},
+	}
+	return crb, cr
+}
+
+// hasSubjectLabel reports whether the target set contains a representative with
+// the given subjectSetOf label ("group:devs", "user:alice", "user:system:...").
+func hasSubjectLabel(targets []PrewarmTarget, label string) bool {
+	for _, l := range subjectSetOf(targets) {
+		if l == label {
+			return true
+		}
+	}
+	return false
+}
+
+// TestF3SAExclusion_MixedSubjects is the load-bearing arm: a MIXED enumeration
+// (Group + all-SA + mixed[SA,Group] + User + system:masters group) → the all-SA
+// cohort is EXCLUDED, every cohort with any User/Group subject is KEPT.
+//
+// K>1 cohorts × M>1 subject kinds. The mixed [SA-first, Group-second] arm is the
+// RED-catcher: a winning-rep-kind gate would drop it (rep=SA). system:masters
+// proves KIND-not-name.
+func TestF3SAExclusion_MixedSubjects(t *testing.T) {
+	ResetBindingsByGVRIndexForTest()
+
+	g := gr("widgets.templates.krateo.io", "flexes")
+	rules := getListRules(g.Group, g.Resource)
+
+	var crbs []*rbacv1.ClusterRoleBinding
+	var crs []*rbacv1.ClusterRole
+	add := func(crb *rbacv1.ClusterRoleBinding, cr *rbacv1.ClusterRole) {
+		crbs = append(crbs, crb)
+		crs = append(crs, cr)
+	}
+
+	// (1) all-Group login cohort — KEPT.
+	add(crbRuleUID("devs", "uid-devs", rbacv1.Subject{Kind: "Group", Name: "devs"}, rules))
+	// (2) all-SA machine cohort — EXCLUDED.
+	add(crbRuleUID("cdc-sa", "uid-cdc", rbacv1.Subject{
+		Kind: "ServiceAccount", Name: "portals-v1-5-1", Namespace: "krateo-system"}, rules))
+	// (3) MIXED [SA-first, Group-second] — KEPT (the RED-catcher). rep picks the
+	//     SA (first-wins) but a Group subject exists → not all-SA → kept.
+	add(crbMultiSubject("mixed", "uid-mixed", []rbacv1.Subject{
+		{Kind: "ServiceAccount", Name: "sidecar", Namespace: "krateo-system"},
+		{Kind: "Group", Name: "ops"},
+	}, rules))
+	// (4) User login identity — KEPT.
+	add(crbRuleUID("alice", "uid-alice", rbacv1.Subject{Kind: "User", Name: "alice"}, rules))
+	// (5) all-Group cohort NAMED system:masters — KEPT (KIND not name-prefix).
+	add(crbRuleUID("masters", "uid-masters", rbacv1.Subject{Kind: "Group", Name: "system:masters"}, rules))
+
+	PublishRBACSnapshotForTest(buildSnap(crbs, crs))
+	BuildBindingsByGVRIndex([]schema.GroupVersionResource{g})
+
+	targets := EnumeratePrewarmTargetsForGVR(g, "list")
+	got := subjectSetOf(targets)
+
+	// EXCLUDED: the all-SA cohort must be ABSENT.
+	if hasSubjectLabel(targets, "user:system:serviceaccount:krateo-system:portals-v1-5-1") {
+		t.Fatalf("ARM-ALLSA-EXCLUDED: the all-ServiceAccount cohort (portals-v1-5-1) MUST be excluded "+
+			"from the seed targets; it is present. got=%v", got)
+	}
+
+	// KEPT: every cohort with any User/Group subject.
+	// The mixed binding's rep is the SA (first-wins) — so it appears under the SA
+	// username, but it MUST be present (KEPT), which is the RED-catch: a
+	// winning-rep-kind gate would have dropped it.
+	mustKeep := []string{
+		"group:devs",
+		"user:alice",
+		"group:system:masters",
+		"user:system:serviceaccount:krateo-system:sidecar", // the MIXED binding, kept, rep=SA
+	}
+	for _, m := range mustKeep {
+		if !hasSubjectLabel(targets, m) {
+			t.Fatalf("ARM-KEPT: cohort %q MUST survive the SA-exclusion (has a User/Group subject, "+
+				"or is a mixed binding kept by the set-predicate); absent. got=%v", m, got)
+		}
+	}
+
+	// Exactly 4 kept (devs, alice, system:masters, mixed) — the all-SA cohort is
+	// the only exclusion.
+	if len(targets) != 4 {
+		t.Fatalf("ARM-COUNT: want 4 kept targets (all-SA excluded, mixed kept), got %d: %v", len(targets), got)
+	}
+}
+
+// TestF3SAExclusion_AllServiceAccount_FullyExcluded is the pure ALL-SA arm: an
+// enumeration of ONLY SA-subject bindings → ZERO seed targets (all excluded).
+// This is the ~222-system-SA-tail-killed shape at unit scale.
+func TestF3SAExclusion_AllServiceAccount_FullyExcluded(t *testing.T) {
+	ResetBindingsByGVRIndexForTest()
+
+	g := gr("widgets.templates.krateo.io", "flexes")
+	rules := getListRules(g.Group, g.Resource)
+
+	var crbs []*rbacv1.ClusterRoleBinding
+	var crs []*rbacv1.ClusterRole
+	for _, sa := range []struct{ name, ns string }{
+		{"kube-controller-manager", "kube-system"},
+		{"cloud-controller-manager", "kube-system"},
+		{"portals-v1-5-1", "krateo-system"},
+	} {
+		crb, cr := crbRuleUID("crb-"+sa.name, "uid-"+sa.name, rbacv1.Subject{
+			Kind: "ServiceAccount", Name: sa.name, Namespace: sa.ns}, rules)
+		crbs = append(crbs, crb)
+		crs = append(crs, cr)
+	}
+	PublishRBACSnapshotForTest(buildSnap(crbs, crs))
+	BuildBindingsByGVRIndex([]schema.GroupVersionResource{g})
+
+	targets := EnumeratePrewarmTargetsForGVR(g, "list")
+	if len(targets) != 0 {
+		t.Fatalf("ARM-ALLSA-FULL: an all-ServiceAccount enumeration must produce ZERO seed targets "+
+			"(the ~222-system-SA tail killed); got %d: %v", len(targets), subjectSetOf(targets))
+	}
+}
+
+// TestF3SAExclusion_Predicate is the direct unit of allSubjectsAreServiceAccountKind
+// — the set predicate, independent of pickRepresentative. It pins the exact
+// truth table the architect's ruling requires.
+func TestF3SAExclusion_Predicate(t *testing.T) {
+	sa := subjectKey{Kind: rbacv1.ServiceAccountKind, Name: "x", Namespace: "ns"}
+	user := subjectKey{Kind: rbacv1.UserKind, Name: "alice"}
+	group := subjectKey{Kind: rbacv1.GroupKind, Name: "devs"}
+
+	cases := []struct {
+		name string
+		in   []subjectKey
+		want bool
+	}{
+		{"empty → false (nothing to exclude)", nil, false},
+		{"all-SA → true (exclude)", []subjectKey{sa, sa}, true},
+		{"single SA → true", []subjectKey{sa}, true},
+		{"mixed SA+Group → false (KEEP — the RED-catch)", []subjectKey{sa, group}, false},
+		{"mixed Group+SA → false (KEEP, order-independent)", []subjectKey{group, sa}, false},
+		{"mixed SA+User → false (KEEP)", []subjectKey{sa, user}, false},
+		{"all-Group → false (KEEP)", []subjectKey{group}, false},
+		{"all-User → false (KEEP)", []subjectKey{user}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := allSubjectsAreServiceAccountKind(tc.in); got != tc.want {
+				t.Fatalf("allSubjectsAreServiceAccountKind(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -194,6 +194,19 @@ type ResolvedEntry struct {
 	RawJSON   []byte    // pre-encoded resolver output, ready to write
 	CreatedAt time.Time // for TTL eviction
 
+	// SeededAtBoot marks an entry written by the Phase-1 boot seed
+	// (seedOneWidget / seedOneRestaction Put), as opposed to a real
+	// user-/call resolve. #130 F3 seed-attribution observable: the
+	// resolved_cache.lookup hit path reads this to tag hit_source
+	// "seed" vs "traffic" and increment hits_seed_attributable, so
+	// "did the boot seed warm this cell" is answerable without forensics.
+	// Boolean provenance ONLY — carries no per-user data, so it is
+	// leak-safe. A refresher/traffic re-Put of the same key overwrites the
+	// entry with SeededAtBoot=false (the natural zero value), correctly
+	// re-classifying the cell as traffic-warmed once real traffic replaces
+	// the seed. Purely additive: legacy entries default false = "traffic".
+	SeededAtBoot bool
+
 	// Inputs is the canonical key-input bundle the entry was resolved
 	// from. The refresher uses it to drive a re-resolve when an
 	// UPDATE/PATCH event fires for any of this entry's dep tuples.

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -477,18 +477,33 @@ type cacheHandle interface {
 // l1_lookup_metrics.go so /debug/vars exposes the same signal
 // without requiring log-line scraping. The bump is one atomic add
 // per call — already on the request-path serial budget.
-func emitResolvedCacheLookup(log *slog.Logger, handlerKind, gvrString, key string, hit bool, residentBytes int) {
+// #130 F3 seed-attribution: seededAtBoot is the hit entry's
+// ResolvedEntry.SeededAtBoot (meaningful only on a hit; pass false on a miss).
+// It drives the hit_source tag ("seed" | "traffic") in the lookup log and the
+// hits_seed_attributable expvar — leak-safe boolean provenance, no per-user data.
+func emitResolvedCacheLookup(log *slog.Logger, handlerKind, gvrString, key string, hit, seededAtBoot bool, residentBytes int) {
 	if log != nil {
+		// hit_source is only meaningful on a hit; on a miss it is "" so a
+		// grep for hit_source:"seed" counts exactly the seed-attributable hits.
+		hitSource := ""
+		if hit {
+			if seededAtBoot {
+				hitSource = "seed"
+			} else {
+				hitSource = "traffic"
+			}
+		}
 		log.Info("resolved_cache.lookup",
 			slog.String("subsystem", "cache"),
 			slog.String("handler", handlerKind),
 			slog.String("gvr", gvrString),
 			slog.String("key_hash", key),
 			slog.Bool("hit", hit),
+			slog.String("hit_source", hitSource),
 			slog.Int("resident_bytes", residentBytes),
 		)
 	}
-	recordL1Lookup(handlerKind, gvrString, hit)
+	recordL1Lookup(handlerKind, gvrString, hit, seededAtBoot)
 }
 
 // emitDispatchCacheKeyDiag — Ship 0.30.188 — pure-additive diagnostic

--- a/internal/handlers/dispatchers/l1_lookup_metrics.go
+++ b/internal/handlers/dispatchers/l1_lookup_metrics.go
@@ -48,11 +48,22 @@ import (
 )
 
 // l1LookupCell holds the hit + miss counters for one
-// (handlerKind, gvrString) pair.
+// (handlerKind, gvrString) pair. seedHit (#130 F3) counts the subset of
+// hits served from a boot-seeded cell (ResolvedEntry.SeededAtBoot) — the
+// seed-attribution observable answering "did the boot seed warm this cell".
 type l1LookupCell struct {
-	hit  atomic.Uint64
-	miss atomic.Uint64
+	hit     atomic.Uint64
+	miss    atomic.Uint64
+	seedHit atomic.Uint64
 }
+
+// hitsSeedAttributable is the process-wide aggregate of resolved-cache hits
+// served from a boot-seeded cell (#130 F3). Published as
+// snowplow_resolved_cache_hits_seed_attributable so acceptance can read ONE
+// number ("the seed warmed >0 browser-hittable cells") without summing the
+// per-(handler,gvr) cells, and every future boot reports it as the standing
+// seed-reachability probe (design §9).
+var hitsSeedAttributable atomic.Uint64
 
 // l1LookupCells is the sync.Map keyed by "<handlerKind>|<gvrString>"
 // → *l1LookupCell. Lazily populated on first observation; never
@@ -68,7 +79,10 @@ var l1LookupCells sync.Map
 // LoadOrStore pattern matches phase1_pip_metrics.go's
 // incFailureCounter so a concurrent first-observation from N workers
 // converges on one cell.
-func recordL1Lookup(handlerKind, gvrString string, hit bool) {
+// #130 F3: seededAtBoot is meaningful only when hit==true (the hit entry's
+// ResolvedEntry.SeededAtBoot). On a miss it is ignored. A seed-attributable
+// hit bumps BOTH the per-cell seedHit counter and the process-wide aggregate.
+func recordL1Lookup(handlerKind, gvrString string, hit, seededAtBoot bool) {
 	if handlerKind == "" {
 		return
 	}
@@ -86,6 +100,10 @@ func recordL1Lookup(handlerKind, gvrString string, hit bool) {
 	c := cell.(*l1LookupCell)
 	if hit {
 		c.hit.Add(1)
+		if seededAtBoot {
+			c.seedHit.Add(1)
+			hitsSeedAttributable.Add(1)
+		}
 	} else {
 		c.miss.Add(1)
 	}
@@ -122,12 +140,18 @@ func registerL1LookupMetrics() {
 					return true
 				}
 				out[ks] = map[string]uint64{
-					"hit_total":  cell.hit.Load(),
-					"miss_total": cell.miss.Load(),
+					"hit_total":      cell.hit.Load(),
+					"miss_total":     cell.miss.Load(),
+					"seed_hit_total": cell.seedHit.Load(),
 				}
 				return true
 			})
 			return out
+		}))
+		// #130 F3: the process-wide seed-attributable aggregate — one scalar
+		// answering "did the boot seed warm any browser-hittable cell".
+		expvar.Publish("snowplow_resolved_cache_hits_seed_attributable", expvar.Func(func() any {
+			return hitsSeedAttributable.Load()
 		}))
 	})
 }

--- a/internal/handlers/dispatchers/l1_lookup_metrics_test.go
+++ b/internal/handlers/dispatchers/l1_lookup_metrics_test.go
@@ -48,9 +48,11 @@ func TestRecordL1Lookup_BumpsHitMissPerCell(t *testing.T) {
 	}
 	beforeHit, beforeMiss := readCell(t, v, handler+"|"+gvr)
 
-	recordL1Lookup(handler, gvr, true)
-	recordL1Lookup(handler, gvr, true)
-	recordL1Lookup(handler, gvr, false)
+	// #130 F3: two hits (one seed-attributable, one traffic) + one miss.
+	seedAttrBefore := hitsSeedAttributable.Load()
+	recordL1Lookup(handler, gvr, true, true)  // seed hit
+	recordL1Lookup(handler, gvr, true, false) // traffic hit
+	recordL1Lookup(handler, gvr, false, false)
 
 	afterHit, afterMiss := readCell(t, v, handler+"|"+gvr)
 	if got, want := afterHit-beforeHit, uint64(2); got != want {
@@ -58,6 +60,15 @@ func TestRecordL1Lookup_BumpsHitMissPerCell(t *testing.T) {
 	}
 	if got, want := afterMiss-beforeMiss, uint64(1); got != want {
 		t.Fatalf("miss_total delta = %d, want %d", got, want)
+	}
+	// #130 F3: exactly ONE of the two hits was seed-attributable — both the
+	// per-cell seed_hit_total and the process-wide aggregate bump by 1.
+	if got, want := hitsSeedAttributable.Load()-seedAttrBefore, uint64(1); got != want {
+		t.Fatalf("hits_seed_attributable delta = %d, want %d (only the SeededAtBoot hit counts)", got, want)
+	}
+	seedHit := readSeedHitCell(t, v, handler+"|"+gvr)
+	if seedHit < 1 {
+		t.Fatalf("seed_hit_total = %d, want >=1 (the seed-attributable hit)", seedHit)
 	}
 }
 
@@ -82,7 +93,7 @@ func TestRecordL1Lookup_ConcurrentFirstObservation(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			recordL1Lookup(handler, gvr, true)
+			recordL1Lookup(handler, gvr, true, false)
 		}()
 	}
 	close(start)
@@ -113,4 +124,17 @@ func readCell(t *testing.T, v expvar.Var, cellKey string) (uint64, uint64) {
 		return 0, 0
 	}
 	return cell["hit_total"], cell["miss_total"]
+}
+
+// readSeedHitCell reads the #130 F3 seed_hit_total for a cell (0 if absent).
+func readSeedHitCell(t *testing.T, v expvar.Var, cellKey string) uint64 {
+	t.Helper()
+	var parsed map[string]map[string]uint64
+	if err := json.Unmarshal([]byte(v.String()), &parsed); err != nil {
+		t.Fatalf("decode expvar JSON: %v", err)
+	}
+	if cell, ok := parsed[cellKey]; ok {
+		return cell["seed_hit_total"]
+	}
+	return 0
 }

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -722,8 +722,9 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	// Put under the per-user key — exactly the shape restactions.go
 	// :212-216 puts under at serve time.
 	handle.Put(key, &cache.ResolvedEntry{
-		RawJSON: encoded,
-		Inputs:  inputs,
+		RawJSON:      encoded,
+		Inputs:       inputs,
+		SeededAtBoot: true, // #130 F3 seed-attribution: this cell was warmed by the boot seed
 	})
 	// counters-hygiene 2026-07-04: this success Put is a seed UNIT resolved +
 	// written to per-user L1 — the real meaning of
@@ -930,8 +931,9 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode s
 	}
 
 	handle.Put(key, &cache.ResolvedEntry{
-		RawJSON: encoded,
-		Inputs:  inputs,
+		RawJSON:      encoded,
+		Inputs:       inputs,
+		SeededAtBoot: true, // #130 F3 seed-attribution: this cell was warmed by the boot seed
 	})
 	// counters-hygiene 2026-07-04 — see seedOneRestaction: this success Put is
 	// a seed UNIT resolved+written; wired so snowplow_phase1_bindingset_seed_resolves_total

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -719,6 +719,14 @@ func seedScopeYielding(ctx context.Context,
 		key       string
 		widgetMax int
 		allMax    int
+		// firstNavReachable (#130 F3 Lever 1) — the identity has >=1 RootIndex==0
+		// (first-nav) widget target. PRIMARY rank tier: frontend-reachable cohorts
+		// sort above any cohort with only non-first-nav widget targets, so every
+		// login cohort's dashboard segment seeds before the non-first-nav tail.
+		// Derived from the SAME RootIndex==0 widget-target data the Lever-2 latch
+		// arms on (uniform discriminator, no static list). Post-SA-exclusion the
+		// seed set is login cohorts only, so this orders WITHIN the login tier.
+		firstNavReachable bool
 	}
 	rankOf := map[string]rankedIdentity{}
 	noteIdentity := func(c seedTarget, isWidget bool) {
@@ -743,11 +751,33 @@ func seedScopeYielding(ctx context.Context,
 			noteIdentity(c, false)
 		}
 	}
+	// #130 F3 Lever 1: compute the first-nav-reachable set — identities with
+	// >=1 RootIndex==0 widget target. This is the SAME RootIndex==0 scan the
+	// Lever-2 latch does (below); computed once here so it can be a rank tier.
+	// Uniform data-derived discriminator, no static cohort list.
+	firstNavReachableSet := map[string]bool{}
+	for _, ws := range widgetSeeds {
+		if ws.e.RootIndex != 0 {
+			continue
+		}
+		for _, c := range ws.targets {
+			firstNavReachableSet[identityKey(c)] = true
+		}
+	}
 	ranked := make([]rankedIdentity, 0, len(rankOf))
 	for _, ri := range rankOf {
+		ri.firstNavReachable = firstNavReachableSet[ri.key]
 		ranked = append(ranked, ri)
 	}
 	sort.SliceStable(ranked, func(i, j int) bool {
+		// #130 F3 Lever 1 — PRIMARY tier: frontend-reachable (has a first-nav
+		// widget) cohorts sort first, so every login cohort's dashboard segment
+		// seeds before any cohort whose widgets are all non-first-nav. PURE
+		// ORDERING — the ranked SET is unchanged (SA-only cohorts are already
+		// removed upstream at enumeration); this only reorders the survivors.
+		if ranked[i].firstNavReachable != ranked[j].firstNavReachable {
+			return ranked[i].firstNavReachable // true sorts before false
+		}
 		if ranked[i].widgetMax != ranked[j].widgetMax {
 			return ranked[i].widgetMax > ranked[j].widgetMax
 		}
@@ -883,11 +913,31 @@ func seedScopeYielding(ctx context.Context,
 	latchStart := time.Now()
 	firstNavRemaining := 0
 	firstNavWidgets := 0
-	// segKey/segRank identify the segment identity + its rank in `ranked`.
-	// segRank stays -1 when NO ranked identity has any RootIndex==0 widget
-	// target (genuinely-no-first-nav topology, F-C3) — the zero-fire boundary
-	// below keys on segRank<0/unreached, preserving the provably-empty
-	// semantics.
+	// ── #130 F3 Lever 2: latch waits for EVERY reachable cohort's first-nav
+	// segment, not just the first (rank-0) one. ──
+	//
+	// PRE-F3 (segment-scoped): the latch armed on the FIRST ranked identity with
+	// a RootIndex==0 widget target (segKey at segRank) and fired the instant THAT
+	// ONE identity's first-nav segment completed — so /readyz flipped with every
+	// OTHER login cohort's dashboard still cold (the admins-starved defect: Ready
+	// fired on devs while admins' cells were never seeded).
+	//
+	// F3: arm firstNavRemaining as the SUM over ALL first-nav-reachable
+	// identities' RootIndex==0 widget targets, and record that set in
+	// reachableFirstNav. Ready fires only when the LAST first-nav target of ANY
+	// reachable cohort seeds (firstNavRemaining==0) — i.e. "every login cohort's
+	// dashboard is warm," which IS the milestone. The MarkPhase1Done /
+	// PHASE1_TIMEOUT backstop is UNCHANGED (C2 liveness — a pathological cohort
+	// cannot hang readiness forever; it goes Ready-degraded for that cohort, the
+	// exception not the rule).
+	//
+	// reachableFirstNav is the membership set the fire-decrement below keys on
+	// (an identity is "reachable" iff it has >=1 RootIndex==0 widget target).
+	// segKey/segRank retain their PRE-F3 meaning (the FIRST reachable identity +
+	// its rank) purely for the fire-log fields + the segRank<0 provably-empty
+	// boundary (F-C3) — segRank stays -1 when NO ranked identity has any
+	// RootIndex==0 widget target, preserving the zero-fire semantics.
+	reachableFirstNav := map[string]bool{}
 	segKey := ""
 	segRank := -1
 	if latch != nil {
@@ -911,11 +961,16 @@ func seedScopeYielding(ctx context.Context,
 				}
 			}
 			if count > 0 {
-				segKey = candidate
-				segRank = r
-				firstNavRemaining = count
-				firstNavWidgets = widgetsWith
-				break
+				// F3: accumulate EVERY reachable cohort (do NOT break at the first).
+				reachableFirstNav[candidate] = true
+				firstNavRemaining += count
+				firstNavWidgets += widgetsWith
+				if segRank < 0 {
+					// First reachable identity — retain for the log fields + the
+					// provably-empty boundary (unchanged semantics).
+					segKey = candidate
+					segRank = r
+				}
 			}
 		}
 	}
@@ -976,16 +1031,17 @@ func seedScopeYielding(ctx context.Context,
 				if seedWidgetTarget(e, c) {
 					return ctx.Err()
 				}
-				// F-C2: fire the latch the instant the LAST segment-identity
-				// RootIndex==0 widget target has been PROCESSED (mid-segRank pass).
-				// #99b: the segment is the segKey identity at rank segRank — the
-				// first ranked identity with a RootIndex==0 widget target, NOT
-				// necessarily ranked[0]. Only that identity's first-nav segment
-				// decrements; RootIndex>0 widgets and every other rank never touch
+				// F-C2 / #130 F3 Lever 2: fire the latch the instant the LAST
+				// FIRST-NAV target of ANY reachable cohort has been PROCESSED. The
+				// decrement now keys on reachableFirstNav MEMBERSHIP (every login
+				// cohort with a RootIndex==0 widget target), NOT the single segKey
+				// identity — so /readyz waits for EVERY reachable cohort's dashboard
+				// segment, not just rank-0's (the admins-starved fix). RootIndex>0
+				// widgets and non-reachable (SA-tail) identities never touch
 				// firstNavRemaining, so this cannot fire early on a RootIndex>0-only
-				// seed (F-C3). segRank<0 means no ranked identity has a first-nav
-				// widget → this branch never matches → the provably-empty fire
-				// below is the only path.
+				// or non-first-nav seed (F-C3). segRank<0 (reachableFirstNav empty)
+				// means no ranked identity has a first-nav widget → this branch never
+				// matches → the provably-empty fire below is the only path.
 				//
 				// PROCESSED, NOT SUCCEEDED (deliberate, C2 liveness). We reach
 				// this line whenever seedWidgetTarget did not abort on ctx-cancel;
@@ -997,7 +1053,7 @@ func seedScopeYielding(ctx context.Context,
 				// real guard that the dashboard is genuinely warm is the
 				// on-cluster post-Ready /dashboard nav#1 l1:HIT content check, not
 				// this counter.
-				if latch != nil && ri == segRank && e.RootIndex == 0 && identityKey(c) == segKey {
+				if latch != nil && e.RootIndex == 0 && reachableFirstNav[identityKey(c)] {
 					firstNavRemaining--
 					if firstNavRemaining == 0 {
 						fireFirstNav("segment-complete")

--- a/internal/handlers/dispatchers/prewarm_f3_key_parity_test.go
+++ b/internal/handlers/dispatchers/prewarm_f3_key_parity_test.go
@@ -1,0 +1,360 @@
+// prewarm_f3_key_parity_test.go — #130 F3 falsifier (c): seed↔browser key parity
+// through REAL derivation, plus the never-worse SA-traffic arm (safety-check #1).
+//
+// C-F3-3 proves the attribution claim from the design §3: for an UNDECLARED
+// first-nav widget the admins group-rep SEED key (Username="", Groups=["admins"])
+// FIELD-equals the real admin BROWSER key (Username="admin", Groups=["admins"]),
+// so a completed admins seed writes a browser-hittable cell. And for a DECLARED
+// identityContext:[username] widget the keys DIVERGE (guards the §4 caveat — such
+// a widget is per-user and not cohort-seed-coverable).
+//
+// BOTH sides run the REAL derivation (withCohortSeedContext vs a real request
+// ctx → dispatchCacheLookupKey → effectiveKeyExtras → widgets.DeclaredIdentity)
+// and the arm asserts PRE-HASH ResolvedKeyInputs FIELD-equality BEFORE the digest
+// (feedback_key_parity_golden_real_inputs_prehash_diff), never hand-fed keys
+// (feedback_consultation_mutation_is_not_key_correctness). curl is inadmissible
+// here (feedback_curl_probes_inadmissible_for_seed_hit_acceptance).
+
+package dispatchers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var f3WidgetGVR = schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "flexes"}
+
+// buildF3AdminsParityWatcher publishes an admins Group ClusterRoleBinding on the
+// widget GVR + two widget CRs: "undeclared-flex" (no identityContext) and
+// "declared-flex" (spec.identityContext:[username]). Makes the GVR servable so
+// the real dispatchCacheLookupKey derivation runs on both.
+func buildF3AdminsParityWatcher(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}:        "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}:        "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:               "RoleList",
+		f3WidgetGVR: "FlexList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{f3WidgetGVR.Group}, Resources: []string{f3WidgetGVR.Resource}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "flex-reader"}, Rules: rule},
+		// admins granted via a GROUP-subject CRB — the group-rep the seed uses.
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "admins-bind", UID: types.UID("uid-admins")},
+			Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "admins"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "flex-reader"},
+		},
+		// UNDECLARED widget — no spec.identityContext → DeclaredIdentity nil → key
+		// is identity-invariant (BindingUID re-derived first-match, same both sides).
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": f3WidgetGVR.Group + "/" + f3WidgetGVR.Version,
+			"kind":       "Flex",
+			"metadata":   map[string]any{"name": "undeclared-flex", "namespace": "krateo-system"},
+			"spec":       map[string]any{},
+		}},
+		// DECLARED widget — spec.identityContext:[username] → DeclaredIdentity
+		// folds the username into the key → seed (no username) vs browser (admin)
+		// keys DIVERGE.
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": f3WidgetGVR.Group + "/" + f3WidgetGVR.Version,
+			"kind":       "Flex",
+			"metadata":   map[string]any{"name": "declared-flex", "namespace": "krateo-system"},
+			"spec":       map[string]any{"identityContext": []any{"username"}},
+		}},
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(f3WidgetGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	cache.BuildBindingsByGVRIndex([]schema.GroupVersionResource{f3WidgetGVR})
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+		cache.ResetBindingsByGVRIndexForTest()
+	})
+}
+
+// f3WidgetCR reconstructs the widget CR object the seeded watcher holds, so the
+// derive helpers can thread it through the REAL keyExtras derivation
+// (effectiveKeyExtras → widgets.DeclaredIdentity) exactly as widgets.go:152 does
+// before calling dispatchCacheLookupKey. The declared CR carries
+// spec.identityContext:[username]; the undeclared CR has an empty spec.
+func f3WidgetCR(widgetName string, declared bool) map[string]any {
+	spec := map[string]any{}
+	if declared {
+		spec["identityContext"] = []any{"username"}
+	}
+	return map[string]any{
+		"apiVersion": f3WidgetGVR.Group + "/" + f3WidgetGVR.Version,
+		"kind":       "Flex",
+		"metadata":   map[string]any{"name": widgetName, "namespace": "krateo-system"},
+		"spec":       spec,
+	}
+}
+
+// buildF3SAOnlyWatcher publishes a ServiceAccount-subject ClusterRoleBinding
+// (the SA-only kind F3 excludes from seeding) granting get/list on the widget
+// GVR + the undeclared widget CR, servable. Used by the never-worse arm to prove
+// the excluded SA still SERVES via the normal dispatch.
+func buildF3SAOnlyWatcher(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}: "ClusterRoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}:        "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}:        "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:               "RoleList",
+		f3WidgetGVR: "FlexList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{f3WidgetGVR.Group}, Resources: []string{f3WidgetGVR.Resource}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "flex-reader"}, Rules: rule},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "cdc-sa-bind", UID: types.UID("uid-cdc-sa")},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "cdc-sa", Namespace: "krateo-system"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "flex-reader"},
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": f3WidgetGVR.Group + "/" + f3WidgetGVR.Version,
+			"kind":       "Flex",
+			"metadata":   map[string]any{"name": "undeclared-flex", "namespace": "krateo-system"},
+			"spec":       map[string]any{},
+		}},
+	}
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(f3WidgetGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	cache.BuildBindingsByGVRIndex([]schema.GroupVersionResource{f3WidgetGVR})
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+		cache.ResetBindingsByGVRIndexForTest()
+	})
+}
+
+// deriveSeedInputs runs the REAL seed derivation for the admins group-rep
+// (Username="", Groups=["admins"]): withCohortSeedContext → effectiveKeyExtras
+// (the SAME keyExtras widgets.go computes) → dispatchCacheLookupKey.
+func deriveSeedInputs(t *testing.T, widgetName string, declared bool) (*cache.ResolvedKeyInputs, string) {
+	t.Helper()
+	c := seedTarget{Username: "", Groups: []string{"admins"}}
+	cctx := withCohortSeedContext(context.Background(), c, endpoints.Endpoint{}, nil)
+	keyExtras := effectiveKeyExtras(cctx, f3WidgetCR(widgetName, declared), nil)
+	key, _, inputs := dispatchCacheLookupKey(cctx, "widgets",
+		f3WidgetGVR.Group, f3WidgetGVR.Version, f3WidgetGVR.Resource,
+		"krateo-system", widgetName, -1, -1, keyExtras)
+	return inputs, key
+}
+
+// deriveBrowserInputs runs the REAL browser derivation (real admin identity:
+// Username="admin", Groups=["admins"]) → effectiveKeyExtras → dispatchCacheLookupKey.
+func deriveBrowserInputs(t *testing.T, widgetName string, declared bool) (*cache.ResolvedKeyInputs, string) {
+	t.Helper()
+	bctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "admin", Groups: []string{"admins"}}))
+	keyExtras := effectiveKeyExtras(bctx, f3WidgetCR(widgetName, declared), nil)
+	key, _, inputs := dispatchCacheLookupKey(bctx, "widgets",
+		f3WidgetGVR.Group, f3WidgetGVR.Version, f3WidgetGVR.Resource,
+		"krateo-system", widgetName, -1, -1, keyExtras)
+	return inputs, key
+}
+
+// hashedKeyInputsEqual compares the SUBSET of ResolvedKeyInputs fields that
+// ComputeKey actually hashes (CacheEntryClass, Group, Version, Resource,
+// Namespace, Name, BindingUID, PerPage, Page, Extras) — NOT the diagnostic
+// RepresentativeUsername/RepresentativeGroups, which ComputeKey deliberately
+// does NOT fold (resolved.go: "Carried on Inputs but NOT folded into
+// ComputeKey"). A raw struct DeepEqual would false-RED on the representative
+// identity, which legitimately differs between the group-rep seed and the real
+// browser — the whole point of the identity-invariant-key design.
+func hashedKeyInputsEqual(a, b *cache.ResolvedKeyInputs) bool {
+	// Stage IS included (arch review): ComputeKey folds it when non-empty
+	// (resolved.go:699). It is "" for the widget class here, so inclusion is
+	// inert — but the helper must mirror ComputeKey's fold set EXACTLY so the
+	// pre-hash field assertion is the discriminating one, not merely digest-backed.
+	return a.CacheEntryClass == b.CacheEntryClass &&
+		a.Group == b.Group && a.Version == b.Version && a.Resource == b.Resource &&
+		a.Namespace == b.Namespace && a.Name == b.Name &&
+		a.BindingUID == b.BindingUID &&
+		a.PerPage == b.PerPage && a.Page == b.Page &&
+		a.Stage == b.Stage &&
+		reflect.DeepEqual(a.Extras, b.Extras)
+}
+
+// TestF3KeyParity_UndeclaredWidget_SeedKeyEqualsBrowserKey is arm (c)(i): the
+// undeclared first-nav widget's seed key (admins group-rep) FIELD-equals the
+// real admin browser key → a completed admins seed writes a browser-hittable
+// cell (the attribution=0 gap was coverage, NOT key divergence).
+func TestF3KeyParity_UndeclaredWidget_SeedKeyEqualsBrowserKey(t *testing.T) {
+	buildF3AdminsParityWatcher(t)
+
+	seedInputs, seedKey := deriveSeedInputs(t, "undeclared-flex", false)
+	browserInputs, browserKey := deriveBrowserInputs(t, "undeclared-flex", false)
+
+	if seedInputs == nil || browserInputs == nil {
+		t.Fatalf("arm (c)(i): nil inputs — seed=%v browser=%v (RBAC/objects.Get setup wrong; the admins "+
+			"binding must first-match on both sides)", seedInputs, browserInputs)
+	}
+	// PRE-HASH equality over the HASHED SUBSET (feedback_key_parity_golden_real_inputs_prehash_diff):
+	// for an undeclared widget DeclaredIdentity is nil on BOTH sides, so nothing
+	// folds Extras, and both re-derive the SAME first-match admins BindingUID. The
+	// diagnostic RepresentativeUsername legitimately differs ("" seed vs "admin"
+	// browser) and is NOT hashed — comparing it (raw struct DeepEqual) would
+	// false-RED. hashedKeyInputsEqual compares exactly what ComputeKey folds.
+	if !hashedKeyInputsEqual(seedInputs, browserInputs) {
+		t.Fatalf("arm (c)(i): undeclared-widget seed vs browser HASHED key inputs DIFFER — "+
+			"a completed admins seed would NOT be browser-hittable (key-divergence, not coverage).\n seed=%+v\n browser=%+v",
+			*seedInputs, *browserInputs)
+	}
+	// The digest matches (closes the loop end-to-end through real ComputeKey).
+	if seedKey != browserKey {
+		t.Fatalf("arm (c)(i): hashed inputs equal but DIFFERENT ComputeKey digest — seed=%q browser=%q", seedKey, browserKey)
+	}
+	// The BindingUID must be a real first-match (not "") — else the parity is the
+	// vacuous empty-identity collapse, not a genuine admins-cohort match.
+	if seedInputs.BindingUID == "" {
+		t.Fatalf("arm (c)(i): re-derived BindingUID is empty — the admins group identity did not first-match "+
+			"a published binding; parity would be vacuous. inputs=%+v", *seedInputs)
+	}
+}
+
+// TestF3KeyParity_DeclaredWidget_SeedKeyDivergesFromBrowser is arm (c)(ii): a
+// declared identityContext:[username] widget folds the username into the key, so
+// the group-rep seed (Username="") and the real admin browser (Username="admin")
+// derive DIFFERENT keys — such a widget is per-user and NOT cohort-seed-coverable
+// (guards the §4 caveat; a future regression that made it seed-covered would
+// write an admin-unhittable cell).
+func TestF3KeyParity_DeclaredWidget_SeedKeyDivergesFromBrowser(t *testing.T) {
+	buildF3AdminsParityWatcher(t)
+
+	seedInputs, seedKey := deriveSeedInputs(t, "declared-flex", true)
+	browserInputs, browserKey := deriveBrowserInputs(t, "declared-flex", true)
+	if seedInputs == nil || browserInputs == nil {
+		t.Fatalf("arm (c)(ii): nil inputs — seed=%v browser=%v", seedInputs, browserInputs)
+	}
+	// Sanity: the declared fold MUST have injected the username into Extras on the
+	// browser side (proving the fold actually ran through the real path — else the
+	// divergence below would be vacuous). effectiveKeyExtras → DeclaredIdentity
+	// reads spec.identityContext:[username] + ctx UserInfo.
+	if _, ok := browserInputs.Extras["username"]; !ok {
+		t.Fatalf("arm (c)(ii) setup: the declared identityContext:[username] fold did NOT inject username into "+
+			"the browser key Extras — the real effectiveKeyExtras/DeclaredIdentity path did not run; the "+
+			"divergence assert would be vacuous. browser=%+v", *browserInputs)
+	}
+	// The declared username fold MUST make the keys diverge (seed folds no
+	// username — group-rep has Username=""; browser folds "admin"). A group-rep
+	// seed would write a cell the admin cannot hit — so such a widget is per-user
+	// and out of cohort-seed scope (guards the §4 caveat).
+	if seedKey == browserKey {
+		t.Fatalf("arm (c)(ii): declared identityContext:[username] widget produced EQUAL seed/browser keys — "+
+			"the username fold is inert; a group-rep seed would write a cell the admin cannot hit yet the "+
+			"key claims parity.\n seed=%+v\n browser=%+v", *seedInputs, *browserInputs)
+	}
+}
+
+// TestF3SAExclusion_NeverWorse_SATrafficStillServes is the safety-check #1 arm:
+// the SA-exclusion touches ONLY the boot SEED target set. An excluded
+// ServiceAccount identity that issues a REAL /call still resolves through the
+// normal dispatch path — it derives a valid (non-empty) BindingUID and its cell
+// cold-fills as a TRAFFIC entry (SeededAtBoot=false → hit_source:"traffic").
+// Proves NEVER-WORSE: excluding the SA from seeding does not deny it service.
+func TestF3SAExclusion_NeverWorse_SATrafficStillServes(t *testing.T) {
+	// A watcher granting a ServiceAccount get/list on the widget GVR (an SA-ONLY
+	// binding — the kind F3 excludes from seeding). Reuse the admins-parity
+	// builder shape but with an SA subject.
+	buildF3SAOnlyWatcher(t)
+
+	// (1) SEED side: the SA-only binding is EXCLUDED from the enumeration.
+	targets := cache.EnumeratePrewarmTargetsForGVR(f3WidgetGVR, "list")
+	for _, tg := range targets {
+		if tg.Subject.Username == "system:serviceaccount:krateo-system:cdc-sa" {
+			t.Fatalf("never-worse setup: the SA-only cohort must be EXCLUDED from seed targets; present: %+v", targets)
+		}
+	}
+
+	// (2) SERVE side (never-worse): a REAL dispatch under the SA identity still
+	// derives a NON-EMPTY BindingUID — the SA can be served; its cell would
+	// cold-fill on first request as a traffic entry. This is the customer /call
+	// path, entirely independent of the seed enumeration the exclusion touched.
+	saCtx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "system:serviceaccount:krateo-system:cdc-sa"}))
+	_, _, inputs := dispatchCacheLookupKey(saCtx, "widgets",
+		f3WidgetGVR.Group, f3WidgetGVR.Version, f3WidgetGVR.Resource,
+		"krateo-system", "undeclared-flex", -1, -1, nil)
+	if inputs == nil {
+		t.Fatalf("never-worse: excluded SA derived nil inputs — the SA can no longer be served (WORSE); "+
+			"exclusion must touch SEED only, not serve")
+	}
+	if inputs.BindingUID == "" {
+		t.Fatalf("never-worse: excluded SA re-derived an EMPTY BindingUID — it cannot be served from cache "+
+			"(the empty-BindingUID serve-miss collapse). Exclusion must NOT deny the SA service; inputs=%+v", *inputs)
+	}
+	// A cell written on this dispatch is a TRAFFIC entry (SeededAtBoot false by
+	// construction — the seed never wrote it), so a subsequent hit reports
+	// hit_source:"traffic". Assert the traffic default holds on a fresh entry.
+	entry := &cache.ResolvedEntry{RawJSON: []byte(`{}`)}
+	if entry.SeededAtBoot {
+		t.Fatalf("never-worse: a non-seed (traffic) ResolvedEntry must default SeededAtBoot=false")
+	}
+}

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
@@ -176,6 +176,19 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 	run := func(t *testing.T, mutateNeuterSegment bool) []latchSeedEvent {
 		resetFirstNavLatchForTest()
 		ensureFirstNavLatch() // build the process latch so seedScopeYielding can fire it
+		// #130 F3 cascade-harden (arch point 5): a FAILED arm previously left the
+		// process-global first-nav latch singleton armed/fired + the fire observer
+		// installed, poisoning the NEXT test in the package (the observed
+		// TestF5_RealCheckDispatchRBAC cascade). Reset the process-global seed
+		// state in t.Cleanup so a mid-seed Fatalf cannot leak it forward. (The
+		// observer is also cleared by installLatchFireObserver's own Cleanup; this
+		// is belt-and-suspenders + the latch/customer-in-flight reset the prior
+		// code only did at the NEXT run's start.)
+		t.Cleanup(func() {
+			resetFirstNavLatchForTest()
+			firstNavFireObserver = nil
+			zeroCustomerInFlight()
+		})
 
 		devs := eID{name: "devs", group: true, collapsed: 442}
 		ops := eID{name: "ops", group: true, collapsed: 5}
@@ -226,26 +239,63 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 		return rec.snapshot()
 	}
 
-	t.Run("green_fires_before_tail", func(t *testing.T) {
+	t.Run("green_fires_after_all_reachable_dashboards_before_last_tail", func(t *testing.T) {
+		// #130 F3 Lever 2 — the latch now waits for EVERY first-nav-reachable
+		// cohort's dashboard segment (devs AND ops), not just rank-0's. The
+		// invariant is re-expressed for the multi-cohort case (arch-ruled: the
+		// single-cohort "fire before ANY tail" is genuinely incompatible with
+		// "wait for all cohorts' dashboards" under the rank-major loop — reaching
+		// ops' dashboard requires traversing devs' full rank first, including devs'
+		// tail widget + devs' fanout RA. That interleaving is intended and
+		// unavoidable without a larger dashboard-first seed reorder, which is out
+		// of F3 scope). The load-bearing readyz-correctness properties that SURVIVE:
+		//   (1) fire AFTER both reachable cohorts' RootIndex==0 dashboards (Ready
+		//       does not flip until every login cohort's dashboard is warm), and
+		//   (2) fire BEFORE the LAST reachable cohort's (ops') tail widget + RA,
+		//       and before the filler-only RA (readyz does not wait on the LAST
+		//       cohort's non-dashboard tail — the whale-fanout the latch removes).
 		ev := run(t, false)
 		latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-		dashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dashboard-flex" && e.identity == "group:devs" })
-		tailWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "estate-graph" })
-		raIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
+		devsDashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
+			return e.class == "widget" && e.label == "dashboard-flex" && e.identity == "group:devs"
+		})
+		opsDashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
+			return e.class == "widget" && e.label == "dashboard-flex" && e.identity == "group:ops"
+		})
+		opsTailWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
+			return e.class == "widget" && e.label == "estate-graph" && e.identity == "group:ops"
+		})
+		opsRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
+			return e.class == "restaction" && e.identity == "group:ops"
+		})
+		fillerRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
+			return e.class == "restaction" && e.identity == "user:filler"
+		})
 
 		if latchIdx == len(ev) {
 			t.Fatalf("F-C1: latch never fired; events=%+v", ev)
 		}
-		// Fire AFTER the rank-1 dashboard widget seeds (segment complete)...
-		if latchIdx < dashIdx {
-			t.Fatalf("F-C1: latch fired at idx %d BEFORE the rank-1 dashboard widget seeded at idx %d — ARM-COLD RED; events=%+v", latchIdx, dashIdx, ev)
+		// (1) fire AFTER BOTH reachable cohorts' dashboards — the Lever-2 core.
+		if devsDashIdx == len(ev) || opsDashIdx == len(ev) {
+			t.Fatalf("F3 Lever2 setup: both devs+ops dashboards must seed; devsDash=%d opsDash=%d events=%+v", devsDashIdx, opsDashIdx, ev)
 		}
-		// ...and BEFORE any tail work (RootIndex>0 widget + fanout RA) — ARM-TAIL.
-		if tailWidgetIdx < len(ev) && latchIdx > tailWidgetIdx {
-			t.Fatalf("F-C1/ARM-TAIL: latch fired at idx %d AFTER the NON-first-nav tail widget seeded at idx %d — readyz would wait on tail work; events=%+v", latchIdx, tailWidgetIdx, ev)
+		if latchIdx < devsDashIdx || latchIdx < opsDashIdx {
+			t.Fatalf("F3 Lever2 ARM-COLD: latch fired at idx %d BEFORE a reachable cohort's dashboard "+
+				"(devsDash=%d opsDash=%d) — readyz would flip with a login cohort's dashboard cold; events=%+v",
+				latchIdx, devsDashIdx, opsDashIdx, ev)
 		}
-		if raIdx < len(ev) && latchIdx > raIdx {
-			t.Fatalf("F-C1/ARM-TAIL: latch fired at idx %d AFTER the fanout restaction seeded at idx %d — readyz would wait on the RA tail; events=%+v", latchIdx, raIdx, ev)
+		// (2) fire BEFORE the LAST cohort's (ops') tail widget + ops' RA + the
+		//     filler-only RA — readyz does not wait on the last cohort's tail whale.
+		if opsTailWidgetIdx < len(ev) && latchIdx > opsTailWidgetIdx {
+			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER ops' NON-first-nav tail widget at idx %d "+
+				"— readyz would wait on the last cohort's tail; events=%+v", latchIdx, opsTailWidgetIdx, ev)
+		}
+		if opsRAIdx < len(ev) && latchIdx > opsRAIdx {
+			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER ops' fanout restaction at idx %d; events=%+v", latchIdx, opsRAIdx, ev)
+		}
+		if fillerRAIdx < len(ev) && latchIdx > fillerRAIdx {
+			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER the filler-only restaction at idx %d "+
+				"— readyz would wait on the RA-only tail; events=%+v", latchIdx, fillerRAIdx, ev)
 		}
 	})
 

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -185,7 +185,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 	// cell to a different ""-deriving identity. See serveFromCacheEligible.
 	if cacheHandle != nil && serveFromCacheEligible(cacheInputs) {
 		if entry, ok := cacheHandle.Get(cacheKey); ok {
-			emitResolvedCacheLookup(log, "restactions", got.GVR.String(), cacheKey, true, len(entry.RawJSON))
+			emitResolvedCacheLookup(log, "restactions", got.GVR.String(), cacheKey, true, entry.SeededAtBoot, len(entry.RawJSON))
 			pcs.l1Hit = "hit"
 			setRefreshKeyHeader(wri, cacheKey, "restactions")
 			writeResolvedJSON(wri, entry.RawJSON)
@@ -197,7 +197,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 			)
 			return
 		}
-		emitResolvedCacheLookup(log, "restactions", got.GVR.String(), cacheKey, false, 0)
+		emitResolvedCacheLookup(log, "restactions", got.GVR.String(), cacheKey, false, false, 0)
 		pcs.l1Hit = "miss"
 	}
 

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -192,7 +192,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 					cache.RecordApiserverFallthrough(req.Context(),
 						cache.ReasonWidgetContentHit, got.GVR.String())
 					emitResolvedCacheLookup(log, "widgetContent", got.GVR.String(),
-						contentKey, true, len(gated))
+						contentKey, true, entry.SeededAtBoot, len(gated))
 					pcs.l1Hit = "content-hit"
 					setRefreshKeyHeader(wri, contentKey, "widgetContent")
 					writeResolvedJSON(wri, gated)
@@ -239,7 +239,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	// populate-side skip; uniform predicate (serveFromCacheEligible, helpers.go).
 	if cacheHandle != nil && serveFromCacheEligible(cacheInputs) {
 		if entry, ok := cacheHandle.Get(cacheKey); ok {
-			emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, true, len(entry.RawJSON))
+			emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, true, entry.SeededAtBoot, len(entry.RawJSON))
 			pcs.l1Hit = "hit"
 			setRefreshKeyHeader(wri, cacheKey, "widgets")
 			writeResolvedJSON(wri, entry.RawJSON)
@@ -249,7 +249,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 			)
 			return
 		}
-		emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, false, 0)
+		emitResolvedCacheLookup(log, "widgets", got.GVR.String(), cacheKey, false, false, 0)
 		pcs.l1Hit = "miss"
 	}
 


### PR DESCRIPTION
**PARKED — Diego-reserved merge.** Frozen SHA `b40117d` (re-frozen from 83775e4: +1 test-only fix — hashedKeyInputsEqual now compares Stage, per arch gate). Dual pre-commit gate (arch + PM) on this SHA. Chart companion is a lockstep at deploy (separate repo).

Gater checkout:
```
git fetch origin f3-login-cohort-seed-coverage && git checkout FETCH_HEAD
```

## Problem
Admin (and every non-devs login cohort) first-nav was cold at boot: admins was **enumerated-but-STARVED** — the serial rank-major seed exhausted its budget on devs before reaching admins (rank 2), and the /readyz latch fired on the devs segment only → Ready with admins' cells cold (0 seed-attributable hits, 56.8% admin first-nav on 1.7.6).

## Change (3 code levers + chart companion)
1. **SA-exclusion** (Diego directive, `internal/cache/prewarm_enumeration.go`): drop bindings whose subject SET is entirely ServiceAccount-kind (`allSubjectsAreServiceAccountKind`). SET predicate NOT winner-kind (arch-caught latent bug — `pickRepresentativeFromSubjects` is first-non-empty-by-slice-order; a mixed `[SA,Group]` binding picks the SA, so a winner-kind gate would drop that login cohort). Subject KIND not name-allowlist (`system:masters` is a GROUP, kept). NEVER-WORSE: seed-only; excluded SA still serves via dispatch (`hit_source:"traffic"`).
2. **Lever 1 reachable-tier rank** (`prewarm_engine_boot.go`): `firstNavReachable` primary rank tier orders login cohorts with a first-nav widget above non-first-nav ones. Pure ordering.
3. **Lever 2 all-cohort latch** (`prewarm_engine_boot.go`): `firstNavRemaining` = SUM over EVERY reachable cohort's RootIndex==0 targets; decrement keys on `reachableFirstNav` membership. Ready waits until every login cohort's dashboard is warm. Backstop preserved.
4. **Seed attribution** (`resolved.go`/`l1_lookup_metrics.go`/`helpers.go`): `ResolvedEntry.SeededAtBoot` → `hit_source:"seed"|"traffic"` + `snowplow_resolved_cache_hits_seed_attributable` expvar. Standing reachability probe.
5. **Chart companion** (snowplow-chart `values.yaml`, lockstep at deploy): `PHASE1_TIMEOUT_SECONDS 180→900`.

## Chart-companion calibration (TRACED — the load-bearing mechanism, verify at gate)
The seed runs under `seedCtx = context.WithTimeout(phase1Ctx, pipGlobalTimeout=480s)` (`phase1_walk.go:826`) — it **INHERITS the phase-1 deadline, NOT a fresh 480s**. Effective seed budget = `min(PHASE1_TIMEOUT − preSeedElapsed, 480s)`. On the 1.7.6 boot the pre-seed phases (roots-walk ~150s + content ~11s + discovery re-walk ~100s) consumed **~251s** before the seed started (ranks emitted at t+251s), so at the live `PHASE1_TIMEOUT=300` the seed got **~49s** and starved (`sync_incomplete`). Raise to **900** → seed gets `900−251=649 > 480` → the seed's own 480s cap is the real bound (the intended state; restores the pre-2026-06 value). **50K note:** pre-seed walk is larger there — re-measure `preSeedElapsed` and re-raise if `900−preSeed < 480` (C-F3-5).
**503-duration TRADE (surfaced for the gate):** the earlier 900→180 lowering guarded against a pathological boot holding /readyz 503 up to 15min. F3 re-accepts a longer worst-case time-to-Ready for correct coverage (Option A); the Lever-2 latch flips Ready at `min(all-reachable-warm, backstop)`, so the COMMON case still flips early — the 900s ceiling is only a pathological-boot worst case.

## Falsifiers (all -race, 3× GREEN — `/tmp/f3-falsifiers/GREEN-3x-race.txt`)
- **SA-exclusion:** `TestF3SAExclusion_MixedSubjects` (RED-catcher — naive winner-kind gate drops the mixed binding, RED `/tmp/f3-falsifiers/RED-mixed-binding-naive-gate.txt`), `_AllServiceAccount_FullyExcluded`, `_Predicate` (8-case truth table), `_NeverWorse_SATrafficStillServes`.
- **Lever 2 latch (C-F3-2):** reworked `TestFirstNavLatch_FiresBeforeTail` green arm to the multi-cohort invariants + single-segment RED (`/tmp/f3-falsifiers/RED-latch-single-segment.txt`) + `mutation_i` kept + `t.Cleanup` singleton-hardening (fixes the observed `TestF5_RealCheckDispatchRBAC` shared-state cascade).
- **Key-parity (C-F3-3):** undeclared widget seed key == browser key (admins seed browser-hittable); declared`[username]` keys DIVERGE — both through REAL `withCohortSeedContext`/`effectiveKeyExtras` derivation, asserting the HASHED SUBSET (`RepresentativeUsername`/`Groups` are diagnostic, NOT hashed by `ComputeKey` — a raw struct DeepEqual false-REDs; this was the fix from the mid-build cut).
- **Observable (C-F3-7):** `l1_lookup_metrics_test` seed_hit + aggregate assertions.
- Existing `TestPrewarmDedup_ARM_DISTINCT` updated to the F3 expectation (SA excluded).
- Full `internal/cache` + `dispatchers` 3× -race GREEN; broader resolvers/objects green; build+vet clean.

## Staged for on-deploy (C-F3-4/5, tester post-merge)
- **C-F3-4:** fresh cold boot (NO prior admin session — clean floor), real Chrome, first-touch per key_hash: `hits_seed_attributable > 0` AND admin first-nav ≥ **85%**, residual misses enumerated as #128/#129-ONLY (any seed-coverage miss = FAIL even at 85%).
- **C-F3-5 (50K):** Ready via segment-complete (NOT backstop) for the reachable tier under the raised timeout, 0 restarts, RSS in-bounds; OR quantify the overrun + pull #123 forward. Flag if a 50K cluster isn't standing.

## Fences honored
No #123 parallelism, no #128, no static cohort list, no name allowlist. #123 (serial per-target ceiling) is the flagged follow-up if the raised budget still overruns at 50K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1