### PR TITLE
docs(feature-journal): #113 templated endpointRef row (code already merged via #114)

### DIFF
--- a/docs/113-templated-endpointref-design-2026-07-15.md
+++ b/docs/113-templated-endpointref-design-2026-07-15.md
@@ -1,0 +1,125 @@
+# #113 — template a RESTAction api-step `endpointRef` from request extras
+
+Date: 2026-07-15
+Author: cache-architect
+Repo: main @ 330a649 (1.7.12); 1.7.13 candidate
+Issue: braghettos/krateo-snowplow #113 (hub-spoke: one RA serves N spokes)
+
+## Headline
+
+Template `endpointRef.name` through the **same** jq/extras evaluator that already renders `path`/`filter`/`payload`/`headers`, evaluated **before** the Secret lookup. One-site change (~15 LOC) at `resolveStageEndpoint`. Cache safety is **structural and already in place** (extras fold into the RA key; a spoke read-back hits the external-touch bump → Put declined → never cached). The issue's "no new trust surface" claim is **correct for the cache but WRONG for credential selection unmitigated** — extras are user query params, so a bare `${.name}` lets a caller select another user's `-clientconfig` Secret. The design's load-bearing content is therefore the **two security guardrails** (name-only V1 + reserved-suffix refusal, both enforced at two layers) and a **seed-skip** that prevents the boot seed caching a truncated body under the no-extras key. Small ship.
+
+## 1. Mechanism (TRACED, file:line)
+
+### 1.1 The evaluator to reuse
+
+`path`/`payload`/`headers` are already extras/jq-templated in `createRequestOption` via `evalJQ(in.Path, ds)` (`internal/resolvers/restactions/api/setup.go:61`, and `:65`/`:72`). `evalJQ` (`setup.go:79`) runs `jqutil.MaybeQuery`-gated `jqutil.Eval` over `ds` — the per-stage data dict — with the snowplow module loader. The **same `ds`** carries the request extras as the reserved sibling key `pig["extras"]` (`internal/resolvers/restactions/api/handler.go:128`, task #10). So `.name` / `.extras.name` are already in scope for every step field **except** `endpointRef`.
+
+`endpointRef` is the lone exception: `resolveStageEndpoint` (`resolve.go:371`) passes `apiCall.EndpointRef` **verbatim** to `r.mapper.resolveOne` (`resolve.go:387`; `resolveOne` at `internal/resolvers/restactions/api/endpoints.go:23`), which consumes `ref.Name`/`ref.Namespace` with no evaluation.
+
+### 1.2 The change
+
+In `resolveStageEndpoint`, for the **non-UAF, non-nil-ref** path only, evaluate `ref.Name` through `evalJQ` against the stage dict before calling `resolveOne`:
+
+```go
+// in resolveStageEndpoint, non-UAF branch, before mapper.resolveOne:
+ref := apiCall.EndpointRef
+if ref != nil && jqutil.MaybeQuery-shaped(ref.Name) {   // only when it's a template
+    name := evalJQ(ref.Name, r.stageDict(id))            // SAME evaluator + SAME ds as path/filter
+    name = kubeutil.MakeDNS1123Compatible(name)          // RFC1123-sanitize (already imported endpoints.go:54)
+    // §2 guardrails applied HERE (fail-fast) — see below
+    ref = &templates.Reference{Name: name, Namespace: ref.Namespace}  // namespace stays LITERAL (V1)
+}
+resolved, err := r.mapper.resolveOne(r.ctx, ref)
+```
+
+- The `ds` handed to `evalJQ` MUST be the SAME per-stage dict the step's `path`/`filter` see (the one carrying `pig["extras"]`) so `.name` resolves identically to how `path` already resolves it. The exact accessor is whatever `createRequestOption` is handed as `ds` for this stage; thread it into `resolveStageEndpoint` (it is a `resolveRun` method, so the dict is reachable — `r.dict`, augmented with the extras sibling key exactly as `handler.go` builds `pig`).
+- `namespace` is **NOT** templated in V1 (§2 guardrail (a)) — `ref.Namespace` passes through literally.
+- **Miss = honest error, unchanged posture**: a resolved name that matches no Secret → `resolveOne`'s `FromInformerSecret` soft-miss → `endpoints.FromSecret` apiserver GET → not-found error → `resolveStageEndpoint` returns `stageReturn` (`resolve.go:391`), which **truncates the resolve** exactly as a static bad `endpointRef` does today. No new error path.
+
+### 1.3 Untouched paths (confirmed)
+
+- **nil-ref / internal-dispatch / `<user>-clientconfig`** path (`endpoints.go:24-57`): only the **named**-ref path gains templating. A nil `EndpointRef` still takes the internal-endpoint-then-clientconfig branch verbatim. The `isInternal` SA override (`endpoints.go:83-85`, `:108-110`) is unchanged.
+- **UAF** stages: `resolveStageEndpoint` short-circuits to `dynamic.ServiceAccountEndpoint()` (`resolve.go:372-385`) before any ref handling — a UAF stage never carries a per-user `endpointRef`, so templating does not touch the UAF SA-endpoint path.
+
+## 2. Security (the two guardrails + threat walk)
+
+**The issue's safety note is wrong unmitigated.** It claims "adds no new trust surface beyond what cluster registration already provisions." But `endpointRef` names an **endpoint Secret**, and the reserved `<user>-clientconfig` Secrets — which carry **per-user apiserver credentials** — live in the **same** `authnNS` (`endpoints.go:52-54`: `Namespace: m.authnNS, Name: <user>-clientconfig`). `extras` are **user-controlled query params** (they flow from the request URL into `pig["extras"]`). So a bare `endpointRef.name: ${ .want }` lets a caller pass `?extras.want=admin-clientconfig` and dial the spoke step **with the admin's credentials** — a credential-selection escalation. This is a genuine new trust surface and the design MUST close it.
+
+### Guardrail (a) — V1 templates NAME only; namespace stays literal
+
+The namespace is the trust boundary of the Secret store. Keeping `ref.Namespace` a chart-authored literal means a templated name can only ever select **within** the namespace the RA author already chose. A caller cannot redirect the lookup into `kube-system`, another tenant's namespace, or any namespace the author didn't bless. Templated namespace is a **rejected alternative** (§5) precisely because it widens this boundary. `.namespace` templating can be a V2 behind an explicit allowlist if a real need appears.
+
+### Guardrail (b) — a templated ref may never resolve to a reserved `-clientconfig` name
+
+This is the direct block on the escalation. The `-clientconfig` suffix is **snowplow's own internal-identity class** (the per-user credential Secrets `resolveOne` synthesizes at `endpoints.go:54`). A **templated** `endpointRef` resolving to any name ending in `-clientconfig` is refused with an honest error. This is a **general boundary, not a per-resource special-case** (`feedback_no_special_cases`): it keys on snowplow's own reserved internal-identity suffix, the same string literal the nil-ref path constructs — not on any spoke/tenant/customer resource name. A statically-authored `endpointRef` is unaffected (only the templated path is gated), because a chart author writing a literal `-clientconfig` ref is the internal path's own business; the danger is exclusively **user-extras-driven** selection.
+
+### Placement — BOTH layers (recommended)
+
+1. **At template-eval** (`resolveStageEndpoint`, the change site): refuse fast with a clear, greppable error the moment a templated name resolves to a `-clientconfig` suffix — so the operator sees exactly why their template was rejected, and the Secret lookup never fires.
+2. **Defense-in-depth in `resolveOne`** (`endpoints.go`, the single choke point EVERY ref lookup passes): a belt-and-suspenders refusal when a **caller-templated** ref (marked as such — see below) carries the reserved suffix. This guarantees a **future** templating call site (a second caller added later) cannot bypass the boundary by forgetting the eval-site check. `resolveOne` is where the internal `-clientconfig` name is itself *constructed*, so it is the natural home for "a request-driven ref may not impersonate the internal identity class."
+
+The two layers need a way for `resolveOne` to know the ref was **request-templated** (so a legitimate internal nil-ref→clientconfig synthesis is not refused — that path MUST still produce a `-clientconfig` name). Cleanest: the eval site passes a small flag/typed marker alongside the ref (e.g. a `templated bool` param or a `ref` origin field), so `resolveOne` refuses `-clientconfig` **only** for templated refs, never for its own internal synthesis. This keeps the internal path byte-identical.
+
+### Threat walk (each an intended falsifier arm — §4)
+
+- **T1 clientconfig forgery**: `?extras.name=admin` with `endpointRef.name: ${ .name + "-clientconfig" }` → resolved name `admin-clientconfig` → **REFUSED** at eval-site AND at `resolveOne` → honest error, no admin-credential dial. (Named falsifier arm — the load-bearing security proof.)
+- **T2 namespace escape**: no vector in V1 — `.namespace` is literal, cannot be templated. (Guardrail (a).)
+- **T3 arbitrary-secret read**: a templated name resolves to some non-`-clientconfig` Secret in the author's namespace that is NOT an endpoint Secret → `endpoints.FromSecret` returns "server-url missing" hard error (`endpoints.go:70-76`) → `stageReturn` truncate. No data leak (the Secret is never dialed; a non-endpoint Secret has no `server-url`). Bounded to the author's chosen namespace by (a).
+- **T4 cross-spoke cache poisoning**: impossible — §3.
+
+## 3. Cache safety (both hold, TRACED)
+
+Two independent mechanisms, either sufficient; together decisive.
+
+### 3.1 Extras fold into the RA key (partition)
+
+The RA dispatch key is built by `dispatchCacheLookupKey` with `Extras: extras` folded in (`internal/handlers/dispatchers/helpers.go:268`). The **raw request extras** are part of the key. So `/clusters/spoke-a` (`extras.name=spoke-a`) and `/clusters/spoke-b` derive **different keys** → different cells → no cross-spoke collision, **even if** external-decline somehow didn't fire. This is the spoke-A/spoke-B **key-partition** falsifier arm.
+
+Subscription/seed key parity note (the TL's "name any consumer where extras do NOT fold" ask): the RA request key folds request extras (`helpers.go:268`), and `DeriveSubscriptionKey` mirrors it (task #67 invariant). The seed key folds the **union** of author-declared inline maps + request extras (`helpers.go:293-319` / `effectiveKeyExtras`). For a templated-endpointRef RA the **selection** variable lives in **request** extras (`.name`), which the seed has none of — so the seed can't derive the same cell a request does. This is exactly why §3.2's external-decline makes it **moot** (the cell is never cached at all), AND why §4's seed-skip is needed (so the seed doesn't cache a *wrong* cell). There is no consumer where the omission is unsafe: the external-decline is the backstop for all of them.
+
+### 3.2 Spoke read-back is external → Put declined (the killer)
+
+A spoke apiserver read-back reaches the **external-touch bump** at `resolve.go:1048` (`cache.ExternalTouchedSinkFromContext(gctx).Bump()`). The comment at `resolve.go:1038-1047` is explicit and load-bearing: **the trigger is the DISPATCH SITE, not the Endpoint shape** — "mis-classifying an internal branch as external is structurally impossible because the signal is the dispatch site." A templated `endpointRef` dialing a spoke's `server-url` is a genuine external HTTP dispatch → it falls through every internal branch (`return nil` before `:1048`) → reaches the bump. Then `extTouchedSink.Count()>0` → the L1 Put surfaces **decline** the Put → spoke data is **served but never cached**, re-fetched live every `/call`.
+
+**C-113-4 correction — the real Put-decline surface is 7 `BumpExternalSkippedPut()` sites, not "5".** As-built inventory (grep `BumpExternalSkippedPut()`): `restactions.go:361`, `widgets.go:384`, `widget_content.go:289`, `apiref/ra_full_list.go:335` + `:367`, `resolve_populate.go:275` (refresher), `phase1_pip_seed.go:1254` (seed). Of these, the ones a bare-RA `/call` (the hub-spoke shape) actually reaches are the **request-path** surfaces — `restactions.go:361` (the top-level RA cell) plus the apiref RAFullList surfaces (`ra_full_list.go`) when the RA is consumed as a widget apiRef. The `resolve_populate.go`/`phase1_pip_seed.go` sites are the refresher/seed paths (not the direct spoke `/call`), and `widgets.go`/`widget_content.go` are widget-class surfaces (reached only if a widget wraps the RA). The external-decline arm (§7.3) covers the reachable request-path set; the decline is uniform across all 7 because they all gate on the SAME `extTouchedSink.Count()>0` signal.
+
+**Templating the name changes WHICH spoke is dialed, not WHETHER the touch is external.** So the external-decline holds identically on the templated path — the external-decline-still-fires falsifier arm (§4).
+
+## 4. Seed-skip (with F4b nuance)
+
+**Why skip.** The boot seed (`seedOneRestaction`, `phase1_pip_seed.go:737` → `restactions.Resolve`) runs with **no route extras**. So `evalJQ(ref.Name, ds)` yields either a jq error-string (`evalJQ` returns `err.Error()` on failure, `setup.go:92-94`) or an empty/partial name → `resolveOne` miss → `stageReturn` **truncate** (`resolve.go:391`).
+
+**The F4b-class nuance (TRACED — this is the real reason to skip, not noise reduction).** An endpoint-resolve miss does **NOT** bump `extTouchedSink` (the external bump at `resolve.go:1048` is downstream of a successful endpoint resolve — a `stageReturn` at `:391` never reaches it) **AND** does **NOT** bump `stageErrSink` (`stageErrSink.Bump` fires only on **item-level httpcall** errors via `recordItemError` at `resolve.go:338`, not on the endpoint-resolve failure at `:391`). So `declineSeedPutOnError` (`phase1_pip_seed.go`, gates on `stageErrSink.Count()>0 || extTouchedSink.Count()>0`) would **NOT decline** — the seed could `Put` a **truncated/degraded body** under the no-extras key. That poisoned cell then serves cold on the first real `/call` until TTL. **That** is the load-bearing reason to seed-skip a templated-endpointRef RA.
+
+**The skip predicate.** Extend the Class-5 precedent. `refHasUnresolvedTemplateToken` (`phase1_walk.go:1801`: `strings.Contains(ref.Name,"{") || strings.Contains(ref.Namespace,"{")`) already skips widget refs carrying an unsubstituted template token at the seed (`phase1_walk.go:1596`). But that check is on the **widget** `ObjectReference` — the `endpointRef` template lives on the **RA api-step** (`API.EndpointRef`, `apis/templates/v1/core.go:46`), a different surface. The new predicate: **skip seeding a RESTAction whose any api-step `EndpointRef.Name` is a jq template (`jqutil.MaybeQuery`-shaped) when the seed context carries no request extras to resolve it.** Provably **non-lossy**: these RAs are external-class (they dial a spoke apiserver → §3.2 external-decline → never cached anyway), so the seed was never going to warm a servable cell for them — skipping it removes only the poisoned-Put risk and per-pass error noise, warms nothing it could have warmed. Hook it in `seedOneRestaction` before the `restactions.Resolve` (`phase1_pip_seed.go:737`): read the fetched RA CR's `spec.api[].endpointRef.name`, and if any is template-shaped, skip with a greppable `phase1.seed.skip.templated_endpointref` line (mirrors the Class-5 skip idiom).
+
+**F4b Lever A interplay (confirmed clean).** Because an endpoint-miss does NOT bump `extTouchedSink`, a templated-endpointRef RA would NOT be marked in the F4b engine-lived declined-external set (#132) — so absent this skip it would re-resolve every resume pass (like the pre-F4b whales, but via a *different* miss class). The seed-skip removes it from the seed set entirely, which is strictly better than relying on F4b's external-mark (which wouldn't fire for this miss class). No conflict with #132; this skip is the correct owner of the templated-endpointRef seed cost.
+
+## 5. Rejected alternatives
+
+- **Per-spoke RESTAction generation** (today's only option). A controller/core-provider generates one RA per registered spoke, each with a hardcoded `endpointRef`. REJECTED as the fix: it's exactly what the issue is trying to eliminate (N near-identical CRs, controller work, registration-time coupling). It also multiplies the RBAC/CRD surface. Templating collapses N RAs to 1.
+- **Templated `endpointRef.namespace` (V1)**. REJECTED for V1 — it widens the credential-selection trust boundary (guardrail (a)): a templated namespace lets user extras redirect the Secret lookup into ANY namespace, re-opening the clientconfig-forgery class across namespaces and defeating guardrail (b)'s single-namespace assumption. Name-only keeps the blast radius inside the author's chosen namespace. A future V2 could allow it behind an explicit namespace-allowlist field on the RA, but that is out of scope and a bigger trust decision.
+- **A new dedicated evaluator / DSL for endpointRef**. REJECTED — `feedback_no_special_cases` + reuse-first: `evalJQ`+`pig["extras"]` already renders every other step field; a second evaluator would drift from the one `path`/`filter` use. Reuse the existing path.
+- **Cache the spoke read-back with a TTL** (to speed repeat spoke reads). REJECTED / out of scope — spoke data is external and un-invalidatable (no dep edge); the external-decline (§3.2) is the correct posture. If spoke-read latency becomes a concern, that's the #129 bounded-TTL-external-cache lever, not this issue.
+
+## 6. Accepted trade-off (documented)
+
+**One RA = one RBAC decision for all spokes.** With a single templated RA, the RBAC on the RESTAction (who may `/call` it) is evaluated once and applies to **every** spoke it can reach. Per-spoke RAs, by contrast, allow per-spoke RBAC granularity (bind user X to spoke-a's RA only). The issue accepts this implicitly ("RBAC on the RESTAction is unchanged"); making it explicit: **if a deployment needs per-spoke authorization granularity, it must keep per-spoke RAs — templating is for the common case where all reachable spokes share one authz decision.** This is a deliberate scope choice, not a defect.
+
+## 7. Falsifiers (PM-gateable)
+
+All hermetic (kind/unit) except where noted; the security arm is gate-blocking.
+
+1. **T1 clientconfig-forgery REFUSED (gate-blocking, security):** a request with `extras` driving `endpointRef.name` to resolve to a `*-clientconfig` name is REFUSED at BOTH the eval-site and `resolveOne`; the spoke step never dials with the reserved-identity Secret. RED arm: remove the reserved-suffix guard → the forged name resolves → the admin-clientconfig Secret is selected → test FAILS. This is the load-bearing security proof.
+2. **Spoke-A/spoke-B key-partition:** two `/call`s with `extras.name=spoke-a` vs `spoke-b` derive DIFFERENT RA cache keys (`dispatchCacheLookupKey` folds request extras). RED arm: drop extras from the key → both collapse to one cell → cross-spoke serve → FAIL.
+3. **External-decline-still-fires:** a templated-endpointRef spoke read-back bumps `extTouchedSink` and the reachable L1 Put surfaces (the 7 `BumpExternalSkippedPut()` sites, §3.2 C-113-4) decline (spoke data never cached, re-fetched live). RED arm: neuter the external bump → the templated resolve caches → FAIL. Proves templating didn't dodge `resolve.go:1048`. (This arm exercises the external-touch→decline mechanism, which is dispatch-site-driven and identical for a templated vs literal external endpointRef — templating changes WHICH spoke is dialed, not WHETHER the touch is external.)
+4. **Seed-skip:** the boot seed (no request extras) SKIPS a RESTAction whose api-step `endpointRef.name` is template-shaped — no `restactions.Resolve`, no Put of a truncated body, greppable skip line. RED arm: remove the skip → the seed resolves → a truncated/degraded body is Put under the no-extras key (neither sink bumped, so `declineSeedPutOnError` does NOT catch it) → FAIL. Proves the §4 nuance.
+5. **Miss = honest error:** a templated name resolving to a non-existent Secret produces the SAME truncated-resolve posture as a static bad `endpointRef` (stageReturn), not a panic/500-new-class. RED arm: n/a (posture-preservation) — assert byte-equal error shape to the static-miss golden.
+6. **Static ref unchanged (regression guard):** a literal (non-template) `endpointRef.name` is byte-identical to pre-change (the `MaybeQuery` gate skips evaluation) — including a literal `-clientconfig` internal ref, which is NOT refused (only templated refs are gated). Proves the internal nil-ref→clientconfig path is untouched.
+
+**On-cluster proof (functional, when a hub-spoke deployment exists):** one `cluster-compositions` RA with `endpointRef.name: ${.name+"-endpoint"}`; `/clusters/spoke-a` dials `spoke-a-endpoint`, `/clusters/spoke-b` dials `spoke-b-endpoint`, each returns that spoke's live data; `/debug/apistage` shows both as external/uncached.
+
+## 8. Effort
+
+Small. ~15 LOC at `resolveStageEndpoint` (eval + sanitize + guardrails) + ~10 LOC defense-in-depth in `resolveOne` (templated-flag reserved-suffix refusal) + ~15 LOC seed-skip predicate in `seedOneRestaction`. No CRD change (`endpointRef.name` is already a free-form string; a jq template is a valid string value). No frontend change. Additive + backward-compatible: a literal `endpointRef.name` is byte-identical (the `MaybeQuery` gate). 1.7.13 candidate.

--- a/docs/feature-113-templated-endpointref-2026-07-15.md
+++ b/docs/feature-113-templated-endpointref-2026-07-15.md
@@ -1,0 +1,87 @@
+# Feature journal — #113 templated api-step endpointRef (hub-spoke)
+
+Date: 2026-07-15
+Ship: snowplow 1.7.13 candidate (PARKED, Diego-reserved merge)
+Frozen SHA: c26654a190c80a42f0e9058f18d767c0aa0ab0b9 (branch fix/113-templated-endpointref, base main @330a649/1.7.12)
+Design: docs/113-templated-endpointref-design-2026-07-15.md
+Gate: DUAL-GATE FINAL ACCEPT (arch soundness PASS + PM final-accept, both own-hands RED re-derived)
+
+## What
+
+A RESTAction api-step `endpointRef.name` can now be a jq template evaluated
+against REQUEST extras through the SAME `evalJQ`/extras path that already renders
+`path`/`payload`/`headers`, evaluated BEFORE the Secret lookup. This collapses N
+near-identical per-spoke RESTActions to ONE (extras.name selects which spoke
+endpoint is dialed) — the hub-spoke case where one RA serves N registered spokes.
+
+Three sites (~40 LOC, all in-package, no CRD or frontend change):
+
+1. **`resolve.go` `evalEndpointRef` (eval site).** For a `MaybeQuery`-shaped
+   `endpointRef.name`, evaluate it via `evalJQ` against `r.dict` — the SAME
+   per-stage dict `path`/`payload` see, so `.name` resolves identically (request
+   extras sit at the TOP LEVEL of `r.dict`; `pig["extras"]` is a handler-side
+   FILTER construct, not what these step fields evaluate against — so the correct
+   template shape is `.name`, not `.extras.name`). RFC1123-sanitize; guardrail (a)
+   keeps `namespace` the author-literal (never templated in V1); guardrail (b)
+   refuses a resolved `-clientconfig` name fast (the Secret is never dialed);
+   returns `templated=true`.
+2. **`endpoints.go` `resolveOne` (defense-in-depth).** A new `templated bool`
+   param DEFAULTS false — the internal nil-ref `<user>-clientconfig` synthesis and
+   static author refs pass false and are NEVER refused. The `-clientconfig`
+   reserved-suffix refusal is gated on `templated` at the single choke point every
+   ref lookup passes, so a FUTURE second templating caller that forgets the
+   eval-site check still cannot dial a per-user credential Secret. A single-source
+   `clientConfigSuffix` const is shared by the synthesis site and both guardrails.
+3. **`phase1_pip_seed.go` `seedOneRestaction` (seed-skip).** Skip seeding an RA
+   whose any api-step `endpointRef.name` is templated (nil-guarded per step and per
+   `*Reference`): the boot seed has no request extras, so the endpoint resolve
+   misses and truncates — a miss that bumps NEITHER GTTL-1 sink, so
+   `declineSeedPutOnError` would NOT catch it and the seed would Put a truncated
+   body under the no-extras key (poisoning it until TTL). Non-lossy: spoke reads
+   are external → external-touch-declined → never cached anyway.
+
+## Security (the load-bearing content)
+
+extras are user-controlled query params, so a bare `endpointRef.name: ${ .name }`
+folding to `admin-clientconfig` would let a caller dial the spoke step with
+ANOTHER user's apiserver credentials — a credential-selection escalation. Closed
+by two guardrails at TWO layers: (a) V1 templates the NAME only (namespace stays
+the author-literal, bounding the blast radius to the author's chosen namespace);
+(b) a templated ref may never resolve to the reserved `-clientconfig` suffix,
+refused at BOTH the eval site (fail-fast) and `resolveOne` (defense-in-depth).
+
+## Test
+
+All arms hermetic, `-race`, `=== RUN` + PASS on the committed tree (full api +
+dispatchers + cache packages green 3×):
+
+- **C-113-1 two-layer security (gate-blocking):** T1 clientconfig-forgery refused
+  at eval-site AND resolveOne INDEPENDENTLY. The "never DIALED" proof seeds the
+  secrets snapshot with a forge-target `admin-clientconfig` carrying a SENTINEL
+  server-url and asserts the guard never lets that sentinel be RETURNED (the
+  escalation is the dial, not merely an error). Both layer REDs proven — neuter
+  either guard and the forged name selects/returns the admin credential.
+- **C-113-2 marker default (two directions):** internal nil-ref synthesis resolves
+  unmarked; a request-templated `-clientconfig` ref is refused. RED = drop the
+  templated gate.
+- **C-113-3 seed-skip real path:** `hasTemplatedEndpointRef` over real CR shapes
+  (8 sub-cases incl nil-step / nil-EndpointRef / nil-RA), plus the §4 both-sinks-
+  zero nuance via the REAL `declineSeedPutOnError`, plus a wiring guard (the skip
+  precedes `restactions.Resolve`). REDs proven.
+- **C-113-5 namespace never templated; C-113-6 static/literal byte-identical**
+  (incl a literal `-clientconfig`, which is the author's own business). RED = drop
+  the `MaybeQuery` gate.
+- **C-113-4 doc:** design §3.2 "5 Put surfaces" corrected to the real 7
+  `BumpExternalSkippedPut` sites.
+
+## Expected / actual
+
+Additive + backward-compatible — a literal `endpointRef.name` is byte-identical
+(the `MaybeQuery` gate skips evaluation). Documented trade-off: one templated RA =
+ONE RBAC decision for all spokes (per-spoke authz granularity needs per-spoke RAs).
+
+**Actual: PENDING** — parked PR (Diego-reserved merge; not tagged/cut). C-113-7
+on-cluster hub-spoke functional proof DEFERRED (no spoke cluster exists; security
+proven hermetically) — owed-when-deployed. Row closes on the on-deploy hub-spoke
+proof (spoke-a/spoke-b dial distinct endpoints, both external/uncached at
+`/debug/apistage`) once a hub-spoke deployment exists.

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -85,6 +85,7 @@ import (
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/plumbing/jqutil"
 	"github.com/krateoplatformops/plumbing/jwtutil"
 	"github.com/krateoplatformops/snowplow/apis"
 	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
@@ -593,6 +594,29 @@ func seedSkipDecision(ctx context.Context, mode seedScopeMode, handle cacheHandl
 	}
 }
 
+// hasTemplatedEndpointRef reports whether any api-step of cr carries a
+// TEMPLATED endpointRef.name — a jq template (${...}-shaped, jqutil.MaybeQuery)
+// that the resolver evaluates against REQUEST extras to select the dispatch
+// endpoint (#113 hub-spoke). Such a RESTAction cannot be seeded (the boot seed
+// has no request extras → the endpoint resolve misses → a truncated body would
+// be Put under the no-extras key without either GTTL-1 sink bumping, the §4
+// poisoning nuance). Each api-step and its *Reference EndpointRef is nil-guarded
+// (API is a *API, EndpointRef a *templates.Reference; either may be nil).
+func hasTemplatedEndpointRef(cr *templatesv1.RESTAction) bool {
+	if cr == nil {
+		return false
+	}
+	for _, step := range cr.Spec.API {
+		if step == nil || step.EndpointRef == nil {
+			continue
+		}
+		if _, isTemplate := jqutil.MaybeQuery(step.EndpointRef.Name); isTemplate {
+			return true
+		}
+	}
+	return false
+}
+
 func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string, mode seedScopeMode) error {
 	got := objects.Get(ctx, ref)
 	if got.Err != nil {
@@ -685,6 +709,33 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	if err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(
 		got.Unstructured.Object, &cr); err != nil {
 		return fmt.Errorf("unstructured -> RESTAction %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+
+	// #113 seed-skip — a RESTAction with a TEMPLATED api-step endpointRef.name
+	// (a jq template that selects the dispatch endpoint from REQUEST extras, e.g.
+	// hub-spoke) cannot be meaningfully seeded: the boot seed carries NO request
+	// extras, so evalJQ(ref.Name, dict) yields an empty/error name → the endpoint
+	// resolve MISSES → the stage TRUNCATES. Crucially that miss bumps NEITHER the
+	// stageErrSink NOR the extTouchedSink (the external bump is downstream of a
+	// SUCCESSFUL endpoint resolve), so declineSeedPutOnError would NOT decline —
+	// the seed would Put a TRUNCATED/degraded body under the no-extras key, which
+	// then serves cold on the first real /call until TTL (the §4 poisoning
+	// nuance). Skip is provably NON-LOSSY: a templated-endpointRef RA dials a
+	// spoke apiserver (external) → the spoke read-back is external-touch-declined
+	// (§3.2) → never cached anyway, so the seed was never going to warm a servable
+	// cell for it. Greppable skip line mirrors the Class-5 refHasUnresolvedTemplateToken
+	// idiom. Every api-step EndpointRef is nil-guarded (*Reference, may be nil).
+	if hasTemplatedEndpointRef(&cr) {
+		slog.Default().Info("phase1.seed.skip.templated_endpointref",
+			slog.String("subsystem", "cache"),
+			slog.String("restaction", ref.Namespace+"/"+ref.Name),
+			slog.String("cohort", cohortLabel),
+			slog.String("effect", "RESTAction has a templated api-step endpointRef.name (request-extras-driven "+
+				"endpoint selection, e.g. hub-spoke); the boot seed has no request extras to resolve it → skipping "+
+				"to avoid Putting a truncated body under the no-extras key (#113 §4). Spoke reads are external → "+
+				"never cached; skip is non-lossy."),
+		)
+		return nil
 	}
 
 	// Ship 0.30.192 — pure-additive per-stage timing sink for cost

--- a/internal/handlers/dispatchers/phase1_seed_templated_endpointref_test.go
+++ b/internal/handlers/dispatchers/phase1_seed_templated_endpointref_test.go
@@ -1,0 +1,160 @@
+// phase1_seed_templated_endpointref_test.go — #113 C-113-3 seed-skip falsifier.
+//
+// A RESTAction whose api-step endpointRef.name is TEMPLATED (request-extras-driven
+// endpoint selection, e.g. hub-spoke) cannot be seeded: the boot seed has no
+// request extras, so the endpoint resolve misses → the stage TRUNCATES. The
+// §4-nuance is the load-bearing reason to SKIP: that endpoint-resolve miss bumps
+// NEITHER the stageErrSink NOR the extTouchedSink (the external bump is downstream
+// of a SUCCESSFUL endpoint resolve), so declineSeedPutOnError would NOT decline —
+// the seed would Put a TRUNCATED body under the no-extras key, poisoning the cell
+// until TTL. The skip is what prevents that.
+//
+// The skip predicate is the REAL prod hasTemplatedEndpointRef over the fetched
+// RESTAction CR (spec.api[].endpointRef.name), NOT a hand-evaluated predicate:
+// this file drives it over real templatesv1.RESTAction shapes. It also proves the
+// §4 both-sinks-zero nuance via the REAL declineSeedPutOnError — the arm that
+// shows WHY the skip is needed (the GTTL-1 gate can't catch this miss class).
+// Hermetic, -race, no cluster.
+
+package dispatchers
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+func raWithSteps(steps ...*templatesv1.API) *templatesv1.RESTAction {
+	return &templatesv1.RESTAction{Spec: templatesv1.RESTActionSpec{API: steps}}
+}
+
+func step(name string, epRef *templatesv1.Reference) *templatesv1.API {
+	return &templatesv1.API{Name: name, EndpointRef: epRef}
+}
+
+// C-113-3 predicate — hasTemplatedEndpointRef fires on a TEMPLATED api-step
+// endpointRef.name and NOT on literal / nil-EndpointRef / nil-step shapes. This
+// is the REAL prod predicate the seed-skip consumes.
+func TestC113_3_HasTemplatedEndpointRef_FiresOnTemplateOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		ra   *templatesv1.RESTAction
+		want bool
+	}{
+		{
+			name: "templated endpointRef.name → skip",
+			ra:   raWithSteps(step("s1", &templatesv1.Reference{Name: `${ .name + "-endpoint" }`, Namespace: "krateo-system"})),
+			want: true,
+		},
+		{
+			name: "templated in a LATER step (not just the first) → skip",
+			ra: raWithSteps(
+				step("s1", &templatesv1.Reference{Name: "static-endpoint", Namespace: "krateo-system"}),
+				step("s2", &templatesv1.Reference{Name: `${ .want }`, Namespace: "krateo-system"}),
+			),
+			want: true,
+		},
+		{
+			name: "literal endpointRef.name → do NOT skip (byte-identical to pre-#113)",
+			ra:   raWithSteps(step("s1", &templatesv1.Reference{Name: "spoke-a-endpoint", Namespace: "krateo-system"})),
+			want: false,
+		},
+		{
+			name: "literal `-clientconfig` endpointRef.name → do NOT skip (author literal, not request-driven)",
+			ra:   raWithSteps(step("s1", &templatesv1.Reference{Name: "alice-clientconfig", Namespace: "krateo-system"})),
+			want: false,
+		},
+		{
+			name: "nil EndpointRef (internal path) → do NOT skip",
+			ra:   raWithSteps(step("s1", nil)),
+			want: false,
+		},
+		{
+			name: "nil api-step element → do NOT skip (nil-guard)",
+			ra:   raWithSteps(nil, step("s2", &templatesv1.Reference{Name: "static", Namespace: "krateo-system"})),
+			want: false,
+		},
+		{
+			name: "no api steps → do NOT skip",
+			ra:   raWithSteps(),
+			want: false,
+		},
+		{
+			name: "nil RESTAction → do NOT skip",
+			ra:   nil,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasTemplatedEndpointRef(tc.ra); got != tc.want {
+				t.Fatalf("hasTemplatedEndpointRef = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// C-113-3 §4 NUANCE (the load-bearing reason to skip, not noise) — an
+// endpoint-resolve MISS on a templated-endpointRef seed bumps NEITHER sink, so
+// declineSeedPutOnError does NOT decline; the seed would Put a truncated body.
+// This arm proves the GTTL-1 gate CANNOT catch this miss class, which is exactly
+// why the SKIP (not the decline gate) must own it. Drives the REAL
+// declineSeedPutOnError with both sinks at their post-miss state (Count()==0).
+func TestC113_3_EndpointMiss_NeitherSinkBumps_DeclineGateCannotCatch(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	ctx := context.Background()
+	// Model the seed's post-endpoint-miss sink state: an endpoint resolve failure
+	// (stageReturn at resolve.go) is UPSTREAM of both the item-level httpcall error
+	// bump (stageErrSink) and the external-touch bump (extTouchedSink), so BOTH
+	// sinks read Count()==0 after such a miss.
+	_, stageSink := cache.WithStageErrorSink(ctx)
+	_, extSink := cache.WithExternalTouchedSink(ctx)
+	if stageSink.Count() != 0 || extSink.Count() != 0 {
+		t.Fatalf("setup: fresh sinks must read 0/0; got %d/%d", stageSink.Count(), extSink.Count())
+	}
+
+	// The REAL GTTL-1 gate: with BOTH sinks at 0, it does NOT decline → the
+	// truncated body WOULD be Put. This is the poisoning the seed-skip prevents.
+	if declineSeedPutOnError(ctx, "restactions", "krateo/hub-spoke-ra", "key/hub-spoke", stageSink, extSink) {
+		t.Fatal("C-113-3 §4 nuance BROKEN: declineSeedPutOnError declined with BOTH sinks at 0 — if the gate DID catch the templated-endpointRef miss, the seed-skip would be redundant; the whole point is that it does NOT, so the skip is load-bearing")
+	}
+
+	// Control (discriminator): the gate DOES decline once a sink is bumped — proving
+	// the gate's verdict is real, just blind to the endpoint-miss class above.
+	stageSink.Bump("someStage", "an actual swallowed stage error")
+	if !declineSeedPutOnError(ctx, "restactions", "krateo/hub-spoke-ra", "key/hub-spoke", stageSink, extSink) {
+		t.Fatal("control: a bumped stage sink MUST decline")
+	}
+}
+
+// C-113-3 wiring guard (source-level) — the seed-skip is wired into
+// seedOneRestaction BEFORE restactions.Resolve, keyed on the REAL predicate.
+// Guards against a future edit dropping the skip (which silently re-opens the
+// truncated-Put poisoning). Mirrors TestSeedPrimitives_InstallErrorSinks.
+func TestC113_3_SeedSkipWiredBeforeResolve(t *testing.T) {
+	src, err := os.ReadFile("phase1_pip_seed.go")
+	if err != nil {
+		t.Fatalf("read phase1_pip_seed.go: %v", err)
+	}
+	s := string(src)
+	for _, want := range []string{
+		"if hasTemplatedEndpointRef(&cr) {",
+		"phase1.seed.skip.templated_endpointref",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("#113 seed-skip wiring: expected %q in seedOneRestaction before restactions.Resolve; not found", want)
+		}
+	}
+	// The skip MUST precede restactions.Resolve (else it can't prevent the Put).
+	skipIdx := strings.Index(s, "if hasTemplatedEndpointRef(&cr) {")
+	resolveIdx := strings.Index(s, "res, err := restactions.Resolve(resCtx, restactions.ResolveOptions{")
+	if skipIdx < 0 || resolveIdx < 0 || skipIdx > resolveIdx {
+		t.Fatalf("#113 seed-skip must appear BEFORE restactions.Resolve (skipIdx=%d resolveIdx=%d)", skipIdx, resolveIdx)
+	}
+}

--- a/internal/resolvers/restactions/api/endpoints.go
+++ b/internal/resolvers/restactions/api/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/endpoints"
@@ -20,8 +21,41 @@ type endpointReferenceMapper struct {
 	rc       *rest.Config
 }
 
-func (m *endpointReferenceMapper) resolveOne(ctx context.Context, ref *templates.Reference) (endpoints.Endpoint, error) {
+// clientConfigSuffix is snowplow's OWN reserved internal-identity suffix: the
+// per-user credential Secret name resolveOne synthesizes for the nil-ref
+// internal path (`<user>-clientconfig`, endpoints.go). #113 guardrail (b) keys
+// on THIS single literal — a request-templated endpointRef may never resolve to
+// a name ending in it (that would let user query-extras select another user's
+// apiserver credentials — the credential-selection escalation). Single source so
+// the guardrail and the synthesis can never drift onto different strings
+// (feedback_consultation_mutation_is_not_key_correctness). It is a general
+// boundary on the reserved suffix, NOT a per-resource carve-out
+// (feedback_no_special_cases).
+const clientConfigSuffix = "-clientconfig"
+
+// resolveOne resolves a named/nil endpoint Reference to an Endpoint. templated
+// reports whether ref was produced by REQUEST-DRIVEN jq templating of
+// endpointRef.name (#113): the eval site in resolveStageEndpoint passes true so
+// this choke point can apply guardrail (b) — the defense-in-depth reserved-suffix
+// refusal — WITHOUT refusing resolveOne's OWN internal nil-ref synthesis (which
+// legitimately produces a `<user>-clientconfig` name and MUST still resolve).
+// Every non-templated caller (internal nil-ref, static author-literal refs)
+// passes false and is byte-identical to pre-#113.
+func (m *endpointReferenceMapper) resolveOne(ctx context.Context, ref *templates.Reference, templated bool) (endpoints.Endpoint, error) {
 	isInternal := false
+	// #113 guardrail (b) — defense-in-depth. A REQUEST-TEMPLATED ref may never
+	// resolve to the reserved `<user>-clientconfig` internal-identity class. This
+	// is the SECOND layer (the eval site refuses first); it lives here because
+	// resolveOne is the single choke point EVERY ref lookup passes AND where the
+	// internal `-clientconfig` name is itself constructed — so a FUTURE templating
+	// call site that forgets the eval-site check still cannot dial a per-user
+	// credential Secret. Gated on templated so the internal nil-ref synthesis
+	// below (which DOES build a `-clientconfig` name) is never refused.
+	if templated && ref != nil && strings.HasSuffix(ref.Name, clientConfigSuffix) {
+		return endpoints.Endpoint{}, fmt.Errorf(
+			"templated endpointRef resolved to the reserved internal-identity name %q (suffix %q); refusing — a request-driven endpointRef may not select a per-user credential Secret (#113 guardrail b)",
+			ref.Name, clientConfigSuffix)
+	}
 	if ref == nil {
 		// 0.30.102 Tag B: when the request is driven by an internal /
 		// startup path (Phase 1's SA-credentialed resolution walk) the
@@ -51,7 +85,7 @@ func (m *endpointReferenceMapper) resolveOne(ctx context.Context, ref *templates
 		}
 		ref = &templates.Reference{
 			Namespace: m.authnNS,
-			Name:      fmt.Sprintf("%s-clientconfig", kubeutil.MakeDNS1123Compatible(m.username)),
+			Name:      kubeutil.MakeDNS1123Compatible(m.username) + clientConfigSuffix,
 		}
 		isInternal = true
 	}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,7 +25,9 @@ import (
 	"github.com/krateoplatformops/plumbing/env"
 	httpcall "github.com/krateoplatformops/plumbing/http/request"
 	"github.com/krateoplatformops/plumbing/http/response"
+	"github.com/krateoplatformops/plumbing/jqutil"
 	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/plumbing/kubeutil"
 	"github.com/krateoplatformops/plumbing/maps"
 	"github.com/krateoplatformops/plumbing/ptr"
 	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
@@ -384,13 +387,68 @@ func (r *resolveRun) resolveStageEndpoint(id string, apiCall *templates.API, uaf
 		}
 		return *saEP, stageProceed
 	}
-	resolved, err := r.mapper.resolveOne(r.ctx, apiCall.EndpointRef)
+	// #113 — template endpointRef.name through the SAME jq/extras evaluator that
+	// already renders this stage's path/payload/headers (evalJQ over r.dict, the
+	// exact ds createRequestOptions is handed at :405), so `.name` resolves
+	// identically to how `path` resolves it. ONLY the templated (MaybeQuery-shaped)
+	// named-ref path is touched; a nil ref (internal/clientconfig synthesis) and a
+	// literal ref pass through byte-identically (§1.3, guardrail (a): namespace
+	// stays literal, never templated). Returns templated=true so resolveOne applies
+	// the guardrail (b) defense-in-depth layer.
+	ref, templated, guardErr := r.evalEndpointRef(apiCall.EndpointRef)
+	if guardErr != nil {
+		// Guardrail (b) refusal at the eval site (fail-fast, before any Secret
+		// lookup): a templated name resolved to the reserved `-clientconfig`
+		// internal-identity class. Same truncating posture as any endpoint-resolve
+		// failure (R-2 stageReturn) — the Secret is never dialed.
+		r.log.Error("templated endpoint reference refused",
+			slog.String("name", id), slog.Any("ref", apiCall.EndpointRef), slog.Any("error", guardErr))
+		return endpoints.Endpoint{}, stageReturn
+	}
+	resolved, err := r.mapper.resolveOne(r.ctx, ref, templated)
 	if err != nil {
 		r.log.Error("unable to resolve api endpoint reference",
-			slog.String("name", id), slog.Any("ref", apiCall.EndpointRef), slog.Any("error", err))
+			slog.String("name", id), slog.Any("ref", ref), slog.Any("error", err))
 		return endpoints.Endpoint{}, stageReturn
 	}
 	return resolved, stageProceed
+}
+
+// evalEndpointRef renders a templated endpointRef.name (#113). For a nil ref or
+// a non-templated (literal) name it returns the ref UNCHANGED with templated=false
+// (byte-identical to pre-#113 — the internal nil-ref synthesis and static author
+// refs are untouched). For a MaybeQuery-shaped name it evaluates the name through
+// evalJQ against r.dict (the SAME per-stage dict path/payload/headers see, so
+// `.name` resolves identically), RFC1123-sanitizes the result, applies guardrail
+// (a) (namespace stays the author-literal — NEVER templated) and guardrail (b)
+// (a resolved `-clientconfig` name is REFUSED here, fail-fast, so the Secret
+// lookup never fires), and returns templated=true so resolveOne applies its
+// defense-in-depth reserved-suffix refusal too. A jq error yields evalJQ's
+// error-string, which is sanitized like any other miss and resolves to a Secret
+// miss downstream (§1.2 honest-error posture) — not a new error class.
+func (r *resolveRun) evalEndpointRef(ref *templates.Reference) (*templates.Reference, bool, error) {
+	if ref == nil {
+		return ref, false, nil
+	}
+	if _, isTemplate := jqutil.MaybeQuery(ref.Name); !isTemplate {
+		// Static/literal name (incl a literal `-clientconfig` internal ref, which
+		// is the author's own business): pass through, NOT templated, NOT gated.
+		return ref, false, nil
+	}
+	name := kubeutil.MakeDNS1123Compatible(evalJQ(ref.Name, r.dict))
+	// Guardrail (b), layer 1 (fail-fast): a request-templated name may never
+	// resolve to the reserved `<user>-clientconfig` internal-identity class.
+	if strings.HasSuffix(name, clientConfigSuffix) {
+		return nil, true, fmt.Errorf(
+			"templated endpointRef.name %q resolved to %q, which carries the reserved internal-identity suffix %q; refusing at the template-eval site (#113 guardrail b) — user query-extras may not select a per-user credential Secret",
+			ref.Name, name, clientConfigSuffix)
+	}
+	// Guardrail (a): namespace is NEVER templated in V1 — it stays the
+	// author-authored literal, so a templated name can only ever select WITHIN
+	// the namespace the RA author already chose (the credential-store trust
+	// boundary). templated=true so resolveOne applies guardrail (b) again (§2
+	// two-layer defense).
+	return &templates.Reference{Name: name, Namespace: ref.Namespace}, true, nil
 }
 
 // collapseOrFanoutPlan builds the per-stage RequestOptions slice (the call

--- a/internal/resolvers/restactions/api/templated_endpointref_test.go
+++ b/internal/resolvers/restactions/api/templated_endpointref_test.go
@@ -1,0 +1,274 @@
+// templated_endpointref_test.go — #113 templated endpointRef falsifiers.
+//
+// #113 lets a RESTAction api-step select its dispatch endpoint Secret from
+// REQUEST extras by templating endpointRef.name through the SAME jq/extras
+// evaluator that already renders path/payload/headers. extras are user-controlled
+// query params, so an UNMITIGATED `${.name}` lets a caller select another user's
+// `<user>-clientconfig` Secret and dial the spoke step with THAT user's apiserver
+// credentials — a credential-selection escalation. The design closes it with two
+// guardrails, both enforced at TWO layers:
+//   (a) V1 templates the NAME only; namespace stays the author-literal.
+//   (b) a templated ref may never resolve to the reserved `-clientconfig` suffix.
+//
+// This file is the GATE-BLOCKING security proof (C-113-1) plus the request-
+// templated-marker default (C-113-2), namespace-literal (C-113-5), and static-ref
+// regression (C-113-6) arms. The seed-skip (C-113-3) lives in the dispatchers
+// package (phase1_seed_templated_endpointref_test.go). Hermetic, -race, no cluster.
+//
+// The C-113-1 "never DIALED" proof is STRONG: the secrets snapshot is seeded with
+// a forge-target `admin-clientconfig` carrying a SENTINEL server-url. If the guard
+// is bypassed, resolveOne HITS the snapshot and RETURNS that admin ServerURL —
+// the escalation SUCCEEDS, observable as a non-empty sentinel URL. With the guard
+// present the sentinel is NEVER returned (the lookup never fires). "Refused" is
+// proven by the admin credential never being SELECTED, not merely by an error.
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const forgedAdminServerURL = "https://ADMIN-CREDS-FORGED.invalid"
+
+// seedForgeableAdminClientconfig makes the secrets cache servable in authnNS with
+// an `admin-clientconfig` Secret carrying a SENTINEL server-url. If a lookup for
+// `admin-clientconfig` ever HITS (guard bypassed), FromInformerSecret returns the
+// sentinel ServerURL — the observable escalation.
+func seedForgeableAdminClientconfig(t *testing.T, authnNS string) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	cache.ResetSecretsInformerForTest()
+	cache.ResetSecretsSnapshotForTest()
+	cache.PublishSecretsSnapshotForTest(&cache.SecretsSnapshot{
+		ByName: map[string]*corev1.Secret{
+			"admin-clientconfig": mkSecret(authnNS, "admin-clientconfig", map[string]string{
+				"server-url": forgedAdminServerURL,
+			}),
+		},
+	})
+	cache.ForceSecretsCacheReadyForTest(authnNS)
+	t.Cleanup(func() {
+		cache.ResetSecretsSnapshotForTest()
+		cache.ResetSecretsInformerForTest()
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-113-1 layer (b) — resolveOne's defense-in-depth reserved-suffix refusal.
+// A REQUEST-TEMPLATED ref resolving to `admin-clientconfig` is refused at the
+// choke point EVERY ref lookup passes, so a FUTURE templating caller that forgets
+// the eval-site check still cannot dial a per-user credential Secret.
+func TestT1_ClientconfigForgery_RefusedInResolveOne_NeverDials(t *testing.T) {
+	authnNS := "krateo-system"
+	seedForgeableAdminClientconfig(t, authnNS)
+
+	m := &endpointReferenceMapper{authnNS: authnNS, username: "victim", rc: nil}
+	forged := &templates.Reference{Name: "admin-clientconfig", Namespace: authnNS}
+
+	// GREEN: templated=true → refused BEFORE the snapshot lookup. The sentinel
+	// admin ServerURL must NEVER be returned.
+	ep, err := m.resolveOne(context.Background(), forged, true /*templated*/)
+	if err == nil {
+		t.Fatal("C-113-1 layer(b) VIOLATED: resolveOne accepted a templated ref resolving to admin-clientconfig — a request-driven endpointRef selected a per-user credential Secret (escalation)")
+	}
+	if ep.ServerURL == forgedAdminServerURL {
+		t.Fatalf("C-113-1 layer(b) ESCALATION: resolveOne DIALED the admin credential (returned the sentinel ServerURL %q) despite the guard", forgedAdminServerURL)
+	}
+	if !strings.Contains(err.Error(), "guardrail b") {
+		t.Fatalf("C-113-1 layer(b): expected the reserved-suffix guardrail error; got %v", err)
+	}
+
+	// RED arm (the escalation the guard prevents): the IDENTICAL forged ref with
+	// templated=FALSE is NOT gated by layer (b) — it flows to the snapshot lookup
+	// and HITS the seeded admin-clientconfig, returning the sentinel ServerURL.
+	// This is EXACTLY what a request-templated ref must never be able to reach;
+	// it proves the guard's verdict flips SOLELY on the templated marker (if the
+	// marker didn't gate, the templated call above would have returned this too).
+	epRed, errRed := m.resolveOne(context.Background(), forged, false /*NOT templated → the pre-guard path*/)
+	if errRed != nil || epRed.ServerURL != forgedAdminServerURL {
+		t.Fatalf("C-113-1 RED-control broke: an UNGATED (templated=false) lookup of admin-clientconfig must HIT the seeded sentinel (proving the forge target is reachable absent the marker); got ep=%+v err=%v", epRed, errRed)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-113-1 layer (a) — the eval site (resolveStageEndpoint→evalEndpointRef)
+// refuses FAST, before resolveOne is ever called, so the Secret lookup never
+// fires. Drives the REAL evalEndpointRef with a template that folds a request
+// extra into a `-clientconfig` name.
+func TestT1_ClientconfigForgery_RefusedAtEvalSite_NeverReachesResolveOne(t *testing.T) {
+	authnNS := "krateo-system"
+	seedForgeableAdminClientconfig(t, authnNS)
+
+	// r.dict carries the request extras at top level (exactly as path sees them):
+	// extras.want = "admin" here. The template folds it into `admin-clientconfig`.
+	r := &resolveRun{
+		dict: map[string]any{"want": "admin"},
+	}
+	forgedTemplate := &templates.Reference{Name: `${ .want + "-clientconfig" }`, Namespace: authnNS}
+
+	ref, templated, guardErr := r.evalEndpointRef(forgedTemplate)
+	if guardErr == nil {
+		t.Fatal("C-113-1 layer(a) VIOLATED: evalEndpointRef did NOT refuse a templated name resolving to admin-clientconfig — the escalation reaches resolveOne/the Secret lookup")
+	}
+	if ref != nil {
+		t.Fatalf("C-113-1 layer(a): a refused template must return a nil ref (never handed to resolveOne); got %+v", ref)
+	}
+	if !templated {
+		t.Fatal("C-113-1 layer(a): a refused template must still report templated=true")
+	}
+	if !strings.Contains(guardErr.Error(), "guardrail b") {
+		t.Fatalf("C-113-1 layer(a): expected the reserved-suffix guardrail error; got %v", guardErr)
+	}
+
+	// Discriminating: the SAME derivation without the `-clientconfig` fold
+	// resolves cleanly (proves the refusal keys on the reserved suffix, not on
+	// templating per se).
+	okTemplate := &templates.Reference{Name: `${ .want + "-endpoint" }`, Namespace: authnNS}
+	okRef, okTemplated, okErr := r.evalEndpointRef(okTemplate)
+	if okErr != nil {
+		t.Fatalf("C-113-1 layer(a) control: a non-clientconfig templated name must NOT be refused; got %v", okErr)
+	}
+	if okRef == nil || okRef.Name != "admin-endpoint" || !okTemplated {
+		t.Fatalf("C-113-1 layer(a) control: expected resolved name admin-endpoint (templated); got %+v templated=%v", okRef, okTemplated)
+	}
+	if okRef.Namespace != authnNS {
+		t.Fatalf("C-113-5: namespace must stay the author-literal %q; got %q", authnNS, okRef.Namespace)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-113-2 — the request-templated marker DEFAULT. resolveOne's OWN internal
+// nil-ref→`<user>-clientconfig` synthesis must NEVER be refused (templated=false),
+// while a request-templated `-clientconfig` ref IS. Two RED directions.
+func TestC113_2_MarkerDefault_InternalSynthesisResolves_TemplatedRefused(t *testing.T) {
+	authnNS := "krateo-system"
+	t.Setenv("CACHE_ENABLED", "true")
+	cache.ResetSecretsInformerForTest()
+	cache.ResetSecretsSnapshotForTest()
+	// Seed the VICTIM's own clientconfig so the internal nil-ref synthesis has a
+	// real cell to resolve (the legitimate path).
+	cache.PublishSecretsSnapshotForTest(&cache.SecretsSnapshot{
+		ByName: map[string]*corev1.Secret{
+			"victim-clientconfig": mkSecret(authnNS, "victim-clientconfig", map[string]string{
+				"server-url": "https://victim.example.com",
+			}),
+		},
+	})
+	cache.ForceSecretsCacheReadyForTest(authnNS)
+	t.Cleanup(func() {
+		cache.ResetSecretsSnapshotForTest()
+		cache.ResetSecretsInformerForTest()
+	})
+
+	m := &endpointReferenceMapper{authnNS: authnNS, username: "victim", rc: nil}
+
+	// (i) DEFAULT direction — the internal nil-ref path synthesizes
+	// `victim-clientconfig` and MUST still resolve when UNMARKED (templated=false,
+	// the default every internal/static caller passes). The internal path resolved
+	// SOMETHING (no guardrail refusal); its ServerURL is the internal-dispatch
+	// override (kubernetes.default.svc) OR the seeded victim URL under TestMode.
+	ep, err := m.resolveOne(context.Background(), nil /*internal nil-ref*/, false)
+	if err != nil {
+		t.Fatalf("C-113-2 (i) VIOLATED: the internal nil-ref clientconfig synthesis was refused when UNMARKED (templated=false); the internal path must never be gated by guardrail (b); got %v", err)
+	}
+	if ep.ServerURL == "" {
+		t.Fatalf("C-113-2 (i): internal synthesis resolved to an empty endpoint; got ep=%+v", ep)
+	}
+
+	// (i)-discriminator — the marker is LOAD-BEARING: pass the SAME kind of
+	// `-clientconfig` name as a REQUEST-TEMPLATED ref (templated=true) and it IS
+	// refused. This is why the marker MUST default false: if the internal path
+	// inherited templated=true, this very refusal would break its own synthesis.
+	// (The internal synthesis itself is guard-safe because its ref is nil at the
+	// guard, but the marker's default is what keeps a `-clientconfig`-shaped name
+	// resolvable for the internal path and refused for a request-driven one.)
+	_, markedErr := m.resolveOne(context.Background(), &templates.Reference{Name: "victim-clientconfig", Namespace: authnNS}, true /*templated*/)
+	if markedErr == nil {
+		t.Fatal("C-113-2 (i)-discriminator: a templated `-clientconfig` ref must be refused — proving the templated marker is what gates guardrail (b), so the internal path MUST pass false")
+	}
+
+	// (ii) TEMPLATED direction — a request-templated ref to ANY `-clientconfig`
+	// name is refused. (Uses victim's own name to show even self-selection via a
+	// template is refused: the boundary is the reserved suffix, not cross-user.)
+	forged := &templates.Reference{Name: "victim-clientconfig", Namespace: authnNS}
+	_, terr := m.resolveOne(context.Background(), forged, true /*templated*/)
+	if terr == nil {
+		t.Fatal("C-113-2 (ii) VIOLATED: a request-templated `-clientconfig` ref was NOT refused")
+	}
+	if !strings.Contains(terr.Error(), "guardrail b") {
+		t.Fatalf("C-113-2 (ii): expected the guardrail error; got %v", terr)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-113-5 — ref.Namespace is NEVER templated in V1 (literal only). A template in
+// the NAME renders; the namespace passes through byte-identically. RED (hypothetical
+// namespace templating) = a `${...}` namespace would let extras redirect the
+// Secret lookup cross-namespace, reachable clientconfig-forgery across namespaces.
+func TestC113_5_NamespaceNeverTemplated(t *testing.T) {
+	r := &resolveRun{dict: map[string]any{"want": "spoke-a"}}
+	// A templated NAME + a namespace that LOOKS like a template: the namespace
+	// must pass through as the literal string, NEVER evaluated.
+	ref := &templates.Reference{Name: `${ .want + "-endpoint" }`, Namespace: `${ .want }`}
+	out, templated, err := r.evalEndpointRef(ref)
+	if err != nil {
+		t.Fatalf("unexpected guard error: %v", err)
+	}
+	if !templated || out == nil {
+		t.Fatalf("expected a templated resolved ref; got %+v templated=%v", out, templated)
+	}
+	if out.Name != "spoke-a-endpoint" {
+		t.Fatalf("name must render: got %q want spoke-a-endpoint", out.Name)
+	}
+	// The load-bearing assert: the namespace is the UNEVALUATED literal — extras
+	// did NOT rewrite it to "spoke-a".
+	if out.Namespace != `${ .want }` {
+		t.Fatalf("C-113-5 VIOLATED: namespace was templated/evaluated (got %q) — V1 keeps namespace literal to bound the credential-store trust boundary", out.Namespace)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C-113-6 — a STATIC (non-template) endpointRef.name is byte-identical to
+// pre-#113: the MaybeQuery gate skips evaluation, templated=false, NOT gated —
+// INCLUDING a literal `-clientconfig` internal ref (only TEMPLATED refs are
+// gated; a chart author writing a literal is the internal path's own business).
+func TestC113_6_StaticRefUnchanged_LiteralClientconfigNotRefused(t *testing.T) {
+	r := &resolveRun{dict: map[string]any{"want": "spoke-a"}}
+
+	// A plain literal name: passes through unchanged, NOT templated.
+	lit := &templates.Reference{Name: "spoke-a-endpoint", Namespace: "krateo-system"}
+	out, templated, err := r.evalEndpointRef(lit)
+	if err != nil || templated || out != lit {
+		t.Fatalf("C-113-6: a literal name must pass through UNCHANGED, not templated, same pointer; got out=%+v templated=%v err=%v (want same ref, false, nil)", out, templated, err)
+	}
+
+	// A literal `-clientconfig` name (author-written, not request-driven) is NOT
+	// refused at the eval site — only templated refs are gated. It returns
+	// templated=false so resolveOne's layer (b) (gated on templated) also lets it
+	// through, preserving the internal path byte-for-byte.
+	litCC := &templates.Reference{Name: "some-clientconfig", Namespace: "krateo-system"}
+	outCC, templatedCC, errCC := r.evalEndpointRef(litCC)
+	if errCC != nil {
+		t.Fatalf("C-113-6 VIOLATED: a LITERAL `-clientconfig` name was refused at the eval site — only TEMPLATED refs must be gated; got %v", errCC)
+	}
+	if templatedCC || outCC != litCC {
+		t.Fatalf("C-113-6: a literal `-clientconfig` ref must pass through unchanged (templated=false); got out=%+v templated=%v", outCC, templatedCC)
+	}
+
+	// And a nil ref (internal path) is a clean pass-through, not templated.
+	outNil, templatedNil, errNil := r.evalEndpointRef(nil)
+	if errNil != nil || templatedNil || outNil != nil {
+		t.Fatalf("C-113-6: a nil ref must pass through as (nil,false,nil); got out=%+v templated=%v err=%v", outNil, templatedNil, errNil)
+	}
+}
+
+// compile-time assertion that endpoints is used (endpoints.Endpoint referenced in
+// the resolveOne signature exercised above).
+var _ = endpoints.Endpoint{}


### PR DESCRIPTION
## Docs-only — the #113 CODE already merged via #114

The #113 templated-endpointRef **code** was merged to main by Diego as **#114** (squash `dc99261`, byte-identical to the dual-gate-green frozen `c26654a`). This PR now carries **only the feature-journal doc** (`docs/feature-113-templated-endpointref-2026-07-15.md`) — `git diff origin/main origin/fix/113-templated-endpointref` is that one file. No code, no conflict.

Merge this to land the feature-journal row alongside the shipped code, or close it if the journal is folded elsewhere.

The row records: the hub-spoke mechanism (evalJQ over `r.dict`, name-only V1), the two-layer `-clientconfig` guardrail (sentinel-dial RED-proven both layers), the seed-skip correctness rationale (endpoint-miss escapes both Put-decline sinks → would poison the no-extras cell), the 6-arm falsifier inventory, the deferred C-113-7 on-cluster proof, and the per-spoke-RBAC trade-off. Dual-gate FINAL ACCEPT (arch + PM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1