### PR TITLE
#130 F3b-r2 — NavOrder-agnostic seed order + all-nav-widget latch (delete RootIndex special-case) [PARKED — 1.7.8 candidate, Diego-reserved merge]

### DIFF
--- a/docs/f3b-r2-agnostic-seed-order-design-2026-07-12.md
+++ b/docs/f3b-r2-agnostic-seed-order-design-2026-07-12.md
@@ -1,0 +1,256 @@
+# F3b-r2 — Agnostic seed order (Fix #130 F3b, redesign)
+
+Date: 2026-07-12
+Author: cache architect
+Repo state: main @ b40117d (F3 build, 1.7.7)
+Supersedes: the RootIndex==0 Phase-A/Phase-B split in docs/f3b-dashboard-first-seed-design-2026-07-12.md (Diego rejected as hardcoded frontend logic)
+
+## TL;DR — the chosen order
+
+**Sort the ENTIRE (widget-target, cohort) work list by `NavOrder` ASC as the primary
+key, in one pass — no phases, no RootIndex branch, no frontend concept.** `NavOrder`
+is a monotonic sequence number the engine ALREADY stamps at walk-discovery time
+(phase1_pip_seed.go:317-333): it is literally "the order the walk reached this widget,"
+which is the order a browser requests things from the nav entry outward. The dashboard
+seeds first because it IS NavOrder-lowest in the DATA — not because any code says
+"dashboard." This is candidate (a) (nav-graph discovery order), realized with the
+field the engine already has and zero frontend vocabulary in the branch.
+
+Fix 2 (the serve-watcher line in `withCohortSeedContext`) is UNCHANGED — uniform,
+keep exactly as designed in the F3b doc. It is what makes the whale LISTs cheap so any
+order fits budget.
+
+## 1. WHY the RootIndex order was a special-case (agreeing with Diego)
+
+The F3 build encodes `RootIndex==0` as a BRANCH in TWO places:
+- The Lever-1 rank tier (`firstNavReachable`, prewarm_engine_boot.go:729/758-766/778):
+  "cohorts with a RootIndex==0 widget sort first."
+- The Lever-2 latch arming (`reachableFirstNav`, prewarm_engine_boot.go:940-976 +
+  fire-decrement :1056): "fire readyz when RootIndex==0 targets are done."
+And my rejected F3b added a THIRD: the Phase-A/Phase-B split keyed on `RootIndex==0`.
+
+`RootIndex==0` means "the default-route/dashboard config-root subtree." Even though the
+VALUE is walk-derived, using `==0` as a partition predicate hardcodes the proposition
+"the first config root is special / is the dashboard / is first-nav." That is a
+frontend-page concept baked into resolver seed logic — exactly what Diego rejects
+(no special cases, one dynamic engine, everything from data). A different portal with
+a different config.json root order, or a multi-root nav, would silently mis-key.
+
+`NavOrder` carries the SAME information WITHOUT the branch: it is a total order, not a
+boolean partition. "Seed lowest-NavOrder first" makes no claim about which root is
+special — it just follows the walk's own discovery sequence. The dashboard wins
+because the walk reached it first (config.json order, depth-first — phase1_pip_seed.go
+:315-317), which is a property of the DATA the operator authored, not a code literal.
+
+## 2. Candidate evaluation (ruling)
+
+- **(a) Nav-graph discovery order (NavOrder ASC) — CHOSEN.** One uniform total order
+  over all (widget-target, cohort) pairs. "Seed in the order a browser walks the nav,
+  nearest-to-entry first." Zero frontend concept in the branch (the branch is just
+  `a.NavOrder < b.NavOrder`). Uses the existing `NavOrder` field — no new plumbing.
+  Generalizes to any portal structure. See §3.
+  - Sub-ruling — BFS-by-depth vs DFS-sequence: I evaluated plumbing a per-widget
+    walk-DEPTH (BFS: "seed all depth-0 across cohorts, then depth-1"). REJECTED as
+    unnecessary: (i) `NavOrder` (DFS discovery seq) already places the dashboard
+    subtree first because it is config-root 0 descended depth-first, and within it the
+    shallowest widgets are reached first; (ii) BFS-depth would need a new field on
+    navWidgetEntry (the walk is DFS-recursive, phase1_walk.go:1326 — depth is a local
+    param, only plumbed onto apiRefPaginationJob:1494, NOT the harvested entry) = more
+    code for no seed-coverage difference on the observed single-root topology; (iii)
+    DFS discovery order is MORE faithful to "the order a browser requests things"
+    (a browser follows the render tree depth-first, not level-order). If a future
+    multi-root portal ever needs cross-root level-interleave, adding a walk-depth field
+    is a clean follow-up — but it is not needed to close this milestone.
+- **(b) Cost-based shortest-job-first.** Post-Fix-2 all targets are cheap, so SJF
+  degenerates to "roughly uniform," losing the "nearest-to-entry" property that makes
+  the FIRST page warm first. It also needs a measured/predicted per-target cost input
+  (new state, or a pilot pass) and can starve a slightly-more-expensive dashboard
+  widget behind many trivial tail widgets. REJECTED: no coverage benefit over (a),
+  adds a cost oracle, and "cheapest first" is itself an arbitrary priority not tied to
+  what the user sees first.
+- **(c) Pure cohort round-robin (one target per cohort per turn).** Achieves per-cohort
+  fairness with zero nav concept, BUT within a cohort it needs a SECONDARY order and
+  the only sensible one is again NavOrder (else it seeds a random tail widget before
+  the cohort's dashboard). So (c) reduces to (a) with a cohort-interleave outer loop.
+  I FOLD the useful part of (c) into (a): the sort is over (NavOrder, cohort-rank) so
+  equal-NavOrder widgets across cohorts interleave fairly (see §3). Standalone (c)
+  without NavOrder REJECTED (random within-cohort order re-opens the "cheap-but-late
+  widget before the dashboard" defect FIX-E already fixed).
+
+## 3. DESIGN — one-pass NavOrder total order
+
+Replace the two-phase / rank-major widget loop with a SINGLE flat sort over all
+(widget, cohort-target) pairs, then one linear seed pass.
+
+### The order (uniform total order, one comparator)
+Build a flat slice of seed units `{navOrder, cohortRankIndex, widgetEntry, target}`
+for every (widgetSeed ws, target c) with c.identityKey a ranked cohort. Sort by:
+
+    1. ws.NavOrder ASC          — walk-discovery order (the ONLY ordering signal)
+    2. cohortRankIndex ASC      — tie-break: at equal NavOrder, cohorts in the
+                                  existing rank order (widgetMax DESC, allMax DESC,
+                                  key ASC) — devs before admins before masters
+    3. ns/name ASC              — final determinism
+
+Then seed the flat list in order (widgets), followed by the RA tail in its existing
+ascending-len order (RAs carry no NavOrder — they are not nav widgets; they seed after
+the widget list, exactly as the RA tail does today).
+
+- Key point: this is ONE pass, ONE comparator, applied to the WHOLE set. There is no
+  "these are special, do them first" branch — the dashboard widgets are simply the
+  low-NavOrder prefix of the sorted list. The SET is unchanged (PURE ORDERING, the
+  FIX-E invariant); only the sequence is now NavOrder-major instead of rank-major.
+- Cohort interleave: because NavOrder is the primary key, widget W's devs-target,
+  admins-target and masters-target (all sharing W's NavOrder) seed adjacently. So every
+  cohort's copy of the dashboard's first widget seeds before any cohort's second
+  widget. This is the "reachable cohorts' dashboards complete early" property — now
+  achieved by the data order, not a RootIndex phase.
+
+### The latch (Diego's explicit question: is the EXISTING RootIndex latch objectionable?)
+**RULING: the latch must ALSO drop RootIndex — replace its fire-condition with a
+NavOrder threshold, keeping the same readiness SEMANTICS.** The latch's JOB (flip
+readyz once "the first-nav page is warm for every cohort") is legitimate data-derived
+readiness — but keying it on `RootIndex==0` re-imports the same frontend-page branch.
+Under Diego's ruling applied consistently, the latch's partition must be data-order,
+not a config-root boolean.
+
+The uniform replacement: the latch fires when the seed pass has completed all units up
+to a NavOrder WATERSHED — the NavOrder at which the walk finished the first
+config-root's subtree. But "first config-root subtree" is itself the RootIndex concept.
+The clean, branch-free formulation: **the latch fires when every cohort has been seeded
+through the same NavOrder prefix that the FIRST-DISCOVERED cohort-reachable widget-set
+spans** — i.e. arm the latch on the count of (widget,cohort) units whose NavOrder ≤ the
+LARGEST NavOrder reachable from nav-root discovery before the walk's first descent
+completes. This is still "a data-derived prefix," but I judge it too clever and
+still smuggles "first subtree = special."
+
+Simpler and honest: **readiness = the whole widget list seeded** (the NavOrder-sorted
+widget prefix, i.e. Phase-A-equivalent = ALL nav widgets across all cohorts, before the
+RA tail). Post-Fix-2 the entire widget list is ~40-120s (§4), well inside budget, so
+gating on "all nav widgets seeded, RA tail may still run" needs no dashboard/first-nav
+concept at all: readyz means "every cohort's nav widgets are warm; the RA-backed
+content tail warms in background." The watershed is the widget/RA class boundary — a
+data-structural fact (a target either is or isn't a nav widget), NOT a frontend-page
+concept. That IS uniform and defensible.
+
+- So the latch arms `navWidgetRemaining` = total (widget × cohort) units, fires at 0.
+  No RootIndex, no NavOrder-threshold magic. The RA tail (Phase-B-equivalent) is
+  explicitly excluded from readiness because RAs are the background content layer
+  (they carry no NavOrder; a widget renders its structure without its RA-backed data,
+  and the RA cells warm moments later + are covered by keepwarm).
+- This is a STRICT GENERALIZATION of today's latch: today it waits for RootIndex==0
+  widgets; now it waits for ALL nav widgets. Since post-Fix-2 all nav widgets are cheap,
+  waiting for all of them (not just root-0) costs little and removes the special-case.
+- Boundary preserved: MarkPhase1Done backstop on PHASE1_TIMEOUT/pipGlobalTimeout is
+  UNCHANGED (C2 liveness — a pathological widget cannot hang readyz forever).
+
+### Legibility / seam
+The seam is now MORE legible than the rejected two-phase design: one flat sorted list,
+one comparator, one linear seed loop, then the RA tail. The "why NavOrder" is a
+one-line comment ("walk-discovery order = nearest-to-nav-entry first; the dashboard is
+the low-NavOrder prefix by DATA, not by branch"). No RootIndex anywhere in the seed
+ordering or the latch. The rank order survives only as the NavOrder tie-break
+(cohortRankIndex) — devs still slightly precede admins at equal NavOrder, preserving
+the largest-cohort-first property within a nav position without any special-case.
+
+## 4. Sizing / Ready projection (with Fix 2)
+
+- 186 distinct nav widgets × 3 reachable cohorts = ~558 widget-target units (the
+  readiness-gating set under the new latch).
+- Post-Fix-2 the ~14 whale widgets (benchapps/compositiondefinitions LISTs) serve from
+  the synced informer (~0.3s each vs ~20s live); the other ~172 are ~0.05s.
+- Per cohort: 14×0.3 + 172×0.05 ≈ 4.2 + 8.6 ≈ 13s. × 3 cohorts serial ≈ **~40s**.
+  (Same ~40s as the F3b doc's Phase A — the readiness-gating widget set is identical;
+  only the ORDER within it changed from RootIndex-phased to NavOrder-sorted.)
+- Well inside pipGlobalTimeout (480s) and PHASE1_TIMEOUT (900s). Ready via the latch
+  (NavOrder-widget-list-complete), NOT the backstop.
+- #128 independence UNCHANGED from the F3b doc: the marketplace-detail null-jq is an
+  RA (seeds in the tail, after the latch fires) and its first op-failure fires
+  ~9.5 min into boot; a ~40s widget pass fires the latch ~8-9 min before the churn.
+  #128 fix NOT a prerequisite for readiness acceptance; still a fast-follow for
+  RA-backed first-nav content.
+
+## 5. WHY THIS CONTAINS NO FRONTEND SPECIAL-CASE (the paragraph for Diego)
+
+The seed order is a single total order — `NavOrder` ASC — applied uniformly to every
+(widget, cohort) unit in one pass. `NavOrder` is not a frontend concept encoded in
+code; it is a monotonic counter the engine stamps as the nav WALK discovers each widget
+(phase1_pip_seed.go:317), i.e. it is the portal operator's own authored nav structure
+expressed as a sequence. The resolver never asks "is this the dashboard?" or "is this
+first-nav?" or "is this config-root 0?" — it asks only "did the walk reach A before B?"
+The dashboard ends up first purely because the walk reaches it first in the DATA; on a
+differently-structured portal, whatever the walk reaches first seeds first, with no
+code change. Every `RootIndex==0` branch — in the rank tier, in the latch, and in the
+rejected two-phase split — is DELETED and replaced by this one data-derived order. The
+readiness latch keys on the widget-vs-RA CLASS boundary (a structural fact: a target
+either is or isn't a nav widget), never on a page/route/dashboard concept. There is no
+static list, no lazy-fill-cold, L1 stays BindingUID-keyed, one engine, and CRUD
+re-runs the identical enumeration + sort.
+
+## 6. Falsifiers (adapted to the new order; PM gate)
+
+- **(a) Hermetic — NavOrder total order, no RootIndex (K>1 cohorts × M>1 widgets).**
+  Build widgetSeeds with NavOrder 0..M-1 spanning K≥2 cohorts, with the LOW-NavOrder
+  widgets deliberately NOT in config-root 0 (set RootIndex arbitrarily / to a non-zero
+  value on a low-NavOrder widget). Assert the seed order follows NavOrder ASC
+  regardless of RootIndex, and every cohort's low-NavOrder widgets seed before any
+  cohort's high-NavOrder widget. RED arm = the F3 RootIndex-keyed order (would seed a
+  RootIndex==0 high-NavOrder widget before a RootIndex!=0 low-NavOrder one) → order
+  diverges. This RED specifically proves the RootIndex branch is GONE. Degenerate
+  K=1/M=1 inadmissible (feedback_falsifier_shape_must_discriminate).
+- **(b) Hermetic — latch fires on all-nav-widgets, no RootIndex.** K≥2 cohorts, each
+  with M≥2 nav widgets (mixed RootIndex) + M≥2 RA tail targets. Assert the latch fires
+  after the LAST nav widget of ANY cohort and BEFORE any RA seeds, independent of
+  RootIndex. RED = the F3 latch (fires when RootIndex==0 widgets done, leaving
+  RootIndex!=0 nav widgets cold) → fires early.
+- **(c) Hermetic — serve-watcher on seed ctx (Fix 2, unchanged).** Cohort-seed widget
+  LIST serves from the informer, not a live paged LIST. RED = remove the
+  WithServeWatcher line.
+- **(d) Standing C-F3-4 acceptance (unchanged) + timing.** Repeat the exact reboot +
+  counted admin first-nav (real Chrome, per-/call resolved_cache.lookup, first-touch,
+  cold boot no prior admin session). REQUIRE: `prewarm.first_nav.latch` FIRES (Ready
+  via latch, NOT backstop) with elapsed « budget (~40s); `hits_seed_attributable > 0`;
+  admin first-nav hit-rate ≥ 85% (same #128/#129 residual justification). Capture the
+  seed order from the (new) telemetry to confirm NavOrder-major.
+- **(e) #128-independence arm (unchanged).** Assert the latch fire timestamp PRECEDES
+  the first marketplace-detail operational_failure timestamp.
+
+## 7. REACHABILITY (F1 lesson — deployed binary reaches the new code)
+
+- The seed engine, rank sort, and latch all RAN on the measured 1.7.7 boot (ranks
+  lines 1968+, seed.abort, backstop Ready). The redesign changes the SAME code loci:
+  - The flat NavOrder sort replaces the rank-major widget loop at
+    prewarm_engine_boot.go:998-1063 (the loop that processed 222 targets on 1.7.7).
+  - The latch arming (:940-976) + fire (:1056) change from RootIndex to
+    navWidgetRemaining — the same latch that (failed to) fire on 1.7.7.
+  - Fix 2 = one line in withCohortSeedContext (phase1_pip_seed.go:439), called by
+    seedOneTarget:593 for every target every boot.
+  - `NavOrder` is already stamped on every harvested entry (phase1_pip_seed.go:333) —
+    already emitted in the widget_targets telemetry (:814) on 1.7.7, so the data the
+    sort consumes is proven present in the deployed binary.
+- All on the unconditional seed path; no flag, no env gate.
+- Deployed-binary reach proof: falsifier (d)'s `first_nav.latch` FIRING on a real
+  reboot (vs 1.7.7's backstop-only) proves the NavOrder-ordered pass reached every
+  cohort's nav widgets within budget; the seed-order telemetry confirms NavOrder-major
+  (not rank-major). The hits_seed_attributable observable is the standing regression
+  probe.
+
+## 8. Options with recommendation (strategic — surface to Diego)
+
+- **Option A (recommended): NavOrder total order + all-nav-widget latch + Fix 2.**
+  Fully agnostic (no RootIndex anywhere), closes the milestone, one comparator + one
+  line. Requires touching the latch (removing its RootIndex) — a slightly larger diff
+  than "reorder only," but it is the consistent application of Diego's ruling.
+- **Option B: NavOrder order for the SEED, keep the RootIndex latch.** Smaller diff
+  (latch untouched) but INCONSISTENT — the latch still hardcodes RootIndex==0, which
+  is the same objection. NOT recommended; Diego's ruling applies to the latch too
+  (his explicit question). Only choose if he decides the latch's readiness semantics
+  are acceptable as-is and only the SEED-ORDER branch was the objection.
+- **Option C: add a walk-depth field + BFS level-order.** More faithful cross-root
+  interleave on hypothetical multi-root portals, but needs new plumbing and gives no
+  coverage gain on the real single-root topology. Defer to a follow-up if multi-root
+  ever appears.
+Recommend A. The one open question for Diego's concept nod (§5): is deleting the
+RootIndex latch (→ all-nav-widget latch) the correct consistent reading, or does he
+consider the latch's RootIndex an acceptable data-derived readiness signal (Option B)?
+State this explicitly to him before the PM gate re-runs.

--- a/internal/handlers/dispatchers/phase1_content_prewarm_falsifier_test.go
+++ b/internal/handlers/dispatchers/phase1_content_prewarm_falsifier_test.go
@@ -203,6 +203,70 @@ func TestFAL_F2_ContentPrewarmSAContext_AttachesServeWatcher(t *testing.T) {
 	}
 }
 
+// TestF3bR2_C_r2_3_CohortSeedContext_AttachesServeWatcher is the #130 F3b Fix 2
+// (C-r2-3) hermetic falsifier — the cohort-seed analog of the content-prewarm
+// arm above. withCohortSeedContext MUST attach cache.WithServeWatcher(rctx,
+// cache.Global()) so the cohort seed's inner widget LIST calls
+// (dispatchViaInternalRESTConfig) serve a servable GVR's LIST from the synced
+// informer indexer instead of a live ~20s/60K paged apiserver LIST — the cost
+// that blew the seed budget on 1.7.7 and makes any NavOrder pass fit budget.
+//
+// RED (remove the `rctx = cache.WithServeWatcher(rctx, cache.Global())` line in
+// withCohortSeedContext): ServeWatcherFromContext(cohortCtx) returns
+// haveRW=false → the cohort seed's LIST takes the live paged LIST (pre-Fix-2
+// behavior). Positive control: the discovery walk ctx has ALWAYS carried the
+// watcher — this arm asserts the cohort ctx now MATCHES it (the Fix-2 parity).
+func TestF3bR2_C_r2_3_CohortSeedContext_AttachesServeWatcher(t *testing.T) {
+	rw := phase1TestWatcher(t)
+	cache.SetGlobal(rw)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+
+	saEP := endpoints.Endpoint{ServerURL: "https://kubernetes.default.svc"}
+	cohort := seedTarget{Username: "system:serviceaccount:krateo-system:dev", Groups: []string{"devs"}}
+	cohortCtx := withCohortSeedContext(context.Background(), cohort, saEP, nil)
+
+	gotRW, haveRW := cache.ServeWatcherFromContext(cohortCtx)
+	if !haveRW {
+		t.Fatalf("F3b Fix 2 (C-r2-3): cohort-seed ctx MUST carry a serve-watcher " +
+			"(cache.WithServeWatcher) — without it the internal-dispatch informer-serve branch is " +
+			"never entered and every whale-widget cohort seed takes the live paged apiserver LIST " +
+			"(~20s/target, the 1.7.7 budget blow-up). This is the RED signature of removing the " +
+			"WithServeWatcher line from withCohortSeedContext.")
+	}
+	if gotRW != rw {
+		t.Fatalf("F3b Fix 2: cohort-seed ctx carries a DIFFERENT watcher than cache.Global() "+
+			"— must attach cache.Global() exactly; got %p want %p", gotRW, rw)
+	}
+	// Parity control: the discovery-walk ctx has always carried the watcher; the
+	// cohort ctx now matches it.
+	walkCtx := withPhase1SAContext(context.Background(), saEP, nil)
+	if _, walkHasRW := cache.ServeWatcherFromContext(walkCtx); !walkHasRW {
+		t.Fatalf("F3b Fix 2 parity control: the discovery-walk ctx (withPhase1SAContext) must carry " +
+			"the serve-watcher — Fix 2 brings the cohort ctx to the SAME state")
+	}
+}
+
+// TestF3bR2_C_r2_3_CohortSeedContext_NilGlobalIsSafe — flag-off path: with
+// cache.Global()==nil the cohort ctx is built WITHOUT a serve-watcher
+// (WithServeWatcher no-ops on nil rw) and does not panic (byte-identical to
+// pre-Fix-2 flag-off: the live LIST runs as today).
+func TestF3bR2_C_r2_3_CohortSeedContext_NilGlobalIsSafe(t *testing.T) {
+	cache.SetGlobal(nil)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+
+	saEP := endpoints.Endpoint{ServerURL: "https://kubernetes.default.svc"}
+	cohort := seedTarget{Username: "system:serviceaccount:krateo-system:dev", Groups: []string{"devs"}}
+	cohortCtx := withCohortSeedContext(context.Background(), cohort, saEP, nil)
+
+	if _, haveRW := cache.ServeWatcherFromContext(cohortCtx); haveRW {
+		t.Fatalf("F3b Fix 2 nil-safe: with cache.Global()==nil the cohort ctx must NOT carry a " +
+			"serve-watcher (WithServeWatcher no-ops on nil rw) — flag-off byte-identical to pre-Fix-2")
+	}
+	if !cache.PrewarmIterSerialFromContext(cohortCtx) {
+		t.Fatalf("F3b Fix 2 nil-safe: the PrewarmIterSerial marker must survive the nil-global path")
+	}
+}
+
 // TestFAL_F2_ContentPrewarmSAContext_NilGlobalIsSafe proves the flag-off / no-
 // consumer path: with cache.Global()==nil (CACHE_ENABLED=false) the content ctx
 // is built WITHOUT a serve-watcher (WithServeWatcher no-ops on nil rw) and does

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -190,16 +190,23 @@ type navWidgetEntry struct {
 	// literal (the ORDERING is the signal, not any hardcoded name).
 	NavOrder int
 
-	// #42 FIX-F seam (STAMP-ONLY — no consumer here). RootIndex is the
-	// zero-based index of the config-root subtree this widget was FIRST
-	// harvested under (BeginRoot increments it as the walk moves to the next
-	// root). Roots iterate in config.json order (phase1_roots.go), so
-	// RootIndex==0 is the default-route/dashboard subtree — the rank-1
-	// first-nav SEGMENT. FIX-F's readyz latch will consume this to flip ready
-	// once the RootIndex==0 segment is seeded (segment-scoped, NOT rank-scoped
-	// — PM condition F-C2). This field is written and never read in this
-	// change; the latch is built in the FIX-F ship (#99). Walk-derived, no
-	// literal — the INDEX is the signal.
+	// RootIndex is the zero-based index of the config-root subtree this widget
+	// was FIRST harvested under (BeginRoot increments it as the walk moves to
+	// the next root). Roots iterate in config.json order (phase1_roots.go).
+	//
+	// #130 F3b-r2 (2026-07-12): RootIndex is now a DEAD-STAMP — no seed-ordering
+	// or readyz-latch branch keys on `RootIndex==0` any longer. The old FIX-F
+	// latch (fire when the RootIndex==0 dashboard segment seeded) and the F3
+	// Lever-1 rank tier (RootIndex==0 cohorts sort first) were BOTH deleted:
+	// keying on `==0` as a partition hardcoded "the first config root is the
+	// dashboard / is first-nav," a frontend-page concept Diego rejected. The
+	// seed order is now a NavOrder total order and the latch keys on the
+	// widget-vs-RA CLASS boundary (design §5). The field is RETAINED because
+	// (a) the redrive-walk stamp-correctness regression test
+	// (TestNavWidgetHarvester_RedriveWalk_StampsRootIndexZeroForRootZero, #99b
+	// Fix 2) still asserts BeginWalk/BeginRoot stamp it right per pass, and
+	// (b) it is emitted as a diagnostic-only `root_index` field in the
+	// widget_targets telemetry. Walk-derived, no literal.
 	RootIndex int
 }
 
@@ -437,6 +444,20 @@ func withCohortSeedContext(ctx context.Context, cohort seedTarget,
 	rctx := xcontext.BuildContext(ctx, opts...)
 	rctx = cache.WithInternalEndpoint(rctx, &saEP)
 	rctx = cache.WithInternalRESTConfig(rctx, saRC)
+	// #130 F3b Fix 2 — attach the shared watcher so the cohort seed's inner LIST
+	// calls (dispatchViaInternalRESTConfig, resolve.go) serve a servable GVR's
+	// LIST from the synced informer indexer instead of a live ~20s/60K paged
+	// apiserver LIST. BYTE-IDENTICAL to the discovery walk's withPhase1SAContext
+	// (phase1_walk.go:1029) and the F2 content-prewarm attach: without it the
+	// internal-dispatch informer-serve branch (internal_dispatch.go, `ServeWatcher
+	// FromContext(ctx); haveRW`) is never entered, so every whale-widget cohort
+	// seed pays the live LIST — the ~20s/target cost that blew the seed budget on
+	// 1.7.7. This is what makes the whale LISTs cheap so the NavOrder pass fits
+	// budget. PREWARM-SCOPED (only this SA cohort context carries it; per-user
+	// /call never does). nil-safe (cache.Global() may be nil under
+	// CACHE_ENABLED=false → WithServeWatcher returns ctx unchanged → live LIST as
+	// today).
+	rctx = cache.WithServeWatcher(rctx, cache.Global())
 	rctx = cache.WithPrewarmIterSerial(rctx)
 	// #42 Option-2 — OVERRIDE the inherited discovery-walk scope with the SEED
 	// scope. rePrewarmBootScoped passes seedScopeYielding the SAME walk-scoped

--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -436,15 +436,16 @@ func Phase1Warmup(ctx context.Context, rc *rest.Config, authnNS string) error {
 			var bootErr error
 			var closeOnce sync.Once
 
-			// #99 FIX-F: build the process first-nav latch BEFORE enqueuing the
-			// boot scope so seedScopeYielding (deep inside the engine worker)
-			// can reach the SAME latch this select awaits. The latch fires the
-			// instant the rank-1 RootIndex==0 first-nav segment seeds (or
-			// provably has none); this select waits on it instead of the whole
-			// boot scope, so /readyz flips WITH the dashboard warm (§F.1) rather
-			// than at the PHASE1_TIMEOUT backstop with cold cells. bootDone and
-			// the scopeDone callback are UNTOUCHED — the boot scope keeps
-			// seeding the tail in background after the flip.
+			// #99 FIX-F / #130 F3b-r2: build the process first-nav latch BEFORE
+			// enqueuing the boot scope so seedScopeYielding (deep inside the engine
+			// worker) can reach the SAME latch this select awaits. The latch fires
+			// the instant EVERY cohort's NAV WIDGETS have seeded (the widget-vs-RA
+			// class boundary — F3b-r2 replaced the old RootIndex==0 dashboard
+			// segment), or provably has none; this select waits on it instead of
+			// the whole boot scope, so /readyz flips WITH every cohort's nav widgets
+			// warm rather than at the PHASE1_TIMEOUT backstop with cold cells.
+			// bootDone and the scopeDone callback are UNTOUCHED — the boot scope
+			// keeps seeding the RA content tail in background after the flip.
 			firstNav := ensureFirstNavLatch()
 
 			// Fix v2 / 0.30.248: the engine worker MUST use a process-

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -719,14 +719,6 @@ func seedScopeYielding(ctx context.Context,
 		key       string
 		widgetMax int
 		allMax    int
-		// firstNavReachable (#130 F3 Lever 1) — the identity has >=1 RootIndex==0
-		// (first-nav) widget target. PRIMARY rank tier: frontend-reachable cohorts
-		// sort above any cohort with only non-first-nav widget targets, so every
-		// login cohort's dashboard segment seeds before the non-first-nav tail.
-		// Derived from the SAME RootIndex==0 widget-target data the Lever-2 latch
-		// arms on (uniform discriminator, no static list). Post-SA-exclusion the
-		// seed set is login cohorts only, so this orders WITHIN the login tier.
-		firstNavReachable bool
 	}
 	rankOf := map[string]rankedIdentity{}
 	noteIdentity := func(c seedTarget, isWidget bool) {
@@ -751,33 +743,18 @@ func seedScopeYielding(ctx context.Context,
 			noteIdentity(c, false)
 		}
 	}
-	// #130 F3 Lever 1: compute the first-nav-reachable set — identities with
-	// >=1 RootIndex==0 widget target. This is the SAME RootIndex==0 scan the
-	// Lever-2 latch does (below); computed once here so it can be a rank tier.
-	// Uniform data-derived discriminator, no static cohort list.
-	firstNavReachableSet := map[string]bool{}
-	for _, ws := range widgetSeeds {
-		if ws.e.RootIndex != 0 {
-			continue
-		}
-		for _, c := range ws.targets {
-			firstNavReachableSet[identityKey(c)] = true
-		}
-	}
+	// #130 F3b-r2 — the RootIndex==0 firstNavReachable rank tier is DELETED. The
+	// seed ORDER is now a NavOrder total order (below), not a rank tier keyed on
+	// the config-root==0 boolean partition (Diego's no-special-case ruling: a
+	// data-order, never a page/route/dashboard concept). `ranked` keeps its
+	// (widgetMax DESC, allMax DESC, key ASC) order — it survives ONLY as the
+	// NavOrder tie-break (cohortRankIndex) so devs still slightly precede admins
+	// at equal NavOrder, and as the keepwarm widget-capable-prefix loop bound.
 	ranked := make([]rankedIdentity, 0, len(rankOf))
 	for _, ri := range rankOf {
-		ri.firstNavReachable = firstNavReachableSet[ri.key]
 		ranked = append(ranked, ri)
 	}
 	sort.SliceStable(ranked, func(i, j int) bool {
-		// #130 F3 Lever 1 — PRIMARY tier: frontend-reachable (has a first-nav
-		// widget) cohorts sort first, so every login cohort's dashboard segment
-		// seeds before any cohort whose widgets are all non-first-nav. PURE
-		// ORDERING — the ranked SET is unchanged (SA-only cohorts are already
-		// removed upstream at enumeration); this only reorders the survivors.
-		if ranked[i].firstNavReachable != ranked[j].firstNavReachable {
-			return ranked[i].firstNavReachable // true sorts before false
-		}
 		if ranked[i].widgetMax != ranked[j].widgetMax {
 			return ranked[i].widgetMax > ranked[j].widgetMax
 		}
@@ -801,9 +778,11 @@ func seedScopeYielding(ctx context.Context,
 		}
 	}
 
-	// Emit per-unit target-count telemetry ONCE up front (the seed loop below is
-	// rank-major, so the *_targets line no longer pairs 1:1 with a contiguous
-	// per-unit block).
+	// Emit per-unit target-count telemetry ONCE up front (the boot/gvr-discovered
+	// seed loop below is NavOrder-flat and the keepwarm loop is rank-major, so the
+	// *_targets line no longer pairs 1:1 with a contiguous per-unit block). The
+	// root_index field is retained as a dead-stamp observability field only — no
+	// seed-ordering or latch branch keys on it after F3b-r2 (design C-r2-6).
 	for _, ws := range widgetSeeds {
 		log.Info("prewarm.engine.seed.widget_targets",
 			slog.String("subsystem", "cache"),
@@ -877,211 +856,93 @@ func seedScopeYielding(ctx context.Context,
 		return false
 	}
 
-	// ── #99 FIX-F: FIRST-NAV LATCH ARMING (segment-scoped, F-C2). ──
-	// The readyz gate flips when the FIRST-NAV WIDGET SEGMENT has seeded — NOT
-	// the whole rank pass, NOT the full seed (prewarm_first_nav_latch.go).
+	// ── #99 FIX-F / #130 F3b-r2: FIRST-NAV READYZ LATCH ARMING. ──
+	// The readyz gate flips when EVERY cohort's NAV WIDGETS have seeded — NOT the
+	// whole seed (the RA content tail is excluded), NOT just the config-root==0
+	// (dashboard) subtree (the deleted RootIndex latch). F3b-r2 replaces the
+	// RootIndex==0 partition with the widget-vs-RA CLASS boundary — a structural
+	// fact (a target either IS or ISN'T a nav widget), never a page/route/
+	// dashboard concept (Diego's no-special-case ruling applied to the latch too,
+	// design §3 "the latch"). Post-Fix-2 every nav widget is cheap (whale LISTs
+	// serve from the synced informer), so waiting for ALL of them (not just
+	// root-0) costs little and removes the special-case: it is a STRICT
+	// GENERALIZATION of the old latch.
 	//
-	// #99b: the segment identity is NOT hard-wired to ranked[0], and the scan
-	// stays live as a SAFETY NET after FIX-3. Post-FIX-3, widgetMax DESC makes
-	// ranked[0] widget-capable by construction in a single-root topology, so the
-	// old "machine SA out-ranks the widget floor" pollution is gone at the RANK
-	// level. But "widget-capable" means >=1 widget target ANYWHERE, not >=1
-	// RootIndex==0 widget target: on a MULTI-ROOT config an identity whose ONLY
-	// widget targets live in a non-first root (RootIndex!=0) can still take
-	// ranked[0]. Then rank1==ranked[0] arming would count 0 FIRST-NAV targets
-	// and the latch would zero-fire with the first-root dashboard COLD. So we
-	// still scan ranked in order and pick the FIRST identity that actually has
-	// >=1 RootIndex==0 widget target as the segment (segKey at rank segRank). The
-	// segment is that identity's RootIndex==0 widget-target PAIRS; the latch
-	// fires the instant the LAST one seeds (mid-segRank pass, before the
-	// RootIndex>0 widgets and before ANY of that rank's restactions — the
-	// heavy NON-first-nav tail is still mid-seed, ARM-TAIL). Seed ORDER is
-	// UNTOUCHED: this is a pure gate fix; the rank-major loop below is
-	// unchanged, so a higher-ranked identity with only RootIndex!=0 widgets
-	// remains a cheap non-first-nav prefix — the latch simply keys its readiness
-	// on the first identity that renders the first-nav page.
+	// navWidgetRemaining = the total count of (widget × cohort) units in the flat
+	// NavOrder seed list (== len(flat) built below). The latch fires the instant
+	// the LAST nav-widget unit of ANY cohort seeds (remaining==0) — i.e. "every
+	// cohort's nav widgets are warm; the RA-backed content tail warms in
+	// background." The MarkPhase1Done / PHASE1_TIMEOUT backstop is UNCHANGED (C2
+	// liveness — a pathological widget cannot hang readiness forever).
 	//
-	// RootIndex is stamped on widgets only (phase1_pip_seed.go
-	// BeginRoot/RootIndex); restactions carry no first-nav marker, so the
-	// segment is the widget subset — the RA cells warm through FIX-E's
-	// ascending-len ordering (cheap dashboard RAs before the fanout whale) as
-	// background tail after the flip. The latch is nil under the pure-unit
-	// seed tests that call seedScopeYielding directly (no engineSeed wrapper
-	// built it) → all fire() calls are nil-safe no-ops, so those tests are
-	// unchanged.
+	// BOOT-ONLY. The latch singleton is armed only at boot (built by engineSeed
+	// before the boot enqueue). In keepwarm/gvr-discovered re-walks currentFirstNav
+	// Latch() returns the already-fired singleton, so every fire() call is a
+	// sync.Once no-op with zero readiness value — and the keepwarm mode keeps its
+	// own rank-major loop below, which never touches this latch. The latch is nil
+	// under the pure-unit seed tests that call seedScopeYielding directly (no
+	// engineSeed wrapper built it) → all fireFirstNav calls are nil-safe no-ops.
 	latch := currentFirstNavLatch()
 	latchStart := time.Now()
-	firstNavRemaining := 0
-	firstNavWidgets := 0
-	// ── #130 F3 Lever 2: latch waits for EVERY reachable cohort's first-nav
-	// segment, not just the first (rank-0) one. ──
-	//
-	// PRE-F3 (segment-scoped): the latch armed on the FIRST ranked identity with
-	// a RootIndex==0 widget target (segKey at segRank) and fired the instant THAT
-	// ONE identity's first-nav segment completed — so /readyz flipped with every
-	// OTHER login cohort's dashboard still cold (the admins-starved defect: Ready
-	// fired on devs while admins' cells were never seeded).
-	//
-	// F3: arm firstNavRemaining as the SUM over ALL first-nav-reachable
-	// identities' RootIndex==0 widget targets, and record that set in
-	// reachableFirstNav. Ready fires only when the LAST first-nav target of ANY
-	// reachable cohort seeds (firstNavRemaining==0) — i.e. "every login cohort's
-	// dashboard is warm," which IS the milestone. The MarkPhase1Done /
-	// PHASE1_TIMEOUT backstop is UNCHANGED (C2 liveness — a pathological cohort
-	// cannot hang readiness forever; it goes Ready-degraded for that cohort, the
-	// exception not the rule).
-	//
-	// reachableFirstNav is the membership set the fire-decrement below keys on
-	// (an identity is "reachable" iff it has >=1 RootIndex==0 widget target).
-	// segKey/segRank retain their PRE-F3 meaning (the FIRST reachable identity +
-	// its rank) purely for the fire-log fields + the segRank<0 provably-empty
-	// boundary (F-C3) — segRank stays -1 when NO ranked identity has any
-	// RootIndex==0 widget target, preserving the zero-fire semantics.
-	reachableFirstNav := map[string]bool{}
-	segKey := ""
-	segRank := -1
-	if latch != nil {
-		for r := range ranked {
-			candidate := ranked[r].key
-			count := 0
-			widgetsWith := 0
-			for _, ws := range widgetSeeds {
-				if ws.e.RootIndex != 0 {
-					continue
-				}
-				hits := 0
-				for _, c := range ws.targets {
-					if identityKey(c) == candidate {
-						hits++
-					}
-				}
-				if hits > 0 {
-					count += hits
-					widgetsWith++
-				}
-			}
-			if count > 0 {
-				// F3: accumulate EVERY reachable cohort (do NOT break at the first).
-				reachableFirstNav[candidate] = true
-				firstNavRemaining += count
-				firstNavWidgets += widgetsWith
-				if segRank < 0 {
-					// First reachable identity — retain for the log fields + the
-					// provably-empty boundary (unchanged semantics).
-					segKey = candidate
-					segRank = r
-				}
-			}
-		}
-	}
-	// firstNavTotal is the segment target count; firstNavRemaining decrements
-	// toward zero as each first-nav target seeds. Captured before the loop so
-	// the fire-log reports the count actually waited on.
-	firstNavTotal := firstNavRemaining
-	// fireFirstNav closes the latch once the segment is complete. reason
-	// discriminates the segment-complete path from the provably-zero path.
-	// segSeeded = the first-nav targets seeded by fire time (= total minus
-	// whatever remains; the zero-targets path reports 0). Nil-safe.
-	fireFirstNav := func(reason string) {
+	fireFirstNav := func(reason string, navWidgets, unitsSeeded int) {
 		if latch != nil {
-			latch.fire(reason, firstNavWidgets, firstNavTotal-firstNavRemaining, segKey, segRank, time.Since(latchStart))
+			// segIdentity/segRank are no longer segment-scoped (the latch keys on
+			// the whole nav-widget class, not one cohort's RootIndex==0 subtree):
+			// segRank=-1 marks "not segment-scoped". navWidgets = the distinct nav
+			// widgets across all cohorts; unitsSeeded = the total (widget × cohort)
+			// units seeded when the latch fired.
+			latch.fire(reason, navWidgets, unitsSeeded, "", -1, time.Since(latchStart))
 		}
 	}
 
-	// (4) RANK-MAJOR, CLASS-INTERLEAVED seed: per rank → widgets(r) in NavOrder,
-	// then restactions(r). FIX-F SEAM (F-C1): the rank-1 first-nav segment
-	// boundary is a clean, well-defined point; the latch fires the instant the
-	// rank-1 RootIndex==0 widget count reaches zero (below), NOT at the rank-1
-	// boundary (which would pull the RA tail into the readyz gate). The seam is
-	// KEPT unobscured — single rank-1 iteration, widgets-then-restactions, no
-	// interleaving of later ranks.
-	for ri := range ranked {
-		// keepwarm c2 (design §4.1): the keepwarm sweep set is the WIDGET-CAPABLE
-		// PREFIX of `ranked` — every identity with widgetMax>=1 (i.e. that renders
-		// at least one widget somewhere), on ALL pages. Because widgetMax DESC is
-		// the primary rank key (Fix-3), the widget-capable identities are a
-		// CONTIGUOUS PREFIX, so the sweep set is a pure LOOP BOUND: break at the
-		// first widgetMax==0 entry (the widget-less tail — RA-only machine SAs,
-		// which the keepwarm sweep does not cover; their cells warm on-demand /
-		// via the refresher). This SUPERSEDES the c1 rank-1 bound: the admin +
-		// narrow login cohorts (widget-capable but rank>=1) are now swept, closing
-		// the c1 cohort-coverage gap. Boot / gvr-discovered sweep every rank (no
-		// break). The age-skip (§4.2) + F.4 requeue stagger this prefix across
-		// chunks so a full sweep completes cost-proportionally.
-		if mode == seedModeKeepwarm && ranked[ri].widgetMax == 0 {
-			break
-		}
-		rankKey := ranked[ri].key
-		// keepwarm cohort_summary (PM probe (b), design §9): snapshot the
-		// age-skip counter + attempted count at this cohort's start so the
-		// per-cohort delta is exact. The keepwarm seed loop is the SOLE
-		// keepwarm-mode caller and runs SERIALLY (one resolve in flight,
-		// WithPrewarmIterSerial), so keepwarmAgeSkipTotal's delta across this
-		// cohort's targets is precisely this cohort's age-skips — no other
-		// keepwarm writer races it. (Boot/gvr-discovered never age-skip, so this
-		// bookkeeping is inert outside keepwarm; emitted only for keepwarm below.)
-		cohortAgeSkipStart := keepwarmAgeSkipTotal.Load()
-		cohortAttempted = 0
-		for _, ws := range widgetSeeds {
-			e := ws.e
-			for _, c := range ws.targets {
-				if identityKey(c) != rankKey {
-					continue
-				}
-				if seedWidgetTarget(e, c) {
-					return ctx.Err()
-				}
-				// F-C2 / #130 F3 Lever 2: fire the latch the instant the LAST
-				// FIRST-NAV target of ANY reachable cohort has been PROCESSED. The
-				// decrement now keys on reachableFirstNav MEMBERSHIP (every login
-				// cohort with a RootIndex==0 widget target), NOT the single segKey
-				// identity — so /readyz waits for EVERY reachable cohort's dashboard
-				// segment, not just rank-0's (the admins-starved fix). RootIndex>0
-				// widgets and non-reachable (SA-tail) identities never touch
-				// firstNavRemaining, so this cannot fire early on a RootIndex>0-only
-				// or non-first-nav seed (F-C3). segRank<0 (reachableFirstNav empty)
-				// means no ranked identity has a first-nav widget → this branch never
-				// matches → the provably-empty fire below is the only path.
-				//
-				// PROCESSED, NOT SUCCEEDED (deliberate, C2 liveness). We reach
-				// this line whenever seedWidgetTarget did not abort on ctx-cancel;
-				// a per-target seed FAILURE is classified + swallowed inside
-				// seedWidgetTarget (classifyEngineSeedErr), so the count still
-				// decrements. This is intentional: a permanently-failing dashboard
-				// target must NOT hang /readyz to the PHASE1_TIMEOUT backstop
-				// (that is the exact cold-cell degeneration FIX-F removes). The
-				// real guard that the dashboard is genuinely warm is the
-				// on-cluster post-Ready /dashboard nav#1 l1:HIT content check, not
-				// this counter.
-				if latch != nil && e.RootIndex == 0 && reachableFirstNav[identityKey(c)] {
-					firstNavRemaining--
-					if firstNavRemaining == 0 {
-						fireFirstNav("segment-complete")
+	if mode == seedModeKeepwarm {
+		// ── keepwarm: UNCHANGED rank-major loop (arch ruling B). ──
+		// The keepwarm sweep set is the WIDGET-CAPABLE PREFIX of `ranked` (every
+		// identity with widgetMax>=1). widgetMax DESC is the primary rank key
+		// (Fix-3), so the widget-capable identities are a CONTIGUOUS PREFIX and the
+		// sweep set is a pure LOOP BOUND: break at the first widgetMax==0 entry (the
+		// widget-less RA-only tail, not covered by keepwarm). This break is
+		// RootIndex-INDEPENDENT and load-bearing; the per-cohort cohort_summary
+		// emission is a PM probe keyed on the cohort-rank boundary. Both are kept
+		// verbatim. The latch is already fired at boot, so keepwarm arms/fires
+		// nothing here.
+		for ri := range ranked {
+			if ranked[ri].widgetMax == 0 {
+				break
+			}
+			rankKey := ranked[ri].key
+			// keepwarm cohort_summary (PM probe (b), design §9): snapshot the
+			// age-skip counter + attempted count at this cohort's start so the
+			// per-cohort delta is exact. The keepwarm seed loop is the SOLE
+			// keepwarm-mode caller and runs SERIALLY (one resolve in flight,
+			// WithPrewarmIterSerial), so keepwarmAgeSkipTotal's delta across this
+			// cohort's targets is precisely this cohort's age-skips.
+			cohortAgeSkipStart := keepwarmAgeSkipTotal.Load()
+			cohortAttempted = 0
+			for _, ws := range widgetSeeds {
+				e := ws.e
+				for _, c := range ws.targets {
+					if identityKey(c) != rankKey {
+						continue
+					}
+					if seedWidgetTarget(e, c) {
+						return ctx.Err()
 					}
 				}
 			}
-		}
-		for _, rs := range restactionSeeds {
-			ref := rs.ref
-			for _, c := range rs.targets {
-				if identityKey(c) != rankKey {
-					continue
-				}
-				if seedRestactionTarget(ref, c) {
-					return ctx.Err()
+			for _, rs := range restactionSeeds {
+				ref := rs.ref
+				for _, c := range rs.targets {
+					if identityKey(c) != rankKey {
+						continue
+					}
+					if seedRestactionTarget(ref, c) {
+						return ctx.Err()
+					}
 				}
 			}
-		}
-		// keepwarm cohort_summary (PM probe (b), design §9): ONE INFO line per
-		// SWEPT cohort per sweep cycle — {identity, reseeds, age_skips}. age_skips
-		// = the per-cohort delta of keepwarmAgeSkipTotal; reseeds = attempted −
-		// age_skips (a re-resolve+Put, OR a declined/failed re-resolve — all
-		// non-skip work). Emitted at the cohort boundary (bounded by cohort count
-		// per cycle — no per-cell noise) so a PRETTY_LOG:false deployment can grep
-		// ONE line to confirm "admin + narrow cohorts re-seeded, not devs-only".
-		// Keepwarm-only: boot/gvr-discovered would flood this with per-boot ranks
-		// and never age-skip, so it is scoped to the cadence sweep.
-		if mode == seedModeKeepwarm {
+			// keepwarm cohort_summary (PM probe (b), design §9): ONE INFO line per
+			// SWEPT cohort per sweep cycle — {identity, reseeds, age_skips}.
 			ageSkips := keepwarmAgeSkipTotal.Load() - cohortAgeSkipStart
 			reseeds := int64(cohortAttempted) - int64(ageSkips)
 			if reseeds < 0 {
@@ -1098,19 +959,113 @@ func seedScopeYielding(ctx context.Context,
 					"young/churny cells (age_skips); one line per swept cohort per cycle (probe b)"),
 			)
 		}
+		return nil
 	}
-	// ── FIX-F SEAM: provably-empty first-nav boundary (F-C3, #99b). ──
-	// segRank<0 means NO ranked identity had a RootIndex==0 widget target —
-	// an all-tail topology, or prewarm reached no dashboard widget, or ranked
-	// was empty (no identities enumerated at all). There is provably nothing
-	// to warm on the first-nav path → fire so the latch never hangs (the
-	// PHASE1_TIMEOUT backstop would otherwise be the only escape). A non-empty
-	// segment already fired "segment-complete" mid-loop (segRank>=0), so this
-	// close is a no-op then (idempotent once). Firing AFTER the seed loop (not
-	// at a per-rank boundary) means the RootIndex>0-only tail is fully
-	// processed first — F-C3 never fires early mid-tail. Nil-safe.
-	if latch != nil && segRank < 0 {
-		fireFirstNav("zero-first-nav-targets")
+
+	// ── boot / gvr-discovered: NavOrder-FLAT seed (arch ruling B). ──
+	// A SINGLE flat pass over ALL (widget × cohort) units, sorted by NavOrder ASC
+	// (walk-discovery order = nearest-to-nav-entry first; the dashboard is the
+	// low-NavOrder prefix by DATA, not by branch). PURE ORDERING (FIX-E
+	// invariant): the seeded (unit × identity) SET is unchanged vs the old
+	// rank-major loop; only the SEQUENCE changes from rank-major to NavOrder-major.
+	// No caps/skips/static lists; no RootIndex.
+	//
+	// cohortRankIndex maps each ranked cohort's key → its index in `ranked`
+	// (widgetMax DESC, allMax DESC, key ASC). It is the NavOrder tie-break so
+	// equal-NavOrder widgets across cohorts interleave in the existing rank order
+	// (devs before admins before masters), preserving largest-cohort-first WITHIN
+	// a nav position without any special-case. A cohort that is NOT in `ranked`
+	// (widget-less RA-only identity) has no widget units, so it never enters the
+	// flat list; its RA seeds land in the RA tail below (unchanged).
+	cohortRankIndex := make(map[string]int, len(ranked))
+	for r := range ranked {
+		cohortRankIndex[ranked[r].key] = r
+	}
+	type seedUnit struct {
+		navOrder  int
+		rankIndex int
+		wsNSName  string
+		e         navWidgetEntry
+		target    seedTarget
+	}
+	flat := make([]seedUnit, 0)
+	for _, ws := range widgetSeeds {
+		nsName := ws.e.W.GetNamespace() + "/" + ws.e.W.GetName()
+		for _, c := range ws.targets {
+			ri, ok := cohortRankIndex[identityKey(c)]
+			if !ok {
+				// Not a ranked cohort — cannot happen for a widget target (every
+				// widget target's identity is noted into rankOf above), but guard
+				// so an unranked identity is never silently dropped from the SET.
+				ri = len(ranked)
+			}
+			flat = append(flat, seedUnit{
+				navOrder:  ws.e.NavOrder,
+				rankIndex: ri,
+				wsNSName:  nsName,
+				e:         ws.e,
+				target:    c,
+			})
+		}
+	}
+	sort.SliceStable(flat, func(i, j int) bool {
+		if flat[i].navOrder != flat[j].navOrder {
+			return flat[i].navOrder < flat[j].navOrder // (1) NavOrder ASC
+		}
+		if flat[i].rankIndex != flat[j].rankIndex {
+			return flat[i].rankIndex < flat[j].rankIndex // (2) cohort rank ASC
+		}
+		return flat[i].wsNSName < flat[j].wsNSName // (3) ns/name ASC (determinism)
+	})
+
+	// Arm the all-nav-widget latch on the flat unit count. distinctNavWidgets is
+	// the number of distinct nav widgets (for the fire-log observability field).
+	navWidgetRemaining := len(flat)
+	distinctNavWidgets := len(widgetSeeds)
+	navUnitsTotal := navWidgetRemaining
+	if navWidgetRemaining == 0 {
+		// Provably-empty: no nav-widget units at all (all-tail topology, or the
+		// walk reached no widget). There is nothing to warm on the nav-widget
+		// path → fire so the latch never hangs to the PHASE1_TIMEOUT backstop.
+		fireFirstNav("zero-nav-widgets", 0, 0)
+	}
+
+	// Seed the flat list in NavOrder order. SAME primitive (seedWidgetTarget),
+	// SAME abort/yield semantics (return ctx.Err() on abort). Fire the latch the
+	// instant the LAST nav-widget unit is PROCESSED (remaining==0) — before the
+	// RA content tail runs, so readyz does not wait on the RA whale-fanout.
+	// PROCESSED, NOT SUCCEEDED (C2 liveness, unchanged): a per-target failure is
+	// classified+swallowed inside seedWidgetTarget, so the count still decrements
+	// — a permanently-failing widget must not hang /readyz to the backstop.
+	for i := range flat {
+		if seedWidgetTarget(flat[i].e, flat[i].target) {
+			return ctx.Err()
+		}
+		navWidgetRemaining--
+		if navWidgetRemaining == 0 {
+			fireFirstNav("segment-complete", distinctNavWidgets, navUnitsTotal)
+		}
+	}
+
+	// RA tail — RAs carry no NavOrder (they are the background content layer, not
+	// nav widgets); they seed AFTER the whole widget list in their existing
+	// ascending-len order (restactionSeeds was sorted ascending-len above). The
+	// tail is explicitly excluded from readiness (the latch already fired). Seed
+	// rank-major across `ranked` so a lower-ranked cohort's RAs never precede a
+	// higher-ranked cohort's — the RA within-class rank order is preserved.
+	for ri := range ranked {
+		rankKey := ranked[ri].key
+		for _, rs := range restactionSeeds {
+			ref := rs.ref
+			for _, c := range rs.targets {
+				if identityKey(c) != rankKey {
+					continue
+				}
+				if seedRestactionTarget(ref, c) {
+					return ctx.Err()
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
+++ b/internal/handlers/dispatchers/prewarm_engine_seed_order_test.go
@@ -1,45 +1,40 @@
-// prewarm_engine_seed_order_test.go — #42 FIX-E: the rank-major, class-
-// interleaved, first-nav-ordered seed falsifier.
+// prewarm_engine_seed_order_test.go — #130 F3b-r2: the NavOrder-FLAT (total
+// order), class-tail seed falsifier. SUPERSEDES the #42 FIX-E rank-major /
+// class-interleaved model for the boot/gvr-discovered path.
 //
-// ── FALSIFIER-SET MIGRATION (2026-07-04, TL-approved delete-with-migration) ──
-// FIX-E replaced the class-major seedScopeYielding (whole-widgets-class then
-// whole-restactions-class, dispatched by the seedClassOrderFn seam) with a
-// UNIFIED rank-major, class-INTERLEAVED, first-nav-ordered loop (per identity
-// rank r → widgets(r) in NavOrder → restactions(r)). The seedClassOrderFn seam
-// was removed. THREE falsifiers that guarded the superseded model were DELETED;
-// their properties are re-covered as follows (PM property-coverage map):
+// ── ORDER MODEL CHANGE (2026-07-12, arch ruling B) ──
+// F3b-r2 replaced the rank-major widget loop (per identity rank r → widgets(r)
+// in NavOrder → restactions(r)) with a SINGLE FLAT PASS over all (widget ×
+// cohort) units sorted by (NavOrder ASC, cohortRankIndex ASC, ns/name ASC),
+// followed by the RA tail. The dashboard seeds first because it is the
+// low-NavOrder prefix in the DATA — no RootIndex/rank branch. Cohort interleave:
+// because NavOrder is the PRIMARY key, every cohort's NavOrder-0 widget seeds
+// before ANY cohort's NavOrder-1 widget (the "reachable cohorts' dashboards
+// complete early" property, now by data order not a phase).
 //
-//   (a) TestSeedScopeYielding_FirstNavFirst_OrderingFalsifier
-//       GUARDED: "widgets seed before restactions (restactions not starved by
-//       widget work)". SUPERSEDED by per-rank interleave — restactions now seed
-//       WITHIN each rank right after that rank's widgets, not after ALL widget
-//       ranks. The underlying #42 property ("restactions must not be starved")
-//       is now guarded by THIS file's rank-major assert (a lower-rank seed
-//       before rank-1 completes → RED) + the revert-interleave mutation.
-//   (b) TestSeedScopeYielding_CheapCohortFirst_SortFalsifier
-//       GUARDED: "restactions in ascending len(targets) order (cheap RA before
-//       the fan-out tail)". RETAINED — the RA within-rank ascending-len tiebreak
-//       survives FIX-E; asserted EXPLICITLY here (property (b) block).
-//   (c) TestSeedScopeYielding_CheapCohortFirst_WidgetsSortFalsifier
-//       GUARDED: "cheap/critical widgets not starved by a whale (A2 widget
-//       len-sort)". SUPERSEDED by NavOrder (count≠cost, proven twice — A2 seeded
-//       a cheap late-nav widget before the dashboard's own widgets). The "cheap/
-//       critical widget seeds first" property is now guarded by first-nav
-//       (NavOrder) order + the sequence assert here.
+// This inverts the old FIX-E rank-major invariant (which required ALL of rank-1
+// devs before ANY rank-2 ops). Under NavOrder-major, ops' NavOrder-0 widget
+// seeds before devs' NavOrder-1 widget. The properties RE-EXPRESSED here:
+//   (nav)  NavOrder-major: every cohort's widget at NavOrder N seeds before any
+//          cohort's widget at NavOrder N+1 (the load-bearing F3b-r2 property).
+//   (rank) within a NavOrder tie, cohorts interleave by rank (devs before ops)
+//          — the cohortRankIndex tie-break (largest-cohort-first per nav slot).
+//   (tail) RAs seed AFTER the whole widget list (RA content tail), and within
+//          the tail in ascending len(targets) order (cheap RA before fan-out).
 //
-// Condition 3: the E fixture derives NavOrder via the REAL harvest-stamping
+// Condition 3: NavOrder is derived via the REAL harvest-stamping
 // (newNavWidgetHarvester + harvestNavWidget in walk order), NOT hand-assigned —
 // so it fails if the harvest-order stamping breaks, not only the seed loop.
 //
 // Hermetic, -race, seams only (no cluster). TestFixD_IdentityRankMajorSeedOrder
-// (rank-major skeleton) stays GREEN unmodified in its own file.
+// (all widgets at NavOrder 0 → the flat sort degenerates to rank-major via the
+// cohortRankIndex tie-break) stays GREEN unmodified in its own file.
 
 package dispatchers
 
 import (
 	"context"
 	"log/slog"
-	"strings"
 	"sync"
 	"testing"
 
@@ -165,13 +160,13 @@ func eRA(name string) templatesv1.ObjectReference {
 	}
 }
 
-// TestFixE_RankMajorClassInterleaveFirstNavOrder — the #42 FIX-E falsifier.
+// TestF3bR2_NavOrderFlatSeedOrder — the #130 F3b-r2 NavOrder-flat falsifier.
 //
-// Fixture: 2 identity ranks (devs collapsed=442 = rank 1; ops collapsed=5 =
-// rank 2), 3 widgets harvested in a deliberate NAV ORDER (dashboard-flex first,
+// Fixture: 2 identity ranks (devs collapsed=442 = rank 0; ops collapsed=5 =
+// rank 1), 3 widgets harvested in a deliberate NAV ORDER (dashboard-flex first,
 // then obs-panel, then settings-card), each widget carrying BOTH identities; 2
 // restactions (cheap 1-target, fanout 3-target) each carrying devs.
-func TestFixE_RankMajorClassInterleaveFirstNavOrder(t *testing.T) {
+func TestF3bR2_NavOrderFlatSeedOrder(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
@@ -237,67 +232,224 @@ func TestFixE_RankMajorClassInterleaveFirstNavOrder(t *testing.T) {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
 
-	assertFixESequence(t, rec.snapshot())
+	assertF3bR2Sequence(t, rec.snapshot())
 }
 
-// assertFixESequence verifies rank-major / class-interleave / nav-order /
-// RA-tiebreak on the recorded event sequence.
-func assertFixESequence(t *testing.T, ev []eSeedEvent) {
+// assertF3bR2Sequence verifies NavOrder-major total order / rank tie-break /
+// RA-tail / RA-tiebreak on the recorded event sequence.
+func assertF3bR2Sequence(t *testing.T, ev []eSeedEvent) {
 	t.Helper()
 
-	// (a) RANK-MAJOR + INTERLEAVE: last rank-1 (devs) event < first rank-2 (ops)
-	// event, across BOTH classes.
-	lastDevs, firstOps := -1, len(ev)
-	for i, e := range ev {
-		switch e.identity {
-		case "group:devs":
-			lastDevs = i
-		case "group:ops":
-			if i < firstOps {
-				firstOps = i
-			}
-		}
-	}
-	if lastDevs < 0 || firstOps == len(ev) {
-		t.Fatalf("FIX-E: expected both devs (rank1) and ops (rank2) seeds; events=%+v", ev)
-	}
-	if lastDevs >= firstOps {
-		t.Fatalf("FIX-E rank-major VIOLATED: a rank-2 (ops) seed at idx %d ran BEFORE the last rank-1 (devs) seed at idx %d — "+
-			"a lower rank must not interleave before rank-1 completes; events=%+v", firstOps, lastDevs, ev)
-	}
-
-	// Within rank-1 (devs): (c) widgets in NavOrder; widgets-before-restactions
-	// (per-rank + FIX-F segment shape); (b) RAs ascending-len tiebreak.
-	var r1widgets, r1ras []string
+	// (nav) NavOrder-MAJOR: recover each widget's NavOrder from its harvest name
+	// (dashboard-flex=0, obs-panel=1, settings-card=2) and assert the WIDGET seed
+	// stream is non-decreasing in NavOrder — i.e. every cohort's NavOrder-N widget
+	// seeds before ANY cohort's NavOrder-(N+1) widget. This is the load-bearing
+	// F3b-r2 property and is the exact INVERSE of the old rank-major invariant
+	// (which required all devs before any ops; under NavOrder-major, ops'
+	// dashboard-flex seeds before devs' obs-panel — see the (rank) block).
+	navOrderOf := map[string]int{"dashboard-flex": 0, "obs-panel": 1, "settings-card": 2}
+	lastNav := -1
+	var widgetSeq []eSeedEvent
 	for _, e := range ev {
-		if e.identity != "group:devs" {
+		if e.class != "widget" {
 			continue
 		}
-		if e.class == "widget" {
-			if len(r1ras) > 0 {
-				t.Fatalf("FIX-E: rank-1 widget %q seeded AFTER a rank-1 restaction — per-rank shape is widgets-then-restactions; events=%+v", e.label, ev)
+		widgetSeq = append(widgetSeq, e)
+		n, ok := navOrderOf[e.label]
+		if !ok {
+			t.Fatalf("F3b-r2 setup: unexpected widget %q; events=%+v", e.label, ev)
+		}
+		if n < lastNav {
+			t.Fatalf("F3b-r2 (nav) NavOrder-MAJOR VIOLATED: widget %q (NavOrder %d) seeded AFTER a NavOrder-%d widget — "+
+				"the flat pass must seed ALL cohorts' NavOrder-N widgets before ANY cohort's NavOrder-(N+1) widget; widget stream=%+v",
+				e.label, n, lastNav, widgetSeq)
+		}
+		lastNav = n
+	}
+	if len(widgetSeq) != 6 {
+		t.Fatalf("F3b-r2 setup: expected 6 widget seeds (3 widgets × 2 cohorts), got %d; events=%+v", len(widgetSeq), ev)
+	}
+
+	// (rank) within a NavOrder tie, cohorts interleave by rank (devs rank 0 before
+	// ops rank 1). At NavOrder 0 the two dashboard-flex seeds are {devs, ops} in
+	// that order; assert devs precedes ops for the SAME widget label.
+	for _, label := range []string{"dashboard-flex", "obs-panel", "settings-card"} {
+		devsIdx, opsIdx := -1, -1
+		for i, e := range widgetSeq {
+			if e.label != label {
+				continue
 			}
-			r1widgets = append(r1widgets, e.label)
-		} else {
-			r1ras = append(r1ras, e.label)
+			if e.identity == "group:devs" {
+				devsIdx = i
+			} else if e.identity == "group:ops" {
+				opsIdx = i
+			}
+		}
+		if devsIdx < 0 || opsIdx < 0 {
+			t.Fatalf("F3b-r2 (rank) setup: widget %q missing a cohort seed (devs=%d ops=%d); widget stream=%+v", label, devsIdx, opsIdx, widgetSeq)
+		}
+		if devsIdx > opsIdx {
+			t.Fatalf("F3b-r2 (rank) tie-break VIOLATED: for widget %q the rank-1 ops seed (idx %d) preceded the rank-0 devs seed (idx %d) — "+
+				"at equal NavOrder the cohortRankIndex tie-break must seed the larger cohort (devs) first; widget stream=%+v", label, opsIdx, devsIdx, widgetSeq)
 		}
 	}
-	// (c) NavOrder: dashboard-flex(0) → obs-panel(1) → settings-card(2).
-	if got, want := strings.Join(r1widgets, ","), "dashboard-flex,obs-panel,settings-card"; got != want {
-		t.Fatalf("FIX-E property (c) NavOrder VIOLATED: rank-1 widget order = %q; want first-nav %q "+
-			"(harvest-stamped NavOrder, NOT A2 count-sort)", got, want)
+
+	// (tail) EVERY widget seeds before EVERY restaction (the RA content tail is
+	// excluded from the nav-widget readiness class).
+	lastWidget, firstRA := -1, len(ev)
+	for i, e := range ev {
+		if e.class == "widget" {
+			lastWidget = i
+		} else if e.class == "restaction" && i < firstRA {
+			firstRA = i
+		}
 	}
-	// (b) RA ascending-len tiebreak: cheap-ra (1 target) before fanout-ra (3).
+	if firstRA == len(ev) {
+		t.Fatalf("F3b-r2 (tail): expected restaction seeds; events=%+v", ev)
+	}
+	if lastWidget > firstRA {
+		t.Fatalf("F3b-r2 (tail) VIOLATED: a restaction at idx %d seeded BEFORE the last widget at idx %d — "+
+			"RAs must seed AFTER the whole widget list; events=%+v", firstRA, lastWidget, ev)
+	}
+
+	// (tail) RA ascending-len tiebreak WITHIN the rank-0 (devs) tail: cheap-ra
+	// (1 target) before fanout-ra (3 targets).
+	var devsRAs []string
+	for _, e := range ev {
+		if e.class == "restaction" && e.identity == "group:devs" {
+			devsRAs = append(devsRAs, e.label)
+		}
+	}
 	seenCheap := false
-	for _, ra := range r1ras {
+	for _, ra := range devsRAs {
 		if ra == "fanout-ra" && !seenCheap {
-			t.Fatalf("FIX-E property (b) RA ascending-len tiebreak VIOLATED: fanout-ra (3 targets) seeded before cheap-ra (1 target); rank-1 RA order=%v", r1ras)
+			t.Fatalf("F3b-r2 (tail) RA ascending-len tiebreak VIOLATED: fanout-ra (3 targets) seeded before cheap-ra (1 target); devs RA order=%v", devsRAs)
 		}
 		if ra == "cheap-ra" {
 			seenCheap = true
 		}
 	}
 	if !seenCheap {
-		t.Fatalf("FIX-E: cheap-ra was not seeded under rank-1; RA order=%v events=%+v", r1ras, ev)
+		t.Fatalf("F3b-r2 (tail): cheap-ra was not seeded under devs; RA order=%v events=%+v", devsRAs, ev)
+	}
+}
+
+// ── C-r2-1 (LOAD-BEARING): NavOrder total order, RootIndex INVERTED ─────────
+// The design's headline falsifier: build widgetSeeds NavOrder 0..M-1 across K>=2
+// cohorts, with the LOW-NavOrder widgets carrying a NON-zero (HIGH) RootIndex and
+// the HIGH-NavOrder widget carrying RootIndex 0 — an INVERSION vs NavOrder. Assert
+// the seed order follows NavOrder ASC regardless of RootIndex; EVERY cohort's
+// low-NavOrder widget seeds before ANY cohort's high-NavOrder widget.
+//
+// RED (captured to /tmp/f3b-r2-falsifiers/ by source-revert of the flat-sort +
+// firstNavReachable-rank-tier deletion): the F3 RootIndex-keyed order would sort
+// the RootIndex==0 (HIGH-NavOrder) widget's cohort FIRST (firstNavReachable rank
+// tier), seeding a RootIndex==0 high-NavOrder widget before the RootIndex!=0
+// low-NavOrder one → the NavOrder-ASC assert diverges. This RED specifically
+// proves the RootIndex branch is GONE, not dormant: if any code still consulted
+// RootIndex==0 for ordering, this inverted fixture would seed high-NavOrder first.
+//
+// K=3 cohorts × M=3 widgets (>1×>1, feedback_falsifier_shape_must_discriminate).
+func TestF3bR2_C_r2_1_NavOrderTotalOrder_RootIndexInverted(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	devs := eID{name: "devs", group: true, collapsed: 442}
+	ops := eID{name: "ops", group: true, collapsed: 50}
+	sre := eID{name: "sre", group: true, collapsed: 5}
+
+	// REAL harvest-stamping gives NavOrder 0,1,2 in harvest order.
+	h := newNavWidgetHarvester()
+	wLow, wMid, wHigh := eWidgetGVR("low"), eWidgetGVR("mid"), eWidgetGVR("high")
+	eHarvestWidget(h, "w-navorder-0", wLow)  // NavOrder 0
+	eHarvestWidget(h, "w-navorder-1", wMid)  // NavOrder 1
+	eHarvestWidget(h, "w-navorder-2", wHigh) // NavOrder 2
+	widgets := h.snapshot()
+	if len(widgets) != 3 {
+		t.Fatalf("harvest setup: want 3 widgets, got %d", len(widgets))
+	}
+	// INVERT RootIndex vs NavOrder: the LOWEST-NavOrder widget gets the HIGHEST
+	// RootIndex, the HIGHEST-NavOrder widget gets RootIndex 0. A sort that keyed on
+	// RootIndex==0 would seed w-navorder-2 FIRST; a NavOrder sort seeds
+	// w-navorder-0 first. (widgets are snapshot copies; NavOrder is the real
+	// harvest stamp, only RootIndex is overridden to build the inversion.)
+	for i := range widgets {
+		switch widgets[i].NavOrder {
+		case 0:
+			widgets[i].RootIndex = 2 // low NavOrder, HIGH RootIndex
+		case 1:
+			widgets[i].RootIndex = 1
+		case 2:
+			widgets[i].RootIndex = 0 // high NavOrder, RootIndex 0 (the "dashboard" bait)
+		}
+	}
+
+	rec := &eSeedRecorder{}
+	prevEnum := enumeratePrewarmTargetsForGVRFn
+	enumeratePrewarmTargetsForGVRFn = func(gvr schema.GroupVersionResource, _ string) []cache.PrewarmTarget {
+		switch gvr {
+		case wLow, wMid, wHigh:
+			return eIdentityTargets(gvr, devs, ops, sre)
+		}
+		return nil
+	}
+	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
+
+	prevW := seedOneWidgetFn
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
+		rec.record("widget", e.W.GetName(), eIdentityLabel(ctx))
+		return nil
+	}
+	t.Cleanup(func() { seedOneWidgetFn = prevW })
+
+	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	ev := rec.snapshot()
+
+	// Map widget name → NavOrder for the assert.
+	navOf := map[string]int{"w-navorder-0": 0, "w-navorder-1": 1, "w-navorder-2": 2}
+
+	// (1) The seed stream is non-decreasing in NavOrder (RootIndex ignored).
+	lastNav := -1
+	for _, e := range ev {
+		n := navOf[e.label]
+		if n < lastNav {
+			t.Fatalf("C-r2-1 VIOLATED: widget %q (NavOrder %d, RootIndex-inverted) seeded AFTER a NavOrder-%d widget — "+
+				"the sort must follow NavOrder ASC, NOT RootIndex (a RootIndex==0 sort would seed w-navorder-2 first); events=%+v",
+				e.label, n, lastNav, ev)
+		}
+		lastNav = n
+	}
+
+	// (2) Every cohort's low-NavOrder widget seeds before ANY cohort's
+	// high-NavOrder widget. The LAST NavOrder-0 seed index < the FIRST NavOrder-2
+	// seed index.
+	lastNav0, firstNav2 := -1, len(ev)
+	for i, e := range ev {
+		switch navOf[e.label] {
+		case 0:
+			lastNav0 = i
+		case 2:
+			if i < firstNav2 {
+				firstNav2 = i
+			}
+		}
+	}
+	if lastNav0 < 0 || firstNav2 == len(ev) {
+		t.Fatalf("C-r2-1 setup: expected both NavOrder-0 and NavOrder-2 seeds; events=%+v", ev)
+	}
+	if lastNav0 >= firstNav2 {
+		t.Fatalf("C-r2-1 VIOLATED: a NavOrder-2 widget (RootIndex 0) seeded at idx %d BEFORE the last NavOrder-0 "+
+			"widget (RootIndex 2) at idx %d — the RootIndex==0 'dashboard' bait was seeded first, so RootIndex is "+
+			"STILL consulted for ordering (the branch is dormant, not gone); events=%+v", firstNav2, lastNav0, ev)
+	}
+
+	// (3) Set completeness: 3 widgets × 3 cohorts = 9 seeds (PURE ORDERING — no
+	// unit dropped by the RootIndex inversion).
+	if len(ev) != 9 {
+		t.Fatalf("C-r2-1 set: expected 9 (widget × cohort) seeds, got %d; events=%+v", len(ev), ev)
 	}
 }

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch.go
@@ -8,37 +8,38 @@
 // PHASE1_TIMEOUT the gate degenerates to a TIME gate and the pod goes Ready
 // with COLD cells (the fix3r reality — seed 388s+ >> the 180s chart budget).
 //
-// FIX-F re-spec §F.1: /readyz should flip when {WaitAllInformersSynced
-// good-enough barrier (unchanged) ∧ the FIX-E rank-1 × FIRST-NAV SEGMENT is
-// seeded} — the walk-derived default-route/dashboard (RootIndex==0) widgets
-// under the rank-1 identity — NOT the full seed (tail excluded by
+// FIX-F re-spec §F.1 (as amended by #130 F3b-r2): /readyz should flip when
+// {WaitAllInformersSynced good-enough barrier (unchanged) ∧ EVERY cohort's NAV
+// WIDGETS are seeded} — NOT the full seed (the RA content tail is excluded by
 // construction), NOT nothing (cells, not just substrate).
 //
-// MECHANISM (§F.1): seedScopeYielding closes firstNavDone the moment the
-// rank-1 RootIndex==0 widget segment completes (or provably has zero
-// targets). engineSeed's select waits on <-firstNavDone instead of
+// MECHANISM (§F.1): seedScopeYielding closes firstNavDone the moment the LAST
+// nav-widget unit (widget × cohort) completes (or provably has zero nav
+// widgets). engineSeed's select waits on <-firstNavDone instead of
 // <-bootDone; bootDone / scopeDone stay untouched (the boot scope keeps
 // running to completion in background — S2 worker-release + engine semantics
 // unchanged). The deferred MarkPhase1Done (phase1_walk.go) then fires at
-// min(first-nav-complete, PHASE1_TIMEOUT backstop, pipGlobalTimeout child) —
+// min(nav-widgets-complete, PHASE1_TIMEOUT backstop, pipGlobalTimeout child) —
 // the C2 "Ready-degraded, never not-Ready-forever" backstop is preserved
 // verbatim (the pctx.Done() arm of engineSeed's select is untouched).
 //
-// SEGMENT-SCOPED, NOT RANK-SCOPED (§F-C2). The segment is the RootIndex==0
-// widget set (stamped by the harvester's BeginRoot/RootIndex, phase1_pip_seed.go),
-// NOT the whole rank-1 pass. The heavy NON-first-nav tail (RootIndex>0 widgets
-// + the rank-1 fanout-tail restactions, ascending-len-sorted LAST by FIX-E) is
-// still mid-seed when the latch fires — §F-C2/ARM-TAIL. And a RootIndex>0-only
-// rank-1 (no dashboard widget seeded) must NOT fire the latch early via the
-// segment path (§F-C3): the completion signal keys on "the RootIndex==0 target
-// COUNT was reached", so an empty first-nav set fires ONLY through the
-// zero-targets guard below (provably-nothing-to-warm), never spuriously.
+// CLASS-SCOPED, NOT ROOTINDEX-SCOPED (#130 F3b-r2). The old FIX-F latch keyed
+// on the RootIndex==0 (config-root/dashboard) widget SEGMENT — a frontend-page
+// concept Diego rejected. F3b-r2 replaced that partition with the widget-vs-RA
+// CLASS boundary: the latch waits for ALL nav widgets across ALL cohorts
+// (navWidgetRemaining == len(flat) → 0), then fires BEFORE the RA content tail.
+// A target either IS or ISN'T a nav widget (a structural fact), never a
+// page/route/dashboard concept. Post-Fix-2 every nav widget is cheap (whale
+// LISTs serve from the synced informer), so waiting for all of them costs little
+// — a STRICT GENERALIZATION of the old latch. A topology with no nav widget
+// (all-RA) fires ONLY through the zero-nav-widgets guard (provably-nothing-to-
+// warm), never spuriously.
 //
-// NO STATIC LIST / NO MAGIC NUMBER: the segment is 100% walk-derived
-// (RootIndex, config.json root order). The latch carries no cap and no env
-// knob — the PHASE1_TIMEOUT / pipGlobalTimeout backstops it composes with are
-// the EXISTING budget config (§F.4: PREWARM_BOOT_BUDGET_SECONDS bounds the
-// ENGINE boot scope only, never the readyz gate).
+// NO STATIC LIST / NO MAGIC NUMBER: the class boundary is 100% structural. The
+// latch carries no cap and no env knob — the PHASE1_TIMEOUT / pipGlobalTimeout
+// backstops it composes with are the EXISTING budget config (§F.4:
+// PREWARM_BOOT_BUDGET_SECONDS bounds the ENGINE boot scope only, never the
+// readyz gate).
 
 package dispatchers
 
@@ -48,8 +49,9 @@ import (
 	"time"
 )
 
-// firstNavLatch is the fire-once readiness signal for the rank-1 first-nav
-// (RootIndex==0) segment. Closed at most once by seedScopeYielding on the
+// firstNavLatch is the fire-once readiness signal for the all-nav-widget class
+// (#130 F3b-r2; formerly the rank-1 RootIndex==0 first-nav segment). Closed at
+// most once by seedScopeYielding on the
 // boot pass; awaited by engineSeed's select. A process has exactly one
 // (firstNavLatchSingleton); post-boot GVR-discovered re-walks reuse the same
 // already-fired latch (close is idempotent via sync.Once), so a re-walk never
@@ -63,16 +65,17 @@ func newFirstNavLatch() *firstNavLatch {
 	return &firstNavLatch{done: make(chan struct{})}
 }
 
-// fire closes the latch exactly once and logs the transition with the
-// segment counts + elapsed the caller measured. reason distinguishes the
-// segment-complete path from the provably-zero-targets path (both are
-// legitimate "first-nav is warm / there is no first-nav to warm" states);
-// segWidgets/segTargets are the RootIndex==0 widget + per-target counts the
-// latch waited on (0/0 on the zero-targets path). segIdentity/segRank name the
-// segment identity + its position in the dedup rank (#99b): the identity the
-// latch keyed readiness on — NOT necessarily ranked[0], since ranked[0] can be
-// a restaction-only identity with zero first-nav widgets. Empty/-1 on the
-// zero-targets path (no ranked identity had a first-nav widget).
+// fire closes the latch exactly once and logs the transition with the nav-widget
+// counts + elapsed the caller measured. reason distinguishes the
+// segment-complete path (all nav widgets seeded) from the zero-nav-widgets path
+// (there is no nav widget to warm) — both legitimate "nav widgets warm / none to
+// warm" states. #130 F3b-r2: segWidgets/segTargets are now the ALL-NAV-WIDGET
+// counts — the distinct nav widgets across all cohorts + the total
+// (widget × cohort) units the latch waited on (0/0 on the zero path), NOT the
+// old RootIndex==0 subset. segIdentity/segRank are RETAINED in the signature for
+// log-field back-compat but are no longer segment-scoped: the caller passes
+// ""/-1 (the latch keys on the widget-vs-RA class boundary, not one cohort's
+// config-root subtree).
 func (l *firstNavLatch) fire(reason string, segWidgets, segTargets int, segIdentity string, segRank int, elapsed time.Duration) {
 	l.once.Do(func() {
 		if firstNavFireObserver != nil {
@@ -92,9 +95,9 @@ func (l *firstNavLatch) fire(reason string, segWidgets, segTargets int, segIdent
 			slog.String("segment_identity", segIdentity),
 			slog.Int("segment_rank", segRank),
 			slog.Int64("elapsed_ms", elapsed.Milliseconds()),
-			slog.String("effect", "rank-1 RootIndex==0 first-nav segment seeded (or provably empty); "+
-				"engineSeed unblocks → /readyz flips Ready with the dashboard warm. The boot scope "+
-				"keeps seeding the tail in background (bootDone unaffected)."),
+			slog.String("effect", "all cohorts' nav widgets seeded (or provably no nav widget); "+
+				"engineSeed unblocks → /readyz flips Ready with every cohort's nav widgets warm. The "+
+				"boot scope keeps seeding the RA content tail in background (bootDone unaffected)."),
 		)
 	})
 }

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_segment_test.go
@@ -55,6 +55,8 @@ package dispatchers
 
 import (
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/krateoplatformops/plumbing/endpoints"
@@ -135,54 +137,49 @@ func TestFirstNavLatch_SegmentIdentity_RestactionOnlyRank0_FiresOnWidgetSegment(
 	}
 
 	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-	// The two RootIndex==0 U1 widgets seed under identity group:u1.
-	dashAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dash-a" && e.identity == "group:u1" })
-	dashBIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dash-b" && e.identity == "group:u1" })
-	tailIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "tail-w" })
 	raIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
 
 	if latchIdx == len(ev) {
 		t.Fatalf("§5 GREEN: latch never fired; events=%+v", ev)
 	}
-	// Fire AFTER both U1 RootIndex==0 widgets seed (segment complete)...
-	lastSegIdx := dashAIdx
-	if dashBIdx > lastSegIdx {
-		lastSegIdx = dashBIdx
+	// F3b-r2: the class-boundary latch fires AFTER ALL nav widgets (dash-a,
+	// dash-b AND the RootIndex==1 tail-w — every nav widget is now part of the
+	// nav-widget class, no RootIndex partition) and BEFORE the RA-only M tail.
+	lastWidgetIdx := -1
+	for i, e := range ev {
+		if e.class == "widget" {
+			lastWidgetIdx = i
+		}
 	}
-	if latchIdx < lastSegIdx {
-		t.Fatalf("§5 GREEN: latch fired at idx %d BEFORE the U1 first-nav segment completed (last U1 widget at idx %d) — ARM-COLD; events=%+v", latchIdx, lastSegIdx, ev)
+	if lastWidgetIdx < 0 {
+		t.Fatalf("§5 setup: no widgets seeded; events=%+v", ev)
 	}
-	// ...and BEFORE the RootIndex==1 NON-first-nav tail widget (U2, rank 2) —
-	// the segment identity's own tail. ARM-TAIL: readyz must not wait on it.
-	if tailIdx < len(ev) && latchIdx > tailIdx {
-		t.Fatalf("§5 GREEN/ARM-TAIL: latch fired at idx %d AFTER the RootIndex==1 tail widget (U2, rank 2) at idx %d — readyz would wait on non-first-nav tail; events=%+v", latchIdx, tailIdx, ev)
+	if latchIdx < lastWidgetIdx {
+		t.Fatalf("F3b-r2: latch fired at idx %d BEFORE the last nav widget at idx %d — the class-boundary latch must wait for ALL nav widgets (incl. the RootIndex==1 tail-w); events=%+v", latchIdx, lastWidgetIdx, ev)
 	}
-	// Post-FIX-3 the M restaction is ranked[2] (widgetMax 0) and legitimately
-	// seeds LAST under the rank-major loop — it is NOT the segment (U1 rank 0),
-	// so the latch fires at U1's segment before M's RA tail ever runs. ARM-TAIL:
-	// readyz must not wait on the RA-only tail. Assert the latch fired at or
-	// before the RA (M) seed to pin the segment-before-tail order under FIX-3.
+	// ARM-TAIL: the M restaction (widget-less, ranked last) seeds in the RA tail
+	// AFTER the latch — readyz must not wait on the RA-only tail.
 	if raIdx < len(ev) && latchIdx > raIdx {
-		t.Fatalf("§5 GREEN/ARM-TAIL: latch fired at idx %d AFTER the RA-only tail (M, rank 2) at idx %d — post-FIX-3 M is the widget-less tail, readyz must not wait on it; events=%+v", latchIdx, raIdx, ev)
+		t.Fatalf("F3b-r2 ARM-TAIL: latch fired at idx %d AFTER the RA-only tail (M) at idx %d — readyz must not wait on it; events=%+v", latchIdx, raIdx, ev)
 	}
 }
 
-// ── COND-2 (FIX-3 mandatory): MULTI-ROOT segKey scan stays discriminating ───
-// Post-FIX-3, ranked[0] is widget-capable by construction — but "widget-capable"
-// means >=1 widget target ANYWHERE, not >=1 RootIndex==0 (first-nav) target. On
-// a MULTI-ROOT config an identity whose ONLY widget targets live in a non-first
-// root can take ranked[0] yet have ZERO first-nav targets. The #99b segKey scan
-// is the guard that walks past it to the first identity with a genuine
-// RootIndex==0 widget. This arm re-covers the retired #99b "scan walks past
-// ranked[0]" property under FIX-3:
-//   (i) ranked[0] = W (widgetMax 9) but ALL W's widgets are RootIndex==1;
-//   (ii) V (widgetMax 2) has a RootIndex==0 widget → segKey==V, segRank>0;
-//   (iii) the latch fires reason=segment-complete on V's FIRST-NAV segment.
-// RED (captured to /tmp/r3/ empirically): neuter the scan (segRank hard-bound
-// to 0) → the latch counts 0 first-nav targets on W → fires
-// "zero-first-nav-targets" BEFORE V's RootIndex==0 widget → the fire-after-V's-
-// widget + reason=segment-complete asserts below both fail.
-func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *testing.T) {
+// ── F3b-r2: MULTI-ROOT — latch is RootIndex-INDEPENDENT (supersedes the #99b
+// segKey scan). ──
+// The #99b segKey scan (walk `ranked` to the first identity with a RootIndex==0
+// widget) is DELETED under F3b-r2: the latch no longer keys on any RootIndex
+// partition, so a multi-root topology where ranked[0]=W has only a RootIndex==1
+// widget and V has the RootIndex==0 widget needs NO scan — the class-boundary
+// latch fires after BOTH nav widgets seed, regardless of which cohort/RootIndex
+// they belong to. This arm re-expresses the multi-root property for F3b-r2:
+//   (i) ranked[0] = W (widgetMax 9), widget RootIndex==1;
+//   (ii) V (widgetMax 2) has a RootIndex==0 widget;
+//   (iii) the latch fires reason=segment-complete AFTER BOTH widgets — never
+//         early on W's widget alone, never via a RootIndex partition.
+// RED (C-r2-2, captured to /tmp/f3b-r2-falsifiers/ by source-revert): the old
+// RootIndex latch would fire when the RootIndex==0 widget (V's) seeds, leaving
+// W's RootIndex==1 nav widget cold — the early-fire flagged by the last-widget guard.
+func TestFirstNavLatch_MultiRoot_LatchIsRootIndexIndependent(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
@@ -190,15 +187,20 @@ func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *test
 
 	resetFirstNavLatchForTest()
 	ensureFirstNavLatch()
+	t.Cleanup(func() {
+		resetFirstNavLatchForTest()
+		firstNavFireObserver = nil
+		zeroCustomerInFlight()
+	})
 
 	// W (widgetMax 9) is ranked[0], widget lives in RootIndex==1 only. V
-	// (widgetMax 2) has a RootIndex==0 widget → the segment identity, segRank>0.
+	// (widgetMax 2) has a RootIndex==0 widget.
 	w := eID{name: "w", group: true, collapsed: 9}
 	v := eID{name: "v", group: true, collapsed: 2}
 
 	h := newNavWidgetHarvester()
-	firstNavW := latchWidgetGVR("flexes")     // RootIndex 0 — V's first-nav widget
-	nonFirstNavW := latchWidgetGVR("tailwid") // RootIndex 1 — W's only widget
+	firstNavW := latchWidgetGVR("flexes")     // RootIndex 0 — V's widget
+	nonFirstNavW := latchWidgetGVR("tailwid") // RootIndex 1 — W's widget
 	harvestWidgetAtRoot(h, "first-nav", firstNavW, 0)
 	harvestWidgetAtRoot(h, "non-first-nav", nonFirstNavW, 1)
 	widgets := h.snapshot()
@@ -208,9 +210,9 @@ func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *test
 		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
 			switch gvr {
 			case firstNavW:
-				return latchTargets(gvr, v) // V, RootIndex 0 → segment
+				return latchTargets(gvr, v) // V, RootIndex 0
 			case nonFirstNavW:
-				return latchTargets(gvr, w) // W, RootIndex 1 → ranked[0], not first-nav
+				return latchTargets(gvr, w) // W, RootIndex 1 → ranked[0]
 			}
 			return nil
 		},
@@ -230,24 +232,28 @@ func TestFirstNavLatch_SegmentIdentity_MultiRoot_ScanFindsFirstNavWidget(t *test
 	}
 	ev := rec.snapshot()
 
-	// (iii) fired segment-complete — NOT zero-first-nav-targets (the neutered-
-	// scan RED reason: W has no first-nav widget so a segRank-hard-0 impl would
-	// find nothing and fire the provably-zero path).
+	// (iii) fired segment-complete (both nav widgets are ordinary nav widgets;
+	// no provably-empty path).
 	if fireReason != "segment-complete" {
-		t.Fatalf("COND-2: latch fired reason=%q; want \"segment-complete\" — with the #99b scan neutered (segRank hard-bound to ranked[0]=W, which has zero RootIndex==0 widgets) the latch would fire \"zero-first-nav-targets\"; events=%+v", fireReason, ev)
+		t.Fatalf("F3b-r2 multi-root: latch fired reason=%q; want \"segment-complete\"; events=%+v", fireReason, ev)
 	}
-	// (ii)+(iii) the latch fired AFTER V's RootIndex==0 widget seeded — i.e. it
-	// keyed on the true first-nav segment (segRank>0, segKey==V), not ranked[0].
+	// The latch fired AFTER BOTH nav widgets seeded (V's RootIndex==0 AND W's
+	// RootIndex==1) — RootIndex-independent, no scan.
 	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-	vWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.identity == "group:v" && e.rootIdx == 0 })
+	lastWidgetIdx := -1
+	for i, e := range ev {
+		if e.class == "widget" {
+			lastWidgetIdx = i
+		}
+	}
 	if latchIdx == len(ev) {
-		t.Fatalf("COND-2: latch never fired; events=%+v", ev)
+		t.Fatalf("F3b-r2 multi-root: latch never fired; events=%+v", ev)
 	}
-	if vWidgetIdx == len(ev) {
-		t.Fatalf("COND-2 setup: V's RootIndex==0 widget never seeded; events=%+v", ev)
+	if lastWidgetIdx < 0 {
+		t.Fatalf("F3b-r2 multi-root setup: no widgets seeded; events=%+v", ev)
 	}
-	if latchIdx < vWidgetIdx {
-		t.Fatalf("COND-2: latch fired at idx %d BEFORE V's first-nav (RootIndex==0) widget at idx %d — the scan did NOT walk past ranked[0]=W to the real first-nav segment; events=%+v", latchIdx, vWidgetIdx, ev)
+	if latchIdx < lastWidgetIdx {
+		t.Fatalf("F3b-r2 multi-root: latch fired at idx %d BEFORE the last nav widget at idx %d — it must wait for ALL nav widgets regardless of RootIndex/rank; events=%+v", latchIdx, lastWidgetIdx, ev)
 	}
 }
 
@@ -373,5 +379,116 @@ func TestKeepwarmSweep_WidgetCapablePrefix_SeedsBothNotSegmentOnly(t *testing.T)
 	}
 	if !seededV {
 		t.Fatalf("c2 keepwarm ruling: sweep did NOT seed V (widgetMax 2, widget-capable) — c2 WIDENS coverage to the whole widget-capable prefix, not ranked[0] only; the #99b property (bound is the widgetMax tier, NOT segRank) must still seed V; events=%+v", ev)
+	}
+}
+
+// countingHandler is a minimal slog.Handler that counts records whose msg matches
+// a target, capturing the "identity" attr of each — for asserting the keepwarm
+// per-cohort cohort_summary emission (#130 F3b-r2 cond 3).
+type countingHandler struct {
+	target     string
+	identities *[]string
+}
+
+func (h countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h countingHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Message == h.target {
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key == "identity" {
+				*h.identities = append(*h.identities, a.Value.String())
+			}
+			return true
+		})
+	}
+	return nil
+}
+func (h countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h countingHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestF3bR2_C_r2_3_KeepwarmUnchanged_PrefixBoundAndCohortSummary is the #130
+// F3b-r2 cond-3 arm (arch-required for mode-ruling B): the keepwarm sweep's TWO
+// load-bearing concerns are UNCHANGED by the boot-mode NavOrder-flat refactor —
+//   (1) the widgetMax==0 PREFIX BOUND: the sweep breaks at the first widgetMax==0
+//       (RA-only, widget-less) cohort → that cohort is NOT swept.
+//   (2) the per-cohort cohort_summary: EXACTLY ONE prewarm.keepwarm.cohort_summary
+//       INFO line per SWEPT (widget-capable) cohort.
+// RED = a "flatten all modes" impl (apply the NavOrder-flat pass to keepwarm too):
+// it has no per-rank cohort boundary, so it would emit ZERO cohort_summary lines
+// AND would not break at widgetMax==0 (it would seed the widget-less tail cohort's
+// RA targets in NavOrder order with the rest). Either divergence fails the asserts.
+func TestF3bR2_C_r2_3_KeepwarmUnchanged_PrefixBoundAndCohortSummary(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+
+	// Capture prewarm.keepwarm.cohort_summary INFO lines (their identity attr).
+	var summaries []string
+	prev := slog.Default()
+	slog.SetDefault(slog.New(countingHandler{target: "prewarm.keepwarm.cohort_summary", identities: &summaries}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Latch already fired at boot (keepwarm runs post-boot).
+	resetFirstNavLatchForTest()
+	latch := ensureFirstNavLatch()
+	latch.fire("boot-already-fired", 0, 0, "", -1, 0)
+	t.Cleanup(func() { resetFirstNavLatchForTest(); zeroCustomerInFlight() })
+
+	// Two WIDGET-CAPABLE cohorts (devs widgetMax high, ops lower) both on a widget
+	// GVR, PLUS a widget-less cohort (machineSA) present ONLY on an RA target GVR
+	// (widgetMax==0 → the prefix-bound tail that must NOT be swept).
+	devs := eID{name: "devs", group: true, collapsed: 442}
+	ops := eID{name: "ops", group: true, collapsed: 5}
+	machineSA := eID{name: "machine", group: true, collapsed: 3} // widget_max 0 (RA-only)
+
+	h := newNavWidgetHarvester()
+	wGVR := latchWidgetGVR("flexes")
+	harvestWidgetAtRoot(h, "w", wGVR, 0)
+	widgets := h.snapshot()
+	raGVR := eFanoutRAGVR
+	ras := []templatesv1.ObjectReference{latchRA("machine-ra")}
+
+	rec := &latchRecorder{}
+	installLatchSeams(t, rec,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			switch gvr {
+			case wGVR:
+				return latchTargets(gvr, devs, ops) // widget-capable cohorts
+			case raGVR:
+				return latchTargets(gvr, machineSA) // widget-LESS cohort (RA only)
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return raGVR, true
+		})
+
+	if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeKeepwarm); err != nil {
+		t.Fatalf("keepwarm seedScopeYielding: %v", err)
+	}
+
+	// (1) PREFIX BOUND: the widget-less machineSA cohort must NOT be swept — no
+	// cohort_summary for it (the break at widgetMax==0 stops before it).
+	for _, id := range summaries {
+		if strings.Contains(id, "machine") {
+			t.Fatalf("cond-3 PREFIX BOUND broken: widget-less cohort 'machine' (widgetMax==0) was swept "+
+				"(got a cohort_summary) — the keepwarm prefix-break at widgetMax==0 is gone. summaries=%v", summaries)
+		}
+	}
+	// (2) COHORT SUMMARY: exactly one per SWEPT (widget-capable) cohort = 2 (devs, ops).
+	if len(summaries) != 2 {
+		t.Fatalf("cond-3 COHORT SUMMARY broken: want exactly 2 cohort_summary lines (devs, ops — the "+
+			"widget-capable prefix), got %d: %v. A flatten-all-modes impl emits ZERO (no per-cohort boundary).", len(summaries), summaries)
+	}
+	devsSeen, opsSeen := false, false
+	for _, id := range summaries {
+		if strings.Contains(id, "devs") {
+			devsSeen = true
+		}
+		if strings.Contains(id, "ops") {
+			opsSeen = true
+		}
+	}
+	if !devsSeen || !opsSeen {
+		t.Fatalf("cond-3: both widget-capable cohorts must get a summary; devs=%v ops=%v (summaries=%v)", devsSeen, opsSeen, summaries)
 	}
 }

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch_test.go
@@ -1,28 +1,28 @@
-// prewarm_first_nav_latch_test.go — #99 FIX-F: the first-nav readyz latch
-// falsifier set (PM conditions F-C1..F-C4, docs/seed-tail-restactions-budget-
-// and-16mb-serve-trace-2026-07-04.md §F.2).
+// prewarm_first_nav_latch_test.go — #130 F3b-r2: the ALL-NAV-WIDGET readyz
+// latch falsifier set. SUPERSEDES the #99 FIX-F RootIndex==0 segment latch.
 //
-// The latch fires when the rank-1 (ri==0) RootIndex==0 first-nav WIDGET
-// segment has seeded (or provably has none). engineSeed's select waits on it
-// so /readyz flips WITH the dashboard warm, NOT at the PHASE1_TIMEOUT backstop
-// with cold cells (the fix3r degeneration §F.0). These arms discriminate the
-// fire-POINT, not merely eventual firing:
+// F3b-r2: the latch keys on the widget-vs-RA CLASS boundary, NOT RootIndex. It
+// fires when EVERY cohort's NAV WIDGETS have seeded (navWidgetRemaining==0),
+// independent of RootIndex — then before ANY RA (the RA content tail is
+// excluded from readiness). The old "fires after the reachable-cohort dashboards
+// (RootIndex==0)" invariant is SUPERSEDED by "fires after ALL nav widgets across
+// all cohorts." These arms discriminate the fire-POINT, not merely eventual
+// firing:
 //
-//   ARM-GREEN (§F.2 ARM-TAIL, F-C1): rank-1 first-nav widgets + a heavy
-//     NON-first-nav tail (RootIndex>0 widget + a fanout restaction). The latch
-//     MUST fire BEFORE any tail seed runs. Asserts ORDERING (latch-fire index
-//     < first tail-seed index), not just that it fired.
-//   ARM-RED-i (mutation → §F.2 mutation (i)): neuter the segment decrement so
-//     the latch can only fire via the zero-targets / rank-boundary path (=
-//     "moved to full-scope completion"). Under the SAME fixture the latch then
-//     fires only AFTER the whole rank-1 pass incl. the tail → RED.
-//   ARM-C3 (§F.2 ARM-COLD / F-C3): a RootIndex>0-ONLY rank-1 (no dashboard
-//     widget authorised for rank-1). firstNavRemaining stays 0, so the latch
-//     must NOT fire via the segment path early; it fires ONLY through the
-//     provably-zero path AFTER the rank-1 seed (never spuriously mid-tail).
-//   ARM-BACKSTOP (§F.2 / C2, F-C4): engineSeed's select composition — the
-//     latch never firing must fall through to the pctx.Done() backstop, so
-//     readiness is never withheld forever. Driven at the select level.
+//   ARM-GREEN (F3b-r2 all-nav-widget): a low-NavOrder widget (RootIndex 0) AND a
+//     high-NavOrder widget (RootIndex 1) across 2 cohorts + a fanout restaction.
+//     The latch MUST fire AFTER the LAST nav widget of ANY cohort (incl. the
+//     RootIndex!=0 one) and BEFORE any RA. Asserts ORDERING.
+//   ARM-RED-earlyfire (C-r2-2 RED): simulate the OLD RootIndex latch — fire the
+//     latch the instant the RootIndex==0 widgets are done, leaving the
+//     RootIndex!=0 nav widget still cold. Under the GREEN guard (fire AFTER the
+//     last nav widget) this is RED. Proves the RootIndex latch is GONE, not
+//     dormant.
+//   ARM-ZERO (provably-empty): an all-RA topology (no nav widget) fires
+//     "zero-nav-widgets" so the latch never hangs to the backstop.
+//   ARM-BACKSTOP (C2, F-C4): engineSeed's select composition — the latch never
+//     firing must fall through to the pctx.Done() backstop, so readiness is
+//     never withheld forever. Driven at the select level.
 //
 // Hermetic, -race, seams only (no cluster / apiserver / informer). Serializes
 // on engineLatchTestMu (shares the process latch singleton + seed counters +
@@ -162,28 +162,34 @@ func firstIndexOf(ev []latchSeedEvent, pred func(latchSeedEvent) bool) int {
 	return len(ev)
 }
 
-// ── ARM-GREEN + ARM-RED-i (F-C1 / §F.2 ARM-TAIL + mutation (i)) ─────────────
-// Fixture: rank-1 (devs, collapsed=442) has a RootIndex==0 dashboard widget
-// (first-nav) AND a RootIndex==1 tail widget; plus a rank-1 fanout restaction.
-// rank-2 (ops) has targets on both widgets. The latch MUST fire after the
-// dashboard widget and BEFORE the tail widget + the restaction.
-func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
+// ── ARM-GREEN + ARM-RED-earlyfire (C-r2-2) ─────────────────────────────────
+// Fixture: 2 cohorts (devs collapsed=442, ops collapsed=5), a low-NavOrder
+// widget dashboard-flex (RootIndex 0) AND a high-NavOrder widget estate-graph
+// (RootIndex 1), each carrying BOTH cohorts; plus a fanout restaction. The
+// all-nav-widget latch MUST fire AFTER the LAST nav widget of ANY cohort (incl.
+// estate-graph, which the OLD RootIndex latch would have left cold) and BEFORE
+// any RA.
+//
+// ARM-RED-earlyfire simulates the OLD RootIndex latch: it fires the latch the
+// instant the RootIndex==0 (dashboard-flex) widgets are done, leaving the
+// RootIndex!=0 nav widget (estate-graph) still cold. The GREEN guard "fire AFTER
+// the last nav widget" flags that as RED — proving the class-boundary latch
+// waits for ALL nav widgets, not just the RootIndex==0 ones.
+func TestFirstNavLatch_AllNavWidgets_GreenAndEarlyFireRed(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
 	quietLoggingE(t)
 
-	run := func(t *testing.T, mutateNeuterSegment bool) []latchSeedEvent {
+	// simulateOldRootIndexLatch, when true, installs a fire observer that fires
+	// the latch early — at the moment the RootIndex==0 dashboard-flex widget of
+	// the LAST cohort seeds — mirroring the deleted RootIndex latch. This is the
+	// C-r2-2 RED mutation, expressed hermetically (no source revert needed for
+	// the arm to RUN; the source-revert RED artifact is captured separately to
+	// /tmp/f3b-r2-falsifiers/).
+	run := func(t *testing.T, simulateOldRootIndexLatch bool) []latchSeedEvent {
 		resetFirstNavLatchForTest()
-		ensureFirstNavLatch() // build the process latch so seedScopeYielding can fire it
-		// #130 F3 cascade-harden (arch point 5): a FAILED arm previously left the
-		// process-global first-nav latch singleton armed/fired + the fire observer
-		// installed, poisoning the NEXT test in the package (the observed
-		// TestF5_RealCheckDispatchRBAC cascade). Reset the process-global seed
-		// state in t.Cleanup so a mid-seed Fatalf cannot leak it forward. (The
-		// observer is also cleared by installLatchFireObserver's own Cleanup; this
-		// is belt-and-suspenders + the latch/customer-in-flight reset the prior
-		// code only did at the NEXT run's start.)
+		latch := ensureFirstNavLatch() // build the process latch so seedScopeYielding can fire it
 		t.Cleanup(func() {
 			resetFirstNavLatchForTest()
 			firstNavFireObserver = nil
@@ -196,14 +202,18 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 		h := newNavWidgetHarvester()
 		dashGVR := latchWidgetGVR("flexes")
 		tailGVR := latchWidgetGVR("estategraphs")
-		harvestWidgetAtRoot(h, "dashboard-flex", dashGVR, 0) // RootIndex 0 — first-nav
-		harvestWidgetAtRoot(h, "estate-graph", tailGVR, 1)   // RootIndex 1 — tail
+		harvestWidgetAtRoot(h, "dashboard-flex", dashGVR, 0) // NavOrder 0, RootIndex 0
+		harvestWidgetAtRoot(h, "estate-graph", tailGVR, 1)   // NavOrder 1, RootIndex 1
 		widgets := h.snapshot()
 
 		fanoutRA := latchRA("fanout-ra")
 		ras := []templatesv1.ObjectReference{fanoutRA}
 
 		rec := &latchRecorder{}
+
+		// Wire the seams. For the RED simulation we override seedOneWidgetFn to
+		// fire the latch early (after the RootIndex==0 dashboard widgets, before
+		// the RootIndex!=0 nav widget) — the old-RootIndex-latch behaviour.
 		installLatchSeams(t, rec,
 			func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
 				switch gvr {
@@ -218,130 +228,138 @@ func TestFirstNavLatch_FiresBeforeTail_GreenAndMutationRed(t *testing.T) {
 				return eFanoutRAGVR, true
 			})
 
-		// Mutation (i): neuter the segment decrement so the latch can only fire
-		// via the rank-boundary / zero-targets path — the "latch moved to
-		// full-scope completion" defect. We simulate by pre-firing NOTHING and
-		// instead force firstNavRemaining to never reach zero: the cleanest
-		// hermetic neuter is to make the RootIndex==0 widget look like a tail
-		// (RootIndex forced >0) via a seam on the harvested entries.
-		if mutateNeuterSegment {
-			for i := range widgets {
-				if widgets[i].RootIndex == 0 {
-					widgets[i].RootIndex = 99 // no widget is first-nav anymore → segment count 0
+		installLatchFireObserver(t, rec)
+
+		if simulateOldRootIndexLatch {
+			// Override the widget seam to fire the latch the instant the LAST
+			// RootIndex==0 (dashboard-flex) widget seeds — the deleted behaviour.
+			prevW := seedOneWidgetFn
+			rootZeroSeeded := 0
+			seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, ns string, m seedScopeMode) error {
+				rec.rec(latchSeedEvent{class: "widget", label: e.W.GetName(), rootIdx: e.RootIndex, identity: eIdentityLabel(ctx)})
+				if e.RootIndex == 0 {
+					rootZeroSeeded++
+					if rootZeroSeeded == 2 { // both cohorts' dashboard-flex done
+						latch.fire("old-rootindex-latch", 1, 2, "", -1, 0)
+					}
 				}
+				return nil
 			}
+			t.Cleanup(func() { seedOneWidgetFn = prevW })
 		}
 
-		installLatchFireObserver(t, rec)
 		if err := seedScopeYielding(context.Background(), ras, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 			t.Fatalf("seedScopeYielding returned %v; want nil", err)
 		}
 		return rec.snapshot()
 	}
 
-	t.Run("green_fires_after_all_reachable_dashboards_before_last_tail", func(t *testing.T) {
-		// #130 F3 Lever 2 — the latch now waits for EVERY first-nav-reachable
-		// cohort's dashboard segment (devs AND ops), not just rank-0's. The
-		// invariant is re-expressed for the multi-cohort case (arch-ruled: the
-		// single-cohort "fire before ANY tail" is genuinely incompatible with
-		// "wait for all cohorts' dashboards" under the rank-major loop — reaching
-		// ops' dashboard requires traversing devs' full rank first, including devs'
-		// tail widget + devs' fanout RA. That interleaving is intended and
-		// unavoidable without a larger dashboard-first seed reorder, which is out
-		// of F3 scope). The load-bearing readyz-correctness properties that SURVIVE:
-		//   (1) fire AFTER both reachable cohorts' RootIndex==0 dashboards (Ready
-		//       does not flip until every login cohort's dashboard is warm), and
-		//   (2) fire BEFORE the LAST reachable cohort's (ops') tail widget + RA,
-		//       and before the filler-only RA (readyz does not wait on the LAST
-		//       cohort's non-dashboard tail — the whale-fanout the latch removes).
+	t.Run("green_fires_after_all_nav_widgets_before_any_ra", func(t *testing.T) {
 		ev := run(t, false)
 		latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-		devsDashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
-			return e.class == "widget" && e.label == "dashboard-flex" && e.identity == "group:devs"
-		})
-		opsDashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
-			return e.class == "widget" && e.label == "dashboard-flex" && e.identity == "group:ops"
-		})
-		opsTailWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
-			return e.class == "widget" && e.label == "estate-graph" && e.identity == "group:ops"
-		})
-		opsRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
-			return e.class == "restaction" && e.identity == "group:ops"
-		})
-		fillerRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool {
-			return e.class == "restaction" && e.identity == "user:filler"
-		})
-
 		if latchIdx == len(ev) {
-			t.Fatalf("F-C1: latch never fired; events=%+v", ev)
+			t.Fatalf("F3b-r2: latch never fired; events=%+v", ev)
 		}
-		// (1) fire AFTER BOTH reachable cohorts' dashboards — the Lever-2 core.
-		if devsDashIdx == len(ev) || opsDashIdx == len(ev) {
-			t.Fatalf("F3 Lever2 setup: both devs+ops dashboards must seed; devsDash=%d opsDash=%d events=%+v", devsDashIdx, opsDashIdx, ev)
+		// (1) fire AFTER the LAST nav widget of ANY cohort — including the
+		//     RootIndex!=0 estate-graph. Find the last widget seed index.
+		lastWidgetIdx := -1
+		for i, e := range ev {
+			if e.class == "widget" {
+				lastWidgetIdx = i
+			}
 		}
-		if latchIdx < devsDashIdx || latchIdx < opsDashIdx {
-			t.Fatalf("F3 Lever2 ARM-COLD: latch fired at idx %d BEFORE a reachable cohort's dashboard "+
-				"(devsDash=%d opsDash=%d) — readyz would flip with a login cohort's dashboard cold; events=%+v",
-				latchIdx, devsDashIdx, opsDashIdx, ev)
+		if lastWidgetIdx < 0 {
+			t.Fatalf("F3b-r2 setup: no widgets seeded; events=%+v", ev)
 		}
-		// (2) fire BEFORE the LAST cohort's (ops') tail widget + ops' RA + the
-		//     filler-only RA — readyz does not wait on the last cohort's tail whale.
-		if opsTailWidgetIdx < len(ev) && latchIdx > opsTailWidgetIdx {
-			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER ops' NON-first-nav tail widget at idx %d "+
-				"— readyz would wait on the last cohort's tail; events=%+v", latchIdx, opsTailWidgetIdx, ev)
+		if latchIdx < lastWidgetIdx {
+			t.Fatalf("F3b-r2 ARM-COLD: latch fired at idx %d BEFORE the last nav widget at idx %d — "+
+				"readyz would flip with a nav widget (e.g. the RootIndex!=0 estate-graph) still cold; events=%+v",
+				latchIdx, lastWidgetIdx, ev)
 		}
-		if opsRAIdx < len(ev) && latchIdx > opsRAIdx {
-			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER ops' fanout restaction at idx %d; events=%+v", latchIdx, opsRAIdx, ev)
+		// (2) fire BEFORE any RA — the RA content tail is excluded from readiness.
+		firstRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
+		if firstRAIdx == len(ev) {
+			t.Fatalf("F3b-r2 setup: no RA seeded; events=%+v", ev)
 		}
-		if fillerRAIdx < len(ev) && latchIdx > fillerRAIdx {
-			t.Fatalf("F3 Lever2 ARM-TAIL: latch fired at idx %d AFTER the filler-only restaction at idx %d "+
-				"— readyz would wait on the RA-only tail; events=%+v", latchIdx, fillerRAIdx, ev)
+		if latchIdx > firstRAIdx {
+			t.Fatalf("F3b-r2 ARM-TAIL: latch fired at idx %d AFTER the first RA at idx %d — "+
+				"readyz must not wait on the RA content tail; events=%+v", latchIdx, firstRAIdx, ev)
+		}
+		// Both RootIndex==0 AND RootIndex!=0 nav widgets are covered: the latch
+		// fired after a RootIndex==1 widget seeded (the discriminator vs the old latch).
+		sawRootOneWidgetBeforeLatch := false
+		for i, e := range ev {
+			if e.class == "widget" && e.rootIdx == 1 && i < latchIdx {
+				sawRootOneWidgetBeforeLatch = true
+			}
+		}
+		if !sawRootOneWidgetBeforeLatch {
+			t.Fatalf("F3b-r2: no RootIndex!=0 nav widget seeded before the latch fired — the class-boundary latch must wait for the RootIndex!=0 nav widgets too; events=%+v", ev)
 		}
 	})
 
-	t.Run("mutation_i_full_scope_completion_red", func(t *testing.T) {
+	t.Run("red_old_rootindex_latch_fires_leaving_nonroot_nav_cold", func(t *testing.T) {
 		ev := run(t, true)
+		// The FIRST LATCH event is the simulated old-RootIndex early fire.
 		latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-		tailWidgetIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "estate-graph" })
-		raIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
-
 		if latchIdx == len(ev) {
-			t.Fatalf("mutation setup: latch never fired at all; events=%+v", ev)
+			t.Fatalf("RED setup: latch never fired; events=%+v", ev)
 		}
-		// With the segment neutered, the ONLY fire path is the rank-boundary
-		// zero-targets check (fires after the rank-1 loop → after ALL tail work).
-		// PROVE the mutation is RED against the GREEN property: the latch now
-		// fires AFTER the tail, i.e. it does NOT fire before tail work.
-		firedBeforeTail := (tailWidgetIdx == len(ev) || latchIdx < tailWidgetIdx) &&
-			(raIdx == len(ev) || latchIdx < raIdx)
-		if firedBeforeTail {
-			t.Fatalf("mutation (i) NOT RED: with the first-nav segment neutered, the latch STILL fired before the tail (idx %d; tailWidget=%d ra=%d) — the ordering assert does not discriminate; events=%+v",
-				latchIdx, tailWidgetIdx, raIdx, ev)
+		lastWidgetIdx := -1
+		for i, e := range ev {
+			if e.class == "widget" {
+				lastWidgetIdx = i
+			}
+		}
+		// PROVE the RED against the GREEN property: the simulated old-RootIndex
+		// latch fires BEFORE the last (RootIndex!=0) nav widget → the GREEN guard
+		// "latch >= lastWidget" is violated.
+		if !(latchIdx < lastWidgetIdx) {
+			t.Fatalf("C-r2-2 NOT RED: the simulated old-RootIndex latch did NOT fire before the last nav widget (latch=%d lastWidget=%d) — the GREEN guard would not discriminate it; events=%+v",
+				latchIdx, lastWidgetIdx, ev)
+		}
+		// And specifically it fired while a RootIndex!=0 nav widget was still cold.
+		rootOneAfterLatch := false
+		for i, e := range ev {
+			if e.class == "widget" && e.rootIdx == 1 && i > latchIdx {
+				rootOneAfterLatch = true
+			}
+		}
+		if !rootOneAfterLatch {
+			t.Fatalf("C-r2-2 RED shape degenerate: no RootIndex!=0 nav widget seeded AFTER the early fire; events=%+v", ev)
 		}
 	})
 }
 
-// ── ARM-C3 (§F.2 ARM-COLD / F-C3): RootIndex>0-only rank-1 ─────────────────
-// No RootIndex==0 widget is authorised for the rank-1 identity → the segment
-// count is 0 → the latch must NOT fire via the segment decrement mid-tail; it
-// fires ONLY through the provably-zero path AFTER the rank-1 seed. Guards
-// against a false-ready when the dashboard segment was never reached.
-func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
+// ── ARM-NONROOT (F3b-r2): RootIndex!=0-only topology still fires on all-nav ──
+// No RootIndex==0 widget exists at all (every nav widget is RootIndex!=0). Under
+// F3b-r2 these are ORDINARY nav widgets (no special first-nav segment); the
+// latch fires AFTER the LAST nav widget seeds — NOT via a provably-empty path.
+// This is the exact inverse of the deleted F-C3 semantics: the old latch treated
+// a RootIndex>0-only topology as "zero first-nav" and fired the provably-empty
+// path; the class-boundary latch treats them as nav widgets and waits for them.
+func TestFirstNavLatch_NonRootWidgetsOnly_FiresAfterAllNavWidgets(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
 	quietLoggingE(t)
 
 	resetFirstNavLatchForTest()
-	ensureFirstNavLatch() // build the process latch so seedScopeYielding can fire it
+	ensureFirstNavLatch()
+	t.Cleanup(func() {
+		resetFirstNavLatchForTest()
+		firstNavFireObserver = nil
+		zeroCustomerInFlight()
+	})
 
 	devs := eID{name: "devs", group: true, collapsed: 442}
+	ops := eID{name: "ops", group: true, collapsed: 5}
 
 	h := newNavWidgetHarvester()
 	tailA := latchWidgetGVR("tailas")
 	tailB := latchWidgetGVR("tailbs")
-	harvestWidgetAtRoot(h, "tail-a", tailA, 1) // RootIndex 1 — no first-nav segment
-	harvestWidgetAtRoot(h, "tail-b", tailB, 2)
+	harvestWidgetAtRoot(h, "tail-a", tailA, 1) // NavOrder 0, RootIndex 1
+	harvestWidgetAtRoot(h, "tail-b", tailB, 2) // NavOrder 1, RootIndex 2
 	widgets := h.snapshot()
 
 	rec := &latchRecorder{}
@@ -349,7 +367,7 @@ func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
 		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
 			switch gvr {
 			case tailA, tailB:
-				return latchTargets(gvr, devs)
+				return latchTargets(gvr, devs, ops)
 			}
 			return nil
 		},
@@ -357,7 +375,13 @@ func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
 			return schema.GroupVersionResource{}, false
 		})
 
-	installLatchFireObserver(t, rec)
+	var fireReason string
+	firstNavFireObserver = func(reason string) {
+		fireReason = reason
+		rec.rec(latchSeedEvent{class: "LATCH", label: reason, rootIdx: -1})
+	}
+	t.Cleanup(func() { firstNavFireObserver = nil })
+
 	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
 	}
@@ -365,23 +389,86 @@ func TestFirstNavLatch_RootIndexGtZeroOnly_NoEarlySegmentFire(t *testing.T) {
 
 	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
 	if latchIdx == len(ev) {
-		t.Fatalf("F-C3: latch never fired for a zero-first-nav rank-1 — readyz would hang to the backstop; events=%+v", ev)
+		t.Fatalf("F3b-r2: latch never fired for a RootIndex!=0-only topology — readyz would hang to the backstop; events=%+v", ev)
 	}
-	// It MUST NOT fire before both tail widgets have seeded — a segment-path
-	// early fire on a RootIndex>0-only rank-1 is the F-C3 false-ready defect.
-	// The provably-zero path fires at the rank-1 boundary, i.e. AFTER both
-	// tail widgets.
-	lastTailIdx := -1
+	// F3b-r2: these are ORDINARY nav widgets → the latch waits for them all and
+	// fires "segment-complete", NOT "zero-nav-widgets".
+	if fireReason != "segment-complete" {
+		t.Fatalf("F3b-r2: latch fired reason=%q; want \"segment-complete\" — RootIndex!=0 widgets are ordinary nav widgets, not a provably-empty first-nav set; events=%+v", fireReason, ev)
+	}
+	lastWidgetIdx := -1
 	for i, e := range ev {
 		if e.class == "widget" {
-			lastTailIdx = i
+			lastWidgetIdx = i
 		}
 	}
-	if lastTailIdx < 0 {
-		t.Fatalf("F-C3 setup: no tail widgets seeded; events=%+v", ev)
+	if lastWidgetIdx < 0 {
+		t.Fatalf("F3b-r2 setup: no widgets seeded; events=%+v", ev)
 	}
-	if latchIdx < lastTailIdx {
-		t.Fatalf("F-C3: latch fired at idx %d BEFORE the last tail widget seeded at idx %d — false-ready on a RootIndex>0-only rank-1 (segment path fired spuriously); events=%+v", latchIdx, lastTailIdx, ev)
+	if latchIdx < lastWidgetIdx {
+		t.Fatalf("F3b-r2: latch fired at idx %d BEFORE the last nav widget at idx %d — the class-boundary latch must wait for ALL nav widgets (RootIndex-independent); events=%+v", latchIdx, lastWidgetIdx, ev)
+	}
+}
+
+// ── ARM-ZERO (F3b-r2 provably-empty): no nav widget at all → zero-nav-widgets ─
+// An all-RA topology (or a walk that reached no widget) has navWidgetRemaining==0
+// at arm time → the latch fires "zero-nav-widgets" immediately so it never hangs
+// to the PHASE1_TIMEOUT backstop, and fires BEFORE any RA seeds.
+func TestFirstNavLatch_ZeroNavWidgets_FiresImmediatelyBeforeRA(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+	zeroCustomerInFlight()
+	quietLoggingE(t)
+
+	resetFirstNavLatchForTest()
+	ensureFirstNavLatch()
+	t.Cleanup(func() {
+		resetFirstNavLatchForTest()
+		firstNavFireObserver = nil
+		zeroCustomerInFlight()
+	})
+
+	devs := eID{name: "devs", group: true, collapsed: 442}
+
+	fanoutRA := latchRA("fanout-ra")
+	ras := []templatesv1.ObjectReference{fanoutRA}
+
+	rec := &latchRecorder{}
+	installLatchSeams(t, rec,
+		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
+			if gvr == eFanoutRAGVR {
+				return latchTargets(eFanoutRAGVR, devs)
+			}
+			return nil
+		},
+		func(_ templatesv1.ObjectReference) (schema.GroupVersionResource, bool) {
+			return eFanoutRAGVR, true
+		})
+
+	var fireReason string
+	firstNavFireObserver = func(reason string) {
+		fireReason = reason
+		rec.rec(latchSeedEvent{class: "LATCH", label: reason, rootIdx: -1})
+	}
+	t.Cleanup(func() { firstNavFireObserver = nil })
+
+	// NO widgets — only an RA.
+	if err := seedScopeYielding(context.Background(), ras, nil, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
+		t.Fatalf("seedScopeYielding returned %v; want nil", err)
+	}
+	ev := rec.snapshot()
+
+	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
+	if latchIdx == len(ev) {
+		t.Fatalf("F3b-r2: latch never fired for a zero-nav-widget topology — readyz would hang to the backstop; events=%+v", ev)
+	}
+	if fireReason != "zero-nav-widgets" {
+		t.Fatalf("F3b-r2: latch fired reason=%q; want \"zero-nav-widgets\" (no nav widget to warm); events=%+v", fireReason, ev)
+	}
+	// Fired BEFORE any RA (the RA tail is excluded from readiness).
+	firstRAIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "restaction" })
+	if firstRAIdx < len(ev) && latchIdx > firstRAIdx {
+		t.Fatalf("F3b-r2: zero-nav-widgets latch fired at idx %d AFTER an RA at idx %d — it must fire immediately at arm time; events=%+v", latchIdx, firstRAIdx, ev)
 	}
 }
 
@@ -494,13 +581,12 @@ func TestFirstNavLatch_BackstopUnblocksWhenLatchNeverFires(t *testing.T) {
 	}
 }
 
-// ── mutation (ii) proof (§F.2): fire-before-segment-complete → ARM-COLD RED ─
-// Directly exercises the ARM-COLD assert from the GREEN arm by FORCING an
-// early fire (mutation (ii): "latch fired before the segment completes") and
-// showing the GREEN arm's dashIdx guard flags it. We fire the latch before
-// seeding anything, then run the same fixture; the recorded LATCH lands before
-// the dashboard widget → the GREEN arm's `latchIdx < dashIdx` guard is RED.
-func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *testing.T) {
+// ── mutation (ii): fire-before-any-nav-widget → ARM-COLD RED ────────────────
+// Directly exercises the GREEN arm's ARM-COLD assert by FORCING an early fire
+// (before any seed) and showing the GREEN guard `latchIdx < lastWidget` flags
+// it. We fire the latch before seeding anything; the recorded LATCH lands before
+// every widget → RED under the all-nav-widget guard.
+func TestFirstNavLatch_MutationII_FireBeforeAnyNavWidget_IsRedUnderGreenGuard(t *testing.T) {
 	engineLatchTestMu.Lock()
 	defer engineLatchTestMu.Unlock()
 	zeroCustomerInFlight()
@@ -508,17 +594,25 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 
 	resetFirstNavLatchForTest()
 	latch := ensureFirstNavLatch()
+	t.Cleanup(func() {
+		resetFirstNavLatchForTest()
+		firstNavFireObserver = nil
+		zeroCustomerInFlight()
+	})
 
 	devs := eID{name: "devs", group: true, collapsed: 442}
 	h := newNavWidgetHarvester()
 	dashGVR := latchWidgetGVR("flexes")
+	tailGVR := latchWidgetGVR("estategraphs")
 	harvestWidgetAtRoot(h, "dashboard-flex", dashGVR, 0)
+	harvestWidgetAtRoot(h, "estate-graph", tailGVR, 1)
 	widgets := h.snapshot()
 
 	rec := &latchRecorder{}
 	installLatchSeams(t, rec,
 		func(gvr schema.GroupVersionResource) []cache.PrewarmTarget {
-			if gvr == dashGVR {
+			switch gvr {
+			case dashGVR, tailGVR:
 				return latchTargets(gvr, devs)
 			}
 			return nil
@@ -528,7 +622,7 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 		})
 
 	installLatchFireObserver(t, rec)
-	// MUTATION (ii): fire BEFORE the segment completes (before any seed).
+	// MUTATION (ii): fire BEFORE any nav widget seeds.
 	latch.fire("mutation-ii-premature", 0, 0, "", -1, 0)
 	if err := seedScopeYielding(context.Background(), nil, widgets, endpoints.Endpoint{}, nil, "authn-ns", seedModeBoot); err != nil {
 		t.Fatalf("seedScopeYielding returned %v; want nil", err)
@@ -536,12 +630,16 @@ func TestFirstNavLatch_MutationII_FireBeforeSegment_IsRedUnderGreenGuard(t *test
 	ev := rec.snapshot()
 
 	latchIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "LATCH" })
-	dashIdx := firstIndexOf(ev, func(e latchSeedEvent) bool { return e.class == "widget" && e.label == "dashboard-flex" })
-	// The GREEN arm's ARM-COLD guard is `latchIdx < dashIdx → FAIL`. Prove that
-	// a premature fire triggers exactly that condition (i.e. the guard
-	// discriminates mutation (ii)).
-	if !(latchIdx < dashIdx) {
-		t.Fatalf("mutation (ii) NOT caught: premature fire did not land before the dashboard-widget seed (latch=%d dash=%d) — the GREEN ARM-COLD guard would not flag it; events=%+v", latchIdx, dashIdx, ev)
+	lastWidgetIdx := -1
+	for i, e := range ev {
+		if e.class == "widget" {
+			lastWidgetIdx = i
+		}
+	}
+	// The GREEN arm's ARM-COLD guard is `latchIdx < lastWidget → FAIL`. Prove a
+	// premature fire triggers exactly that condition.
+	if !(latchIdx < lastWidgetIdx) {
+		t.Fatalf("mutation (ii) NOT caught: premature fire did not land before the last nav-widget seed (latch=%d lastWidget=%d) — the GREEN ARM-COLD guard would not flag it; events=%+v", latchIdx, lastWidgetIdx, ev)
 	}
 }
 


### PR DESCRIPTION
**PARKED — Diego-reserved merge (1.7.8 candidate).** Frozen SHA `e9632ed`. Dual pre-commit gate (arch + PM) on this SHA. Design: `docs/f3b-r2-agnostic-seed-order-design-2026-07-12.md`.

Gater checkout:
```
git fetch origin f3b-r2-agnostic-seed-order && git checkout FETCH_HEAD
```

## Problem
F3 (1.7.7) ranked admins #1 correctly, but rank-major serial seeding couldn't finish devs (rank 0) within the 480s seed budget → admins (rank 1) never reached → Ready via **backstop**, **0 seed-attributable hits** (on-deploy proven). Root causes: (1) seed order was rank-major (devs' ~537 targets first); (2) the whale LISTs were live (~20s each).

## Change (Diego Option A: RootIndex deleted everywhere)
1. **Fix 2** (`phase1_pip_seed.go` `withCohortSeedContext`): `cache.WithServeWatcher(rctx, cache.Global())` — cohort-seed whale LISTs now serve from the synced informer (~0.3s vs ~20s). Byte-identical to walk:1029/F2, nil-safe. Makes any order fit budget.
2. **NavOrder-flat seed** (boot + gvr-discovered): one flat pass over all (widget-target × cohort) units sorted `NavOrder ASC → cohortRankIndex ASC → ns/name`, then the RA tail (ascending-len, unchanged). NavOrder = the walk's own discovery sequence (already stamped); the dashboard is the low-NavOrder prefix **by data, not by branch**. Pure ordering (SET unchanged).
3. **All-nav-widget latch**: `navWidgetRemaining = total(widget×cohort)`, fire at 0 before the RA tail; DELETED all 3 RootIndex==0 consumers (rank tier `firstNavReachable`, latch `reachableFirstNav` + fire-decrement, zero-first-nav branch). Readiness keys on the widget-vs-RA **class boundary**, never a page concept.

## Arch ruling (B) — the mode-integration decision (verified)
NavOrder-flat applies to **boot + gvr-discovered ONLY**; **keepwarm keeps its rank-major loop UNCHANGED** — its `widgetMax==0` prefix-break is RootIndex-independent and its per-cohort `cohort_summary` is a PM probe; the latch is boot-only (keepwarm fires are already `sync.Once` no-ops). RootIndex field kept as a **dead-stamp** (the #99b re-walk-stamp regression test reads it); **zero live `==0` branches** remain in production (grep-verified, C-r2-6). Mode-branch is not a special-case (mode is a first-class param).

## Falsifiers (all -race, 3× GREEN — `/tmp/f3b-r2-falsifiers/`)
- **C-r2-1 (LOAD-BEARING)** `TestF3bR2_C_r2_1_NavOrderTotalOrder_RootIndexInverted` — K=3×M=3, low-NavOrder widgets given NON-zero RootIndex; order follows NavOrder regardless. RED = RootIndex primary tier resurrected → order diverges (`RED-c-r2-1-*.txt`). **Proves the RootIndex branch is DELETED, not dormant.**
- **C-r2-2** `TestFirstNavLatch_AllNavWidgets_GreenAndEarlyFireRed` — latch fires after the LAST nav widget of ANY cohort (incl. RootIndex!=0 `estate-graph`), before any RA. RED = simulated old-RootIndex latch fires early (`RED-c-r2-2-*.txt`).
- **C-r2-3** `TestF3bR2_C_r2_3_CohortSeedContext_AttachesServeWatcher` — Fix 2 serve path. RED = remove the line (`RED-c-r2-3-*.txt`).
- **C-r2-3 (keepwarm)** `TestF3bR2_C_r2_3_KeepwarmUnchanged_PrefixBoundAndCohortSummary` — keepwarm's `widgetMax==0` prefix-bound + one-`cohort_summary`-per-swept-cohort UNCHANGED. RED = flatten-all-modes → 0 summaries (`RED-cond3-flatten-all-modes.txt`).
- Reworked (not deleted) the F3 RootIndex-segment latch tests to the all-nav-widget invariant; kept mutation-style REDs adapted.
- dispatchers + cache 3× -race GREEN; resolvers/objects GREEN; build+vet clean.

## Staged for on-deploy (C-r2-4/5, tester post-merge)
- Cold boot, NO prior admin session, real Chrome: latch **reason=segment-complete** (NOT backstop), nav-widget-list elapsed ~40s, `hits_seed_attributable>0`, admin first-nav ≥85% (residual #128/#129-only), **latch-fire timestamp PRECEDES the first `marketplace-detail` #128 op-failure**. 50K re-confirm sub-minute via informer reads (flag 50K logistics if no cluster standing; not a build blocker).

## Fences honored
No #123 parallelism, no #128 fold, no static list, no frontend concept in the seed order or latch. #128 (marketplace-detail null-jq rewalk churn) tracked separately (issue #105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1