### PR TITLE
feat(cache): F6 spec.keyExtras author-declared request-extras key allowlist (#130)

### DIFF
--- a/docs/f6-chrome-route-key-design-2026-07-12.md
+++ b/docs/f6-chrome-route-key-design-2026-07-12.md
@@ -1,0 +1,213 @@
+# F6 — Chrome-widget route-context cache-key gap (#130 final gap-chain)
+
+Date: 2026-07-12 · snowplow 1.7.9 · repo @ origin/main 26b48b3
+Run-dir / artifacts:
+- Boot+window log: `/tmp/f4-deploy/boot-1.7.9-milestone-t0.log`
+- Tester milestone report: `/tmp/f4-deploy/c-r2-4-milestone-report.md`
+- SPA source: `/Users/diegobraga/krateo/frontend-draganddrop/frontend` (current, not the stale `~/krateo/frontend`)
+
+## TL;DR
+
+The 8 chrome widgets miss on the first non-dashboard nav because the **frontend folds the
+current route's params (`namespace`, `name`) into the `?extras=` of EVERY widget /call**, and
+those params partition the per-cohort `widgets` cache key. On `/compositions/:namespace/:name`
+the route params are non-empty → a route-specific key that the seed (extras-less) never warmed
+and no prior nav touched. The rendered content of these chrome widgets is **byte-identical across
+routes** (all three admin app-shell keys serve `resident_bytes:1538`), so the partitioning is
+**SPURIOUS over-keying**, not a semantic requirement.
+
+This is the **F-ARCH-1 seed-key-divergence class one level up**: the seed folds no request
+extras (`extras_len:0`), the browser folds one (`extras_len:1`) → the seeded cell is not
+browser-reachable, exactly the `TestFARCH1_RED_OldFrontendRequest_Misses` shape but with route
+params instead of identity.
+
+Recommended fix = **author-declared extras-dependence** (`spec.keyExtras`), a byte-for-byte mirror
+of the existing A2 `spec.identityContext` contract: a widget only folds the request extras it
+actually consumes. Chrome/layout widgets declare none → their key stops partitioning by route →
+one seeded cell serves all routes. No static route list, no name-table, no cross-user sharing
+change, per-user/cohort keying untouched.
+
+## 1. Mechanism (TRACED)
+
+### 1.1 Where route context enters the key
+
+- Frontend: `useWidgetQuery.ts:126` reads `useParams()` (React-Router route params);
+  `useWidgetQuery.ts:135` passes them to `buildExtrasParam`; `buildExtrasParam`
+  (`useWidgetQuery.ts:84-101`) merges **all** route params into the extras JSON
+  (`useWidgetQuery.ts:92-94`) and serializes to `?extras=<json>`. This is unconditional for every
+  widget the SPA fetches — there is no per-widget filter for which params a widget consumes.
+- snowplow ingest: `util.ParseExtras` (`internal/handlers/util/extras.go:13-27`) JSON-decodes
+  `?extras=` into `map[string]any` (the request extras).
+- Key fold: `widgets.go:152` `keyExtras := effectiveKeyExtras(req.Context(), got.Unstructured.Object, extras)`.
+  `effectiveKeyExtras` (`helpers.go:368-399`) unions the request extras into the key material via
+  `unionForKey` (`helpers.go:322-338`) — request wins. That `keyExtras` feeds BOTH:
+  - the per-cohort `widgets` key: `dispatchCacheLookupKey` → `ComputeKey` (`helpers.go:228-270`,
+    `Extras: extras` at :268), AND
+  - the identity-free `widgetContent` key: `dispatchWidgetContentKey` (`helpers.go:175-195`,
+    `Extras: extras` at :193).
+
+So the route params fold into the ComputeKey digest for both layers.
+
+### 1.2 Same widget, differing key inputs, dashboard vs compositions (TRACED, from the log)
+
+`app-shell` (Layout), admin/[admins], per-cohort `widgets` layer — three distinct
+`dispatch.cache_key.computed` `key_hash` values, all `extras_len:1`, all same user/groups/gvr/pagination:
+
+| key_hash (12) | route (by timestamp) | hit? | resident_bytes |
+|---|---|---|---|
+| `75adfc21…` | dashboard (11:57, 12:03:49) | hit@2nd | 1538 |
+| `cdad05b9…` | compositions-A (11:57:55, 12:03:58, 12:04:14) | hit | 1538 |
+| `008d0cbe…` | compositions-B (12:04:07, 12:04:24) | **MISS**@12:04:07 (first-nav) | 1538 |
+
+The seed computed `app-shell` only at `extras_len:0` (`handler_kind:widgets`, keys
+`0f3c6032…/221b882b…/…` per cohort) — none of which equals any browser key (browser is
+`extras_len:1`). The miss at 12:04:07.015 is `l1:miss` at the `widgets` handler, followed
+114ms later by a `widgetContent` HIT (`8a7a3acc…`, `l1:content-hit`) — i.e. the SPA fetches the
+chrome widget both ways; only the per-cohort `widgets` fetch (route-keyed) misses.
+
+### 1.3 The base key vs dashboard key vs widgetContent key (answers brief Q3)
+
+Three distinct cells exist for one chrome widget:
+- **Per-cohort `widgets` cells** — keyed by BindingUID + extras. The browser's carry
+  `extras_len:1` (route params). The seed's carry `extras_len:0`. **They never match** → the
+  seed's `widgets` cell is dead weight for chrome widgets (the "base key" the tester saw seeded).
+- **`widgetContent` cell** (`8a7a3acc…`, `resident_bytes:1564`) — identity-free, single stable
+  cell, HITs on every nav. **NOT seeded by boot** (seed emits no widgetContent for app-shell); it
+  self-warms on the first dashboard traffic and then serves all routes. Its extras_len is
+  effectively 0 on the wire path that the SPA uses for it (the tester's stable hit), which is why
+  it does NOT partition by route.
+
+So the "seed warmed a base key + dashboard key" observation = seed warmed the extras-less
+per-cohort `widgets` cells (unreachable by the browser) and dashboard traffic warmed the
+route-A `widgets` cell + the shared `widgetContent` cell. The compositions-route `widgets` cell
+is the only cold one on first nav.
+
+## 2. Required-vs-spurious verdict: **SPURIOUS** (EVIDENCE)
+
+Falsifiable content check from the log: all three route-partitioned `widgets` keys for `app-shell`
+serve `resident_bytes:1538` — identical size (a change in rendered content would change the
+serialized byte length; app-shell/sidebar-nav/brand-logo render fixed chrome, they do not consume
+`namespace`/`name` in their jq). The route context changes the KEY but not the resolved body.
+This is over-keying: the cell is needlessly partitioned by inputs that do not affect resolution.
+
+Caveat (bounds the fix): SOME widgets on a composition route genuinely DO consume `namespace`/`name`
+(the composition-detail / resources widgets — that's what those params are FOR). For those the
+route param is semantically required and MUST stay in the key. So a blanket "strip route extras"
+is wrong; the fix must be **per-widget, author-declared**, matching the A2 identity precedent.
+
+## 3. Prior art
+
+- k8s/client-go: no applicable primitive — this is a cache-key-composition policy, not an
+  informer/lister concern.
+- **In-repo A2 contract IS the prior art**: `spec.identityContext`
+  (`internal/resolvers/widgets/widgets.go:29-150`, `GetIdentityContext` + `DeclaredIdentity`) is
+  an author-declared enum of which IDENTITY dimensions a widget's resolution depends on; only
+  declared dimensions fold into the key (`effectiveKeyExtras` merges `declaredIdentityForKey`).
+  The route-extras problem is the identical shape for REQUEST-EXTRAS dimensions. Reuse the pattern;
+  do not invent a new mechanism.
+
+## 4. Design — ranked options
+
+### Option A (RECOMMENDED): author-declared `spec.keyExtras` allowlist (snowplow-side, mirrors A2)
+
+Add a widget CR field `spec.keyExtras: []string` — the enumerated request-extras keys whose values
+this widget's resolution depends on. `effectiveKeyExtras` folds ONLY the declared request-extras
+keys into the key (identity injection and the two inline maps are unchanged). Undeclared keys are
+still passed to the RESOLVE input (the jq dict) — they just don't PARTITION the cache. Absent
+declaration = fold NO request extras (prod-inert for chrome widgets; the ~99% path).
+
+- File:line target: `effectiveKeyExtras` (`internal/handlers/dispatchers/helpers.go:368-399`) —
+  filter the raw `requestExtras` arg into `unionForKey` via
+  `filterDeclaredKeyExtras(cr, requestExtras)`; add `GetKeyExtras(obj)` accessor in
+  `internal/resolvers/widgets/widgets.go` next to `GetIdentityContext`. LOC bound: ~40
+  (accessor ~20, filter+wiring ~15, one shared call site).
+  NOTE (as-built, PM-caught doc correction): `effectiveKeyExtras` / `unionForKey` / the
+  key-builders live in `internal/handlers/dispatchers/helpers.go` — NOT in a
+  `resolvers/widgets/helpers.go` (there is none). The `GetIdentityContext`-style accessors
+  (`GetKeyExtras`) live in `internal/resolvers/widgets/widgets.go`. Every `helpers.go` file
+  reference in this doc means `internal/handlers/dispatchers/helpers.go`.
+- Composition-detail / resources widgets declare `keyExtras: [namespace, name]` (portal-chart
+  widget YAML) → their key still partitions correctly. Chrome widgets declare nothing → single cell.
+- Anti-drift: the filter is applied in the SINGLE shared `effectiveKeyExtras`, so all four key
+  consumers (dispatch, widgetContent, subscription, seed) fold identically — same guarantee A1
+  gave. The subscription-arming path (`refresh_subscription.go:137`) and seed
+  (`phase1_pip_seed.go:817`) both go through `effectiveKeyExtras`, so parity holds by construction.
+- **DEFAULT/ROLLOUT CARE**: default-absent = fold-nothing is the RIGHT default for chrome, but it
+  is a KEY CHANGE for widgets that TODAY rely on route params partitioning correctly WITHOUT
+  declaring them. Those widgets would start sharing a cell across routes and serve stale/wrong
+  content. Two sub-options:
+  - **A-strict** (safer rollout): default = fold ALL request extras (today's behavior); a widget
+    OPTS OUT of a key by NOT... no — inverted, unsafe. Reject.
+  - **A-declare** (recommended): default = fold NOTHING; widgets that consume route params MUST
+    declare `keyExtras`. Requires a one-time audit of the portal-chart widget corpus (which widgets
+    read `.namespace`/`.name`/query params in their jq) and adding the declaration to those.
+    This is a coordinated frontend-chart + snowplow change (like A6). The audit is bounded — grep
+    the widget RA/widget YAML for `extras.namespace` / `extras.name` / query-param reads.
+
+Falsifier:
+- RED: a widget that DOES read `extras.namespace` in its jq, with NO `keyExtras` declaration, must
+  produce byte-identical keys across two different namespaces AND (the bug arm) serve the wrong
+  body — proving why the audit+declaration is mandatory. GREEN once it declares `keyExtras:[namespace]`.
+- GREEN (the win): a chrome widget (no declaration) produces ONE key regardless of route params;
+  seed key == browser key (extends `TestFARCH1_SeedParity_*` with a route-param-bearing serve
+  request that now folds nothing). On-cluster: compositions first-nav app-shell = `l1:*hit` (seed
+  or content), `dispatch.cache_key.computed extras_len:0` on the widgets layer for chrome widgets.
+
+### Option B: seed enumerates route contexts (walk-derived, NO static list)
+
+Keep the key as-is; make the seed replay the per-route extras for each nav-widget. The walk already
+discovers routes via routesloaders/ROUTES_LOADER roots (`feedback_prewarm_follows_frontend`); the
+seed would, for each discovered route, re-seed the chrome widgets with that route's params folded.
+
+- Rejected as primary because: (1) it seeds SPURIOUS cells (byte-identical bodies under N keys) —
+  wasted memory + wasted seed budget; (2) cost multiplies: N routes × 8 chrome × 7 cohorts. From
+  the milestone, the single seed pass is 369.8s of 480s (≈110s headroom); even a handful of routes
+  risks the F4b overshoot (#132). (3) It does not fix the STRUCTURE — a route the walk didn't see
+  (deep-linked composition) still cold-misses. Option A makes the cell route-invariant so no route
+  enumeration is needed.
+- Keep B as the fallback ONLY for widgets that legitimately vary per route (the composition-detail
+  class) — but those are already reached by normal nav and their route set is unbounded (any
+  namespace/name), so seeding them per-route is infeasible anyway. So B is not a general answer.
+
+### Option C: frontend stops sending route params to chrome widgets
+
+Mirror the `injectIdentity` capability-flag pattern: the SPA folds route params into extras only
+for widgets that consume them. Rejected as PRIMARY: the frontend cannot know which widgets consume
+which params without the same author declaration Option A introduces server-side — so this is
+Option A's data, enforced on the wrong side, and it leaves the seed/subscription parity to the
+frontend. Option A centralizes the policy in the widget CR (single source of truth, both sides read
+it). C could be a companion (skip sending undeclared extras to cut wire size) but is not required.
+
+## 5. Recommendation
+
+**Option A-declare.** It is the exact A2 pattern one dimension over, keeps the anti-drift single
+site, honors every invariant (no static list, no name-table, per-user/cohort keying inviolable,
+layers removable, prod-inert default for the identity-free corpus). It requires a coordinated
+portal-chart widget audit + declaration for the route-consuming widgets — surface this to Diego as
+the one strategic dependency (same shape as the A6 cross-repo landing).
+
+Strategic choice for TL/Diego: **A-declare (default fold-nothing, audit route-consumers) vs. keep
+the gap.** The gap is 83.3% vs 98.4% first-nav on non-dashboard routes; it is a real but bounded
+UX miss (self-warms on first touch, P2=100%). If the audit is deemed too risky pre-1.0, the gap is
+shippable as a known-corner and A-declare lands as a fast-follow.
+
+## 6. Cost estimate
+
+- Option A: ~40 LOC snowplow + N widget-YAML declarations (N = count of route-consuming widgets in
+  the portal chart, expected small — composition-detail/resources family). Zero seed-budget impact
+  (fewer cells, not more). Memory: chrome widgets collapse from up-to-N-route cells to 1.
+- Option B (rejected): +(routes × 8 × 7) seed targets against a ~110s headroom — high F4b-overshoot
+  risk.
+
+## 7. Falsifiers (summary)
+
+1. Unit (permanent, extends farch_seed_parity): chrome widget (no `keyExtras`) — seed key
+   (`effectiveKeyExtras(ctx, cr, nil)`) == serve key with a route-param-bearing request
+   (`effectiveKeyExtras(ctx, cr, {"namespace":"x","name":"y"})`); L1 HIT, zero resolver calls.
+2. Unit RED (mandatory, proves the audit necessity): route-consuming widget with NO declaration —
+   keys collide across namespaces AND wrong body served; GREEN after declaring `keyExtras:[namespace]`.
+3. On-cluster (the milestone re-run): admin (or any cohort) FIRST nav to `/compositions` — the 8
+   chrome widgets show `l1:*hit` (not `l1:miss`); `dispatch.cache_key.computed` for chrome widgets
+   on the `widgets` layer shows `extras_len:0`; compositions first-nav hit-rate → ~100% (was 83.3%).
+4. CI invariant (#67 generalization): the emit/sub/seed parity test asserts the declared-keyExtras
+   filter is applied identically on all three paths (guards the anti-drift property).

--- a/internal/handlers/dispatchers/effective_key_extras_test.go
+++ b/internal/handlers/dispatchers/effective_key_extras_test.go
@@ -22,10 +22,19 @@ import (
 )
 
 // TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold — the A1 nothing-moved
-// golden across the corpus-representative extras shapes: no-extras, apiRef-inline
-// only, rrt-inline only, both inline maps, request-extras only, and inline+request
-// with a COLLISION (request must win — the pre-A1 precedence). At each shape the
-// shared helper must deep-equal the pre-A1 inline fold.
+// golden across the INLINE (CR-fixed) extras shapes: no-extras, apiRef-inline
+// only, rrt-inline only, both inline maps. At each shape the shared helper must
+// deep-equal the pre-A1 inline fold.
+//
+// F6 RECONCILIATION (docs/f6-chrome-route-key-design-2026-07-12.md, arch-ruled
+// 2026-07-13): the pre-A1 fold (keyExtrasFor / unionForKey) folded the per-REQUEST
+// extras VERBATIM. F6 intentionally reversed that — an UNDECLARED widget folds
+// NOTHING from request extras into the KEY (they still reach the resolve input).
+// So the byte-identical-to-unionForKey golden holds ONLY for the INLINE maps
+// (apiRef.extras + resourcesRefsTemplateExtras) — CR-fixed, which F6 does NOT
+// filter. The former "request-extras only" + "inline+request collision" cases
+// moved to TestF6_UndeclaredRequestExtras_DropFromKey, asserting the NEW contract.
+// The A2 identity slot stays inert here (no identityContext declared → nil).
 func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
 	ctx := ctxWithIdentity()
 
@@ -39,19 +48,14 @@ func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
 		{name: "apiRef-inline only", apiRefJSON: `{"tenant":"acme"}`},
 		{name: "rrt-inline only", rrtJSON: `{"region":"eu"}`},
 		{name: "both inline maps", apiRefJSON: `{"tenant":"acme"}`, rrtJSON: `{"region":"eu"}`},
-		{name: "request-extras only", request: map[string]any{"page": "detail"}},
-		{
-			name:       "inline + request, request wins on collision",
-			apiRefJSON: `{"tenant":"acme","shared":"inline"}`,
-			rrtJSON:    `{"region":"eu"}`,
-			request:    map[string]any{"shared": "request", "q": "x"},
-		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cr := widgetCRWithExtras(t, tc.apiRefJSON, tc.rrtJSON)
 
+			// No request extras in these cases, so the pre-A1 inline fold and the
+			// F6-filtered fold coincide (F6 only filters the REQUEST half).
 			want := keyExtrasFor(cr, tc.request)           // the pre-A1 inline fold
 			got := effectiveKeyExtras(ctx, cr, tc.request) // the A1 shared helper
 
@@ -60,6 +64,35 @@ func TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestF6_UndeclaredRequestExtras_DropFromKey — the F6 reconciliation of the A1
+// golden's former request-extras cases (arch-ruled 2026-07-13). Under F6 an
+// UNDECLARED widget (no spec.keyExtras) folds NOTHING from the per-request extras
+// into the KEY — the reversal of the pre-A1 "fold request verbatim" property. The
+// INLINE maps still fold (CR-fixed, unfiltered); request extras still reach the
+// RESOLVE input (asserted in the resolver tests); only the KEY drops them.
+func TestF6_UndeclaredRequestExtras_DropFromKey(t *testing.T) {
+	ctx := ctxWithIdentity()
+
+	t.Run("request-extras only → EMPTY key fold (was: folded verbatim)", func(t *testing.T) {
+		cr := widgetCRWithExtras(t, "", "") // undeclared, no inline
+		got := effectiveKeyExtras(ctx, cr, map[string]any{"page": "detail"})
+		if len(got) != 0 {
+			t.Fatalf("F6: an undeclared widget must fold EMPTY key extras from a request; got %#v — the 'page' request extra must NOT partition the key", got)
+		}
+	})
+
+	t.Run("inline + request → only INLINE folds, request drops", func(t *testing.T) {
+		cr := widgetCRWithExtras(t, `{"tenant":"acme","shared":"inline"}`, `{"region":"eu"}`)
+		got := effectiveKeyExtras(ctx, cr, map[string]any{"shared": "request", "q": "x"})
+		// Inline maps fold unchanged; the request "q" AND the request "shared"
+		// override BOTH drop (undeclared) → the inline "shared" survives.
+		want := map[string]any{"tenant": "acme", "shared": "inline", "region": "eu"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("F6: only the CR-fixed inline maps may fold for an undeclared widget; the request extras (incl the 'shared' collision override) must drop\n  got  = %#v\n  want = %#v", got, want)
+		}
+	})
 }
 
 // TestA2_DeclaredIdentityForKey_WiresInjection — the A1 inert-slot guard,

--- a/internal/handlers/dispatchers/farch_f6_keyextras_test.go
+++ b/internal/handlers/dispatchers/farch_f6_keyextras_test.go
@@ -1,0 +1,527 @@
+// farch_f6_keyextras_test.go — F6 author-declared request-extras allowlist
+// falsifiers (docs/f6-chrome-route-key-design-2026-07-12.md §4 Option A-declare,
+// §7). F6 closes the #130 chrome-widget first-nav gap: the frontend folds the
+// route params ({namespace, name}) into the ?extras= of EVERY widget /call, and
+// those params partition the per-cohort widgets key. A chrome widget (app-shell,
+// sidebar-nav) renders byte-identical content on every route, so the route-param
+// partitioning is SPURIOUS over-keying — the seed (extras-less) cell is never
+// browser-reachable. The fix: only the request-extras keys the widget author
+// DECLARES in spec.keyExtras fold into the key. A chrome widget declares nothing
+// → its cell stops partitioning by route → one seeded cell serves all routes.
+//
+// This is the F-ARCH-1 seed-key-divergence class one dimension over (route
+// params instead of identity), so the arms mirror farch_seed_parity_test.go:
+// drive BOTH sides through the REAL effectiveKeyExtras → ComputeKey (never
+// hand-fed keys; feedback_key_parity_golden_real_inputs_prehash_diff) and assert
+// the shared cell is reachable / the wrong body is NOT served.
+//
+//	Chrome arm (F6-1, the win): a widget with NO keyExtras — seed key
+//	  (nil extras) == serve key with route-param extras {namespace, name}; L1
+//	  HIT, zero resolver invocations.
+//	RED arm (F6-2, audit necessity): a widget whose jq reads extras.namespace
+//	  with NO declaration collides two DIFFERENT namespaces onto one key AND
+//	  serves the first-warmed body to the second route (wrong body). This is why
+//	  the audit+declaration is MANDATORY. GREEN once it declares keyExtras:[namespace].
+//	Declared-partition arm (F6-3, C-F6-3): a DECLARED widget still partitions —
+//	  two routes → two distinct keys → correct distinct content.
+//	Subscription-parity arm (F6-5, C-F6-5 BLOCKING): a route-param-bearing
+//	  chrome-widget subscription coord derives the SAME key as the fold-nothing
+//	  seed cell, driven through the REAL DeriveSubscriptionKey path (#66 lesson:
+//	  never a shadow copy).
+//	Self-quarantine arm (F6-6, arch-ruled 2026-07-13, per-cohort cell): two users
+//	  in the SAME BindingUID cohort; a widget with NO keyExtras + no apiRef +
+//	  widgetDataTemplate echoing extras.foo. A sends foo=evil, B clean. GREEN: the
+//	  guard declines A's shared-cohort Put → B misses → resolves clean (B's body !=
+//	  evil), AND cacheKey_A == cacheKey_B (the collision is real; the GUARD, not key
+//	  divergence, protects B). RED: neuter the decline → B served evil. Plus the
+//	  declared-counterpart (keyExtras:[foo]) → distinct keys, no decline, guard inert.
+package dispatchers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// routeParamsRequest is the extras a post-A6 buildExtrasParam
+// (useWidgetQuery.ts:84-101) folds for a widget rendered on
+// /compositions/:namespace/:name — the route params merged into ?extras=. This
+// is the exact wire shape F6 pins the key against.
+func routeParamsRequest(namespace, name string) map[string]any {
+	return map[string]any{"namespace": namespace, "name": name}
+}
+
+// chromeWidgetCR is a chrome/layout widget (app-shell, sidebar-nav): NO
+// spec.keyExtras, NO spec.identityContext, no inline extras — renders fixed
+// chrome that does not consume route params. The ~identity-free-corpus shape.
+func chromeWidgetCR() map[string]any { return map[string]any{"spec": map[string]any{}} }
+
+// declaredKeyExtrasCR is a route-consuming widget (composition-detail /
+// resources) that DECLARES spec.keyExtras=keys — the request-extras keys its jq
+// reads. Only these partition its cell.
+func declaredKeyExtrasCR(keys ...string) map[string]any {
+	anyKeys := make([]any, len(keys))
+	for i, k := range keys {
+		anyKeys[i] = k
+	}
+	return map[string]any{"spec": map[string]any{"keyExtras": anyKeys}}
+}
+
+// TestFARCH_F6_1_ChromeWidget_RouteParamsFoldNothing_HIT — the F6 win. A chrome
+// widget (no keyExtras) seeded under the extras-less seed fold is HIT by a
+// browser request carrying route params in ?extras=. Pre-hash: BOTH sides fold
+// EMPTY effective extras (route params dropped by the fold-nothing default) →
+// same key → real Put-under-seed / Get-under-serve HIT, correct body, zero
+// resolver invocations. This is the cell that fixes #130 first-nav.
+func TestFARCH_F6_1_ChromeWidget_RouteParamsFoldNothing_HIT(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity() // cyberjoker / [devs]
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "panels", "krateo-system", "app-shell"
+		perPage, page     = 10, 1
+	)
+	cr := chromeWidgetCR()
+
+	// SEED key: the extras-less seed fold (the boot seed carries no request).
+	seedExtras := effectiveKeyExtras(ctx, cr, nil)
+	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, seedExtras)
+	if seedHandle == nil || seedKey == "" {
+		t.Fatal("F6-1: expected a live per-cohort handle + key under the seed ctx")
+	}
+	body := []byte(`{"status":{"widgetData":{"chrome":"shell"}}}`)
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: body, Inputs: seedInputs})
+
+	// SERVE key: the browser folds route params on a /compositions route.
+	serveExtras := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-a", "demo-1"))
+	serveKey, serveHandle, serveInputs := dispatchCacheLookupKey(ctx, "widgets",
+		g, v, r, ns, name, perPage, page, serveExtras)
+	if serveHandle == nil || serveKey == "" {
+		t.Fatal("F6-1: expected a live per-cohort handle + key under the serve ctx")
+	}
+
+	// Pre-hash: a chrome widget under F6 folds EMPTY effective extras on BOTH
+	// sides — the route params are dropped by the fold-nothing default.
+	if len(seedExtras) != 0 || len(serveExtras) != 0 {
+		t.Fatalf("F6-1 pre-hash: a chrome widget (no keyExtras) must fold EMPTY extras on BOTH sides; seed=%#v serve=%#v", seedExtras, serveExtras)
+	}
+	if !reflect.DeepEqual(seedInputs.Extras, serveInputs.Extras) {
+		t.Fatalf("F6-1 pre-hash: seed vs serve ResolvedKeyInputs.Extras differ; seed=%#v serve=%#v", seedInputs.Extras, serveInputs.Extras)
+	}
+	if seedKey != serveKey {
+		t.Fatalf("F6-1 INVARIANT: seed key %q != route-param serve key %q — the chrome cell still partitions by route (the #130 F6 first-nav miss)", seedKey, serveKey)
+	}
+	got, hit := serveHandle.Get(serveKey)
+	if !hit {
+		t.Fatal("F6-1: route-param serve MISSED the seeded chrome cell — #130 F6 not fixed")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("F6-1: served the wrong body; got %q want %q", got.RawJSON, body)
+	}
+}
+
+// TestFARCH_F6_2_RED_UndeclaredRouteConsumer_CollidesAndServesWrongBody — the F6
+// RED arm (audit necessity). A widget whose jq reads extras.namespace but does
+// NOT declare it in spec.keyExtras produces byte-IDENTICAL keys across two
+// DIFFERENT namespaces (the fold-nothing default drops the discriminating param)
+// AND serves the first namespace's body to the second route (wrong body). This
+// proves why every route-consuming widget MUST declare keyExtras — an undeclared
+// consumer silently shares a cell it must not. The arm is GREEN because it
+// ASSERTS the collision+wrong-body (the defect that mandates the declaration);
+// the paired F6-3 proves declaring it fixes both.
+func TestFARCH_F6_2_RED_UndeclaredRouteConsumer_CollidesAndServesWrongBody(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, name = "widgets.templates.krateo.io", "v1beta1", "panels", "resources-table"
+		perPage, page = 10, 1
+	)
+	// UNDECLARED route consumer: no keyExtras. Its jq reads extras.namespace, so
+	// its rendered body DOES vary by namespace — but the key will not.
+	cr := chromeWidgetCR()
+
+	// Route A (team-a) warms a cell with team-a's body.
+	extrasA := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-a", "x"))
+	keyA, handleA, inputsA := dispatchCacheLookupKey(ctx, "widgets", g, v, r, "team-a", name, perPage, page, extrasA)
+	if handleA == nil || keyA == "" {
+		t.Fatal("F6-2 RED: expected a live handle + key on route A")
+	}
+	bodyA := []byte(`{"namespace":"team-a"}`)
+	handleA.Put(keyA, &cache.ResolvedEntry{RawJSON: bodyA, Inputs: inputsA})
+
+	// Route B (team-b) — a DIFFERENT namespace. Same GVR+name (the same widget
+	// CR, only the route differs). Without a declaration the namespace extra is
+	// dropped from the key → key collision with route A.
+	extrasB := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-b", "x"))
+	keyB, handleB, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, "team-b", name, perPage, page, extrasB)
+	if handleB == nil || keyB == "" {
+		t.Fatal("F6-2 RED: expected a live handle + key on route B")
+	}
+
+	// NOTE: the resource NAMESPACE (a first-class ComputeKey field) differs
+	// between A and B, so their keys legitimately differ on that axis. F6 keys on
+	// the ROUTE-PARAM extra, which is a SEPARATE dimension from the object
+	// namespace: a chrome/detail widget on /compositions/:namespace can carry a
+	// route :namespace param that is NOT the widget CR's own namespace (the param
+	// names the COMPOSITION being viewed, not the panel). To isolate the F6
+	// dimension, hold the object coordinates fixed and vary ONLY the route param.
+	extrasA2 := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-a", "x"))
+	extrasB2 := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-b", "x"))
+	keyA2, hA2, iA2 := dispatchCacheLookupKey(ctx, "widgets", g, v, r, "krateo-system", name, perPage, page, extrasA2)
+	keyB2, hB2, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, "krateo-system", name, perPage, page, extrasB2)
+	if hA2 == nil || hB2 == nil {
+		t.Fatal("F6-2 RED: expected live handles on the isolated-dimension arm")
+	}
+	if len(extrasA2) != 0 || len(extrasB2) != 0 {
+		t.Fatalf("F6-2 RED: an undeclared widget must fold EMPTY extras even when the request carries route params; A=%#v B=%#v", extrasA2, extrasB2)
+	}
+	if keyA2 != keyB2 {
+		t.Fatalf("F6-2 RED: keys did NOT collide across route params for an undeclared widget (A=%q B=%q) — the arm is not discriminating; the fold-nothing default MUST drop the route param from the key", keyA2, keyB2)
+	}
+	// The wrong-body proof: route-A body warms the shared cell; route B reads it.
+	bodyA2 := []byte(`{"route_namespace":"team-a"}`)
+	hA2.Put(keyA2, &cache.ResolvedEntry{RawJSON: bodyA2, Inputs: iA2})
+	gotB, hitB := hB2.Get(keyB2)
+	if !hitB {
+		t.Fatal("F6-2 RED: route-B request did not hit the route-A-warmed shared cell — collision not demonstrated")
+	}
+	if string(gotB.RawJSON) != string(bodyA2) {
+		t.Fatalf("F6-2 RED: expected the WRONG (route-A) body served to route B; got %q", gotB.RawJSON)
+	}
+	// keyA/keyB (distinct object namespaces) are used above only to show the
+	// object-namespace axis is orthogonal; reference them so the arm's setup is
+	// not dead.
+	if keyA == "" || keyB == "" {
+		t.Fatal("F6-2 RED: object-namespace arm produced empty keys")
+	}
+}
+
+// TestFARCH_F6_3_DeclaredWidget_PartitionsByRoute_DistinctContent — C-F6-3. A
+// widget that DECLARES keyExtras:[namespace] still partitions correctly: two
+// different route namespaces produce two DISTINCT keys, each serving its own
+// body. This is the GREEN counterpart to F6-2 — the declaration is what makes a
+// genuine route-consumer safe. Isolated on the route-param dimension (object
+// coordinates held fixed), so the discriminant is ONLY the declared extra.
+func TestFARCH_F6_3_DeclaredWidget_PartitionsByRoute_DistinctContent(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity()
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "panels", "krateo-system", "composition-detail"
+		perPage, page     = 10, 1
+	)
+	cr := declaredKeyExtrasCR("namespace")
+
+	extrasA := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-a", "x"))
+	extrasB := effectiveKeyExtras(ctx, cr, routeParamsRequest("team-b", "x"))
+	if extrasA["namespace"] != "team-a" || extrasB["namespace"] != "team-b" {
+		t.Fatalf("F6-3: a declared[namespace] widget must fold the route namespace into the key; A=%#v B=%#v", extrasA, extrasB)
+	}
+	// The undeclared "name" param must NOT fold (only "namespace" is declared).
+	if _, ok := extrasA["name"]; ok {
+		t.Fatalf("F6-3: only DECLARED keys fold; the undeclared 'name' route param leaked into the key: %#v", extrasA)
+	}
+	keyA, hA, iA := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, extrasA)
+	keyB, hB, iB := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, extrasB)
+	if hA == nil || hB == nil || keyA == "" || keyB == "" {
+		t.Fatal("F6-3: expected live handles + keys for both routes")
+	}
+	if keyA == keyB {
+		t.Fatalf("F6-3: a declared[namespace] widget MUST partition by the route namespace — keyA == keyB %q (spurious collapse)", keyA)
+	}
+	bodyA := []byte(`{"ns":"team-a"}`)
+	bodyB := []byte(`{"ns":"team-b"}`)
+	hA.Put(keyA, &cache.ResolvedEntry{RawJSON: bodyA, Inputs: iA})
+	hB.Put(keyB, &cache.ResolvedEntry{RawJSON: bodyB, Inputs: iB})
+	if gA, hit := hA.Get(keyA); !hit || string(gA.RawJSON) != string(bodyA) {
+		t.Fatalf("F6-3: route A served wrong/no body (hit=%v got=%q)", hit, gA.RawJSON)
+	}
+	if gB, hit := hB.Get(keyB); !hit || string(gB.RawJSON) != string(bodyB) {
+		t.Fatalf("F6-3: route B served wrong/no body (hit=%v got=%q)", hit, gB.RawJSON)
+	}
+}
+
+// TestFARCH_F6_5_SubscriptionParity_ChromeWidget_FoldsNothing — C-F6-5 (BLOCKING).
+// The /refreshes subscription-arming path (DeriveSubscriptionKey →
+// subscriptionKeyExtras → effectiveKeyExtras, the SAME single site the seed and
+// dispatch use) must derive the SAME key for a route-param-bearing chrome-widget
+// subscription as the extras-less seed cell — so a chrome widget that self-warms
+// its seeded cell is still reachable by its live-refresh subscription. Driven
+// through the REAL DeriveSubscriptionKey path (#66 anti-drift lesson: never a
+// shadow copy). The seeded CR declares NO keyExtras, so the subscription's route
+// params are dropped exactly as the seed's absent extras were.
+func TestFARCH_F6_5_SubscriptionParity_ChromeWidget_FoldsNothing(t *testing.T) {
+	// Reuse the two-user RBAC informer harness; seed a compositions CR with NO
+	// keyExtras (chrome-widget shape) so subscriptionKeyExtras→objects.Get serves
+	// it from the informer and the real arming path runs (not a fail-closed skip).
+	buildTwoUserRBACWatcher(t)
+
+	// The subscription coord carries route params in Extras (the frontend echoes
+	// the route params into ?sub= the same way it does ?extras=). A chrome
+	// widget declares nothing → the arming fold drops them.
+	coords := compositionsCoords()
+	coords.Extras = routeParamsRequest("team-a", "demo-1")
+
+	subKey, ok := DeriveSubscriptionKey(ctxAs("userA"), coords)
+	if !ok || subKey == "" {
+		t.Fatalf("F6-5: DeriveSubscriptionKey failed for a chrome-widget coord (ok=%v key=%q)", ok, subKey)
+	}
+
+	// The SEED / extras-less arming: same coord, NO route params. For a widget
+	// declaring no keyExtras the arming fold is byte-identical (route params
+	// dropped) → the subscription key MUST equal the extras-less key.
+	seedCoords := compositionsCoords() // Extras nil
+	seedKey, ok := DeriveSubscriptionKey(ctxAs("userA"), seedCoords)
+	if !ok || seedKey == "" {
+		t.Fatalf("F6-5: DeriveSubscriptionKey failed for the extras-less seed coord (ok=%v key=%q)", ok, seedKey)
+	}
+
+	if subKey != seedKey {
+		t.Fatalf("F6-5 PARITY: route-param subscription key %q != extras-less seed key %q — the arming path partitions the chrome cell by route while the seed does not; the seeded cell would be unreachable by its own subscription (the #66 drift class, one dimension over)", subKey, seedKey)
+	}
+}
+
+// f6PanelGVR is the widget GVR the F6-6 self-quarantine harness seeds.
+var f6PanelGVR = schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
+
+// buildF6SharedBindingWatcher seeds a fake RBAC snapshot with ONE ClusterRoleBinding
+// listing BOTH userA and userB (→ identical BindingUID uid-AB → SAME per-cohort
+// cell) granting get/list on panels, plus a panel-1 widget CR carrying the supplied
+// spec.keyExtras declaration (nil = undeclared). Published as cache.Global() for the
+// test. The two-users-one-binding shape is the F6-6 collision precondition: A and B
+// derive the SAME per-cohort key, so only the guard (not key divergence) can protect B.
+func buildF6SharedBindingWatcher(t *testing.T, keyExtrasDecl []string) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		f6PanelGVR: "PanelList",
+	}
+	rule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{"widgets.templates.krateo.io"}, Resources: []string{"panels"}}}
+	spec := map[string]any{}
+	if keyExtrasDecl != nil {
+		decl := make([]any, len(keyExtrasDecl))
+		for i, k := range keyExtrasDecl {
+			decl[i] = k
+		}
+		spec["keyExtras"] = decl
+	}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "panel-reader"}, Rules: rule},
+		// ONE binding, BOTH users → identical BindingUID → SAME per-cohort cell.
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "ab-bind", UID: types.UID("uid-AB")},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "userA"}, {Kind: "User", Name: "userB"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "panel-reader"},
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1",
+			"kind":       "Panel",
+			"metadata":   map[string]any{"name": "panel-1", "namespace": "demo"},
+			"spec":       spec,
+		}},
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(f6PanelGVR)
+	_ = rw.WaitForCacheSync(ctx, 5*time.Second)
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+func f6CtxUser(username string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username}))
+}
+
+// TestFARCH_F6_6_SelfQuarantine_UndeclaredExtrasDeclinePut — the F6-6 permanent
+// self-quarantine arm (arch-ruled 2026-07-13, per-cohort cell). Two users in the
+// SAME BindingUID cohort request a widget with NO keyExtras whose widgetDataTemplate
+// reads extras.foo. userA sends ?extras={"foo":"evil"}; userB sends nothing.
+//
+// The COLLISION is real (proven): under F6 the undeclared foo drops from the key, so
+// cacheKey_A == cacheKey_B — both derive the SAME shared per-cohort cell. Without the
+// guard, A's evil-shaped body Put at widgets.go's genuine-Put would be served to B.
+// The GUARD (requestExtrasFullyDeclared → decline the Put) is what protects B: A's
+// polluting request declines the shared-cell Put, so B misses and resolves clean.
+//
+// This arm drives the REAL guard predicate + the REAL per-cohort key derivation
+// (dispatchCacheLookupKey → effectiveKeyExtras, the SAME path widgets.go uses), then
+// simulates the genuine-Put gate exactly as widgets.go structures it: IF
+// requestExtrasFullyDeclared → Put; ELSE decline. Asserts (1) key collision, (2) the
+// guard declines A's Put, (3) B misses (would resolve clean). RED = neuter the guard
+// (Put unconditionally) → B hits A's evil body.
+func TestFARCH_F6_6_SelfQuarantine_UndeclaredExtrasDeclinePut(t *testing.T) {
+	buildF6SharedBindingWatcher(t, nil) // UNDECLARED — no keyExtras
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "panels", "demo", "panel-1"
+		perPage, page     = -1, -1
+	)
+	ctxA := f6CtxUser("userA")
+	ctxB := f6CtxUser("userB")
+	cr := map[string]any{"spec": map[string]any{}} // undeclared, no keyExtras
+
+	// userA carries a polluting request extra; userB is clean.
+	extrasA := map[string]any{"foo": "evil"}
+	var extrasB map[string]any // nil — clean
+
+	// REAL per-cohort key derivation (the widgets.go:152/:221 path).
+	keyExtrasA := effectiveKeyExtras(ctxA, cr, extrasA)
+	keyA, handleA, inputsA := dispatchCacheLookupKey(ctxA, "widgets", g, v, r, ns, name, perPage, page, keyExtrasA)
+	keyExtrasB := effectiveKeyExtras(ctxB, cr, extrasB)
+	keyB, handleB, _ := dispatchCacheLookupKey(ctxB, "widgets", g, v, r, ns, name, perPage, page, keyExtrasB)
+	if handleA == nil || handleB == nil || keyA == "" || keyB == "" {
+		t.Fatalf("F6-6: expected live handles + keys (A=%q B=%q)", keyA, keyB)
+	}
+
+	// (1) THE COLLISION IS REAL: A and B (same BindingUID, foo dropped from the key)
+	// derive the SAME per-cohort key. This is what makes the guard load-bearing —
+	// nothing else keeps A's body away from B.
+	if keyA != keyB {
+		t.Fatalf("F6-6: expected cacheKey_A == cacheKey_B (same BindingUID cohort, undeclared foo dropped from key) — got A=%q B=%q; if they differ the collision is not demonstrated", keyA, keyB)
+	}
+
+	// (2) THE GUARD: userA's request carries an UNDECLARED extra (foo) → the genuine
+	// per-cohort Put must be DECLINED. This is the exact predicate widgets.go gates on.
+	if requestExtrasFullyDeclared(cr, extrasA) {
+		t.Fatal("F6-6: userA's request carries an undeclared extra (foo) → requestExtrasFullyDeclared MUST be false (decline the shared-cell Put)")
+	}
+	// Simulate widgets.go's genuine-Put gate EXACTLY: the F6 decline branch runs
+	// BEFORE the Put, so an undeclared-extras request never writes the shared cell.
+	aEvilBody := []byte(`{"status":{"widgetData":{"echoedFoo":"evil"}}}`)
+	if requestExtrasFullyDeclared(cr, extrasA) {
+		// (not reached — asserted false above; this mirrors the prod if-structure)
+		handleA.Put(keyA, &cache.ResolvedEntry{RawJSON: aEvilBody, Inputs: inputsA})
+	}
+
+	// (3) userB (clean, fully-declared trivially) now reads the shared key → MISS,
+	// because A's Put was declined. B would fall through to resolve clean.
+	if !requestExtrasFullyDeclared(cr, extrasB) {
+		t.Fatal("F6-6: userB's clean request (no extras) must be fully-declared → its Put is allowed and it is safe")
+	}
+	if _, hit := handleB.Get(keyB); hit {
+		t.Fatal("F6-6 GREEN: userB unexpectedly HIT the shared cell — A's evil-extras body must NOT have been written (the guard should have declined A's Put); B must miss and resolve clean")
+	}
+}
+
+// TestFARCH_F6_6_RED_NeuteredGuard_ServesEvilToB — the F6-6 RED companion. It
+// reproduces what happens WITHOUT the guard: A's Put is NOT declined (the neutered
+// behaviour), so A's evil body lands in the shared cohort cell and userB — deriving
+// the SAME key — is served it. This is GREEN precisely because it ASSERTS the leak
+// the guard prevents; it discriminates the exact requestExtrasFullyDeclared predicate
+// (if the guard were always-on, A's Put would be declined and this arm's HIT would
+// not occur).
+func TestFARCH_F6_6_RED_NeuteredGuard_ServesEvilToB(t *testing.T) {
+	buildF6SharedBindingWatcher(t, nil) // undeclared
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "panels", "demo", "panel-1"
+		perPage, page     = -1, -1
+	)
+	ctxA := f6CtxUser("userA")
+	ctxB := f6CtxUser("userB")
+	cr := map[string]any{"spec": map[string]any{}}
+
+	keyExtrasA := effectiveKeyExtras(ctxA, cr, map[string]any{"foo": "evil"})
+	keyA, handleA, inputsA := dispatchCacheLookupKey(ctxA, "widgets", g, v, r, ns, name, perPage, page, keyExtrasA)
+	keyExtrasB := effectiveKeyExtras(ctxB, cr, nil)
+	keyB, handleB, _ := dispatchCacheLookupKey(ctxB, "widgets", g, v, r, ns, name, perPage, page, keyExtrasB)
+	if handleA == nil || handleB == nil || keyA != keyB {
+		t.Fatalf("F6-6 RED: setup expects a real key collision (A=%q B=%q)", keyA, keyB)
+	}
+
+	// NEUTERED guard: Put unconditionally (the pre-guard / regression behaviour).
+	aEvilBody := []byte(`{"status":{"widgetData":{"echoedFoo":"evil"}}}`)
+	handleA.Put(keyA, &cache.ResolvedEntry{RawJSON: aEvilBody, Inputs: inputsA})
+
+	// userB, on the SAME key, is served A's evil body — the leak the guard prevents.
+	got, hit := handleB.Get(keyB)
+	if !hit {
+		t.Fatal("F6-6 RED: expected userB to HIT the shared cell A polluted (neutered guard) — the collision leak is not demonstrated")
+	}
+	if string(got.RawJSON) != string(aEvilBody) {
+		t.Fatalf("F6-6 RED: expected userB served A's evil body; got %q", got.RawJSON)
+	}
+}
+
+// TestFARCH_F6_6_DeclaredCounterpart_GuardInert — the F6-6 declared-counterpart
+// GREEN arm. When the widget DECLARES keyExtras:[foo], the foo extra folds into the
+// key → A (foo=evil) and B (foo=clean, or absent) derive DISTINCT keys → normal
+// partition, no shared-cell collision, and the guard is INERT (foo is declared, so
+// requestExtrasFullyDeclared is true — the Put is allowed and correct). This proves
+// the guard fires ONLY for the misconfigured (undeclared-consumer) corpus; the
+// correctly-declared corpus partitions and pays nothing.
+func TestFARCH_F6_6_DeclaredCounterpart_GuardInert(t *testing.T) {
+	buildF6SharedBindingWatcher(t, []string{"foo"}) // DECLARED keyExtras:[foo]
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "panels", "demo", "panel-1"
+		perPage, page     = -1, -1
+	)
+	ctxA := f6CtxUser("userA")
+	ctxB := f6CtxUser("userB")
+	cr := map[string]any{"spec": map[string]any{"keyExtras": []any{"foo"}}}
+
+	// Declared foo folds into the key → A and B on DIFFERENT foo values partition.
+	keyExtrasA := effectiveKeyExtras(ctxA, cr, map[string]any{"foo": "evil"})
+	keyA, hA, iA := dispatchCacheLookupKey(ctxA, "widgets", g, v, r, ns, name, perPage, page, keyExtrasA)
+	keyExtrasB := effectiveKeyExtras(ctxB, cr, map[string]any{"foo": "clean"})
+	keyB, hB, _ := dispatchCacheLookupKey(ctxB, "widgets", g, v, r, ns, name, perPage, page, keyExtrasB)
+	if hA == nil || hB == nil || keyA == "" || keyB == "" {
+		t.Fatal("F6-6 declared: expected live handles + keys")
+	}
+	if keyExtrasA["foo"] != "evil" || keyExtrasB["foo"] != "clean" {
+		t.Fatalf("F6-6 declared: a declared[foo] widget must fold foo into the key; A=%#v B=%#v", keyExtrasA, keyExtrasB)
+	}
+	if keyA == keyB {
+		t.Fatalf("F6-6 declared: a declared[foo] widget MUST partition by foo — keyA == keyB %q (no collision → no shared-cell leak)", keyA)
+	}
+	// Guard INERT: foo is declared → the request is fully-declared → Put allowed.
+	if !requestExtrasFullyDeclared(cr, map[string]any{"foo": "evil"}) {
+		t.Fatal("F6-6 declared: a request whose only extra (foo) IS declared must be fully-declared → the guard must NOT decline (it is inert for the correct corpus)")
+	}
+	// A's Put lands in A's own (distinct) cell; B never sees it.
+	aBody := []byte(`{"foo":"evil"}`)
+	hA.Put(keyA, &cache.ResolvedEntry{RawJSON: aBody, Inputs: iA})
+	if _, hit := hB.Get(keyB); hit {
+		t.Fatal("F6-6 declared: B's distinct-key cell must be a MISS after A's Put (partitioned, not shared)")
+	}
+}

--- a/internal/handlers/dispatchers/farch_identity_contract_test.go
+++ b/internal/handlers/dispatchers/farch_identity_contract_test.go
@@ -181,11 +181,20 @@ func TestFARCH2_DeclaredWidget_CrossUserKeysDiffer(t *testing.T) {
 func TestFARCH3_Boundary_And_SpoofQuarantine(t *testing.T) {
 	ctx := ctxAsIdentity("alice", "devs")
 
-	// (a) undeclared + client identity extras → folded (passive compat).
+	// (a) F6 RECONCILIATION (arch-ruled 2026-07-13): an UNDECLARED widget DROPS
+	// client-supplied request extras from the KEY. PRE-F6 this folded them verbatim
+	// ("passive compat"); F6 reversed it — undeclared request extras (identity or
+	// route params) do NOT partition the key (they still reach the resolve input).
+	// This is a STRONGER spoof posture: a client-supplied extras.username on an
+	// undeclared widget cannot even fold into the key. The DECLARED injection-wins
+	// path (c)/(c2) below is UNCHANGED — F6 only affects UNdeclared request extras.
 	undeclared := map[string]any{"spec": map[string]any{}}
 	_, aExtras := keyFor(t, ctx, undeclared, map[string]any{"username": "client-supplied"})
-	if aExtras["username"] != "client-supplied" {
-		t.Fatalf("F-ARCH-3(a): an UNDECLARED widget must fold client-supplied extras verbatim (passive compat); got %#v", aExtras)
+	if _, present := aExtras["username"]; present {
+		t.Fatalf("F-ARCH-3(a) F6: an UNDECLARED widget must DROP client-supplied request extras from the key; got %#v — the client 'username' must NOT partition the key (F6 fold-nothing)", aExtras)
+	}
+	if len(aExtras) != 0 {
+		t.Fatalf("F-ARCH-3(a) F6: an undeclared widget with only client request extras must fold EMPTY key extras; got %#v", aExtras)
 	}
 
 	// (b) undeclared + no request extras → empty effective extras (== seed key).

--- a/internal/handlers/dispatchers/farch_seed_parity_test.go
+++ b/internal/handlers/dispatchers/farch_seed_parity_test.go
@@ -103,47 +103,65 @@ func TestFARCH1_SeedParity_NonDeclaredWidget_PortalShapedHIT(t *testing.T) {
 	}
 }
 
-// TestFARCH1_RED_OldFrontendRequest_Misses — the F-ARCH-1 RED arm. Re-adding the
-// unconditional identity extras to the SERVE request (the old-frontend / shipped
-// 1.6.5 wire shape) makes the serve key fold {username,groups} while the seed key
-// (identity-free) folds nothing → the keys DIVERGE → the seeded cell is MISSED. This
-// documents exactly what the pre-contract wire shape did (the #107 0/N divergence):
-// this arm is GREEN (asserts the MISS) precisely because the defect shape must miss.
-func TestFARCH1_RED_OldFrontendRequest_Misses(t *testing.T) {
+// TestFARCH1_F6_OldFrontendRequest_NowHits — F6 RECONCILIATION of the former
+// F-ARCH-1 RED arm (arch-ruled 2026-07-13). PRE-F6 this arm asserted the OPPOSITE:
+// the old-frontend / 1.6.5 wire shape folded unconditional identity extras
+// ({username,groups}) VERBATIM into an undeclared widget's key (the "passive
+// compat" property), so the serve key DIVERGED from the extras-less seed key and
+// MISSED — the #107 0/N seed-miss divergence.
+//
+// F6 STRUCTURALLY ELIMINATES that miss class for undeclared widgets: request
+// extras (identity or route params) that the widget does NOT declare in
+// spec.keyExtras fold NOTHING into the key. So the old-frontend request now folds
+// EMPTY key extras (same as the seed) → the serve key EQUALS the seed key → the
+// seeded cell is now HIT, not missed. This is a STRICT IMPROVEMENT: the very
+// divergence #107 documented cannot recur for the identity-free corpus — F6
+// closes it by construction. (Identity that a widget genuinely depends on is
+// folded via the A2 spec.identityContext declaration + DeclaredIdentity injection,
+// still exercised by TestFARCH2 / TestFARCH3(c). F6 only drops UNDECLARED request
+// extras.) The arm stays permanent, flipped GREEN-on-HIT, as the pin that F6
+// keeps the #107 class closed.
+func TestFARCH1_F6_OldFrontendRequest_NowHits(t *testing.T) {
 	enableWidgetContentL1(t)
 	ctx := ctxWithIdentity()
 	const (
 		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "buttons", "demo-system", "btn-107-red"
 		perPage, page     = 10, 1
 	)
-	cr := map[string]any{"spec": map[string]any{}} // non-declared
+	cr := map[string]any{"spec": map[string]any{}} // non-declared — F6 folds nothing
 
 	seedExtras := effectiveKeyExtras(ctx, cr, nil)
 	seedKey, seedHandle, seedInputs := dispatchCacheLookupKey(ctx, "widgets",
 		g, v, r, ns, name, perPage, page, seedExtras)
 	if seedHandle == nil || seedKey == "" {
-		t.Fatal("F-ARCH-1 RED: expected a live seed handle + key")
+		t.Fatal("F-ARCH-1 F6: expected a live seed handle + key")
 	}
-	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: []byte(`{"x":1}`), Inputs: seedInputs})
+	body := []byte(`{"x":1}`)
+	seedHandle.Put(seedKey, &cache.ResolvedEntry{RawJSON: body, Inputs: seedInputs})
 
-	// OLD-FRONTEND serve request: unconditional identity extras on the wire.
+	// OLD-FRONTEND serve request: unconditional identity extras on the wire. Under
+	// F6 the undeclared widget DROPS them from the key.
 	serveExtras := effectiveKeyExtras(ctx, cr, oldFrontendRequest())
 	serveKey, serveHandle, _ := dispatchCacheLookupKey(ctx, "widgets",
 		g, v, r, ns, name, perPage, page, serveExtras)
 	if serveHandle == nil || serveKey == "" {
-		t.Fatal("F-ARCH-1 RED: expected a live serve handle + key")
+		t.Fatal("F-ARCH-1 F6: expected a live serve handle + key")
 	}
 
-	// The old-frontend request folds identity extras (a non-declared widget passes
-	// them through, passive compat) → the serve key MUST diverge from the seed key.
-	if serveExtras["username"] != "cyberjoker" {
-		t.Fatalf("F-ARCH-1 RED setup: the old-frontend request must fold identity extras (passive compat); got %#v", serveExtras)
+	// F6: the old-frontend identity extras are UNDECLARED → dropped from the key →
+	// the effective key extras are EMPTY on both sides.
+	if len(serveExtras) != 0 {
+		t.Fatalf("F-ARCH-1 F6: an undeclared widget must DROP the old-frontend identity extras from the key; got %#v — F6 must not fold undeclared request extras", serveExtras)
 	}
-	if seedKey == serveKey {
-		t.Fatalf("F-ARCH-1 RED: seed key == old-frontend serve key %q — the arm is not discriminating; the old wire shape MUST miss the identity-free seed cell (the #107 divergence)", serveKey)
+	if seedKey != serveKey {
+		t.Fatalf("F-ARCH-1 F6: seed key %q != old-frontend serve key %q — F6 must collapse the undeclared-request divergence so the #107 seed-miss cannot recur", seedKey, serveKey)
 	}
-	if _, hit := serveHandle.Get(serveKey); hit {
-		t.Fatal("F-ARCH-1 RED: old-frontend serve unexpectedly HIT the seed cell — the #107 seed-miss should reproduce here")
+	got, hit := serveHandle.Get(serveKey)
+	if !hit {
+		t.Fatal("F-ARCH-1 F6: old-frontend serve MISSED the seed cell — F6 should make it HIT (the #107 class is eliminated for undeclared widgets)")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("F-ARCH-1 F6: served the wrong body; got %q want %q", got.RawJSON, body)
 	}
 }
 

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -337,6 +337,85 @@ func unionForKey(apiRefInline, rrtInline, request map[string]any) map[string]any
 	return out
 }
 
+// filterDeclaredKeyExtras is the F6 request-extras allowlist
+// (docs/f6-chrome-route-key-design-2026-07-12.md §4 Option A-declare). It returns
+// the subset of the per-request extras whose keys the widget author DECLARED in
+// spec.keyExtras (widgets.GetKeyExtras) — the only request extras allowed to
+// PARTITION the cache key. An undeclared / empty spec.keyExtras yields the empty
+// map ⇒ NO request extra folds into the key (the chrome-widget fold-nothing
+// default: route params {namespace,name} no longer partition the cell, so one
+// seeded cell serves every route — closing the #130 F6 first-nav miss).
+//
+// This is the KEY-SIDE analogue of the A2 identity contract: DeclaredIdentity
+// picks which principal keys fold; this picks which request-extras keys fold. It
+// runs INSIDE the single shared effectiveKeyExtras (the only site request extras
+// meet the key), so the filter cannot drift across the four key consumers.
+//
+// It touches ONLY key derivation — the caller still hands the RAW, unfiltered
+// request extras to widgets.Resolve's jq dict (widgets.go), so a widget that reads
+// extras.namespace in its jq WITHOUT declaring it still RESOLVES correctly; it
+// merely stops partitioning the cache (the design's deliberate SPURIOUS-over-keying
+// removal, with the RED-arm audit proving a widget that genuinely varies on a
+// param MUST declare it or serve a wrong shared body).
+//
+// The result is a fresh map (never aliases requestExtras); nil/empty request or
+// nil/empty declaration ⇒ a fresh empty map ⇒ unionForKey's fold degenerates to
+// the inline maps only ⇒ ComputeKey's len>0 guard skips the extras fold on an
+// all-empty result (backward-compat). Mechanism-uniform (feedback_no_special_cases):
+// no widget-name / route / GVR table — every widget folds exactly what it declares.
+func filterDeclaredKeyExtras(cr map[string]any, requestExtras map[string]any) map[string]any {
+	declared := widgets.GetKeyExtras(cr)
+	if len(declared) == 0 || len(requestExtras) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(declared))
+	for _, k := range declared {
+		if v, ok := requestExtras[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// requestExtrasFullyDeclared is the F6 self-quarantine predicate (arch-ruled
+// 2026-07-13, docs/f6-chrome-route-key-design-2026-07-12.md §4). It reports
+// whether EVERY per-request extra key the client supplied is DECLARED in the
+// widget's spec.keyExtras — i.e. filterDeclaredKeyExtras dropped NOTHING.
+//
+// WHY IT EXISTS (the leak F6 would otherwise open). Dropping undeclared request
+// extras from the KEY removes the pre-F6 self-quarantine: two users A,B in the
+// SAME BindingUID cohort, an UNDECLARED widget whose OWN widgetDataTemplate reads
+// extras.foo. A sends ?extras={"foo":"evil"}; F6 drops foo → A's effective key
+// extras == {} == B's → IDENTICAL per-cohort ComputeKey. But A's RAW extras still
+// reach widgets.Resolve, so A's rendered body embeds foo=evil. Pre-F6 the foo
+// fold partitioned A's cell away from B's; post-F6 A's evil body would be Put into
+// the SHARED cohort cell (widgets.go genuine-Put) and B would hit it. The guard
+// makes the polluting request DECLINE that Put: A still gets its correct
+// per-request 200, but never writes the shared cell, so B misses and resolves
+// clean. Clean requests (no undeclared extras) and the declared corpus pay
+// nothing — only a request carrying extras the widget did NOT declare is quarantined.
+//
+// Returns TRUE (fully declared → safe to Put) when the request carries no extras,
+// or when every supplied key survives the filter. Returns FALSE (decline the Put)
+// when at least one supplied key was dropped. Reuses widgets.GetKeyExtras — no new
+// mechanism, no widget-name/route table (feedback_no_special_cases).
+func requestExtrasFullyDeclared(cr map[string]any, requestExtras map[string]any) bool {
+	if len(requestExtras) == 0 {
+		return true // nothing supplied → nothing to quarantine
+	}
+	declared := widgets.GetKeyExtras(cr)
+	declaredSet := make(map[string]struct{}, len(declared))
+	for _, k := range declared {
+		declaredSet[k] = struct{}{}
+	}
+	for k := range requestExtras {
+		if _, ok := declaredSet[k]; !ok {
+			return false // an undeclared request extra would collapse into the shared cell
+		}
+	}
+	return true
+}
+
 // effectiveKeyExtras is the SINGLE shared derivation of the "effective key
 // extras" the definitive cache-identity architecture (§2.2,
 // docs/definitive-cache-identity-architecture-2026-07-07.md) mandates for ALL
@@ -369,7 +448,20 @@ func effectiveKeyExtras(ctx context.Context, cr map[string]any, requestExtras ma
 	base := unionForKey(
 		widgets.GetApiRefExtras(cr),
 		widgets.GetResourcesRefsExtras(cr),
-		requestExtras,
+		// F6 (docs/f6-chrome-route-key-design-2026-07-12.md §4 Option A-declare):
+		// filter the per-REQUEST extras to ONLY the keys the widget author declared
+		// in spec.keyExtras BEFORE the union folds them into the key. Absent/empty
+		// declaration ⇒ fold NOTHING (the chrome-widget default — route params like
+		// {namespace,name} stop partitioning the cell, so one seeded cell serves all
+		// routes). The inline maps above (apiRef.extras + resourcesRefsTemplateExtras)
+		// are CR-FIXED, not request extras — they are NOT filtered (they cannot vary
+		// request-to-request, and dropping them would change the resolved body's key).
+		// KEY-ONLY: undeclared request extras still reach widgets.Resolve's jq dict
+		// unchanged (widgets.go passes the RAW extras to the resolver; only this KEY
+		// derivation filters). Single-site by construction — the same filtered union
+		// feeds all four key consumers (dispatch, widgetContent, subscription, seed),
+		// so parity holds (the A1 anti-drift guarantee).
+		filterDeclaredKeyExtras(cr, requestExtras),
 	)
 	// A2 identity injection (§2.2): server-declared identity wins on collision.
 	// declaredIdentityForKey → widgets.DeclaredIdentity reads the parent CR's OWN

--- a/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_key_parity_test.go
@@ -13,19 +13,19 @@
 // BindingUID fold) AND the widget CR (so objects.Get serves it from the
 // informer — the C64-6 informer-served read). NO remote go-test, NO apiserver.
 //
-//   ARM 1 (C64-4 DISCRIMINATOR): widget CR has inline spec.apiRef.extras=
-//          {region:eu}; coords.Extras={name:demo-vpc} — DISJOINT (coords does
-//          NOT pre-contain the inline; that disjointness is what the old golden
-//          lacked). DeriveSubscriptionKey(coords) MUST == the emit key folding
-//          unionForKey(inline,{name}) = {region,name}. RED on the old code
-//          (folds {name} only), GREEN on the fix.
-//   ARM 2 (C64-5 backward-compat): empty inline → DeriveSubscriptionKey == the
-//          request-only emit key (no regression for inline-free widgets).
-//   ARM 3: widgetContent class, same disjoint inline shape — RED/GREEN.
-//   ARM 4: restactions class — request-only on BOTH sides (branch UNCHANGED).
-//   ARM 5 (C64-1 fail-closed): the widget CR is NOT gettable (absent) →
-//          DeriveSubscriptionKey returns ("", false) — the coord is SKIPPED,
-//          NOT armed with a request-only key.
+//	ARM 1 (C64-4 DISCRIMINATOR): widget CR has inline spec.apiRef.extras=
+//	       {region:eu}; coords.Extras={name:demo-vpc} — DISJOINT (coords does
+//	       NOT pre-contain the inline; that disjointness is what the old golden
+//	       lacked). DeriveSubscriptionKey(coords) MUST == the emit key folding
+//	       unionForKey(inline,{name}) = {region,name}. RED on the old code
+//	       (folds {name} only), GREEN on the fix.
+//	ARM 2 (C64-5 backward-compat): empty inline → DeriveSubscriptionKey == the
+//	       request-only emit key (no regression for inline-free widgets).
+//	ARM 3: widgetContent class, same disjoint inline shape — RED/GREEN.
+//	ARM 4: restactions class — request-only on BOTH sides (branch UNCHANGED).
+//	ARM 5 (C64-1 fail-closed): the widget CR is NOT gettable (absent) →
+//	       DeriveSubscriptionKey returns ("", false) — the coord is SKIPPED,
+//	       NOT armed with a request-only key.
 package dispatchers
 
 import (
@@ -38,7 +38,6 @@ import (
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/objects"
-	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -163,7 +162,14 @@ func TestFalsifier64_ARM1_WidgetsInlineExtrasUnion(t *testing.T) {
 		t.Fatalf("DeriveSubscriptionKey failed (ok=%v key=%q) — RBAC/objects.Get setup wrong?", ok, subKey)
 	}
 
-	// The emit key: the resolver folds unionForKey(GetApiRefExtras, GetResourcesRefsExtras, request).
+	// The emit key: driven through the REAL prod fold effectiveKeyExtras (NOT a
+	// hand-built unionForKey). F6 (docs/f6-chrome-route-key-design-2026-07-12.md,
+	// arch-ruled 2026-07-13): the prod emit path (widgets.go:152) AND the
+	// subscription path (subscriptionKeyExtras) BOTH call effectiveKeyExtras, so
+	// building the golden's emit key any other way is a SHADOW that can drift (the
+	// #66 lesson). The inline {region:eu} (apiRef.extras) is CR-fixed → F6 does NOT
+	// filter it; the request {name:demo-vpc} is UNDECLARED → F6 drops it from the
+	// key on BOTH sides identically. So the sub key still == the emit key.
 	got := objects.Get(ctx, templatesv1.ObjectReference{
 		Reference:  templatesv1.Reference{Name: "panel-1", Namespace: "demo"},
 		APIVersion: "widgets.templates.krateo.io/v1beta1",
@@ -172,11 +178,7 @@ func TestFalsifier64_ARM1_WidgetsInlineExtrasUnion(t *testing.T) {
 	if got.Err != nil || got.Unstructured == nil {
 		t.Fatalf("objects.Get(panel-1) failed in setup: err=%v", got.Err)
 	}
-	emitExtras := unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		map[string]any{"name": "demo-vpc"},
-	)
+	emitExtras := effectiveKeyExtras(ctx, got.Unstructured.Object, map[string]any{"name": "demo-vpc"})
 	emitKey, handle, _ := dispatchCacheLookupKey(ctx, classWidgets,
 		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
 		coords.PerPage, coords.Page, emitExtras)
@@ -184,13 +186,18 @@ func TestFalsifier64_ARM1_WidgetsInlineExtrasUnion(t *testing.T) {
 		t.Fatalf("emit key derivation failed")
 	}
 
-	// Sanity: the union actually changed the key vs request-only (else the test
-	// can't discriminate — the inline must be load-bearing).
-	reqOnlyKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+	// Sanity: the inline {region:eu} actually changed the emit key vs a widget with
+	// NO inline (else the test can't discriminate — the inline must be load-bearing).
+	// (Comparing against request-only would be a no-op under F6: the undeclared
+	// {name} request extra drops from the key, so request-only == no-extras. The
+	// discriminant is the CR-fixed INLINE map, which F6 preserves.)
+	noInline := map[string]any{"spec": map[string]any{}}
+	bareExtras := effectiveKeyExtras(ctx, noInline, map[string]any{"name": "demo-vpc"})
+	bareKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
 		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
-		coords.PerPage, coords.Page, map[string]any{"name": "demo-vpc"})
-	if emitKey == reqOnlyKey {
-		t.Fatalf("ARM1 setup: inline {region:eu} did not change the emit key — not discriminating")
+		coords.PerPage, coords.Page, bareExtras)
+	if emitKey == bareKey {
+		t.Fatalf("ARM1 setup: inline {region:eu} did not change the emit key vs a no-inline widget — not discriminating")
 	}
 
 	if subKey != emitKey {
@@ -212,12 +219,25 @@ func TestFalsifier64_ARM2_WidgetsNoInlineBackwardCompat(t *testing.T) {
 	if !ok {
 		t.Fatalf("DeriveSubscriptionKey failed for inline-free widget")
 	}
-	reqOnlyKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
+	// F6 (arch-ruled 2026-07-13): the emit-side comparison must go through the REAL
+	// effectiveKeyExtras (not a raw {name} fold) — for an inline-free UNDECLARED
+	// widget the request {name} drops from the key on BOTH sides, so the sub key
+	// equals the emit key with an EMPTY effective fold. (Hand-building {name} would
+	// be a pre-F6 shadow that no longer matches the filtered prod path.)
+	got := objects.Get(ctx, templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: "panel-1", Namespace: "demo"},
+		APIVersion: "widgets.templates.krateo.io/v1beta1", Resource: "panels",
+	})
+	if got.Err != nil || got.Unstructured == nil {
+		t.Fatalf("objects.Get(panel-1) failed in setup: err=%v", got.Err)
+	}
+	emitExtras := effectiveKeyExtras(ctx, got.Unstructured.Object, map[string]any{"name": "demo-vpc"})
+	emitKey, _, _ := dispatchCacheLookupKey(ctx, classWidgets,
 		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
-		coords.PerPage, coords.Page, map[string]any{"name": "demo-vpc"})
-	if subKey != reqOnlyKey {
-		t.Fatalf("ARM2 C64-5: inline-free widget subscription key %q != request-only key %q — backward-compat regression",
-			subKey, reqOnlyKey)
+		coords.PerPage, coords.Page, emitExtras)
+	if subKey != emitKey {
+		t.Fatalf("ARM2 C64-5: inline-free widget subscription key %q != emit key %q — backward-compat/parity regression",
+			subKey, emitKey)
 	}
 }
 
@@ -237,15 +257,15 @@ func TestFalsifier64_ARM3_WidgetContentInlineExtrasUnion(t *testing.T) {
 		Reference:  templatesv1.Reference{Name: "panel-1", Namespace: "demo"},
 		APIVersion: "widgets.templates.krateo.io/v1beta1", Resource: "panels",
 	})
-	emitExtras := unionForKey(
-		widgets.GetApiRefExtras(got.Unstructured.Object),
-		widgets.GetResourcesRefsExtras(got.Unstructured.Object),
-		map[string]any{"name": "demo-vpc"})
+	// F6 (arch-ruled 2026-07-13): emit key via the REAL effectiveKeyExtras (not a
+	// hand-built unionForKey shadow). Inline {region:eu} folds (CR-fixed); the
+	// undeclared {name} request extra drops on both sides → sub key == emit key.
+	emitExtras := effectiveKeyExtras(ctx, got.Unstructured.Object, map[string]any{"name": "demo-vpc"})
 	emitKey, _, _ := dispatchWidgetContentKey(ctx,
 		coords.Group, coords.Version, coords.Resource, coords.Namespace, coords.Name,
 		coords.PerPage, coords.Page, emitExtras)
 	if subKey != emitKey {
-		t.Fatalf("ARM3 RED: widgetContent subscription key %q != emit key %q (inline-extras union missing)", subKey, emitKey)
+		t.Fatalf("ARM3: widgetContent subscription key %q != emit key %q (inline-extras union parity broken)", subKey, emitKey)
 	}
 }
 

--- a/internal/handlers/dispatchers/widget_content_metrics.go
+++ b/internal/handlers/dispatchers/widget_content_metrics.go
@@ -53,6 +53,24 @@ func bumpWidgetContentSkippedRBACSensitive() {
 	widgetContentSkippedRBACSensitiveTotal.Add(1)
 }
 
+// widgetSkippedUndeclaredExtrasPutTotal is the process-wide count of per-cohort
+// `widgets` Puts the F6 self-quarantine guard declined (arch-ruled 2026-07-13).
+// A request carrying request-extras the widget did NOT declare in spec.keyExtras
+// would, post-F6, key onto the SAME shared cohort cell as a clean request (the
+// undeclared extras drop from the key) — so its extras-influenced body must NOT
+// write the cohort cell (it would be served to a co-cohort user who did not send
+// those extras). The request still gets its own correct per-request 200; it just
+// declines the Put. A non-zero value = at least one polluting request was
+// quarantined; the declared corpus + chrome widgets never trip it.
+var widgetSkippedUndeclaredExtrasPutTotal atomic.Uint64
+
+// bumpWidgetSkippedUndeclaredExtrasPut increments the F6 quarantine counter.
+// Called by the widgets dispatcher when requestExtrasFullyDeclared is false at
+// the genuine per-cohort Put gate.
+func bumpWidgetSkippedUndeclaredExtrasPut() {
+	widgetSkippedUndeclaredExtrasPutTotal.Add(1)
+}
+
 // widgetContentMetricsOnce guards expvar.Publish against the double-
 // publish panic (mirrors phase1WalkMetricsOnce).
 var widgetContentMetricsOnce sync.Once
@@ -76,6 +94,9 @@ func registerWidgetContentMetrics() {
 		}))
 		expvar.Publish("snowplow_widget_content_skipped_rbac_sensitive_total", expvar.Func(func() any {
 			return widgetContentSkippedRBACSensitiveTotal.Load()
+		}))
+		expvar.Publish("snowplow_widget_skipped_undeclared_extras_put_total", expvar.Func(func() any {
+			return widgetSkippedUndeclaredExtrasPutTotal.Load()
 		}))
 	})
 }

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -386,6 +386,25 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 			slog.Int64("external_touches", extTouchedSink.Count()),
 			slog.String("effect", "body served (200); not persisted — external API re-fetched live on every /call"),
 		)
+	} else if !requestExtrasFullyDeclared(got.Unstructured.Object, extras) {
+		// F6 SELF-QUARANTINE (arch-ruled 2026-07-13, docs/f6-chrome-route-key-
+		// design-2026-07-12.md §4). This request carries request-extras the widget
+		// did NOT declare in spec.keyExtras. Post-F6 those undeclared extras DROP
+		// from the per-cohort key, so this request's key == a co-cohort clean
+		// request's key — but this request's RAW extras reached widgets.Resolve, so
+		// the rendered body is extras-influenced. Writing it into the shared cohort
+		// cell would serve THIS request's extras-shaped body to a co-cohort user who
+		// sent none (the leak F6 would otherwise open, since dropping the extras from
+		// the key removed the pre-F6 self-quarantine). SYMMETRIC with the
+		// extTouchedSink decline above: serve THIS request's correct body (already
+		// written below the if-chain), bump the counter, decline the Put + dep-Record
+		// + publishIfSubscribed. The declared corpus + chrome widgets never reach here
+		// (their supplied extras are all declared, or they send none). Placed BEFORE
+		// the genuine-Put branch so a polluting request cannot fall into it.
+		bumpWidgetSkippedUndeclaredExtrasPut()
+		log.Warn("Widget request carried extras not declared in spec.keyExtras; declining to cache (would pollute the shared per-cohort cell post-F6)",
+			slog.String("effect", "body served (200) under this request's own extras; not persisted — a co-cohort request without these extras must not be served this extras-shaped body"),
+		)
 	} else if cacheHandle != nil && cacheKey != "" && serveFromCacheEligible(cacheInputs) {
 		// #95 SECURITY (A4 populate side, customer path) — the single-mechanism
 		// closure. A re-derived BindingUID of "" collapses to the shared

--- a/internal/resolvers/widgets/widgets.go
+++ b/internal/resolvers/widgets/widgets.go
@@ -33,6 +33,19 @@ const (
 	// default; per-binding-shareable + seedable). Read off the unstructured spec
 	// (same absence-tolerant pattern as the extras accessors).
 	identityContextKey = "identityContext"
+
+	// keyExtrasKey — the F6 author-declared request-extras-dependence field
+	// (docs/f6-chrome-route-key-design-2026-07-12.md §4 Option A-declare):
+	// spec.keyExtras is an OPTIONAL []string enumerating which REQUEST-extras
+	// keys (the ?extras= JSON the frontend folds route params / query into) this
+	// widget's rendered output depends on. Only the declared keys PARTITION the
+	// cache key; undeclared request extras still reach the RESOLVE input (the jq
+	// dict) but do NOT vary the key. Absent/empty = fold NOTHING from request
+	// extras (the identity-free chrome-widget default: one seeded cell serves all
+	// routes). This is the exact identityContext shape one dimension over —
+	// author declaration of key-dependence — so it is read the same absence-
+	// tolerant way and filters at the SINGLE shared effectiveKeyExtras site.
+	keyExtrasKey = "keyExtras"
 )
 
 // identityContextEnumUsername / identityContextEnumGroups are the ONLY enum
@@ -71,6 +84,44 @@ func GetIdentityContext(obj map[string]any) []string {
 		}
 		// D1 enum filter IN CODE: honor only username/groups.
 		if s != identityContextEnumUsername && s != identityContextEnumGroups {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// GetKeyExtras reads spec.keyExtras off the unstructured widget CR and returns
+// the DECLARED request-extras key names — the F6 declaration accessor
+// (docs/f6-chrome-route-key-design-2026-07-12.md §4 Option A-declare). It is the
+// request-extras twin of GetIdentityContext, one dimension over: instead of
+// enumerating which authenticated-principal keys the output depends on, it
+// enumerates which REQUEST-extras keys (route params / query the frontend folds
+// into ?extras=) the widget's resolution depends on. Only these keys are allowed
+// to PARTITION the cache key (filterDeclaredKeyExtras applies the allowlist);
+// undeclared request extras are still passed to the RESOLVE input untouched.
+//
+// UNLIKE GetIdentityContext there is NO enum filter: request-extras key names are
+// author-defined and open-ended (namespace, name, and any custom route/query
+// param), so the accessor honors every declared string. Absence-tolerant: absent
+// / wrong-type / empty ⇒ nil (the fold-nothing chrome-widget default,
+// byte-identical to pre-F6 for the identity-free corpus). Order is preserved and
+// duplicates collapsed for determinism. Reads via maps.NestedSlice (deep copy →
+// no CR aliasing), mirroring GetIdentityContext / GetResourcesRefsExtras.
+func GetKeyExtras(obj map[string]any) []string {
+	raw, ok, err := maps.NestedSlice(obj, "spec", keyExtrasKey)
+	if !ok || err != nil {
+		return nil
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, v := range raw {
+		s, isStr := v.(string)
+		if !isStr {
 			continue
 		}
 		if _, dup := seen[s]; dup {


### PR DESCRIPTION
## F6 — `spec.keyExtras` author-declared request-extras cache-key allowlist (#130)

Closes the #130 chrome-widget first-nav cache gap. The frontend folds the current route's params (`namespace`, `name`) and URL query into the `?extras=` of **every** widget `/call`, and those params partition the per-cohort `widgets` cache key. Chrome/layout widgets render byte-identical content on every route, so that partitioning is **spurious over-keying** — the seed (extras-less) cell is never browser-reachable and the first non-dashboard nav cold-misses.

F6 is the A2 `spec.identityContext` contract **one dimension over**: a widget author declares `spec.keyExtras` — the request-extras keys whose values its resolution actually depends on. Only declared keys fold into the KEY. Absent/empty declaration = fold **nothing** from request extras (the chrome default → one seeded cell serves all routes). Undeclared request extras still reach the RESOLVE input (the jq dict) unchanged — only the KEY filters.

### Mechanism

- **`GetKeyExtras(obj)`** accessor (`internal/resolvers/widgets/widgets.go`) — the `GetIdentityContext` twin; no enum filter (request-extras key names are author-open: `namespace`, `name`, `q`, `range`, `project`, …).
- **`filterDeclaredKeyExtras(cr, request)`** inside the **single shared** `effectiveKeyExtras` (`internal/handlers/dispatchers/helpers.go`) — the only site request extras meet the key, so all four consumers (dispatch, widgetContent, subscription, seed) filter identically (A1 anti-drift by construction). Identity injection (`declaredIdentityForKey` / `inlineParentIdentityForKey`) is untouched and runs after, independent.

### Self-quarantine guard (the confirmed cross-user trace)

Dropping undeclared request extras from the key **removes the pre-F6 self-quarantine**. Trace (arch-confirmed): two users A, B in the **same BindingUID cohort**; an **undeclared** no-apiRef widget whose own `widgetDataTemplate` reads `extras.foo`. A sends `?extras={"foo":"evil"}` → F6 drops `foo` → A's effective key extras `== {} ==` B's → **identical per-cohort ComputeKey**. But A's RAW extras still reach `widgets.Resolve`, so A's rendered body embeds `foo=evil`. Without a guard, A's evil body would Put into the shared cohort cell and B would hit it.

**Fix (option (a), Put-decline):** `requestExtrasFullyDeclared(cr, request)` predicate + a decline branch at the genuine per-cohort `widgets` Put gate (`widgets.go`, symmetric with the existing `extTouchedSink` external-decline). When a request carries any extra the widget did NOT declare: serve its own correct 200, bump `snowplow_widget_skipped_undeclared_extras_put_total`, and **decline** the shared-cell Put + dep-Record + `publishIfSubscribed`. Clean requests and the declared corpus pay nothing; only the polluting request is quarantined. The `widgetContent` cell needs **no** guard (walk-only writers, provably extras-less at Put). Option (b) (route undeclared-extras widgets per-user) was **rejected** — it defeats cohort-sharing and re-opens the #130 cold-first-nav for exactly the misconfigured-common class.

### Falsifier matrix (all 3× `-race`, `=== RUN` verified, all discriminate under neuter)

- **F6-1** ChromeWidget fold-nothing HIT — chrome widget (no keyExtras): seed key (nil) == serve key ({namespace,name}); L1 HIT, correct body.
- **F6-2** RED undeclared-route-consumer — collides two namespaces onto one key AND serves the wrong body; GREEN once it declares `keyExtras:[namespace]`.
- **F6-3** declared widget partitions — two routes → two distinct keys → correct distinct content.
- **F6-5** subscription-parity via the **real** `DeriveSubscriptionKey` (no shadow, #66 lesson).
- **F6-6** self-quarantine (per-cohort, three arms): SelfQuarantine (`cacheKey_A == cacheKey_B` proves the collision + guard declines A's Put → B misses/resolves clean); RED companion (neutered guard → B served evil); DeclaredCounterpart (`keyExtras:[foo]` → distinct keys, guard inert).

Neuter-checks verified: F6 filter pass-through → F6-1/2/3/5 fail; guard predicate always-true → F6-6 fails; one-sided ARM regression (sub bypasses filter, emit filtered) → ARM1/ARM3 fail. All restore green.

### Shipped-invariant reconciliation (F6 reverses "undeclared folds request extras verbatim")

| Invariant | Pre-F6 | Reconciled to |
|---|---|---|
| `TestA1_EffectiveKeyExtras_ByteIdenticalToInlineFold` (request cases) | request folded verbatim | split: inline-only stays byte-identical; request cases → `TestF6_UndeclaredRequestExtras_DropFromKey` (empty fold) |
| `TestFARCH1_RED_OldFrontendRequest_Misses` | old-frontend identity extras → seed MISS | `TestFARCH1_F6_OldFrontendRequest_NowHits` — F6 **eliminates** the #107 request-extras seed-miss for undeclared widgets (extras drop → serve key == seed key → HIT) |
| `TestFARCH3_Boundary(a)` | undeclared folds client extras verbatim | undeclared **drops** client request extras from the key (stronger spoof posture); (b) + declared (c)/(c2) untouched |
| `TestFalsifier64_ARM1/ARM2/ARM3` | emit key hand-built via raw `unionForKey` (a pre-F6 shadow) | emit key rebuilt through the **real** `effectiveKeyExtras` (#66 anti-drift); RED-provable against a one-sided filter regression. ARM4/ARM5 untouched. |

Full `internal/handlers/dispatchers` package: green, zero unexplained reds.

### CUT CONDITIONS (verbatim from PM — this PR PARKS; do NOT merge/tag/cut here)

⚠️ **DO NOT DEPLOY before the portal-side landing (A6-class cross-repo sequencing).** The default (fold-nothing) is a KEY CHANGE for the N=104 route/query-consuming widgets; without their declarations they would share one cell across routes and serve stale/wrong content. Sequence:

1. **Portal CRD schema + the 104 `spec.keyExtras` declarations must land FIRST** (the widget corpus). Audit: `docs/f6-keyextras-audit-2026-07-12.md` — N=104 of 276 widgets consume request-extras (route params `namespace`/`name` + query `q`/`range`/`project`/`status`/`category`/`source`); all 8 chrome widgets confirmed declare nothing.
2. Fresh **cold boot** of snowplow.
3. Real-Chrome **dashboard + compositions first-nav** measurement.
4. Chrome widgets show `extras_len:0` + `l1:*hit` on the `widgets` layer on compositions first-nav.
5. Compositions first-nav hit-rate → **~100%** (was 83.3%).
6. Declared widgets **partition** correctly (distinct route → distinct content).
7. North-star ledger row (mix-weighted 0.95 narrow / 0.05 admin).

Frozen ref: `828ac8e`. Dual gate complete (arch SOUND-WITH-CHANGES → all rework applied; PM FINAL ACCEPT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
