### PR TITLE
feat(cache): F5 backstop-Ready is an explicit failure signal (#131)

### DIFF
--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -429,6 +429,10 @@ func Phase1Warmup(ctx context.Context, rc *rest.Config, authnNS string) error {
 			authnNS:   authnNS,
 		}
 		engineSeed = func(pctx context.Context) error {
+			// F5 (#131): anchor the backstop-elapsed clock. Used only to
+			// attribute the readyz.backstop.fired ERROR when the flip takes the
+			// C2 backstop arm rather than the firstNav-complete happy path.
+			engineSeedStart := time.Now()
 			// bootDone is closed by the engine's scopeDone callback the
 			// instant the BOOT scope finishes — so this goroutine returns at
 			// ACTUAL completion (S2), not after the full pipGlobalTimeout.
@@ -513,10 +517,24 @@ func Phase1Warmup(ctx context.Context, rc *rest.Config, authnNS string) error {
 			//     withheld forever; on backstop the pod goes Ready-degraded.
 			select {
 			case <-firstNav.wait():
+				// Happy path — every cohort's nav widgets seeded. NOT a backstop.
 				return nil
 			case <-bootDone:
+				// The boot scope finished before the latch could fire. If the
+				// latch DID fire (e.g. a tie ordering) this is the happy path;
+				// otherwise the boot ended early (roots_list_failed / re-walk
+				// error) with nav widgets unseeded → F5 backstop alert (#131).
+				if !firstNav.fired() {
+					recordReadinessBackstop("boot_error", time.Since(engineSeedStart), -1)
+				}
 				return bootErr
 			case <-pctx.Done():
+				// PHASE1_TIMEOUT / pipGlobalTimeout backstop. If the latch never
+				// fired, readiness flips Ready-DEGRADED with nav widgets unseeded
+				// — the FAILED-but-serving boot #130/#131 requires be surfaced.
+				if !firstNav.fired() {
+					recordReadinessBackstop("phase1_timeout", time.Since(engineSeedStart), -1)
+				}
 				return pctx.Err()
 			}
 		}
@@ -807,6 +825,10 @@ func phase1WarmupWith(ctx context.Context, rw *cache.ResourceWatcher, lister roo
 	// flips at min(seed-complete, pipGlobalTimeout).
 	if pipSeed != nil {
 		func() {
+			// F5 (#131): anchor the panic-path backstop clock BEFORE the defers,
+			// so the recover block can attribute elapsed (seedStart below is not
+			// yet in scope at defer-declaration time).
+			panicStart := time.Now()
 			// C2: guaranteed flip — runs on normal return, error, timeout, AND
 			// after a panic-recover. Innermost so it is the LAST deferred to run.
 			defer cache.MarkPhase1Done()
@@ -818,6 +840,12 @@ func phase1WarmupWith(ctx context.Context, rw *cache.ResourceWatcher, lister roo
 						slog.String("effect", "per-cohort SYNC seed aborted; readiness flips to "+
 							"Ready-DEGRADED (backstop) — first /call per cohort falls back to per-user resolve"),
 					)
+					// F5 (#131): a panicking seed is the WORST failure mode —
+					// readiness flips Ready-DEGRADED via the MarkPhase1Done defer
+					// with the seed aborted mid-flight. Count + alert it like the
+					// other backstop paths, never silent. elapsed is best-effort
+					// from panicStart (anchored before the defers below).
+					recordReadinessBackstop("seed_panic", time.Since(panicStart), -1)
 				}
 			}()
 			// Bound the SYNC seed by pipGlobalTimeout (its own existing budget,
@@ -836,6 +864,11 @@ func phase1WarmupWith(ctx context.Context, rw *cache.ResourceWatcher, lister roo
 						"cohort falls back to per-user resolve"),
 					slog.Int64("elapsed_ms", time.Since(seedStart).Milliseconds()),
 				)
+				// F5 (#131): a seed error means readiness flips Ready-DEGRADED via
+				// the C2 backstop with an incomplete seed — a FAILED-but-serving
+				// boot per #130. Surface it loud (ERROR + expvar) on top of the
+				// existing WARN, which stays as the human-readable per-cohort note.
+				recordReadinessBackstop("seed_incomplete", time.Since(seedStart), -1)
 			}
 		}()
 	} else {
@@ -979,6 +1012,7 @@ const phase1MaxWalkDepth = 32
 //     (objects.Get, resourcesrefs.Resolve) use it verbatim via
 //     cache.ClientConfigFor instead of rebuilding a client from saEP
 //     through kubeconfig.NewClientConfig.
+//
 // withPhase1SAContext builds the SA-credentialed context Phase 1
 // resolution runs under. It is the SINGLE place the SA identity +
 // internal-dispatch markers are installed, shared by the navigation-root

--- a/internal/handlers/dispatchers/prewarm_first_nav_latch.go
+++ b/internal/handlers/dispatchers/prewarm_first_nav_latch.go
@@ -108,6 +108,21 @@ func (l *firstNavLatch) wait() <-chan struct{} {
 	return l.done
 }
 
+// fired reports whether the latch has already fired (its done channel is
+// closed). F5 (#131) reads this on engineSeed's backstop arms to distinguish a
+// backstop-Ready flip (latch NOT fired → nav widgets unseeded → alert) from a
+// benign tie where the latch fired just as bootDone closed. Race-safe: a
+// non-blocking receive on a closed channel returns immediately; close happens-
+// before every fired() call that observes it (the sync.Once in fire()).
+func (l *firstNavLatch) fired() bool {
+	select {
+	case <-l.done:
+		return true
+	default:
+		return false
+	}
+}
+
 // firstNavLatchSingleton is the process latch. Built once (set-once at the
 // first engineSeed invocation via ensureFirstNavLatch); the boot pass fires
 // it, and engineSeed waits on it. Package-level so seedScopeYielding (invoked
@@ -117,7 +132,7 @@ func (l *firstNavLatch) wait() <-chan struct{} {
 // wait).
 var (
 	firstNavLatchSingleton *firstNavLatch
-	firstNavLatchOnce       sync.Once
+	firstNavLatchOnce      sync.Once
 )
 
 // ensureFirstNavLatch returns the process first-nav latch, building it once.

--- a/internal/handlers/dispatchers/readiness_backstop_metrics.go
+++ b/internal/handlers/dispatchers/readiness_backstop_metrics.go
@@ -1,0 +1,81 @@
+// readiness_backstop_metrics.go — F5 (#131, Diego-ruled): backstop-Ready is an
+// EXPLICIT FAILURE SIGNAL, never silent.
+//
+// THE CONTRACT (#130 acceptance / #131 ruling). Under the prewarm-complete
+// readiness gate (shape A, #87) /readyz is meant to flip 200 only once every
+// cohort's first-nav widgets are seeded (the firstNav latch fires). But the C2
+// backstop (§F.0) flips Ready-DEGRADED regardless on PHASE1_TIMEOUT /
+// pipGlobalTimeout expiry or a seed error — so a pod that CANNOT warm in budget
+// still joins the Service with COLD cells. Per Diego's #130 ruling that is a
+// FAILED boot: the pod serves, but its first customer /call per affected cohort
+// falls back to a cold per-user resolve (the exact miss #130 set out to close).
+// It MUST be loud: an ERROR-level structured log + a process expvar counter, so
+// an operator/alert sees "this boot degraded" instead of a silent green /readyz.
+//
+// SCOPE (tiny, per the ruling). This is instrumentation ONLY — it changes NO
+// readiness behaviour (the backstop still fires; MarkPhase1Done is untouched).
+// It fires EXACTLY on the backstop path (engineSeed returns via bootErr /
+// pctx.Done() without the firstNav latch having fired, OR pipSeed returns an
+// error), NEVER on the happy path (firstNav fired → clean Ready).
+//
+// PRIOR ART: the expvar shape mirrors l1_lookup_metrics.go (sync.Once-guarded
+// expvar.Publish of an atomic counter via expvar.Func) — the established
+// process-counter idiom in this package.
+package dispatchers
+
+import (
+	"expvar"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// readinessBackstopFired is the process-wide count of boots whose /readyz flipped
+// Ready via the C2 backstop rather than the firstNav-complete happy path — i.e.
+// FAILED-but-serving boots (#131). Published as snowplow_readyz_backstop_fired so
+// an alert can fire on any non-zero value. A healthy boot leaves it 0.
+var readinessBackstopFired expvar.Int
+
+// readinessBackstopMetricsOnce guards the expvar.Publish (panics on duplicate
+// key) — same pattern as l1LookupMetricsOnce.
+var readinessBackstopMetricsOnce sync.Once
+
+func init() { registerReadinessBackstopMetrics() }
+
+// registerReadinessBackstopMetrics publishes the single expvar key. Idempotent
+// (sync.Once), so a test helper can call it after init without a double-publish.
+func registerReadinessBackstopMetrics() {
+	readinessBackstopMetricsOnce.Do(func() {
+		expvar.Publish("snowplow_readyz_backstop_fired", &readinessBackstopFired)
+	})
+}
+
+// recordReadinessBackstop is the SINGLE F5 alerting site. Called ONLY when
+// readiness flipped via the backstop (a FAILED boot per #130). It bumps the
+// process counter and emits ONE ERROR-level structured log carrying the reason
+// (which backstop arm fired), the elapsed seed time, and the count of nav-widget
+// units still unseeded at the flip (-1 when that count is not measurable at the
+// call site — the timeout arm cannot read the latch's internal remaining, so it
+// reports the "did the firstNav latch fire" boolean via reason instead).
+//
+// reason values:
+//   - "phase1_timeout"     — engineSeed unblocked on pctx.Done() (PHASE1_TIMEOUT /
+//     pipGlobalTimeout) BEFORE the firstNav latch fired: nav widgets not all seeded.
+//   - "boot_error"         — the boot scope finished with an error before the
+//     latch could fire (roots_list_failed / re-walk error).
+//   - "seed_incomplete"    — pipSeed returned an error (the phase1.seed.sync_incomplete
+//     path): the per-cohort SYNC seed did not complete.
+func recordReadinessBackstop(reason string, elapsed time.Duration, unseededRemaining int) {
+	readinessBackstopFired.Add(1)
+	slog.Error("readyz.backstop.fired",
+		slog.String("subsystem", "cache"),
+		slog.String("reason", reason),
+		slog.Int64("elapsed_ms", elapsed.Milliseconds()),
+		slog.Int("unseeded_remaining", unseededRemaining),
+		slog.String("effect", "/readyz flipped Ready-DEGRADED via the C2 backstop, NOT the "+
+			"firstNav-complete path — this boot FAILED to warm every cohort's first-nav L1 in "+
+			"budget (#130 acceptance). The pod serves, but the first /call per affected cohort "+
+			"falls back to a cold per-user resolve. Investigate seed budget / cluster health; "+
+			"snowplow_readyz_backstop_fired is now non-zero (alert)."),
+	)
+}

--- a/internal/handlers/dispatchers/readiness_backstop_metrics_test.go
+++ b/internal/handlers/dispatchers/readiness_backstop_metrics_test.go
@@ -1,0 +1,117 @@
+// readiness_backstop_metrics_test.go — F5 (#131) falsifiers: backstop-Ready is a
+// LOUD, counted failure signal, and the happy path is SILENT.
+//
+//	F5-1 (the alert fires): recordReadinessBackstop bumps snowplow_readyz_backstop_fired.
+//	F5-2 (latch discriminates): a FIRED firstNav latch reports fired()==true (happy
+//	     path → no alert), an unfired latch reports false (backstop arm → alert). This
+//	     is the exact predicate engineSeed's backstop arms gate the alert on, so it
+//	     pins the "silent on happy path, loud on backstop" contract.
+//	F5-3 (expvar published + reads back): the counter is registered and reflects the
+//	     process count operators/alerts scrape at /debug/vars.
+//	F5-4 (panic path, arch item 5): a pipSeed that PANICS drives the REAL
+//	     phase1WarmupWith recover block → recordReadinessBackstop("seed_panic") →
+//	     counter bumps AND readiness still flips (MarkPhase1Done fires). The worst
+//	     failure mode is counted, not silent. Exercises the real closure, not a shadow.
+package dispatchers
+
+import (
+	"context"
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestF5_1_RecordBackstop_BumpsCounter — the alert-fires arm. Each
+// recordReadinessBackstop call increments the process expvar by exactly one.
+func TestF5_1_RecordBackstop_BumpsCounter(t *testing.T) {
+	before := readinessBackstopFired.Value()
+	recordReadinessBackstop("phase1_timeout", 200*time.Millisecond, -1)
+	if got := readinessBackstopFired.Value(); got != before+1 {
+		t.Fatalf("F5-1: snowplow_readyz_backstop_fired = %d, want %d (one bump per backstop-Ready)", got, before+1)
+	}
+	// A second, different reason still bumps (the counter is reason-agnostic —
+	// ANY backstop-Ready is a failed boot).
+	recordReadinessBackstop("seed_incomplete", time.Second, 3)
+	if got := readinessBackstopFired.Value(); got != before+2 {
+		t.Fatalf("F5-1: second backstop must also bump; got %d want %d", got, before+2)
+	}
+}
+
+// TestF5_2_LatchFired_DiscriminatesHappyVsBackstop — the discrimination arm. The
+// engineSeed backstop arms gate the alert on !firstNav.fired(). A latch that has
+// FIRED (happy path — all nav widgets seeded) must report fired()==true so NO
+// alert is emitted; an unfired latch (backstop — nav widgets unseeded) reports
+// false so the alert fires. This is the "silent on the happy path" guarantee.
+func TestF5_2_LatchFired_DiscriminatesHappyVsBackstop(t *testing.T) {
+	l := newFirstNavLatch()
+	if l.fired() {
+		t.Fatal("F5-2: a fresh latch must report fired()==false (nothing seeded yet → backstop arm would alert)")
+	}
+	// Fire it (the happy path: all cohorts' nav widgets seeded).
+	l.fire("segment_complete", 3, 3, "", -1, 50*time.Millisecond)
+	if !l.fired() {
+		t.Fatal("F5-2: a FIRED latch must report fired()==true → engineSeed's backstop arms must NOT alert on the happy path")
+	}
+}
+
+// TestF5_3_ExpvarPublished — the observability arm. The counter is published under
+// the canonical key so /debug/vars (and any alert scraping it) sees it.
+func TestF5_3_ExpvarPublished(t *testing.T) {
+	registerReadinessBackstopMetrics() // idempotent
+	v := expvar.Get("snowplow_readyz_backstop_fired")
+	if v == nil {
+		t.Fatal("F5-3: snowplow_readyz_backstop_fired must be published at /debug/vars")
+	}
+	before := readinessBackstopFired.Value()
+	recordReadinessBackstop("boot_error", 10*time.Millisecond, -1)
+	// The published var and the backing counter are the SAME object → the scrape
+	// reflects the bump.
+	if v != expvar.Get("snowplow_readyz_backstop_fired") {
+		t.Fatal("F5-3: the published var must be stable across scrapes")
+	}
+	if readinessBackstopFired.Value() != before+1 {
+		t.Fatalf("F5-3: the published counter must reflect the bump; got %d want %d", readinessBackstopFired.Value(), before+1)
+	}
+}
+
+// TestF5_4_PanicSeed_CountsBackstop — arch item 5. A pipSeed that PANICS must
+// drive the REAL phase1WarmupWith recover block: recover logs phase1.seed.panic,
+// then recordReadinessBackstop("seed_panic") bumps the counter, then the
+// MarkPhase1Done defer still flips readiness (Ready-DEGRADED, never
+// not-Ready-forever). Drives the actual closure via a panicking pipSeedFn — no
+// shadow of the recover logic.
+func TestF5_4_PanicSeed_CountsBackstop(t *testing.T) {
+	rw := phase1TestWatcher(t)
+	cache.ResetPhase1DoneForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	// No roots — the walk completes its sync barrier fast; the seed is the only
+	// interesting step. A nil-root lister keeps the arm focused on the panic path.
+	lister := func(ctx context.Context) ([]navigationRoot, error) { return nil, nil }
+	resolver := func(ctx context.Context, root navigationRoot) error { return nil }
+
+	// The pipSeed that PANICS — the worst failure mode the recover block guards.
+	panicSeed := pipSeedFn(func(ctx context.Context) error {
+		panic("F5-4: simulated seed panic")
+	})
+
+	before := readinessBackstopFired.Value()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// phase1WarmupWith must NOT propagate the panic (the recover swallows it) and
+	// must still return nil / flip Ready-degraded.
+	if err := phase1WarmupWith(ctx, rw, lister, resolver, nil, nil, panicSeed, nil); err != nil {
+		t.Fatalf("F5-4: phase1WarmupWith must survive a panicking seed (recover), got err=%v", err)
+	}
+
+	if got := readinessBackstopFired.Value(); got != before+1 {
+		t.Fatalf("F5-4: a panicking seed must count ONE backstop-Ready; snowplow_readyz_backstop_fired = %d, want %d — the worst failure mode went silent", got, before+1)
+	}
+	// C2 backstop preserved: readiness still flipped despite the panic.
+	if !cache.IsPhase1Done() {
+		t.Fatal("F5-4: MarkPhase1Done must still fire after a seed panic (Ready-DEGRADED, never not-Ready-forever)")
+	}
+}


### PR DESCRIPTION
## F5 — backstop-Ready is an explicit failure signal (#131)

Per Diego's #131 ruling: under the prewarm-complete readiness gate (shape A, #87), `/readyz` should flip 200 only once every cohort's first-nav widgets are seeded (the `firstNav` latch fires). The C2 backstop flips **Ready-DEGRADED** regardless — on `PHASE1_TIMEOUT` / `pipGlobalTimeout` expiry, a seed error, or a seed **panic** — so a pod that cannot warm in budget still joins the Service with COLD cells. That is a **FAILED boot per the #130 acceptance** and must never be silent.

### Change (instrumentation ONLY — no readiness-behaviour change)

`MarkPhase1Done` and the backstop firing itself are untouched. Added:

- **`readiness_backstop_metrics.go`**: `recordReadinessBackstop(reason, elapsed, unseededRemaining)` — ONE ERROR-level structured log (`readyz.backstop.fired`, carrying `reason` / `elapsed_ms` / `unseeded_remaining`) + a process expvar counter `snowplow_readyz_backstop_fired` (alert on any non-zero; a healthy boot leaves it 0).
- **`firstNavLatch.fired()`** — race-safe non-blocking channel check, so the alert gates only on a genuine backstop (latch not fired), never on the happy path.

Wired at the **four** backstop paths, gated so the happy path stays silent:

1. `phase1_timeout` — `engineSeed` unblocks on `pctx.Done()` before the latch fired.
2. `boot_error` — the boot scope ended (roots_list_failed / re-walk error) before the latch fired.
3. `seed_incomplete` — `pipSeed` returned an error (the `phase1.seed.sync_incomplete` path), alongside the existing human-readable WARN.
4. `seed_panic` — the `pipSeed` panic-recover branch (the worst failure mode, previously counted nowhere).

### Falsifiers (all 3× `-race`, `=== RUN` verified, discriminate under neuter)

- **F5-1** counter bumps per backstop (reason-agnostic).
- **F5-2** `firstNavLatch.fired()` discriminates happy-vs-backstop — the exact predicate the alert gates on (silent on the happy path).
- **F5-3** expvar published + reflects the bump (what `/debug/vars` and alerts scrape).
- **F5-4** a panicking `pipSeed` drives the **real** `phase1WarmupWith` recover block → counter == 1 AND `MarkPhase1Done` still fires (Ready-degraded, never not-Ready-forever); no shadow.

Neuter-check verified: removing the `seed_panic` record → F5-4 fails; restored green.

Frozen ref: `49ad977`. Dual gate complete (arch SOUND-WITH-CHANGES → seed_panic path added; PM FINAL ACCEPT, instrumentation-only confirmed). This PR PARKS — do NOT merge/tag/cut (Diego-reserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
