### PR TITLE
fix(cache): F6 Put-guard exempts identity extras — declared widgets cache again (#130)

### DIFF
--- a/docs/f6-chrome-route-key-design-2026-07-12.md
+++ b/docs/f6-chrome-route-key-design-2026-07-12.md
@@ -211,3 +211,28 @@ shippable as a known-corner and A-declare lands as a fast-follow.
    on the `widgets` layer shows `extras_len:0`; compositions first-nav hit-rate → ~100% (was 83.3%).
 4. CI invariant (#67 generalization): the emit/sub/seed parity test asserts the declared-keyExtras
    filter is applied identically on all three paths (guards the anti-drift property).
+
+## Addendum (1.7.11) — the Put-guard judges the SAME two axes the folder partitions
+
+The F6 self-quarantine Put-guard (`requestExtrasFullyDeclared`) originally checked
+request extras against ONLY `spec.keyExtras`, but the folder `effectiveKeyExtras`
+partitions on TWO axes: `spec.keyExtras` AND the A2/A6 identity axis
+(`declaredIdentityForKey`). The frontend's `buildExtrasParam` sends identity keys
+(`username`, `displayName`) on the wire whenever `SNOWPLOW_IDENTITY_INJECTION` is
+off, so a declared widget with empty `identityContext` received those keys and was
+spuriously declined — declared widgets never cached, revisit always cold (tester
+falsifier, west4 2026-07-14). Fix: the guard EXEMPTS identity-dimension keys
+(`{username, groups, displayName}`) — they never pollute a shared cell (the
+per-cohort cell is BindingUID-keyed; the identity-free widgetContent cell is
+walk-only-written and per-user re-gated at serve). The quarantine still fires for a
+genuinely-undeclared, body-affecting non-identity key.
+
+**Contract note (arch, 1.7.11):** the identity exemption assumes wire-identity is
+body-INERT for an UNDECLARED widget. A widget whose server-side
+`widgetDataTemplate`/`resourcesRefsTemplate` READS `.extras.username` /
+`.displayName` / `.groups` MUST declare `spec.identityContext` — which folds
+identity into the key AND triggers injection-wins (resolve.go). Declaring it is the
+existing contract; the current corpus honors it (`greeting-title` resolves
+`{displayName}` client-side, not server-side). An undeclared server-side identity
+read would put a representative's identity value into the BindingUID-shared cell —
+the same latent surface F6's design already pushes toward declaration.

--- a/internal/handlers/dispatchers/farch_f6_keyextras_test.go
+++ b/internal/handlers/dispatchers/farch_f6_keyextras_test.go
@@ -525,3 +525,95 @@ func TestFARCH_F6_6_DeclaredCounterpart_GuardInert(t *testing.T) {
 		t.Fatal("F6-6 declared: B's distinct-key cell must be a MISS after A's Put (partitioned, not shared)")
 	}
 }
+
+// TestFARCH_F6_7_RevisitHit_IdentityExtrasExempt — the 1.7.11 revisit-HIT arm
+// (tester falsifier, west4 2026-07-14). This is the dimension the DeclaredCounterpart
+// unit arm was BLIND to: identity extras on the wire. When SNOWPLOW_IDENTITY_INJECTION
+// is off, the frontend's buildExtrasParam folds IDENTITY keys (username, displayName)
+// into ?extras= alongside the route params. A declared widget (keyExtras:[name,namespace],
+// NO identityContext) then receives {name, namespace, username, displayName}. The folder
+// keeps {name,namespace} (extras_len=2, correct key) and drops the identity keys; but the
+// pre-fix guard saw username/displayName as "undeclared" → declined EVERY Put → the
+// widget's content was never cached → revisit always MISS (the exact 14/14-same-key /
+// 0/14-hit west4 failure).
+//
+// GREEN (the fix): the guard exempts identity-dimension keys → the Put is ALLOWED → a
+// second identical request HITs the extras_len>0 key. RED = remove the identity
+// exemption (re-introduce the divergence) → the guard declines → revisit MISS returns.
+func TestFARCH_F6_7_RevisitHit_IdentityExtrasExempt(t *testing.T) {
+	enableWidgetContentL1(t)
+	ctx := ctxWithIdentity() // cyberjoker / [devs]
+	const (
+		g, v, r, ns, name = "widgets.templates.krateo.io", "v1beta1", "paragraphs", "krateo-system", "composition-detail-header"
+		perPage, page     = -1, -1
+	)
+	// A DECLARED widget: keyExtras:[name,namespace], NO identityContext (the exact
+	// composition-detail-header shape that broke on west4).
+	cr := declaredKeyExtrasCR("name", "namespace")
+
+	// The browser's wire shape with injection OFF: route params + identity keys.
+	req := map[string]any{
+		"namespace":   "team-a",
+		"name":        "demo-1",
+		"username":    "cyberjoker",
+		"displayName": "Cyber Joker",
+	}
+
+	// FOLDER: keeps only the declared keyExtras subset → extras_len=2 (identity dropped).
+	keyExtras := effectiveKeyExtras(ctx, cr, req)
+	if len(keyExtras) != 2 || keyExtras["name"] != "demo-1" || keyExtras["namespace"] != "team-a" {
+		t.Fatalf("F6-7: the folder must keep ONLY the declared [name,namespace] (identity dropped); got %#v", keyExtras)
+	}
+
+	// GUARD: must NOT decline — name/namespace are declared, username/displayName are
+	// identity-dimension keys (exempt). This is the fix's core assertion.
+	if !requestExtrasFullyDeclared(cr, req) {
+		t.Fatal("F6-7 REGRESSION: the guard declined a declared widget carrying identity extras (username/displayName) — identity keys must be EXEMPT (they never pollute a shared cell); this is the west4 revisit-miss bug")
+	}
+
+	// End-to-end: first request Puts at the extras_len>0 key; second identical request HITs.
+	key1, handle1, inputs1 := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtras)
+	if handle1 == nil || key1 == "" {
+		t.Fatal("F6-7: expected a live handle + key")
+	}
+	body := []byte(`{"status":{"widgetData":{"detail":"header"}}}`)
+	// The Put only happens because the guard allowed it (mirrors widgets.go's
+	// genuine-Put gate: the F6 decline branch is skipped when requestExtrasFullyDeclared).
+	if requestExtrasFullyDeclared(cr, req) {
+		handle1.Put(key1, &cache.ResolvedEntry{RawJSON: body, Inputs: inputs1})
+	}
+
+	// REVISIT: same widget, same request → same key → HIT (was 0/14 on west4).
+	keyExtras2 := effectiveKeyExtras(ctx, cr, req)
+	key2, handle2, _ := dispatchCacheLookupKey(ctx, "widgets", g, v, r, ns, name, perPage, page, keyExtras2)
+	if key2 != key1 {
+		t.Fatalf("F6-7: revisit must derive the SAME extras_len>0 key; key1=%q key2=%q", key1, key2)
+	}
+	got, hit := handle2.Get(key2)
+	if !hit {
+		t.Fatal("F6-7 REVISIT: declared widget MISSED on revisit at the identical key — the Put was declined (the west4 bug); the identity exemption must allow it to cache")
+	}
+	if string(got.RawJSON) != string(body) {
+		t.Fatalf("F6-7: revisit served the wrong body; got %q want %q", got.RawJSON, body)
+	}
+}
+
+// TestFARCH_F6_7b_GenuinelyUndeclaredStillDeclines — the paired no-over-fix arm.
+// The identity exemption must NOT weaken the quarantine for a genuinely-undeclared,
+// BODY-affecting request key. A declared[name,namespace] widget receiving a NON-identity
+// undeclared key (foo) must STILL decline — otherwise the F6-6 self-quarantine leak
+// reopens. Discriminates the exemption from an over-broad "allow everything".
+func TestFARCH_F6_7b_GenuinelyUndeclaredStillDeclines(t *testing.T) {
+	cr := declaredKeyExtrasCR("name", "namespace")
+	// Identity keys exempt, declared keys fine — but foo is a genuinely-undeclared
+	// non-identity body-affecting key → MUST still decline.
+	req := map[string]any{"name": "demo-1", "namespace": "team-a", "username": "cyberjoker", "foo": "evil"}
+	if requestExtrasFullyDeclared(cr, req) {
+		t.Fatal("F6-7b OVER-FIX GUARD: a genuinely-undeclared non-identity key (foo) must STILL be quarantined even alongside declared+identity keys — the exemption must not allow body-affecting undeclared extras (F6-6 leak would reopen)")
+	}
+	// Sanity: without foo, the same request is fully-declared (identity exempt).
+	req2 := map[string]any{"name": "demo-1", "namespace": "team-a", "username": "cyberjoker"}
+	if !requestExtrasFullyDeclared(cr, req2) {
+		t.Fatal("F6-7b: declared keys + identity keys only must be fully-declared")
+	}
+}

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -395,10 +395,42 @@ func filterDeclaredKeyExtras(cr map[string]any, requestExtras map[string]any) ma
 // clean. Clean requests (no undeclared extras) and the declared corpus pay
 // nothing — only a request carrying extras the widget did NOT declare is quarantined.
 //
+// IDENTITY-DIMENSION EXEMPTION (1.7.11 fix — tester falsifier, west4 2026-07-14):
+// the guard must judge the SAME dimension the folder filters. The folder
+// (effectiveKeyExtras) partitions request extras on TWO independent axes — the
+// author-declared keyExtras (filterDeclaredKeyExtras) AND the A2/A6 IDENTITY axis
+// (declaredIdentityForKey: username/groups declared via spec.identityContext).
+// The guard originally checked ONLY keyExtras, so a widget carrying identity
+// extras on the wire — which the frontend's buildExtrasParam sends (username,
+// displayName) whenever SNOWPLOW_IDENTITY_INJECTION is off — was declined even
+// when its keyExtras request keys were all declared. That is spurious: identity
+// keys are NEVER a shared-cell body-pollution risk. The per-cohort `widgets` cell
+// is already BindingUID-keyed (per RBAC-identity cohort), and the identity-free
+// widgetContent cell is re-gated per-user at serve (gateWidgetEnvelope). A request
+// carrying username/displayName/groups cannot leak one user's body to another via
+// a shared cell — that is exactly what the identity dimension already guarantees.
+// So identity keys are EXEMPT from the quarantine: they may reach the Put without
+// declining, mirroring how the folder treats them (folded-if-declared, dropped-as-
+// identity otherwise). The quarantine still fires for a genuinely-undeclared,
+// BODY-affecting request key (the F6-6 `foo` case) — that is the only shared-cell
+// pollution the guard exists to stop.
+//
+// identityDimensionKeys is the closed set the frontend can put on the wire as
+// identity (audit §1: buildExtrasParam sends username + displayName when not
+// injecting) plus groups (the other A2 identityContext enum value). Not a
+// widget-name/route table (feedback_no_special_cases) — a fixed, mechanism-level
+// identity vocabulary, the same axis DeclaredIdentity honors.
+var identityDimensionKeys = map[string]struct{}{
+	"username":    {},
+	"groups":      {},
+	"displayName": {},
+}
+
 // Returns TRUE (fully declared → safe to Put) when the request carries no extras,
-// or when every supplied key survives the filter. Returns FALSE (decline the Put)
-// when at least one supplied key was dropped. Reuses widgets.GetKeyExtras — no new
-// mechanism, no widget-name/route table (feedback_no_special_cases).
+// or when every supplied key is EITHER declared in spec.keyExtras OR is an
+// identity-dimension key. Returns FALSE (decline the Put) when at least one
+// supplied key is a genuinely-undeclared, non-identity request key. Reuses
+// widgets.GetKeyExtras — no new mechanism, no widget-name/route table.
 func requestExtrasFullyDeclared(cr map[string]any, requestExtras map[string]any) bool {
 	if len(requestExtras) == 0 {
 		return true // nothing supplied → nothing to quarantine
@@ -409,9 +441,13 @@ func requestExtrasFullyDeclared(cr map[string]any, requestExtras map[string]any)
 		declaredSet[k] = struct{}{}
 	}
 	for k := range requestExtras {
-		if _, ok := declaredSet[k]; !ok {
-			return false // an undeclared request extra would collapse into the shared cell
+		if _, ok := declaredSet[k]; ok {
+			continue // author-declared keyExtras key — partitions the key, safe
 		}
+		if _, ok := identityDimensionKeys[k]; ok {
+			continue // A2/A6 identity axis — folder handles it, never shared-cell pollution
+		}
+		return false // a genuinely-undeclared body-affecting request extra → quarantine
 	}
 	return true
 }


### PR DESCRIPTION
## Fix: F6 Put-guard exempts identity extras — declared widgets cache again (#130)

Fixes a snowplow-side F6 defect surfaced by the tester's revisit falsifier on west4 (snowplow 1.7.10, portal 1.5.16 declarations in-chart): declared widgets computed the **correct** identical `extras_len>0` key on both visits (folder works, key-parity proven) but **every Put was declined**, so revisits never HIT (14/14 same-key, 0/14 hit; 235 declines / 38 widgets incl. all 34 `composition-detail-*`). Report: `/tmp/f6-deploy/f6-west4-mechanism-report.md`.

### Root cause (traced + proven empirically)

The folder `effectiveKeyExtras` partitions request extras on **two** axes — author-declared `spec.keyExtras` (`filterDeclaredKeyExtras`) AND the A2/A6 **identity** axis (`declaredIdentityForKey`, from `spec.identityContext`). But the Put-guard `requestExtrasFullyDeclared` judged request keys against **only** `spec.keyExtras`.

The frontend's `buildExtrasParam` sends identity keys (`username`, `displayName`) on the wire whenever `SNOWPLOW_IDENTITY_INJECTION` is **off** (confirmed off on the west4 configmap). So a declared `[name,namespace]` widget with **empty** `identityContext` received `{name, namespace, username, displayName}`: the folder kept `{name,namespace}` and correctly dropped the identity keys (identity-free cell), but the guard saw `username`/`displayName` as "undeclared" → declined every Put → declared widgets never cached.

### The fix (single-site, ~15 LOC)

`requestExtrasFullyDeclared` now exempts the identity-dimension keys `{username, groups, displayName}`: a request key passes if it's in `spec.keyExtras` **OR** is an identity key. The quarantine still fires for a genuinely-undeclared, body-affecting non-identity key (the F6-6 `foo` case) — no over-fix.

**Why identity keys are leak-safe** (arch-confirmed): the per-cohort `widgets` cell is `BindingUID`-keyed (`RepresentativeUsername` is carried on `ResolvedKeyInputs` but NOT folded into `ComputeKey` — per-binding sharing by design); the identity-free `widgetContent` cell is walk-only-written (never customer-Put) and re-gated per-user at serve (`gateWidgetEnvelope`). A request carrying `username`/`displayName`/`groups` cannot serve one user's body to another via a shared cell.

### Falsifier matrix (3× `-race`, both discriminate)

- **F6-7** `RevisitHit_IdentityExtrasExempt` — declared `[name,namespace]` widget + request `{name,namespace,username,displayName}` → guard allows → Put → **revisit HITs** the identical `extras_len>0` key. RED = remove the exemption → declines/miss return (the exact west4 symptom).
- **F6-7b** `GenuinelyUndeclaredStillDeclines` — `foo` alongside declared+identity keys **STILL declines** (no over-fix; the F6-6 self-quarantine leak stays closed).
- F6-1..6 + full `internal/handlers/dispatchers` package green.

The unit F6-6 `DeclaredCounterpart` harness was **blind to the identity dimension** (the `feedback_spoof_quarantine` two-dimension lesson, now on the guard side) — F6-7 permanently exercises it and would have caught west4 pre-deploy.

### Dual gate

GREEN on the frozen SHA. **Arch: SOUND** (no-leak security verdict, traced both cells + the live corpus — the only identity-reading widget resolves `{displayName}` client-side, zero shared-cell body variance). **PM: ACCEPT** (independently re-ran the falsifiers + neuter-checked the exemption). Regression-journal row written (`project_regression_journal.md`, 2026-07-14). Design-doc addendum added.

### Environment note (config decision for Diego, not a blocker)

west4 (installer-release) runs with **`SNOWPLOW_IDENTITY_INJECTION` OFF** — that is why identity keys ride the wire at all. installer-test ran injection **ON** (the A6/A7 arc). Whether west4 should have injection enabled is a config decision. **This fix is correct under BOTH modes** — F6-7's harness includes the wire-identity keys (injection-off shape); under injection-on the frontend sends no identity keys, so the guard sees only route params and the fix is inert. Not gating; flag for Diego's config call.

### PM ship-close condition

This is a mechanism fix validated at unit level. The north-star proof is the tester's **real-Chrome `l1:HIT` + `DISPATCH_KEY_DIAG` key-equality** on the declared / `composition-detail-*` widgets post-deploy (curl inadmissible per `feedback_curl_probes_inadmissible_for_seed_hit_acceptance`). The ledger row is not complete without it.

Parked for Diego's merge. Ship chain on merge: tag 1.7.11 → chart 1.0.73 lockstep → installer bump (snowplow chart → 1.0.73, branch-off-current-main per doctrine) → helm upgrade west4 → tester re-runs the revisit arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
