### PR TITLE
feat(cache): #130 F4 — per-seed-pass RA-resolve memo + skip unpaginated 4a pin

### DIFF
--- a/docs/f4-statwidget-apiref-cost-design-2026-07-12.md
+++ b/docs/f4-statwidget-apiref-cost-design-2026-07-12.md
@@ -1,0 +1,144 @@
+# F4 — statistics/tag-widget apiRef seed cost (the #130 binding constraint)
+
+Date: 2026-07-12
+Author: cache-architect
+Artifacts: `/tmp/f3br2-deploy/boot-1.7.8-t0.log` (12578 lines), `/tmp/f3br2-deploy/acceptance-summary-1.7.8.txt`
+Cluster (read-only diagnostic): `gke_operations-dev-krateo-io_europe-west3_krateo-installer-test`, pod `snowplow-85766bd5cd-vzqnn` (image 1.7.8, krateo-system)
+Repo: main = ship line, 1.7.8 = merge b365223
+
+## Headline
+
+The ~71 slow nav widgets are **NOT** class (a) live-apiserver, **NOT** class (b) external HTTP, **NOT** class (c) nested-composition fan-out, **NOT** (d)-as-guessed. The mechanism is a single class:
+
+**Per-widget re-execution of an expensive multi-pass `gojq` filter over the whole 60,000-object `benchapps.composition.krateo.io` GVR, run TWICE per widget seed (Ship-4a unpaginated + paged double-resolve), across ~71 widgets that all share one of two composition-listing RESTActions.** The apiserver/informer bytes are already cheap (informer-served, all content HITs); the cost is CPU spent in jq over a 60K-item array. This is a **jq-over-large-list cost class**, closest to (d), and it is fully informer-servable-substrate — the informer is not the problem, the **repeated jq materialization** is.
+
+Split: **all ~71 are the same class** (jq over the shared 60K composition list). **0 are external/(b)** — #129's TTL-external-cache lever does NOT apply here.
+
+## Root cause (TRACED)
+
+### 1. What the slow widgets are and where their cost lands
+
+Slow-widget inventory (`apiref_ms > 3s`, from `phase1.seed.widget.phase.timing`, boot log):
+
+| widget | kind | apiRef → RA | count (incl re-walks) |
+|---|---|---|---|
+| stat-compositions / stat-healthy / stat-reconciles / stat-failed | Statistic | `compositions-list` | 43 |
+| delta-tag-reconciles / -healthy / -failed | Tag | `compositions-list` | 30 |
+| delta-tag-compositions | Tag | `dashboard-data` | 3 |
+| greeting-subtitle | Paragraph | (composition list) | 2 |
+
+All apiRefs resolve to `compositions-list` or `dashboard-data`, both in krateo-system (`kubectl get statistics/tags -o json`, apiRef field). Both RAs have the identical hot step:
+
+```
+compositions-list.spec.api[1]: name=allCompositions verb=GET
+  path=${ "/apis/composition.krateo.io/" + (.version) + "/" + (.plural) }   endpointRef=None
+dashboard-data.spec.api[1]:    name=allCompositions  (identical shape)
+```
+
+`allCompositions` fans over the 29 `composition.krateo.io` CRDs (`kubectl get crds`, group filter). Of those GVRs, **`benchapps` holds 60,000 objects** (`kubectl get benchapps -A | wc -l` = 60000). The other 28 hold 0–1 each.
+
+### 2. The cost is jq, not I/O — proven by the per-stage timing breakdown
+
+`phase1.seed.widget.timing` (emitted at `internal/handlers/dispatchers/phase1_pip_seed.go:910`, wrapping the full `widgets.Resolve` at :928; per-api-stage entries from the timing sink installed at :906/:921) for `stat-reconciles`:
+
+```
+elapsed_ms_total: 23550   stages_total: 4     (crds, allCompositions, crds, allCompositions — the stage list appears TWICE)
+  stage=allCompositions el_ms=2807 iter_calls=29 iter_ms=2806 content_hits=29 content_misses=0  disp_ms=0 parse_ms=0 put_ms=0
+  stage=allCompositions el_ms=2372 iter_calls=29 iter_ms=2371 content_hits=29 content_misses=0  disp_ms=0 parse_ms=0 put_ms=0
+```
+
+Key reads:
+- **`content_hits=29, content_misses=0`** — every per-GVR LIST (including the 60K benchapps LIST) is served from the synced informer, NOT the live apiserver. Corroborated by `internal_dispatch.list.informer_served` (208 over the boot; `cache.streaming_list.completed items=60000 pages=1` at 07:53:36) and `internal_dispatch.list.serve_miss` = only 2 total. So the **apiserver-read hypothesis (a) is FALSIFIED**: reads are already informer-served.
+- **`endpointRef=None`** on both hot steps — no external HTTP backend. **Class (b) is FALSIFIED** for these widgets: `compositions-list`/`dashboard-data` never touch ClickHouse/observability. #129's external-TTL-cache lever is IRRELEVANT here.
+- **Stage-sum ≈ 5.2s but `elapsed_ms_total` = 23.5s.** The missing ~18s is spent OUTSIDE the per-stage instrumentation — i.e. in the **RESTAction-level `spec.filter` jq** (`internal/resolvers/restactions/restactions.go:63-70`, `jqutil.Eval` over the accumulated dict) and the widget's `widgetDataTemplate` jq (`widget_data_ms`=1800 captures only part; the RA-filter is un-instrumented). Neither is an I/O phase; both are pure gojq CPU over the 60K-item array.
+
+### 3. Why the RA filter is ~18s of CPU
+
+`compositions-list.spec.filter` (read live) makes ~8 full passes over `.allCompositions` (the 60K array):
+- `map(select(project match))` — 60K
+- `map(. + {state, railState, healthPercent})` — 60K, evaluates `any(conditions[]?...)` per item
+- `map(select(date-window))` — 60K, `fromdateiso8601` per item
+- `map(select(status/q match))` for `filtered` — 60K
+- 4× `map(select(...)) | length` for `counts` — 4×60K
+- emits `list: $all` = the FULL 60K enriched array back to the widget
+
+The widget then runs `widgetDataTemplate` jq (`stat-reconciles`: `[.list[] | {...}] | unique` and `[.list[]|select(...)]|length`) over that same 60K array. So the pipeline is roughly **~10 full 60K-array gojq passes per resolve** — measured ~18-21s of CPU.
+
+### 4. Why it runs TWICE per widget (the 2× in `stages_total:4`)
+
+The widget seed path resolves the apiRef twice:
+1. `widgets.Resolve` (paged, per-user cell) — `phase1_pip_seed.go:928`.
+2. `seedRAFullListForWidget` (unpaginated full-list pin, Ship-4a) — `phase1_pip_seed.go:983` → `apiref.Resolve` → `raFullListServe` → `resolveRA(ctx, 0, 0)` unpaginated (`apiref/resolve.go:167-177`).
+
+Both re-run the whole `allCompositions` + filter pipeline. Hence two `allCompositions` stages and ~2× the jq cost. The unpaginated full-list resolve materializes and filters all 60K rows specifically to establish the sliceability verdict — for a Statistic/Tag widget that only needs a scalar count, this is pure waste.
+
+### 5. Why the milestone fails and the post-Ready rewalk churn (secondary item)
+
+`prewarm.engine.boot.rewalk_complete ... widgets:186 elapsed_ms=317963`. Summing `apiref_ms` for slow widgets ≈ **647s of jq (unique) — 1295s counting re-walk dupes** — against a 480s (`pipGlobalTimeout`) budget (`phase1_pip_seed.go:141`). No seed ORDER fits ~647s into 480s → `prewarm.engine.scope_incomplete err="context deadline exceeded"` (08:04:00) → F.4 `scope_requeued attempt:1` → 317s rewalk → cut again (08:12) → attempt:2. The rewalk churn is **NOT a separate defect** — it is this same per-target-cost overrun re-entering via the F.4 boot-resume, `operational_failure=0` confirming no error trigger. It disappears when the per-widget jq cost is cut below budget.
+
+**Falsifier basis:** the smoking gun is `content_hits=29/content_misses=0` (I/O cheap) with `elapsed_ms_total`≫stage-sum (jq expensive) — reproducible on any boot log. A hand-curl probe would MASK this (it wouldn't exercise the seed's double-resolve nor the 71-widget fan-out) — mechanism traced against the runtime log + live CR shapes, not constructed.
+
+## Prior art check
+
+- client-go / informer: already used (reads are informer-served). No further client-go lever — the bottleneck is downstream of the informer, in jq.
+- Ship-4a RAFullList (`apiref/resolve.go`) already exists to share a page-independent full list ACROSS pages+widgets — but its *serve* is a Go-slice, while its *first-sight* still runs the full RA filter per (widget×cohort), and Statistic/Tag widgets are unpaginated so 4a's slice-serve never engages for them.
+- `#121/#122` compile-jq-once covers the refilter/step path (`refilter_compile_once_falsifier_test.go`), NOT the RA-level `spec.filter` at `restactions.go:65`. Compilation is not the cost anyway — execution over 60K is.
+
+## Options (ranked, PM-gateable)
+
+### Option 1 — Shared RA-resolve memo across widgets (RECOMMENDED)
+
+The 71 widgets re-resolve the SAME two RAs (`compositions-list`, `dashboard-data`) at the SAME identity (boot SA / cohort) with the SAME empty/near-empty extras. The RA `allCompositions`+filter output is **identical** across all Statistic/Tag widgets sharing an apiRef — they differ only in the cheap `widgetDataTemplate` jq applied afterward. Today each widget re-runs the whole 18s filter from scratch.
+
+**Design:** within a single seed pass, memoize the resolved RA `Status` (post-filter dict) keyed by (RA namespace/name, identity/cohort key, effective-extras hash, page/perPage). First widget pays the ~18s; the other ~70 sharing that apiRef hit the memo (~0). Place the memo at the `apiref.Resolve` seam (`internal/resolvers/widgets/apiref/resolve.go:78`) or one level down at `restactions.Resolve` entry, scoped to the seed context (a `context`-carried `sync.Map`, torn down at pass end — never a process-global that could leak identity across users).
+
+- Effect on symptom: 71×18s → ~2×18s (one per shared RA) + 71× cheap widgetDataTemplate. ~636s → ~40s. Fits 480s with wide margin. Rewalk churn disappears (same lever).
+- Cost bound: one memo entry per (RA,identity,extras,page) per pass; bounded by RA-count not object-count. Torn down per pass.
+- RBAC safety: the memo key MUST include the full identity/cohort key (per `feedback_l1_per_user_keyed_never_cohort`) — the seed already resolves per-cohort, so the memo is per-cohort-identity, never cross-user. This is the load-bearing safety condition.
+- LOC: ~40-70 (memo struct + context accessor + key derivation reusing existing coordinate derivation + wrap at one seam).
+- Also collapses the Ship-4a double-resolve within a pass (the unpaginated + paged resolves of the same RA/identity share the memo IF page is part of the key and the unpaginated result can serve the paged slice — needs care; simplest correct version keys page in, giving 2× not 1×, still ~40s).
+
+### Option 2 — Skip the unpaginated Ship-4a full-list pin for count-only (unpaginated-consuming) widgets
+
+The `seedRAFullListForWidget` unpaginated resolve (`phase1_pip_seed.go:983`) exists to pin a sliceable full-list for PAGINATED /call serves. Statistic/Tag widgets are unpaginated (they consume `list:` wholesale for a count) — they gain nothing from the 4a slice cache but pay the second full 18s materialization.
+
+**Design:** skip `seedRAFullListForWidget` when the widget resolve is unpaginated (page/perPage == 0), reusing the EXISTING `shouldServeRAFullList` predicate shape (`apiref/resolve.go:68`, already gates on `perPage>0 && page>0`). Data-derived (reads pagination, not widget-kind) → satisfies `feedback_no_special_cases`.
+
+- Effect: halves the slow-widget cost (~647s → ~324s). Alone, still over 480s — insufficient, but a clean ~30% cut and a natural companion to Option 1.
+- LOC: ~10.
+
+### Option 3 — Parallelism within the seed budget
+
+The seed is effectively serialized: `enterSeedUnit` (`phase1_pip_seed.go:881`, `seed_bound.go`) serializes against GOMEMLIMIT headroom. On this pod NO SEED/FOOTPRINT/GOMEMLIMIT env is set (verified: pod env has none) so the adaptive gate is transparent — but the cohort fan-out width still bounds concurrency, and 647s of CPU on a 4-CPU pod (limits.cpu=4) cannot parallelize below ~160s regardless.
+
+**Design:** widen seed cohort concurrency. **Rejected as primary** — 647s/4cpu ≈ 162s floor is under 480s but leaves no margin, wastes the whole pod's CPU on redundant work, and does nothing for the real waste (the same list filtered 71×). Parallelism should come AFTER Option 1 removes the redundancy, not instead of it.
+
+### Option 4 — (b)-class external TTL cache (#129)
+
+**Not applicable.** Traced: these widgets have `endpointRef=None`, are informer-served, touch no external backend. Keep #129 parked for the genuinely-external observability widgets; it will not move this needle.
+
+## Recommendation
+
+**Option 1 (shared RA-resolve memo), with Option 2 folded in** as the companion cut. Option 1 attacks the actual waste (71 identical 18s filters → ~1-2), Option 2 removes the redundant unpaginated pin for count-only widgets. Together: ~647s → ~20-40s, comfortably inside 480s, and the post-Ready rewalk churn resolves as a consequence (same root cause). Do NOT reach for Option 3/4.
+
+### PROJECTION CORRECTION (PM gate C-F4-1, 2026-07-12 — supersedes the "~20-40s" / "~40s" figures above)
+
+The "~40s" figures in §95, §99, §122 are a **single-cohort** projection (§91 states the premise: "the SAME identity (boot SA / cohort)"). The memo key correctly folds the full RBAC identity (username + sorted groups — C-F4-4), so it **cannot** collapse resolves across cohorts. The honest **aggregate** residual is therefore per-cohort:
+
+    residual ≈ #cohorts × #distinct-heavy-RAs × ~18s  ≈  5 × 2 × 18  ≈  ~180s
+
+- `#distinct-heavy-RAs` ≈ 2 (`compositions-list`, `dashboard-data`).
+- `#cohorts` is **data-derived** (the count of distinct dedup-collapsed identity ranks the seed enumerates at 60K) — a **tester on-cluster confirm**, not a code constant. ~5 is the 1.7.8-observed order of magnitude; the projection scales linearly with it. If the live cohort count is materially >5, re-check the 480s fit.
+- ~180s still fits the 480s budget with margin, so the milestone (latch fires via segment-complete, `scope_incomplete=0`, seed hits >0) holds. Option 2 additionally removes the second (4a-pin) 18s resolve per unpaginated widget, so the per-cohort cost is ~(2 RAs × 18s) not ~(2 RAs × 2 passes × 18s).
+
+Acceptance is measured against **~180s aggregate residual**, NOT the single-cohort ~40s. The tester confirms the actual cohort count on-cluster and re-derives the fit.
+
+Strategic choice to surface to Diego / TL: **memo scope**. Recommended = per-seed-pass context-carried memo (torn down each pass, per-cohort-identity keyed). A longer-lived memo (survive across passes) would help the rewalk even more but raises the cross-user-leak and staleness surface — recommend NOT going there until per-pass is proven.
+
+## Falsifier (proves the fix works — or didn't)
+
+1. **Primary (symptom):** re-boot 1.7.x+fix on installer-test, grep `phase1.seed.widget.phase.timing`: the 2nd..71st slow widget's `apiref_ms` drops from 6-24s to <500ms (memo hit); first-per-RA stays ~18s. Sum of slow `apiref_ms` < 480s.
+2. **Milestone:** `prewarm.first_nav.latch` line FIRES (>0), `prewarm.engine.scope_incomplete` = 0, Ready via segment-complete not backstop, `hit_source` seed-attributable > 0.
+3. **Rewalk:** zero `scope_requeued` for the boot scope over 20min.
+4. **RBAC safety (hermetic, gate-blocking):** two cohorts with divergent RBAC resolving the same shared-apiRef widget get DIFFERENT memo entries (key includes identity); a RED arm that drops identity from the memo key must leak cohort-A's filtered list into cohort-B and FAIL the test. This is the load-bearing arm per `feedback_l1_per_user_keyed_never_cohort`.
+5. **Correctness:** memo-hit widget output == cold-resolve widget output (byte-identical widgetData) for the same (RA,identity,page).

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -721,6 +721,29 @@ func ComputeKey(in ResolvedKeyInputs) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// HashExtras returns a stable, order-independent hash of a JSON-native extras
+// map — the SAME canonicalisation ComputeKey folds into the L1 key (single
+// derivation site via canonicaliseExtras, so the F4 seed-resolve memo's notion
+// of "same effective extras" cannot drift from the L1 key's). Empty/nil map →
+// the fixed sentinel "e0" (never empty, so an empty-extras key segment is
+// unambiguous). Used by the apiref seam to build the SeedResolveMemo key's
+// extras component; keeping the canonicalisation here means a future extras
+// schema change updates memo + L1 key together.
+func HashExtras(m map[string]any) string {
+	if len(m) == 0 {
+		return "e0"
+	}
+	buf, err := canonicaliseExtras(m)
+	if err != nil {
+		// Deterministic-but-pessimistic fallback — mirrors ComputeKey's
+		// marshal-failure branch so a cyclic/non-JSON value still varies the
+		// key rather than colliding.
+		buf = []byte(fmt.Sprintf("%v", m))
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
 // canonicaliseExtras emits a sorted-key JSON encoding of m. Nested
 // maps are recursively canonicalised; everything else round-trips
 // through json.Marshal as-is.

--- a/internal/cache/seed_resolve_memo.go
+++ b/internal/cache/seed_resolve_memo.go
@@ -1,0 +1,219 @@
+// seed_resolve_memo.go — the #130 F4 per-seed-pass RA-resolve memo.
+//
+// THE DEFECT (docs/f4-statwidget-apiref-cost-design-2026-07-12.md): the boot
+// seed resolves ~71 statistics/tag widgets whose apiRef points at one of a
+// SMALL set of heavy RESTActions (compositions-list / dashboard-data). Each
+// such RESTAction runs ~10 full gojq passes over the 60K-item benchapps array
+// — ~18s of CPU — and the seed runs it TWICE per widget (the paginated
+// widgets.Resolve pass AND the unpaginated seedRAFullListForWidget accelerator),
+// once per cohort. The I/O is already cheap (informer-served, F3b Fix 2:
+// content_hits=29/misses=0) — the residual cost is pure jq CPU over a list that
+// is IDENTICAL across every widget sharing that (RA, identity, page). ~71
+// widgets × 2 passes × N cohorts collapses to (#distinct RA) × (#cohorts) ×
+// (#distinct pages) real resolves once identical (RA, identity, page, extras)
+// resolves are memoized.
+//
+// WHY A CONTEXT-CARRIED MEMO (not a process-global cache) — mirrors
+// StageErrorSink / ExternalTouchedSink (the established per-resolve sink idiom):
+//
+//   - CORRECTNESS / TEARDOWN: the memo is installed by the seed pass
+//     (withCohortSeedContext) and lives ONLY for that pass's context. It is
+//     torn down when the pass's context goes away — it can never serve a stale
+//     RA body to a later seed pass or (critically) to a user /call. A user
+//     /call context never carries a memo, so SeedResolveMemoFromContext returns
+//     nil there and the memo is a strict no-op on the request path (C-F4-8).
+//
+//   - RBAC SAFETY (C-F4-4): the memo KEY folds the full RBAC-determining
+//     identity — username + sorted groups, exactly the (Username, Groups) that
+//     internal/resolvers/restactions/api/refilter.go + cluster_list.go +
+//     apiref/ra_full_list.go read off ctx to FILTER the list. Two cohorts with
+//     divergent RBAC derive divergent identity keys, so cohort B can NEVER read
+//     cohort A's memoized (RBAC-filtered) body. Dropping identity from the key
+//     is a cross-user leak — proven RED by the divergent-output memo test.
+//
+//   - JSON-NATIVE VALUES (C-F4-3): the caller stores an already-deep-copied,
+//     JSON-native snapshot (plumbing/maps.DeepCopyJSON at the apiref seam) and
+//     the memo returns a fresh deep copy on every hit, so no two callers alias
+//     the stored map and no caller can mutate it. The stored value is opaque to
+//     this package — the apiref seam owns the DeepCopyJSON round-trip so a
+//     non-JSON-native value ([]string etc.) panics AT THE SEAM under -race,
+//     never silently aliased here.
+//
+// TOGGLE (C-F4-9): the memo is only ever installed on the seed context, which
+// only exists when the seed runs, which only runs under
+// ResolvedCacheEnabled() / the prewarm gate. A cache-off process never installs
+// a memo → SeedResolveMemoFromContext is nil everywhere → zero behavior change.
+// The install site (withCohortSeedContext) additionally no-ops the install when
+// Disabled().
+
+package cache
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// ctxKeySeedResolveMemoType is the typed empty-struct context key for the
+// per-seed-pass RA-resolve memo. Distinct unexported type — no cross-package
+// raw-string-key collision (mirrors ctxKeyExternalTouchedSinkType).
+type ctxKeySeedResolveMemoType struct{}
+
+var ctxKeySeedResolveMemo = ctxKeySeedResolveMemoType{}
+
+// SeedResolveMemo memoizes the resolved output of a heavy RESTAction across the
+// many widgets that share it WITHIN A SINGLE SEED PASS. It is keyed by
+// (RA ns/name, RBAC identity, effective-extras hash, perPage, page) — every
+// input that can change the resolved body — so a hit is only ever served to a
+// caller that would compute a byte-identical result (C-F4-6). Concurrency-safe
+// (sync.Map): the seed fans widgets across cohort goroutines.
+//
+// The memo holds ONE entry per distinct (RA, identity, page, extras) tuple; the
+// value is a JSON-native map[string]any snapshot the CALLER deep-copied before
+// Store (and the memo deep-copies again on Load) so stored bodies are never
+// aliased or mutated.
+type SeedResolveMemo struct {
+	m    sync.Map // key string -> map[string]any (JSON-native, caller-deep-copied)
+	// copyFn deep-copies a stored JSON-native map on Load so no two callers
+	// alias the stored value. Injected by the installer (apiref/widgets seam
+	// owns plumbing/maps.DeepCopyJSON; keeping the dep out of the cache package
+	// avoids importing a resolver util downward). nil copyFn ⇒ Load returns the
+	// stored map directly (test-only / degenerate); production always injects.
+	copyFn func(map[string]any) map[string]any
+
+	hits   uint64
+	misses uint64
+	mu     sync.Mutex // guards hits/misses (diagnostic counters only)
+}
+
+// seedResolveMemoKey canonicalizes the memo key. The identity component is the
+// RBAC-determining tuple (username + SORTED groups, unit-separated) so the key
+// is stable regardless of group ordering and cannot collide across cohorts with
+// divergent RBAC. extrasHash is the caller-computed stable hash of the
+// effective extras map (the same effective-extras the resolve folds).
+func seedResolveMemoKey(raNS, raName, username string, groups []string, extrasHash string, perPage, page int) string {
+	// Copy + sort groups so ["a","b"] and ["b","a"] fold identically without
+	// mutating the caller's slice.
+	g := make([]string, len(groups))
+	copy(g, groups)
+	sortStrings(g)
+	var b strings.Builder
+	b.WriteString(raNS)
+	b.WriteByte('|')
+	b.WriteString(raName)
+	b.WriteString("|u=")
+	b.WriteString(username)
+	b.WriteString("|g=")
+	b.WriteString(strings.Join(g, "\x1f"))
+	b.WriteString("|x=")
+	b.WriteString(extrasHash)
+	b.WriteString("|pp=")
+	b.WriteString(strconv.Itoa(perPage))
+	b.WriteString("|p=")
+	b.WriteString(strconv.Itoa(page))
+	return b.String()
+}
+
+// Key builds the canonical memo key for a resolve of RESTAction (raNS/raName)
+// under the RBAC identity (username + groups), effective-extras hash extrasHash
+// (from HashExtras), at pagination (perPage, page). The apiref seam calls this
+// so the identity/extras/page folding lives in ONE place (cannot drift from the
+// Load/Store consumers). nil-receiver-safe: a nil memo still produces a
+// well-formed key (harmless — the subsequent nil.Load is a miss).
+func (mo *SeedResolveMemo) Key(raNS, raName, username string, groups []string, extrasHash string, perPage, page int) string {
+	return seedResolveMemoKey(raNS, raName, username, groups, extrasHash, perPage, page)
+}
+
+// sortStrings is a tiny insertion sort (groups slices are short: a handful of
+// RBAC groups). Avoids pulling "sort" for a hot-path helper.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// Load returns the memoized resolved body for the key and true on a hit, or
+// (nil, false) on a miss. On a hit the returned map is a FRESH deep copy (via
+// the injected copyFn) so the caller may mutate/consume it without corrupting
+// the stored snapshot or aliasing a sibling caller. nil-receiver-safe:
+// (nil).Load is always a miss so a call site with no memo installed behaves as
+// "always resolve".
+func (mo *SeedResolveMemo) Load(key string) (map[string]any, bool) {
+	if mo == nil {
+		return nil, false
+	}
+	v, ok := mo.m.Load(key)
+	if !ok {
+		mo.mu.Lock()
+		mo.misses++
+		mo.mu.Unlock()
+		return nil, false
+	}
+	stored, _ := v.(map[string]any)
+	mo.mu.Lock()
+	mo.hits++
+	mo.mu.Unlock()
+	if mo.copyFn == nil {
+		return stored, true
+	}
+	return mo.copyFn(stored), true
+}
+
+// Store records a JSON-native, caller-deep-copied resolved body under key. The
+// caller MUST deep-copy (plumbing/maps.DeepCopyJSON) before Store so the stored
+// snapshot is not aliased by the caller's live result. LoadOrStore semantics:
+// the FIRST writer wins; a concurrent second resolve of the same tuple discards
+// its (byte-identical) body. nil-receiver-safe (no-op) so an uninstalled call
+// site never stores.
+func (mo *SeedResolveMemo) Store(key string, snapshot map[string]any) {
+	if mo == nil {
+		return
+	}
+	mo.m.LoadOrStore(key, snapshot)
+}
+
+// Stats returns the memo's hit/miss counters (diagnostic — feeds the
+// phase1.seed.memo.summary falsifier line). nil-receiver-safe.
+func (mo *SeedResolveMemo) Stats() (hits, misses uint64) {
+	if mo == nil {
+		return 0, 0
+	}
+	mo.mu.Lock()
+	defer mo.mu.Unlock()
+	return mo.hits, mo.misses
+}
+
+// NewSeedResolveMemo builds a memo with the given deep-copy function. copyFn is
+// applied to a stored map on every Load hit so callers never alias the stored
+// snapshot. Production passes plumbing/maps.DeepCopyJSON (injected from the
+// apiref seam to keep the resolver util out of the cache package's imports).
+func NewSeedResolveMemo(copyFn func(map[string]any) map[string]any) *SeedResolveMemo {
+	return &SeedResolveMemo{copyFn: copyFn}
+}
+
+// WithSeedResolveMemo returns a child context carrying memo. Installed ONLY by
+// the seed pass (withCohortSeedContext) — a user /call, the refresher, and the
+// discovery walk never install one, so the memo is a strict no-op off the seed
+// path (C-F4-8). Inert under Disabled(): returns ctx unchanged so a cache-off
+// process carries no memo.
+func WithSeedResolveMemo(ctx context.Context, memo *SeedResolveMemo) context.Context {
+	if ctx == nil || memo == nil || Disabled() {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeySeedResolveMemo, memo)
+}
+
+// SeedResolveMemoFromContext returns the *SeedResolveMemo installed on ctx, or
+// nil when none is present. A nil return MUST be treated as "no memo — always
+// resolve" (the methods are nil-receiver-safe). Off the seed path this is
+// always nil, which is what makes the memo provably untouched on the /call path.
+func SeedResolveMemoFromContext(ctx context.Context) *SeedResolveMemo {
+	if ctx == nil {
+		return nil
+	}
+	v, _ := ctx.Value(ctxKeySeedResolveMemo).(*SeedResolveMemo)
+	return v
+}

--- a/internal/cache/seed_resolve_memo_test.go
+++ b/internal/cache/seed_resolve_memo_test.go
@@ -1,0 +1,278 @@
+// seed_resolve_memo_test.go — #130 F4 falsifiers for the per-seed-pass
+// RA-resolve memo (SeedResolveMemo). Covers PM conditions C-F4-3 (JSON-native
+// value + -race + DeepCopyJSON round-trip), C-F4-4 (RBAC key divergence — the
+// decisive leak RED arm), C-F4-5 (teardown), C-F4-6 (correctness: hit is
+// byte-identical to the stored body), C-F4-8 (miss-when-absent), C-F4-9
+// (toggle-off inert).
+//
+// The memo mechanism itself is falsified here (pure, no apiserver). The seam
+// wiring — memo consulted ONLY under the seed context, never on the /call path
+// — is falsified in internal/resolvers/widgets/apiref/seed_memo_seam_test.go.
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	pmaps "github.com/krateoplatformops/plumbing/maps"
+)
+
+func memoCacheOn(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+}
+
+// filteredBody simulates a RESTAction's RBAC-filtered resolved Status: a list
+// of the compositions THIS identity may see. Two cohorts with divergent RBAC
+// return PROVABLY DIVERGENT bodies (C-F4-4: same-output pairs are inadmissible).
+func filteredBody(visible []string) map[string]any {
+	items := make([]any, 0, len(visible))
+	for _, n := range visible {
+		items = append(items, map[string]any{"metadata": map[string]any{"name": n}})
+	}
+	return map[string]any{"kind": "List", "items": items}
+}
+
+func visibleNames(body map[string]any) []string {
+	items, _ := body["items"].([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		md, _ := m["metadata"].(map[string]any)
+		name, _ := md["name"].(string)
+		out = append(out, name)
+	}
+	return out
+}
+
+// TestSeedResolveMemo_RBACKeyDivergence_DECISIVE — C-F4-4 RED arm. Cohort A
+// (groups [team-a]) and cohort B (groups [team-b]) resolve the SAME RESTAction
+// but see PROVABLY DIVERGENT filtered bodies (A sees comp-a1/a2, B sees comp-b1).
+// The production memo folds identity (username+groups) into the key, so A's
+// Store under A's key and B's Load under B's key MISS → B resolves its own body.
+// The RED half computes a key that DROPS identity (RA/page only): B's Load then
+// HITS A's cell and B is served A's compositions — a cross-user RBAC LEAK. The
+// arm FAILS (as it must) if the identity-less key ever serves B a body != B's.
+func TestSeedResolveMemo_RBACKeyDivergence_DECISIVE(t *testing.T) {
+	memoCacheOn(t)
+
+	bodyA := filteredBody([]string{"comp-a1", "comp-a2"})
+	bodyB := filteredBody([]string{"comp-b1"})
+	// Premise guard: the two cohorts' outputs MUST diverge (same-output pair is
+	// inadmissible per C-F4-4).
+	if reflect.DeepEqual(visibleNames(bodyA), visibleNames(bodyB)) {
+		t.Fatal("premise broken: cohort A and B must have PROVABLY DIVERGENT filtered output")
+	}
+
+	const raNS, raName = "demo-system", "compositions-list"
+	extrasHash := HashExtras(nil)
+
+	// ── PRODUCTION key (folds identity). A stores; B must MISS and resolve its own.
+	prod := NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	keyA := prod.Key(raNS, raName, "alice", []string{"team-a"}, extrasHash, 0, 0)
+	keyB := prod.Key(raNS, raName, "bob", []string{"team-b"}, extrasHash, 0, 0)
+	if keyA == keyB {
+		t.Fatal("RED: production memo key COLLIDES across divergent-RBAC cohorts — identity is not folded into the key. This is the A→B leak. C-F4-4.")
+	}
+	prod.Store(keyA, pmaps.DeepCopyJSON(bodyA))
+	if _, ok := prod.Load(keyB); ok {
+		t.Fatal("RED: cohort B HIT cohort A's memo cell under the production (identity-folded) key — cross-user RBAC leak. C-F4-4.")
+	}
+
+	// ── LEAK key (identity DROPPED — RA/page only). This is the defect the
+	// production key prevents; here we PROVE it would leak, so the arm has teeth.
+	leakKey := func() string {
+		return raNS + "|" + raName + "|pp=0|p=0" // NO username/groups
+	}
+	leak := NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	leak.Store(leakKey(), pmaps.DeepCopyJSON(bodyA)) // A resolves first
+	got, ok := leak.Load(leakKey())                  // B "resolves" — same key
+	if !ok {
+		t.Fatal("harness broken: identity-less key should self-hit")
+	}
+	if reflect.DeepEqual(visibleNames(got), visibleNames(bodyB)) {
+		t.Fatal("harness broken: the leak arm must serve B something != B's own body")
+	}
+	// The leak arm serves B cohort A's compositions — this is exactly the leak
+	// the identity-folded production key eliminates. Assert the leak IS present
+	// so a future refactor that silently drops identity is caught by the
+	// production half above going RED while this half stays a demonstrated leak.
+	if !reflect.DeepEqual(visibleNames(got), visibleNames(bodyA)) {
+		t.Fatalf("harness broken: identity-less key must serve B cohort A's body; got %v", visibleNames(got))
+	}
+}
+
+// TestSeedResolveMemo_CorrectnessByteIdentical — C-F4-6. A memo hit returns a
+// body byte-identical (JSON-canonical) to the stored resolve for the same
+// (RA, identity, page). Also proves the returned map is a DISTINCT deep copy
+// (mutating the hit does not corrupt the stored snapshot — no aliasing).
+func TestSeedResolveMemo_CorrectnessByteIdentical(t *testing.T) {
+	memoCacheOn(t)
+	memo := NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	body := filteredBody([]string{"comp-x", "comp-y"})
+	key := memo.Key("ns", "ra", "carol", []string{"g1", "g2"}, HashExtras(nil), 5, 1)
+
+	memo.Store(key, pmaps.DeepCopyJSON(body))
+	hit, ok := memo.Load(key)
+	if !ok {
+		t.Fatal("RED: expected memo HIT for the stored (RA, identity, page). C-F4-6.")
+	}
+	wantJSON, _ := json.Marshal(body)
+	gotJSON, _ := json.Marshal(hit)
+	if string(wantJSON) != string(gotJSON) {
+		t.Fatalf("RED: memo hit body != cold-resolve body.\n want %s\n got  %s", wantJSON, gotJSON)
+	}
+	// Aliasing guard: mutate the hit; a second Load must still equal the original.
+	hit["items"] = []any{}
+	hit2, _ := memo.Load(key)
+	got2JSON, _ := json.Marshal(hit2)
+	if string(got2JSON) != string(wantJSON) {
+		t.Fatalf("RED: mutating a memo hit corrupted the stored snapshot (aliasing). Load must return a fresh deep copy.\n want %s\n got  %s", wantJSON, got2JSON)
+	}
+}
+
+// TestSeedResolveMemo_KeyDivergesOnPageAndExtras — every input that changes the
+// resolved body must change the key (C-F4-6 correctness precondition): page,
+// perPage, and extras. If any of these collide, a hit would serve a wrong-page
+// or wrong-extras body.
+func TestSeedResolveMemo_KeyDivergesOnPageAndExtras(t *testing.T) {
+	memoCacheOn(t)
+	m := NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	base := m.Key("ns", "ra", "u", []string{"g"}, HashExtras(nil), 5, 1)
+	cases := map[string]string{
+		"page":    m.Key("ns", "ra", "u", []string{"g"}, HashExtras(nil), 5, 2),
+		"perPage": m.Key("ns", "ra", "u", []string{"g"}, HashExtras(nil), 10, 1),
+		"extras":  m.Key("ns", "ra", "u", []string{"g"}, HashExtras(map[string]any{"k": "v"}), 5, 1),
+		"raName":  m.Key("ns", "ra2", "u", []string{"g"}, HashExtras(nil), 5, 1),
+	}
+	for dim, k := range cases {
+		if k == base {
+			t.Fatalf("RED: memo key does NOT diverge on %s — a hit could serve a body computed for a different %s.", dim, dim)
+		}
+	}
+	// Group ORDER must NOT change the key (RBAC identity is a set).
+	if m.Key("ns", "ra", "u", []string{"a", "b"}, HashExtras(nil), 5, 1) !=
+		m.Key("ns", "ra", "u", []string{"b", "a"}, HashExtras(nil), 5, 1) {
+		t.Fatal("RED: memo key changes with group ORDER — must be order-independent (groups are a set).")
+	}
+}
+
+// TestSeedResolveMemo_Teardown_NoSurviveAcrossPass — C-F4-5. The memo is
+// context-carried; a fresh context (a NEW seed pass) carries NO memo, so it
+// cannot serve the prior pass's body. Also: a context that never installed a
+// memo returns nil (the /call posture — C-F4-8).
+func TestSeedResolveMemo_Teardown_NoSurviveAcrossPass(t *testing.T) {
+	memoCacheOn(t)
+
+	// Pass 1: install a memo, store a body.
+	pass1 := WithSeedResolveMemo(context.Background(), NewSeedResolveMemo(pmaps.DeepCopyJSON))
+	m1 := SeedResolveMemoFromContext(pass1)
+	if m1 == nil {
+		t.Fatal("premise broken: pass-1 ctx should carry a memo")
+	}
+	k := m1.Key("ns", "ra", "u", nil, HashExtras(nil), 0, 0)
+	m1.Store(k, pmaps.DeepCopyJSON(filteredBody([]string{"leftover"})))
+
+	// Pass 2: a fresh base context (the previous pass returned; nothing
+	// references its memo). No memo installed ⇒ nil ⇒ the pass MUST resolve, not
+	// serve the pass-1 leftover.
+	pass2 := context.Background()
+	if got := SeedResolveMemoFromContext(pass2); got != nil {
+		t.Fatal("RED: a fresh context carried a memo — the memo survived the seed pass (C-F4-5). It must be strictly context-carried, never process-global.")
+	}
+}
+
+// TestSeedResolveMemo_MissWhenAbsent — C-F4-8. A nil memo (no memo on ctx = the
+// /call path) is ALWAYS a miss; nil-receiver methods are safe. Store on a nil
+// memo is a no-op (never panics).
+func TestSeedResolveMemo_MissWhenAbsent(t *testing.T) {
+	memoCacheOn(t)
+	var nilMemo *SeedResolveMemo // as returned by SeedResolveMemoFromContext off the /call path
+	if _, ok := nilMemo.Load("anything"); ok {
+		t.Fatal("RED: nil memo (no memo installed — the /call path) reported a HIT. C-F4-8.")
+	}
+	nilMemo.Store("anything", map[string]any{"x": 1}) // must not panic
+	h, mi := nilMemo.Stats()
+	if h != 0 || mi != 0 {
+		t.Fatalf("RED: nil memo Stats non-zero (%d/%d).", h, mi)
+	}
+}
+
+// TestSeedResolveMemo_ToggleOffInert — C-F4-9. Under Disabled() (CACHE_ENABLED
+// =false) WithSeedResolveMemo returns the ctx UNCHANGED, so no memo is ever
+// installed and the seam is byte-identical to pre-F4.
+func TestSeedResolveMemo_ToggleOffInert(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+	ctx := WithSeedResolveMemo(context.Background(), NewSeedResolveMemo(pmaps.DeepCopyJSON))
+	if got := SeedResolveMemoFromContext(ctx); got != nil {
+		t.Fatal("RED: WithSeedResolveMemo installed a memo while Disabled() — the memo must be inert in cache-off mode. C-F4-9.")
+	}
+}
+
+// TestSeedResolveMemo_JSONNativeConcurrent_Race — C-F4-3. Store/Load a
+// JSON-native body concurrently across many goroutines (the seed fans widgets
+// across cohort goroutines). Run with -race. Uses pmaps.DeepCopyJSON (the
+// production copyFn) so a non-JSON-native value would PANIC here — the round
+// trip is exercised on every Store and every Load. Also asserts every hit is a
+// valid, uncorrupted deep copy under concurrency.
+func TestSeedResolveMemo_JSONNativeConcurrent_Race(t *testing.T) {
+	memoCacheOn(t)
+	memo := NewSeedResolveMemo(pmaps.DeepCopyJSON)
+
+	// JSON-native body: nested map + []any + string/float64/bool/nil — every
+	// type DeepCopyJSON accepts. A []string here would panic (the C-F4-3 guard).
+	body := map[string]any{
+		"kind":  "List",
+		"count": float64(3),
+		"ok":    true,
+		"nested": map[string]any{
+			"tags":  []any{"x", "y"},
+			"inner": map[string]any{"z": nil},
+		},
+	}
+	wantJSON, _ := json.Marshal(body)
+
+	const cohorts, widgetsPer = 8, 32
+	var wg sync.WaitGroup
+	for c := 0; c < cohorts; c++ {
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			// Each cohort has its own identity → own key; within a cohort the
+			// widgetsPer goroutines race Store/Load on the SAME key (the
+			// shared-RA fan-out the memo exists to collapse).
+			key := memo.Key("ns", "ra", fmt.Sprintf("user-%d", c), []string{fmt.Sprintf("g-%d", c)}, HashExtras(nil), 0, 0)
+			var inner sync.WaitGroup
+			for w := 0; w < widgetsPer; w++ {
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					if hit, ok := memo.Load(key); ok {
+						if got, _ := json.Marshal(hit); string(got) != string(wantJSON) {
+							t.Errorf("RED: concurrent memo hit corrupted: got %s", got)
+						}
+					} else {
+						memo.Store(key, pmaps.DeepCopyJSON(body))
+					}
+				}()
+			}
+			inner.Wait()
+			// After the storm every cohort key must resolve to the body.
+			hit, ok := memo.Load(key)
+			if !ok {
+				t.Errorf("RED: cohort %d key never populated", c)
+				return
+			}
+			if got, _ := json.Marshal(hit); string(got) != string(wantJSON) {
+				t.Errorf("RED: cohort %d final body corrupted: %s", c, got)
+			}
+		}(c)
+	}
+	wg.Wait()
+}

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -980,6 +980,29 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode s
 	// raFullListServe — G2-A), reading the cohort identity from resCtx. No
 	// bindingUID is threaded (the eg1 defect was threading the WIDGET-coordinate
 	// bindingUID, which key-diverged from the RA-CR verdict → G inert).
+	//
+	// #130 F4 Option 2 — SKIP the 4a full-list pin when THIS widget resolves
+	// UNPAGINATED (apiref.IsPaginatedResolve(e.PerPage, e.Page) false). The 4a
+	// pin exists to warm a sliceable full-list for a subsequent PAGINATED /call
+	// (shouldServeRAFullList engages only when perPage>0 && page>0). An
+	// unpaginated-consuming widget (a Statistic/Tag widget counting `list:`
+	// wholesale) resolves at (0,0)/(−1,−1), so its own /call never engages the
+	// slice serve — the pin's second full ~18s benchapps materialization is pure
+	// waste. Reuses the EXACT serve-gate pagination predicate (one derivation
+	// site, no drift) and is DATA-DERIVED (reads the resolve tuple, never
+	// widget-kind — feedback_no_special_cases / C-F4-7). A paginated widget is
+	// byte-unchanged (still pins). Emits a greppable skip line for the falsifier.
+	if !apiref.IsPaginatedResolve(e.PerPage, e.Page) {
+		slog.Default().Info("phase1.seed.rafulllist.skip_unpaginated",
+			slog.String("subsystem", "cache"),
+			slog.String("widget", e.W.GetNamespace()+"/"+e.W.GetName()),
+			slog.Int("perpage", e.PerPage),
+			slog.Int("page", e.Page),
+			slog.String("effect", "F4 Option 2 — widget consumes the list unpaginated; the 4a full-list "+
+				"pin would never be slice-served on its own /call, so the redundant unpaginated re-resolve is skipped"),
+		)
+		return nil
+	}
 	seedRAFullListForWidget(resCtx, in, authnNS, e.W.GetNamespace(), e.W.GetName())
 	return nil
 }

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/krateoplatformops/plumbing/endpoints"
+	pmaps "github.com/krateoplatformops/plumbing/maps"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/objects"
@@ -483,6 +484,34 @@ func seedScopeYielding(ctx context.Context,
 	saEP endpoints.Endpoint, saRC *rest.Config, authnNS string, mode seedScopeMode) error {
 
 	log := slog.Default()
+
+	// #130 F4 — install ONE per-seed-pass RA-resolve memo on ctx for the whole
+	// pass. Every per-cohort cohortCtx (withCohortSeedContext → BuildContext)
+	// inherits it, so the ~71 statistics/tag widgets that share a heavy
+	// RESTAction (compositions-list / dashboard-data, ~18s of gojq over the 60K
+	// benchapps array) resolve it ONCE per distinct (RA, identity, page, extras)
+	// rather than 2× per widget per cohort. The memo lives ONLY for this
+	// function's scope — nothing references it once seedScopeYielding returns
+	// (C-F4-5 teardown: the next pass builds a fresh one). Keyed by the full
+	// RBAC identity so it is per-cohort correct (C-F4-4). Inert under
+	// Disabled(): WithSeedResolveMemo returns ctx unchanged (C-F4-9). copyFn =
+	// plumbing/maps.DeepCopyJSON (JSON-native round-trip on every hit, C-F4-3).
+	memo := cache.NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	ctx = cache.WithSeedResolveMemo(ctx, memo)
+	defer func() {
+		h, m := memo.Stats()
+		if h+m == 0 {
+			return // never consulted (cache-off / no heavy widgets this pass)
+		}
+		log.Info("phase1.seed.memo.summary",
+			slog.String("subsystem", "cache"),
+			slog.String("mode", mode.String()),
+			slog.Uint64("memo_hits", h),
+			slog.Uint64("memo_misses", m),
+			slog.String("effect", "F4 per-seed-pass RA-resolve memo — each hit skipped a full "+
+				"gojq-over-benchapps re-resolve of a heavy RESTAction shared across statistics/tag widgets"),
+		)
+	}()
 
 	// CTX-CANCEL ABORT OBSERVABILITY (fold 2026-07-03, §4.3b — migrated from the
 	// deleted seedCohort's 0.30.191 Fix-C `phase1.cohort.abort` reporter). The

--- a/internal/handlers/dispatchers/seed_memo_install_test.go
+++ b/internal/handlers/dispatchers/seed_memo_install_test.go
@@ -1,0 +1,62 @@
+// seed_memo_install_test.go — #130 F4: proves the PRODUCTION seed pass installs
+// the per-seed-pass RA-resolve memo on ctx AND that the per-cohort cohortCtx
+// (withCohortSeedContext → xcontext.BuildContext) INHERITS it, so the memo
+// reaches the nested apiref.Resolve. Plus the Option-2 pagination gate in
+// seedOneWidget skips the 4a full-list pin for an unpaginated widget.
+//
+// The memo install lives at the top of seedScopeYielding (one memo per pass,
+// torn down when the function returns — C-F4-5). withCohortSeedContext must
+// carry it through unchanged (it layers values without stripping ctx values).
+
+package dispatchers
+
+import (
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets/apiref"
+)
+
+// TestCohortSeedContext_InheritsSeedResolveMemo — the memo the seed pass
+// installs on ctx must survive through withCohortSeedContext so the nested
+// apiref.Resolve (which reads cache.SeedResolveMemoFromContext(ctx)) consults
+// it. If withCohortSeedContext's BuildContext ever stripped ctx values this arm
+// goes RED and the memo would be invisible to the resolve (silent no-op).
+func TestCohortSeedContext_InheritsSeedResolveMemo(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	// Mirror seedScopeYielding's install (top of the function).
+	base := cache.WithSeedResolveMemo(xcontext.BuildContext(t.Context()),
+		cache.NewSeedResolveMemo(nil))
+	if cache.SeedResolveMemoFromContext(base) == nil {
+		t.Fatal("premise broken: base ctx should carry the memo the pass installs")
+	}
+
+	// The per-cohort ctx must still carry it.
+	cohortCtx := withCohortSeedContext(base, seedTarget{Username: "admin"}, endpoints.Endpoint{}, nil)
+	if cache.SeedResolveMemoFromContext(cohortCtx) == nil {
+		t.Fatal("RED: withCohortSeedContext DROPPED the seed-resolve memo — the nested apiref.Resolve would never consult it (silent no-op, F4 inert). The memo must propagate through BuildContext.")
+	}
+}
+
+// TestOption2_PaginationPredicate_MirrorsServeGate — the Option-2 skip in
+// seedOneWidget gates on apiref.IsPaginatedResolve(e.PerPage, e.Page). A widget
+// seeded UNPAGINATED (the Statistic/Tag count-only shape) must be classified
+// skip; a paginated widget must still pin. Data-derived — no widget-kind
+// (C-F4-7). This is the exact predicate the production seedOneWidget branch
+// uses (single import, no local re-derivation).
+func TestOption2_PaginationPredicate_MirrorsServeGate(t *testing.T) {
+	// Unpaginated / partial → skip the 4a pin. (e.PerPage/e.Page are the
+	// navWidgetEntry resolution tuple the production seedOneWidget branch reads.)
+	for _, tc := range []struct{ pp, pg int }{{0, 0}, {-1, -1}, {5, 0}, {0, 1}} {
+		if apiref.IsPaginatedResolve(tc.pp, tc.pg) {
+			t.Fatalf("RED: unpaginated widget (perPage=%d,page=%d) classified paginated — seedOneWidget would run the redundant 4a pin. Option 2 must skip it.", tc.pp, tc.pg)
+		}
+	}
+	// Paginated → still pin (byte-unchanged from pre-F4).
+	if !apiref.IsPaginatedResolve(5, 1) {
+		t.Fatal("RED: paginated widget (5,1) classified unpaginated — a paginated widget must still pin the full list.")
+	}
+}

--- a/internal/resolvers/widgets/apiref/resolve.go
+++ b/internal/resolvers/widgets/apiref/resolve.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
+	pmaps "github.com/krateoplatformops/plumbing/maps"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/objects"
@@ -65,8 +66,24 @@ type ResolveOptions struct {
 // UNTOUCHED — only the discovery walk (which has no use for the slice cache) is
 // suppressed. The serve-time slice cache is populated by the first real
 // foreground /call, exactly as before this change.
+// IsPaginatedResolve is the SINGLE pagination predicate that gates the Ship-4a
+// full-list machinery: 4a serves a bounded page window from a shared full list,
+// so it is meaningful ONLY for a paginated resolve (perPage>0 && page>0). An
+// unpaginated resolve (0,0 / -1,-1) consumes the whole list wholesale (e.g. a
+// Statistic/Tag widget counting `list:`) and gains nothing from the slice cache.
+//
+// #130 F4 Option 2 reuses this exact predicate at the seed to SKIP
+// seedRAFullListForWidget for an unpaginated-consuming widget — the second full
+// ~18s benchapps materialization that only ever pinned a slice cache the
+// widget's own unpaginated /call would never engage. Data-derived (reads
+// pagination only, never widget-kind — feedback_no_special_cases). Exported so
+// the seed and the serve gate share ONE derivation and cannot drift.
+func IsPaginatedResolve(perPage, page int) bool {
+	return perPage > 0 && page > 0
+}
+
 func shouldServeRAFullList(ctx context.Context, perPage, page int) bool {
-	if perPage <= 0 || page <= 0 || !cache.ResolvedCacheEnabled() {
+	if !IsPaginatedResolve(perPage, page) || !cache.ResolvedCacheEnabled() {
 		return false
 	}
 	if fs := cache.FallthroughScope(ctx); fs != nil && fs.Path == cache.ScopeBootPrewarmWalk {
@@ -158,6 +175,45 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 		return rawExtensionToMap(local.Status)
 	}
 
+	// #130 F4 — per-seed-pass RA-resolve memo. Installed ONLY on the boot-seed
+	// context (cache.WithSeedResolveMemo in withCohortSeedContext); nil (a strict
+	// no-op) on the user /call path, the refresher, and the discovery walk, so
+	// the request path is provably untouched (C-F4-8). The memo collapses the
+	// ~71 statistics/tag widgets that share a small set of heavy RESTActions
+	// (compositions-list / dashboard-data — ~18s of gojq over the 60K benchapps
+	// array each) to ONE real resolve per distinct (RA, identity, page, extras)
+	// within the pass. Keyed by the FULL RBAC-determining identity (username +
+	// sorted groups off ctx — the same tuple refilter/cluster_list/ra_full_list
+	// read to FILTER the list) so a hit is only ever served to a caller who would
+	// compute a byte-identical body; dropping identity would leak cohort A's
+	// RBAC-filtered body to cohort B (C-F4-4, proven RED by the divergent-output
+	// arm). The memo wraps BOTH the 4a serve and the page-keyed fallthrough: the
+	// key includes (perPage, page), so the unpaginated first-sight (0,0), the 4a
+	// paginated serve, and any page-keyed fallthrough occupy distinct memo slots
+	// and never cross-serve.
+	memo := cache.SeedResolveMemoFromContext(ctx)
+	var memoKey string
+	if memo != nil {
+		username, groups := identityForMemo(ctx)
+		memoKey = memo.Key(opts.ApiRef.Namespace, opts.ApiRef.Name,
+			username, groups, cache.HashExtras(opts.Extras), opts.PerPage, opts.Page)
+		if hit, ok := memo.Load(memoKey); ok {
+			// Load returns a fresh deep copy; safe to hand straight back.
+			return hit, nil
+		}
+	}
+
+	// storeMemo deep-copies the resolved body (JSON-native round-trip, C-F4-3 —
+	// panics AT THIS SEAM on a non-JSON-native value rather than aliasing a bad
+	// value into the shared memo) and records it so sibling widgets in the pass
+	// hit it. No-op when no memo is installed (nil memo / empty key).
+	storeMemo := func(out map[string]any) {
+		if memo == nil || memoKey == "" || out == nil {
+			return
+		}
+		memo.Store(memoKey, pmaps.DeepCopyJSON(out))
+	}
+
 	// Ship 4a (0.30.198) — page-independent RAFullList serve at the apiRef
 	// chokepoint. Engaged ONLY when shouldServeRAFullList (below) is true. On a
 	// hit / verified-sliceable shape it serves a cheap Go-slice over the cached
@@ -169,10 +225,31 @@ func Resolve(ctx context.Context, opts ResolveOptions) (map[string]any, error) {
 			opts.ApiRef.Name, &ra, opts.PerPage, opts.Page, opts.Extras, resolveRA); serr != nil {
 			return map[string]any{}, serr
 		} else if ok {
+			storeMemo(served)
 			return served, nil
 		}
 		// served=false, no error — fall through to the page-keyed resolve.
 	}
 
-	return resolveRA(ctx, opts.PerPage, opts.Page)
+	out, err := resolveRA(ctx, opts.PerPage, opts.Page)
+	if err != nil {
+		return map[string]any{}, err
+	}
+	storeMemo(out)
+	return out, nil
+}
+
+// identityForMemo reads the RBAC-determining identity (username + groups) off
+// ctx — the SAME xcontext.UserInfo the RESTAction resolver reads to RBAC-filter
+// the list (refilter.go / cluster_list.go / ra_full_list.go). On the seed path
+// withCohortSeedContext installs it via xcontext.WithUserInfo(cohort.Username,
+// cohort.Groups). A UserInfo-err (no identity on ctx) yields ("", nil) — a
+// distinct, non-colliding identity segment; the memo simply never cross-serves
+// an identity-less body to an identity-bearing one.
+func identityForMemo(ctx context.Context) (string, []string) {
+	ui, err := xcontext.UserInfo(ctx)
+	if err != nil {
+		return "", nil
+	}
+	return ui.Username, ui.Groups
 }

--- a/internal/resolvers/widgets/apiref/seed_memo_seam_test.go
+++ b/internal/resolvers/widgets/apiref/seed_memo_seam_test.go
@@ -1,0 +1,105 @@
+// seed_memo_seam_test.go — #130 F4 seam-level falsifiers at the apiref.Resolve
+// chokepoint: the memo is consulted ONLY when a SeedResolveMemo is installed on
+// ctx (the seed path), and NEVER on the /call / discovery-walk / refresher path
+// (C-F4-8); the Option-2 pagination predicate (IsPaginatedResolve) is the exact
+// serve-gate shape (C-F4-7 data-derived, no widget-kind); and identityForMemo
+// reads the RBAC-determining UserInfo off ctx (C-F4-4 key-input provenance).
+//
+// The full apiref.Resolve integration (objects.Get against a live apiserver) is
+// covered by the on-cluster acceptance run; these unit arms falsify the memo
+// WIRING deterministically without an apiserver.
+
+package apiref
+
+import (
+	"context"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	pmaps "github.com/krateoplatformops/plumbing/maps"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestSeedMemo_NotConsultedOffSeedPath — C-F4-8. The memo lookup in
+// apiref.Resolve is `memo := cache.SeedResolveMemoFromContext(ctx)`; it must be
+// nil for every non-seed ctx so the /call path is provably untouched. A user
+// /call, the discovery walk, and the refresher NEVER install a memo.
+func TestSeedMemo_NotConsultedOffSeedPath(t *testing.T) {
+	cacheOn(t)
+
+	// Foreground /call ctx (ScopeCallWidgets) — the customer path.
+	if m := cache.SeedResolveMemoFromContext(foregroundCallCtx(t)); m != nil {
+		t.Fatal("RED: a foreground /call ctx carried a seed-resolve memo — the memo must be consulted ONLY under the seed context. C-F4-8.")
+	}
+	// Discovery-walk ctx (ScopeBootPrewarmWalk) — no memo.
+	if m := cache.SeedResolveMemoFromContext(bootWalkCtx(t)); m != nil {
+		t.Fatal("RED: the discovery-walk ctx carried a seed-resolve memo. C-F4-8.")
+	}
+	// Refresher ctx (WithBackgroundResolve) — no memo.
+	refCtx := cache.WithBackgroundResolve(xcontext.BuildContext(t.Context(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "admin"})))
+	if m := cache.SeedResolveMemoFromContext(refCtx); m != nil {
+		t.Fatal("RED: the refresher ctx carried a seed-resolve memo. C-F4-8.")
+	}
+	// Bare context — no memo.
+	if m := cache.SeedResolveMemoFromContext(context.Background()); m != nil {
+		t.Fatal("RED: a bare context carried a seed-resolve memo. C-F4-8.")
+	}
+}
+
+// TestSeedMemo_ConsultedUnderSeedCtx — the positive: a ctx with a memo installed
+// (as withCohortSeedContext does in production) IS consulted, and the identity
+// the memo keys on is the one on ctx.
+func TestSeedMemo_ConsultedUnderSeedCtx(t *testing.T) {
+	cacheOn(t)
+	memo := cache.NewSeedResolveMemo(pmaps.DeepCopyJSON)
+	seedCtx := cache.WithSeedResolveMemo(
+		xcontext.BuildContext(t.Context(),
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: "cyberjoker", Groups: []string{"dev-team"}})),
+		memo)
+
+	if cache.SeedResolveMemoFromContext(seedCtx) == nil {
+		t.Fatal("RED: seed ctx did not carry the memo — the seed path must consult it.")
+	}
+	// identityForMemo must read the ctx UserInfo (the RBAC-determining tuple the
+	// memo key folds — same UserInfo the RA resolver filters on).
+	u, g := identityForMemo(seedCtx)
+	if u != "cyberjoker" || len(g) != 1 || g[0] != "dev-team" {
+		t.Fatalf("RED: identityForMemo did not read the ctx UserInfo; got (%q, %v). The memo key must fold the RBAC identity. C-F4-4.", u, g)
+	}
+	// No UserInfo on ctx ⇒ ("", nil) — a distinct, non-colliding identity.
+	if u2, g2 := identityForMemo(context.Background()); u2 != "" || g2 != nil {
+		t.Fatalf("RED: identityForMemo on an identity-less ctx returned (%q, %v), want (\"\", nil).", u2, g2)
+	}
+}
+
+// TestIsPaginatedResolve_Option2Predicate — C-F4-7. Option 2 skips the 4a pin
+// for an UNPAGINATED widget via IsPaginatedResolve — a DATA-DERIVED predicate
+// (reads the pagination tuple only, no widget-kind). It must be true iff both
+// perPage>0 AND page>0, matching shouldServeRAFullList's serve gate exactly (one
+// derivation site, no drift).
+func TestIsPaginatedResolve_Option2Predicate(t *testing.T) {
+	cacheOn(t)
+	// Paginated ⇒ 4a pin RUNS (byte-unchanged from pre-F4).
+	if !IsPaginatedResolve(5, 1) {
+		t.Fatal("RED: (perPage=5,page=1) not paginated — a paginated widget must still pin the full list.")
+	}
+	// Unpaginated-consuming shapes ⇒ 4a pin SKIPPED (the F4 Option-2 cut).
+	for _, tc := range []struct{ pp, pg int }{{0, 0}, {-1, -1}, {0, 1}, {5, 0}, {-1, 1}, {5, -1}} {
+		if IsPaginatedResolve(tc.pp, tc.pg) {
+			t.Fatalf("RED: (perPage=%d,page=%d) reported paginated — an unpaginated/partial tuple must skip the 4a pin (Option 2). C-F4-7.", tc.pp, tc.pg)
+		}
+	}
+	// The predicate must agree with the serve gate for the same tuple + a
+	// non-walk cache-on ctx (single derivation site — shouldServeRAFullList
+	// wraps IsPaginatedResolve).
+	fg := foregroundCallCtx(t)
+	for _, tc := range []struct{ pp, pg int }{{5, 1}, {0, 0}, {5, 0}, {0, 1}} {
+		serve := shouldServeRAFullList(fg, tc.pp, tc.pg)
+		if serve != IsPaginatedResolve(tc.pp, tc.pg) {
+			t.Fatalf("RED: IsPaginatedResolve(%d,%d)=%v disagrees with the serve gate=%v — the Option-2 skip predicate drifted from the serve gate.",
+				tc.pp, tc.pg, IsPaginatedResolve(tc.pp, tc.pg), serve)
+		}
+	}
+}


### PR DESCRIPTION
## #130 F4 — statistics/tag widget apiRef cost (PARKED — Diego-reserved merge)

**Do NOT merge/tag/cut.** Parked for Diego's merge word. Frozen SHA `c8130e4`, dual-gate ACCEPTed (architect SOUND + PM all-9-PASS).

### Root cause
The boot seed resolves ~71 statistics/tag widgets whose `apiRef` points at a small set of heavy RESTActions (`compositions-list` / `dashboard-data`). Each runs ~18s of gojq over the 60K `benchapps` array, run **twice** per widget seed (paginated `widgets.Resolve` + unpaginated `seedRAFullListForWidget` 4a pin), per cohort. I/O is already cheap (informer-served, F3b Fix 2, `content_hits`≫0/`misses`=0) — the residual is pure jq CPU over a list **identical** across every widget sharing that (RA, identity, page). 1.7.8 symptom: seed ran the full 480s processing only ~210 targets, latch never fired (Ready via backstop), 0 seed hits.

### Mechanism (two levers, one ship)
- **Option 1 — per-seed-pass RA-resolve memo** (`internal/cache/seed_resolve_memo.go`): a context-carried `sync.Map` installed by `seedScopeYielding` (one per pass, torn down at pass end — **never** process-global), inherited by every cohortCtx via `withCohortSeedContext`, consulted at the `apiref.Resolve` seam. Keyed by **(RA ns/name, full RBAC identity [username + sorted groups off `xcontext.UserInfo(ctx)` — the same tuple `refilter`/`cluster_list`/`ra_full_list` filter on], effective-extras hash, perPage, page)**. Values JSON-native (`plumbing/maps.DeepCopyJSON` round-trip on Store and every Load hit). Collapses ~71 identical 18s filters per cohort to one real resolve per distinct (RA, identity, page, extras). Strict no-op off the seed path (nil on /call, refresher, discovery walk); inert under `Disabled()`.
- **Option 2 — skip `seedRAFullListForWidget` when the widget resolves UNPAGINATED** (`phase1_pip_seed.go`), gated on the exported `apiref.IsPaginatedResolve(e.PerPage, e.Page)` — the exact serve-gate pagination predicate (single derivation site). The 4a pin only ever warms a slice for a subsequent **paginated** /call; an unpaginated-consuming Statistic/Tag widget never engages it, so the second ~18s materialization is pure waste. Data-derived, no widget-kind (`feedback_no_special_cases`).
- `cache.HashExtras` exported off `canonicaliseExtras` so the memo's extras hash cannot drift from the L1 key's.

### Acceptance projection (C-F4-1, honest per-cohort)
`residual ≈ #cohorts × #distinct-heavy-RAs × ~18s ≈ 5 × 2 × 18 ≈ ~180s` — **not** the design doc body's single-cohort ~40s (the memo key correctly folds identity, so it cannot collapse across cohorts). Cohort count is **data-derived** (distinct dedup-collapsed identity ranks at 60K) and a **tester on-cluster confirm**, scales linearly; fits the 480s budget with margin. Ledgered in `docs/f4-statwidget-apiref-cost-design-2026-07-12.md` §Recommendation PROJECTION CORRECTION.

### Falsifier matrix (all green 3× `-race`, `=== RUN` confirmed)
| Cond | Arm | Result |
|---|---|---|
| C-F4-3 | JSON-native + concurrent DeepCopyJSON round-trip (8×32) | PASS |
| C-F4-4 | RBAC key divergence — divergent-output cohorts; identity-drop **RED-proven** (PM re-verified teeth) | PASS |
| C-F4-5 | teardown — fresh ctx carries no memo | PASS |
| C-F4-6 | correctness — hit byte-identical + no-alias | PASS |
| C-F4-7 | no widget-kind (grep + pagination-only predicate) | PASS |
| C-F4-8 | miss-when-absent + not-consulted-off-seed-path (seam) | PASS |
| C-F4-9 | toggle-off inert under Disabled() | PASS |

Run: `go test ./internal/cache/ ./internal/resolvers/widgets/apiref/ ./internal/handlers/dispatchers/ -run 'TestSeedResolveMemo|TestSeedMemo|TestIsPaginatedResolve|TestCohortSeedContext_InheritsSeedResolveMemo|TestOption2_PaginationPredicate' -race -count=1 -v`

### Post-deploy acceptance (tester, on-cluster — NOT curl; real Chrome + slog only)
1. Actual cohort count (distinct identity ranks at 60K) — re-derive the 480s fit if materially >5.
2. `phase1.seed.memo.summary`: `memo_hits` ≫ `memo_misses` (~69 hits/cohort/shared-RA); `phase1.seed.rafulllist.skip_unpaginated` count for the Statistic/Tag widgets.
3. `prewarm.first_nav.latch` fires via **segment-complete** (not the 180s/backstop); `prewarm.engine.scope_incomplete` = 0.
4. `hits_seed_attributable` > 0.
5. Real-Chrome dashboard nav#1 **CONTENT-checked** l1:HIT.

### Gate record
- **Architect: SOUND** — RBAC-leak answered decisively (username+sorted-groups is the complete/correct filter identity; the BindingUID divergence from the L1 key is a *safe over-partition*, never a leak); errors provably not memoized; placement/teardown/toggle/extras-hash sound.
- **PM: ACCEPT — all 9 conditions PASS** at c8130e4 (C-F4-1 cleared; rework verified docs-only, so bf614f4 clearances carry over byte-for-byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1