### PR TITLE
fix(cache): #118 (d) interim — short-TTL cap for userAccessFilter resolved cells (default-off)

### DIFF
--- a/docs/118-uaf-rbac-stale-read-design-2026-07-22.md
+++ b/docs/118-uaf-rbac-stale-read-design-2026-07-22.md
@@ -1,0 +1,411 @@
+# #118 — userAccessFilter RBAC stale-read: resolved-cache key blind to the refilter's RBAC dependency
+
+Design doc. Author: cache-architect. Date: 2026-07-22.
+Checkout: `feat/c6c8s5 @ bae1f6b` (= `main @ dd073f8` #116 + 3 export-security commits that do
+not touch any file cited here; the UAF/cache/RBAC surface is byte-identical to `dd073f8`).
+KUBECONFIG unset for the whole trace; no cluster touched; no `go test ./internal/rbac/...`.
+
+Every code claim below is **TRACED** (file:line on this checkout) unless labelled **INFERRED**.
+
+---
+
+## Headline
+
+- **Real bug — CONFIRMED.** All three legs of defect 1 verified in source. An RBAC grant/revoke
+  bumps `RBACGen` + rebuilds the snapshot but evicts **zero** resolved cells; the resolved-cache
+  key folds a single dispatch-authorizing `BindingUID` and **no RBAC generation**, while the UAF
+  refilter re-evaluates RBAC **per object per per-object-namespace** — a dependency the key never
+  sees. Defect 2 (dynamically-published composition types watched lazily-only) is also confirmed,
+  with the exact registration hook identified.
+- **Recommended fix: option (c) — per-user RBAC sub-generation folded into the key, with option
+  (d) short-TTL as the same-cycle interim stopgap.** Rationale: (c) is the only option that is
+  both correct AND survives the 50K composition-install RBAC storm (blast radius = only users
+  whose *own* effective bindings changed). (a) global RBACGen is correct but collides head-on with
+  the install storm; (b) per-user binding-UID set is correct but pays a full binding-set walk per
+  request. See §fix-options for why (c) is feasible against the existing typed snapshot indexes.
+- **Seeded/subscribed parity answer:** UAF **IS seeded** (proactive-RA seed enumerates all
+  RBAC-reachable RESTActions incl. UAF ones, resolved under a **cohort representative identity** —
+  NOT userless), and UAF **IS subscribable** on `/refreshes` (identity-bound restactions class,
+  same `dispatchCacheLookupKey` derivation). Both consumers call the SAME key-derivation function,
+  so a term folded into `dispatchCacheLookupKey` propagates to seed + subscription **for free** —
+  the parity surface is one function, not eight. C7's "userless→empty→frozen" hazard does **not**
+  apply to today's seed (it uses a real representative identity + fail-closed ""-skip).
+- **Interim mitigation: YES, ship option (d) short-TTL first.** But with a corrected exposure model:
+  the window is NOT "until restart." TTL is a hard absolute lifetime from write (`CreatedAt`), and
+  a hot cell that keeps getting **data-plane refreshed** slides `CreatedAt` forward on every refresh
+  → effectively unbounded for an actively-churning composition-list cell. A quiescent cell expires
+  at `RESOLVED_CACHE_TTL_SECONDS` (default 3600s). So the stopgap is worth shipping.
+
+---
+
+## §root-cause
+
+### Defect 1, leg 1 — the key folds the wrong RBAC identity
+
+`dispatchCacheLookupKey` (helpers.go:228-271) derives one `BindingUID` via a single
+`rbac.EvaluateRBAC` call for the **layer's own GET-permit** (helpers.go:240-248):
+
+```
+_, bindingUID, _ := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+    Username: ui.Username, Groups: ui.Groups, Verb: "get",
+    Group: group, Resource: resource, Namespace: namespace, Name: name})
+```
+
+That `bindingUID` is the ONLY identity material in `ResolvedKeyInputs` (helpers.go:256).
+`ComputeKey` (resolved.go:638-722) folds: version, class, GVR, ns, name, `BindingUID`
+(all classes except widgetContent, resolved.go:682-685), perPage, page, Stage, Extras — and
+**nothing else identity/RBAC-derived**.
+
+But the UAF refilter (`evalSingle`, refilter.go:250-308) fires a SEPARATE `rbac.EvaluateRBAC`
+**per object, per that object's own NamespaceFrom-derived namespace**, with `SkipBindingUID: true`
+(refilter.go:279-289). The set of objects the refilter KEEPS is a function of the user's
+per-namespace RoleBindings across every namespace in the result — a completely different RBAC
+evaluation from the single dispatch-GET `BindingUID`. **The key is blind to it.** Two RBAC states
+that produce the same dispatch `BindingUID` but different per-namespace refilter outcomes collide
+on the same cell.
+
+### Defect 1, leg 2 — `RBACGen` exists but is never consulted by the cache key
+
+`RBACGen()` (rbac_snapshot.go:254-256) returns `rbacSnapshotPublishSeq` (rbac_snapshot.go:241),
+bumped `.Add(1)` on every snapshot publish (rbac_snapshot.go:477). Its only non-test consumers:
+- `internal/metrics/metrics.go:394` — expvar observation.
+- `internal/cache/rbac_snapshot_expvar.go:55` — expvar `snowplow_rbac_publish_seq`.
+- `internal/handlers/refreshes.go:211` — `refreshWarmupIncomplete` boot-gate (`RBACGen()==0`).
+
+It is referenced **zero** times in helpers.go, resolved.go (`ComputeKey`), or any eviction path.
+The generation counter that would let a cell notice "the RBAC store changed under me" is computed
+and published but **never wired into the resolved cache**.
+
+### Defect 1, leg 3 — RBAC-plane changes evict no resolved cell
+
+Snapshot rebuilds are scheduled by `scheduleRBACRebuild` (rbac_snapshot.go:306), wired to the
+4 typed-RBAC GVR informers' Add/Update/Delete handlers (`rbacSnapshotEventHandlers`,
+rbac_snapshot.go:859-887). That path rebuilds the snapshot and bumps the gen — and stops there.
+
+The resolved-cache invalidation surface is entirely **data-plane**: `Deps().OnAdd/OnUpdate/OnDelete`
+(deps.go:635/647/721), driven by the *data* informers' events keyed by the watched object's
+`(gvr, namespace, name)` (deps_watch.go:117-223). There is **no edge** from `scheduleRBACRebuild`
+(or any RBAC-GVR event) into `OnAdd/OnUpdate/OnDelete` or any resolved-cell eviction/dirty-mark.
+
+⇒ **An RBAC change bumps `RBACGen` + rebuilds the snapshot but dirty-marks/evicts NO resolved
+cell.** The stale UAF result is served until the cell leaves cache by another mechanism (TTL /
+LRU / a data-plane DELETE of the cell's own object) — see §interim-mitigation for the real window.
+
+### Defect 2 — dynamically-published composition types are watched lazily-only
+
+Data informers register lazily: `ensureWatcherInformerForGVR` (deps_extract.go:147) →
+`rw.EnsureResourceType` (watcher.go:613), called only **after** a successful resolve Put
+(e.g. restactions.go:399). A CompositionDefinition that publishes a new CRD/type post-boot
+(e.g. `selfservicekrateoes`) is observed by the **CRD-discovery informer** (`triggerCRDDiscovery`,
+crd_discovery_side_effect.go:344, wired to the CRD informer AddFunc, :214), which on ADD refreshes
+the discovery cache + invalidates the schema memo + relists **already-registered** GVRs
+(`triggerCRDSchemaRelist`, :559) — but it deliberately does **NOT** register a data informer for
+the newly-served GVR: the relist is gated `if !rw.IsRegistered(gvr) { continue }`
+(crd_discovery_side_effect.go:607) with the comment "lazy registration is the resolver's job."
+
+So the new type stays unwatched until first resolver touch. Defect 1's permanent-hit
+(the same user's frozen composition-list cell that never re-dispatches into the new type) starves
+that touch → the type is never watched → no data-change invalidation for it → self-reinforcing
+freeze. Confirmed compound, as the brief states. #119/#120 are split out (noted at end).
+
+---
+
+## §severity — within-user, invariants preserved
+
+- **WITHIN-USER staleness, not cross-user leak.** The key folds `ui.Username`-derived `BindingUID`,
+  and the #95 serve-side guard `serveFromCacheEligible` (helpers.go:288-290) treats a re-derived
+  `""`-BindingUID as a MISS (falls through to a direct resolve under the request's own identity).
+  A different user with a different effective `BindingUID` lands on a different cell. So the hazard
+  is: **the same user sees their own now-stale UAF view** — e.g. access granted in namespace N is
+  not yet visible, or access revoked in N is still visible — until the cell leaves cache.
+- **Serious but bounded to the user's own identity.** It is an authz-**freshness** defect (revoked
+  access served, or newly-granted access withheld) with a potentially long window (§interim), not a
+  confidentiality breach across tenants.
+- **Invariants the fix MUST NOT regress:**
+  - L1 stays **per-user-keyed**, never cohort/groups-only (feedback_l1_per_user_keyed_never_cohort).
+    Options (b)/(c) preserve this by folding a per-USER discriminant; (a) global RBACGen is also
+    per-user-safe (it only adds a term, never widens sharing).
+  - The #95 `""`-BindingUID serve+populate guard (helpers.go:288, restactions.go:368,
+    phase1_pip_seed.go:668) stays intact — the new term is folded **alongside** BindingUID, the
+    fail-closed empty-identity collapse is unchanged.
+
+---
+
+## §fix-options
+
+All options add a term to `ResolvedKeyInputs` + `ComputeKey` (resolved.go:303/638) and bump
+`resolvedKeyVersion` v4→v5 (resolved.go:416) so no pre-fix cell serves as a post-fix hit on the
+rolling restart. They differ only in WHAT term and its blast radius under RBAC churn.
+
+### (a) Global RBACGen in the key — correct, worst herd
+Fold `RBACGen()` into `ComputeKey`. Any RBAC snapshot publish rotates the entire UAF key space at
+once. **Correct** (any RBAC change → new key → cold miss → fresh resolve → fresh refilter).
+**Fatal at 50K:** composition installs CREATE RBAC bindings continuously
+(project_composition_install_rbac_scale), each bump invalidates ALL identity-bound cells (not just
+UAF — every restactions/widgets/apistage/raFullList cell folds BindingUID and would fold RBACGen),
+so a steady install stream keeps the whole L1 permanently cold. Collides head-on with the
+install-storm snowplow must survive. **REJECT** as the standalone fix.
+
+### (b) Per-user relevant-binding-UID SET folded in — correct, expensive per request
+Fold a hash of the SET of binding UIDs that grant the requesting user anything relevant. Blast
+radius bounded to users whose binding set changed. **Correct**, per-user-safe. **Cost:** requires
+walking the user's full effective binding set on every /call (not just the single dispatch-GET
+EvaluateRBAC), on the hot path. At 50K/1M-binding scale that walk is the concern. Feasible but
+pays per-request CPU that (c) avoids.
+
+### (c) Per-user RBAC sub-generation — RECOMMENDED
+Maintain a per-subject counter that bumps ONLY when THAT subject's effective bindings change, and
+fold the requesting user's current sub-gen into the key. Blast radius = exactly the users whose
+own bindings changed; a composition-install binding for tenant-X bumps only tenant-X's subjects,
+leaving every other user's cells hot. **Correct** (a relevant RBAC change → the user's sub-gen
+bumps → new key → cold miss → fresh refilter), per-user-safe, and herd-proportional to the change,
+not to total traffic.
+
+**Feasibility against the existing snapshot (the crux of whether (c) is real, not hand-waved):**
+The typed snapshot already maintains subject→bindings indexes — `CRBsByUser`, `CRBsByGroup`,
+`CRBsByServiceAccount`, `CRBsCatchAll`, and `RoleBindingsByNS` (rebuilt in `rebuildSubjectIndexes`,
+rbac_snapshot.go:462/504, logged at :497-500). The per-event binding delta hooks
+(`onBindingAdd/Update/Delete`, wired at rbac_snapshot.go:864-885) already fire per binding change
+and already know the binding's subjects (they maintain the BindingsByGVR index). So the sub-gen
+map can be bumped from those SAME hooks: on a binding event, resolve its subjects (users + groups +
+SAs) and bump each affected subject's counter. A request's effective sub-gen = a fold over the
+user's own username-counter + each of its groups' counters (read lock-free like `RBACGen`). This
+reuses existing subject-index machinery — no new informer, no new walk on the hot path beyond a
+handful of map reads. **INFERRED** that the group-fold cost is bounded (a user has O(10) groups);
+must be confirmed by the dev against the exact `onBinding*` subject-extraction shape, but the
+indexes and hooks needed all exist.
+
+**Group-vs-user granularity caveat (dev must resolve):** a binding can grant via a GROUP the user
+is in. The sub-gen fold therefore must include every group the user presents, or a group-scoped
+grant/revoke won't bump the user's effective sub-gen. Folding `max`/`sum` over
+`{userCounter} ∪ {groupCounter[g] for g in ui.Groups}` handles this; the RED falsifier below
+(`grant via group`) pins it.
+
+### (d) Short-TTL / cache-bypass for UAF-bearing RESTActions only — interim stopgap
+Stamp a short `TTLOverride` (reuse the R1 Layer 2 machinery, resolved.go:270-279/788-796) on any
+resolved cell whose RESTAction declares `userAccessFilter`, OR bypass cache entirely for UAF cells.
+Bounds the window to the short TTL regardless of the key defect. Cheap, uniform (per-class-ish
+predicate: "entry's RA has a UAF stage"), reversible. Does NOT fix the key — a within-TTL RBAC
+change is still stale — but caps exposure. **Ship this in the same cycle as the interim.**
+
+### Recommendation
+**Ship (d) as the interim in the same PR/cycle, then (c) as the durable fix.** (d) caps the
+exposure window immediately at low risk; (c) is the correct key fix that also survives 50K. This
+is the "interim (d) + eventual (c)" hybrid the brief flagged as acceptable. Avoid (a) entirely at
+50K; keep (b) as the fallback if (c)'s per-subject bump proves infeasible against the snapshot
+(it should not).
+
+---
+
+## §key-parity-surface
+
+**Is UAF seeded? YES.** `proactive_ra_seed.go` enumerates ALL RBAC-reachable RESTActions
+(`RBACReachableRestActionRefs`, :55) with **no GVR/resource filter** (Option B rejected, :35), so
+UAF-bearing RESTActions are in the seed set. They resolve under a **cohort REPRESENTATIVE
+identity**, not userless: `withCohortSeedContext` installs `xcontext.WithUserInfo{Username:
+cohort.Username, Groups: cohort.Groups}` (phase1_pip_seed.go:438-441); `seedOneRestaction`
+(:620) calls `dispatchCacheLookupKey` which reads that identity (:638) and fail-closed-skips a
+`""`-BindingUID (:668). So the seed folds a real BindingUID under a real representative — C7's
+"userless→empty→frozen" cell does NOT exist in today's seed.
+
+**Is UAF subscribed? YES.** UAF RESTActions are `restactions`-class, an identity-bound subscribable
+class (refresh_subscription.go:11-13, 51-53). `/refreshes` arms them by re-deriving the key via the
+SAME `dispatchCacheLookupKey` under the connection's identity (refresh_subscription.go header,
+:85-88 — "dispatchCacheLookupKey's only external touch is rbac.EvaluateRBAC").
+
+**The parity surface is ONE function, not eight.** Because seed (`seedOneRestaction`
+phase1_pip_seed.go:638), subscription (`deriveSubscription` → `dispatchCacheLookupKey`,
+refresh_subscription.go), and dispatch (helpers.go:270) all route through
+`dispatchCacheLookupKey` → `cache.ComputeKey`, **any term folded into `ResolvedKeyInputs` +
+`ComputeKey` propagates to all three automatically.** The consumers the brief listed that must
+stay byte-parity:
+
+| Consumer | file:line | Folds via |
+|---|---|---|
+| dispatch (customer /call) | helpers.go:270 | `dispatchCacheLookupKey`→`ComputeKey` |
+| seed / prewarm | phase1_pip_seed.go:638-654, :889 | `dispatchCacheLookupKey`→`ComputeKey` |
+| subscription-refresh | refresh_subscription.go (deriveSubscription) | `dispatchCacheLookupKey`→`ComputeKey` |
+| widget / widget content | widgets.go:433, widget_content.go:303 | `ComputeKey` (widgetContent identity-free — see below) |
+| ra_full_list | ra_full_list.go (RAFullList class) | `ComputeKey` |
+| apistage | apistage.go | `ComputeKey` (folds Stage + BindingUID) |
+| cluster_list | cluster_list.go | `ComputeKey` |
+| refresher re-Put | resolve_populate.go:316 | uses stored `Inputs` → `ComputeKey` recompute |
+
+**Scoping consequence:** the new RBAC sub-gen term must be populated wherever a
+`ResolvedKeyInputs` is BUILT (helpers.go for dispatch/seed/subscription; widgets.go / apistage.go /
+etc. for the widget-side builders) — NOT just in `ComputeKey` (which only hashes what it's given).
+The clean placement is **inside `dispatchCacheLookupKey`** (it already does the `EvaluateRBAC`
+call and has `ui.Username`/`ui.Groups` in hand — helpers.go:240) plus the widget-side key builders,
+so every builder stamps the term from the same helper. **widgetContent stays identity-free**
+(resolved.go:682) — it is a shared envelope re-filtered per-user at serve time, so it does NOT fold
+the RBAC sub-gen; the fix must NOT touch its key or it breaks the shared-content invariant. UAF
+lives in restactions/apistage (identity-bound), so widgetContent exclusion is safe for #118.
+
+**#64 / F-ARCH lesson honored:** the CI invariant test (#67) already asserts
+`DeriveSubscriptionKey == ComputeKey` per class; the new term must be added to BOTH sides via the
+shared helper so that test keeps passing — and a new key-parity arm (§falsifiers) pins it.
+
+---
+
+## §interim-mitigation ruling — and the corrected exposure model
+
+**Does TTL bound the window at all? YES — but with a critical nuance the "until restart" framing
+misses.**
+
+- `CreatedAt` is stamped exactly once, at Put, only when zero (resolved.go:843-844). `Get` expires
+  on `time.Since(entry.CreatedAt) > effectiveTTL` (resolved.go:823); the LRU touch on a hit does
+  **not** reset `CreatedAt` (resolved.go:830). So for a cell that is only ever READ, the window is
+  a hard **absolute** lifetime = `RESOLVED_CACHE_TTL_SECONDS` (default 3600s = 1h,
+  resolved.go:103) from first write. **Not "until restart."**
+- **BUT** the refresher re-Put builds a FRESH `ResolvedEntry` with zero `CreatedAt`
+  (resolve_populate.go:287-295 — no CreatedAt field set), so the Put stamps a NEW `time.Now()`
+  → **`CreatedAt` slides forward on every data-plane refresh.** The keepwarm sweep does the same by
+  design (prewarm_keepwarm_sweep.go:18/118: "each sweep Put resets CreatedAt"). A UAF
+  composition-list cell whose underlying watched objects keep churning (an active tenant) is
+  data-plane-refreshed repeatedly → its TTL never elapses → the stale RBAC/refilter result is
+  served **effectively indefinitely** (until the cell falls out of the refresh/keepwarm rotation
+  for a full TTL, or a DELETE of its own object evicts it). This is why the "until restart"
+  intuition is directionally right for a hot cell even though the mechanism is TTL-slide, not
+  no-TTL.
+
+**Ruling: SHIP option (d) short-TTL as the interim, same cycle.** A short `TTLOverride` on
+UAF-bearing cells caps the window even for a hot, refreshed cell — as long as the override applies
+on the refresh re-Put too (it will, via the same `IsServable`/predicate stamp path the R1 Layer 2
+`TTLOverride` already uses; the dev must confirm the UAF predicate is applied on the refresher Put
+in resolve_populate.go:287, not only the first customer Put). This is worth doing because the
+un-mitigated window is unbounded-for-hot-cells, and (c) is a larger change requiring the per-subject
+sub-gen plumbing.
+
+---
+
+## §defect-2 informer-registration design
+
+**Prior art:** the hook already exists — the CRD-discovery informer AddFunc → `triggerCRDDiscovery`
+(crd_discovery_side_effect.go:214/344). It currently refreshes discovery + schema memo + relists
+**registered** GVRs (:607 gates on `IsRegistered`). It does NOT register a data informer for a
+newly-served GVR.
+
+**Design:** add an additive, gated branch in `triggerCRDDiscovery`'s ADD path that, for a CRD whose
+served GVRs are **not yet registered** AND whose group is navigation-discovered
+(`AddNavigationDiscoveredGroup(group)` already runs at :396), eagerly calls `rw.EnsureResourceType(gvr)`
+for each served GVR (crdServedGVRs, :593) — i.e. register the data informer at CRD-publish time
+rather than waiting for first resolver touch. Then `Deps().OnResourceTypeSchemaRelisted(gvr)` (or an
+ADD-equivalent) to dirty-mark any dependent LIST cells so a change to the freshly-self-served type
+invalidates them.
+
+**Bounding (no unbounded informer growth):**
+- Gate on **navigation-discovered group** only (reuse `AddNavigationDiscoveredGroup`/the
+  removable-discriminator at watcher.go:749/1064) so snowplow does not spawn informers for every
+  CRD in the cluster — only for groups the portal navigation actually reaches. This is the same
+  discriminator the schema-relist already trusts.
+- `EnsureResourceType` is registration-idempotent + singleflighted via `rw.mu` (watcher.go:613),
+  so double-fire under CRD churn is safe.
+- The informer count is bounded by the number of nav-reachable served GVRs — the same set the
+  resolver would have lazily registered anyway; this only changes WHEN (publish-time vs
+  first-touch), not the ceiling.
+
+**Toggle-able (cache is provisional/removable — project_caching_is_provisional):** gate the eager
+registration behind an env flag (e.g. `CRD_EAGER_INFORMER_REGISTER`, default off or on per Diego),
+so it is cleanly removable and the lazy path remains the fallback. When off, behavior is exactly
+today's.
+
+**Interaction with defect 1's fix:** once (c) evicts the frozen UAF cell on the user's own RBAC
+change, the user re-dispatches, which lazily registers the type anyway — so defect 2's fix is
+belt-and-suspenders (covers the data-change-invalidation gap for a freshly-published type even
+before any user touches it). Both are worth shipping; defect 2 can be a separate PR.
+
+---
+
+## §falsifiers
+
+Each is the specific artifact that proves the fix works (or didn't). Empirical-first: the on-cluster
+arms are the acceptance gate; the hermetic arms are the standing regression guard.
+
+1. **RBAC-grant → immediate-visibility (on-cluster, kind or GKE).** User U with a UAF
+   composition-list cell warm (l1:HIT). Grant U access in namespace N (create a RoleBinding).
+   Within one refresh interval, U's next /call MUST include N's items. **RED before fix**
+   (item stays absent until TTL/restart); GREEN after (c).
+2. **RBAC-revoke → immediate-drop (on-cluster).** Symmetric: revoke U's access in N; U's next
+   /call MUST drop N's items promptly. **RED before fix** (revoked item still served); GREEN after.
+   This is the security-load-bearing arm.
+3. **Per-user-keying NOT regressed (hermetic + on-cluster).** Two users U1, U2 with different
+   effective bindings resolve the same UAF RA: distinct keys, distinct cells, no cross-serve.
+   Assert `ComputeKey(U1 inputs) != ComputeKey(U2 inputs)` and that U1's grant change does NOT
+   bump U2's sub-gen (per-subject isolation). Pins feedback_l1_per_user_keyed_never_cohort.
+4. **#95 ""-BindingUID guard intact (hermetic).** A `""`-BindingUID request still MISSes and
+   falls through (serveFromCacheEligible + the populate-side skip). The new sub-gen term must NOT
+   make a `""`-BindingUID cell servable. RED arm = a fix that folds sub-gen but drops the ""-guard.
+5. **Key-parity across consumers (hermetic, extends #67).** For a UAF coord: assert
+   `DeriveSubscriptionKey(coords, identity) == ComputeKey(dispatch)` AND
+   `seedKey == dispatchKey` after the sub-gen term is added — driving BOTH sides through the REAL
+   `dispatchCacheLookupKey` (no shadow copy; feedback_key_parity_golden_real_inputs_prehash_diff:
+   assert PRE-HASH field equality of `ResolvedKeyInputs.RBACSubGen`, not just the digest). RED arm
+   = fold the term on the dispatch side only → keys diverge → the test catches it.
+6. **Grant-via-GROUP bumps the user's sub-gen (hermetic).** A binding that grants via a group U is
+   in must bump U's effective sub-gen. RED arm = a fold over only `{userCounter}` (blind to groups)
+   → this test fails; GREEN = fold over `{user} ∪ {groups}`. This pins the granularity caveat in (c).
+7. **50K herd bound (bench analysis + arm).** Under a simulated composition-install RBAC-binding
+   stream for tenant-X only, assert cells for an UNRELATED tenant-Y stay HIT (their sub-gen does not
+   bump). This is the arm that discriminates (c) from (a): under (a) all cells go cold; under (c)
+   only tenant-X's do. Falsifier shape must have ≥2 tenants (feedback_falsifier_shape_must_discriminate
+   — a single-tenant arm masks the global-vs-per-user distinction). Runs on the bench; the negative
+   control is "swap (c)→(a) and watch tenant-Y go cold."
+8. **Interim (d) window bound (on-cluster).** With (d) enabled, a UAF cell's staleness after an
+   RBAC change is ≤ the short TTL even for a data-plane-refreshed hot cell — confirm the UAF
+   `TTLOverride` predicate is applied on the refresher Put (resolve_populate.go:287), not only the
+   first Put; otherwise the slide defeats it. Falsifier: churn the cell's data to force refreshes,
+   verify `CreatedAt`-slide does not extend a UAF cell past its override.
+9. **Defect-2: freshly-published type is watched at publish (on-cluster).** Publish a
+   CompositionDefinition creating a new type post-boot; WITHOUT any user touching it, mutate an
+   object of that type and assert a dependent LIST cell dirty-marks. RED before fix (unwatched
+   until first touch); GREEN after the eager-register branch. Bound-check: assert no informer is
+   spawned for a CRD in a NON-nav-discovered group (the growth bound).
+
+---
+
+## §rejected-alternatives
+
+- **Global RBACGen in the key (option a) as the standalone fix** — REJECTED: correct but collides
+  with the 50K install storm (every binding create invalidates all identity-bound cells).
+- **Evict-on-RBAC-change by walking L1 for affected cells** — REJECTED: L1 is keyed by an opaque
+  hash with no reverse index from `(subject → keys)`; a wholesale scan on every RBAC publish is the
+  same herd as (a) plus a full-map walk. The key-fold approach (c) achieves the same effect lazily
+  (next lookup misses) without a scan.
+- **Fold the full per-request refilter RBAC evaluation into the key** — REJECTED: the refilter's
+  RBAC eval is per-object over the (unknown-until-resolved) result set; it cannot be computed at
+  key-derivation time without resolving first (chicken-and-egg). The sub-gen is the right proxy:
+  it captures "did anything about this user's RBAC change" without enumerating the result.
+- **widgetContent folding the RBAC term** — REJECTED: widgetContent is deliberately identity-free
+  (shared envelope, per-user serve-time filter, resolved.go:682); folding identity/RBAC there
+  breaks the shared-content invariant. UAF is not a widgetContent concern.
+- **Userless-prewarm exclusion for UAF (C7)** — NOT NEEDED as a fix: today's seed uses a real
+  cohort representative identity (phase1_pip_seed.go:438-441), not userless, and fail-closed-skips
+  `""`-BindingUID (:668). There is no userless-empty UAF cell to freeze. (If a future change adds a
+  userless prewarm arm, THEN exclude UAF — noted as a forward guard, not a #118 fix.)
+
+---
+
+## §effort
+
+- **Interim (d):** ~30-60 LOC. UAF-predicate detection on the resolved entry (does the entry's RA
+  declare a UAF stage) + `TTLOverride` stamp at both Put sites (customer + refresher). Reuses R1
+  Layer 2 machinery. Same cycle.
+- **Durable (c):** ~150-250 LOC. New per-subject sub-gen map + bump from `onBinding*` hooks
+  (rbac_snapshot.go:864-885) + a `RBACSubGenForSubject(user, groups)` reader (lock-free, mirrors
+  `RBACGen`) + `RBACSubGen` field on `ResolvedKeyInputs` + fold in `ComputeKey` + stamp in
+  `dispatchCacheLookupKey` and the widget-side key builders + `resolvedKeyVersion` v4→v5 bump.
+  Plus the 6-9 falsifier arms.
+- **Defect 2:** ~40-80 LOC. Additive eager-register branch in `triggerCRDDiscovery`
+  (crd_discovery_side_effect.go:344) gated on nav-discovered group + env flag + dirty-mark.
+  Separate PR.
+
+Sequence: interim (d) + defect-2 can ship first/cheap; (c) is the main effort and the security
+close-out. All default-off/toggle-able per project_caching_is_provisional until validated.
+
+---
+
+## Compound / split-out notes
+- **#119** (readyz-unserved-group) and **#120** (roots rate-limiter) are SPLIT OUT per the brief;
+  not folded here. Both compound defect 2's freeze (a freshly-published group being unserved /
+  rate-limited delays the first touch that would lazily register it), but their fixes are
+  independent.

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -66,6 +66,21 @@ const (
 	// before). Operators set it via the chart value.
 	envCatalogUnservableTTLSeconds = "CATALOG_UNSERVABLE_TTL_SECONDS"
 
+	// envUAFResolvedTTLSeconds — #118 (d) INTERIM stopgap for the
+	// userAccessFilter RBAC stale-read (design docs/118-uaf-rbac-stale-read-
+	// design-2026-07-22.md). A resolved cell whose RESTAction declares a
+	// userAccessFilter stage is stamped this short TTLOverride so its
+	// staleness window after an out-of-band RBAC change is CAPPED at this
+	// value — even for a hot, data-plane-refreshed cell (the override is
+	// re-stamped on the refresher re-Put too, else the CreatedAt-slide would
+	// defeat it: #118 C-118-6). This does NOT fix the cache key (a within-TTL
+	// RBAC change is still served stale — that is #118 (c)'s job); it only
+	// bounds the exposure window. Default 0 = DISABLED (purely additive, the
+	// per-entry override is unset → UAF cells use the standard TTL exactly as
+	// today). Operators set it via the chart value; cleanly removable per
+	// project_caching_is_provisional.
+	envUAFResolvedTTLSeconds = "UAF_RESOLVED_TTL_SECONDS"
+
 	// envResolvedCacheMaxResidentBytes is the Ship 4a (0.30.198) byte
 	// budget for the PINNED resident region — the eviction-protected cells
 	// (expensive prewarmed RAFullList full-list caches). Resident bytes are
@@ -371,6 +386,20 @@ type ResolvedKeyInputs struct {
 	// pre-existing entry's key does not shift). The api-stage resolver
 	// builds the Stage value; ComputeKey only folds it into the hash.
 	Stage string
+
+	// HasUAF — #118 (d) interim: true when the resolved cell's RESTAction
+	// declares a userAccessFilter stage. Set by the customer dispatch (which
+	// has the resolved CR in hand) into the cacheInputs before Put, and CARRIED
+	// on ResolvedEntry.Inputs so the refresher re-Put (which only has the stored
+	// Inputs, not the CR) can re-stamp the short UAF TTLOverride too — the
+	// #118 C-118-6 both-Put-sites requirement (else the CreatedAt-slide on a hot
+	// refreshed cell defeats the cap).
+	//
+	// EXCLUDED FROM COMPUTEKEY. Like RepresentativeUsername/Groups above, this
+	// is bookkeeping carried on Inputs, NOT key material — ComputeKey does not
+	// hash it, so adding it does NOT shift the key space (no resolvedKeyVersion
+	// bump) and a UAF cell keeps the SAME key as before, only a shorter TTL.
+	HasUAF bool
 }
 
 // resolvedKeyVersion is folded into every key hash so a key-schema
@@ -1532,6 +1561,24 @@ func intFromEnv(key string, def int) int {
 // knobs since it governs per-entry expiry in this store.
 func CatalogUnservableTTL() time.Duration {
 	s := intFromEnv(envCatalogUnservableTTLSeconds, 0)
+	if s <= 0 {
+		return 0
+	}
+	return time.Duration(s) * time.Second
+}
+
+// UAFResolvedTTL returns the #118 (d) interim short-TTL stamped on resolved
+// cells whose RESTAction declares a userAccessFilter stage, or 0 when DISABLED
+// (the default — env unset/0/invalid). When > 0, a UAF-bearing entry should
+// carry this as ResolvedEntry.TTLOverride at BOTH Put sites (customer dispatch
+// AND refresher re-Put — #118 C-118-6) so its RBAC-staleness window is capped
+// even under CreatedAt-sliding data-plane refresh churn. Read at Put time
+// (cheap os.Getenv + Atoi), mirroring CatalogUnservableTTL. effectiveTTLLocked
+// already honours the SHORTER of TTLOverride and the store ttl, so a UAF TTL
+// only ever TIGHTENS the bound. INTERIM ONLY: caps the window, does not fix the
+// key (#118 (c) is the durable per-user-RBAC-subgen key fix).
+func UAFResolvedTTL() time.Duration {
+	s := intFromEnv(envUAFResolvedTTLSeconds, 0)
 	if s <= 0 {
 		return 0
 	}

--- a/internal/cache/resolved_uaf_ttl_test.go
+++ b/internal/cache/resolved_uaf_ttl_test.go
@@ -1,0 +1,63 @@
+// resolved_uaf_ttl_test.go — #118 (d) interim short-TTL falsifiers, store level.
+//
+// A UAF-bearing resolved cell carries a short TTLOverride so its RBAC-staleness
+// window is capped; a non-UAF cell keeps the standard ttl (no collateral
+// shortening); the knob defaults to 0 (disabled → no override → today's
+// behavior). These are the store-level + env-accessor arms; the C-118-6
+// both-Put-sites RED arm lives in the dispatchers package (it needs the two Put
+// sites' override derivation).
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUAFResolvedTTL_DisabledByDefault: the env accessor is 0 (disabled) unless
+// set — the override is purely additive, so toggle-off is byte-identical today.
+func TestUAFResolvedTTL_DisabledByDefault(t *testing.T) {
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "")
+	if d := UAFResolvedTTL(); d != 0 {
+		t.Fatalf("UAFResolvedTTL unset must be 0 (disabled); got %v", d)
+	}
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "0")
+	if d := UAFResolvedTTL(); d != 0 {
+		t.Fatalf("UAFResolvedTTL=0 must be 0 (disabled); got %v", d)
+	}
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "30")
+	if d := UAFResolvedTTL(); d != 30*time.Second {
+		t.Fatalf("UAFResolvedTTL=30 must be 30s; got %v", d)
+	}
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "garbage")
+	if d := UAFResolvedTTL(); d != 0 {
+		t.Fatalf("UAFResolvedTTL invalid must be 0 (disabled); got %v", d)
+	}
+}
+
+// TestUAFShortTTL_CapsUAFCell_NotNonUAF is the store-level discriminator: with
+// the store ttl a long 1h, a UAF cell carrying the short override self-evicts
+// within the bound, while a NON-UAF cell (no override) stays a HIT — proving the
+// cap is scoped to UAF cells and does not collaterally shorten every cell.
+func TestUAFShortTTL_CapsUAFCell_NotNonUAF(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour) // standard ttl = 1h
+
+	// UAF cell: short 1s override, aged 2s → past the override, far inside 1h.
+	c.Put("k-uaf", &ResolvedEntry{
+		RawJSON:     []byte(`{}`),
+		CreatedAt:   time.Now().Add(-2 * time.Second),
+		TTLOverride: 1 * time.Second,
+	})
+	// Non-UAF cell: NO override, same age → governed by the 1h standard ttl.
+	c.Put("k-plain", &ResolvedEntry{
+		RawJSON:   []byte(`{}`),
+		CreatedAt: time.Now().Add(-2 * time.Second),
+	})
+
+	if _, ok := c.Get("k-uaf"); ok {
+		t.Fatal("#118(d): a UAF cell with the short override (age 2s > 1s override) must be a MISS — the staleness cap did not fire")
+	}
+	if _, ok := c.Get("k-plain"); !ok {
+		t.Fatal("#118(d): a NON-UAF cell (no override, age 2s, 1h ttl) must still be a HIT — the UAF cap must not collaterally shorten non-UAF cells")
+	}
+}

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -814,12 +814,30 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 		return nil
 	}
 
+	// #118 (d) interim — THE THIRD PUT SITE (arch gate on 3783e65). The boot
+	// seed Puts a UAF restactions cell under a cohort REPRESENTATIVE identity
+	// (proactive_ra_seed enumerates ALL RBAC-reachable RESTActions incl. UAF
+	// composition-list RAs), but `inputs` came from dispatchCacheLookupKey which
+	// NEVER sets HasUAF (only the customer path does). Without this stamp a
+	// boot-seeded UAF cell is governed by the LONG standard TTL AND stays
+	// un-capped across refresher re-Puts (HasUAF not carried) until a customer
+	// /call overwrites it — exactly the seeded/warm-without-a-fresh-dispatch
+	// population (d) exists to cap. Set HasUAF from the typed CR (`cr`, converted
+	// above) and stamp the short override via the SAME single-source helper the
+	// customer + refresher Puts use, so all THREE Put sites cap identically
+	// (C-118-6 extended to the seed). uafTTLOverrideForEntry returns 0 (no
+	// override) when the knob is unset or the RA has no UAF stage → byte-identical
+	// to today for a non-UAF seed cell and when disabled.
+	if inputs != nil {
+		inputs.HasUAF = restactionHasUAFStage(&cr)
+	}
 	// Put under the per-user key — exactly the shape restactions.go
 	// :212-216 puts under at serve time.
 	handle.Put(key, &cache.ResolvedEntry{
 		RawJSON:      encoded,
 		Inputs:       inputs,
 		SeededAtBoot: true, // #130 F3 seed-attribution: this cell was warmed by the boot seed
+		TTLOverride:  uafTTLOverrideForEntry(inputs),
 	})
 	// counters-hygiene 2026-07-04: this success Put is a seed UNIT resolved +
 	// written to per-user L1 — the real meaning of

--- a/internal/handlers/dispatchers/resolve_populate.go
+++ b/internal/handlers/dispatchers/resolve_populate.go
@@ -292,6 +292,16 @@ func resolveAndPopulateL1(ctx context.Context, inputs cache.ResolvedKeyInputs, s
 		// expensive cell to the transient LRU. Put honours the pin subject
 		// to the resident budget (else demotes — the safe degrade).
 		Pinned: prePinned,
+		// #118 (d) interim — C-118-6 CRUX: re-stamp the short UAF TTLOverride on
+		// the REFRESHER re-Put too. The refresher builds a FRESH entry with zero
+		// CreatedAt (Put stamps a new time.Now()), so a hot, data-plane-refreshed
+		// UAF cell would slide its CreatedAt forward every refresh and OUTLIVE the
+		// cap if the override were stamped only on the first customer Put. inputs
+		// is the STORED ResolvedKeyInputs (carrying HasUAF from the original
+		// dispatch), so uafTTLOverrideForEntry re-derives the same override here
+		// without needing the RESTAction CR. Returns 0 (no override) when the knob
+		// is unset or the cell is non-UAF → byte-identical to today.
+		TTLOverride: uafTTLOverrideForEntry(&inputs),
 	}
 	// Ship #97 (0.30.214) — restore the R3 fast-path on refresher Puts
 	// of apistage-class LIST entries. Pre-fix the refresher Put wrote

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -380,9 +380,22 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 			got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 			got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
 			perPage, page, extras)
+		// #118 (d) interim — if THIS RESTAction declares a userAccessFilter stage,
+		// record it on the carried Inputs (so the refresher re-Put re-stamps the
+		// same short TTL — C-118-6) and stamp the short UAF TTLOverride on the
+		// entry, capping the RBAC-staleness window (the resolved key is blind to
+		// the per-object refilter RBAC dependency; #118 (c) is the durable key
+		// fix). uafTTLOverrideForEntry returns 0 (no override) when the knob is
+		// unset OR the RA has no UAF stage → byte-identical to today for every
+		// non-UAF cell and when disabled. HasUAF is NOT key-folded (ComputeKey
+		// skips it), so the cell keeps its existing key — only its TTL tightens.
+		if cacheInputs != nil {
+			cacheInputs.HasUAF = restactionHasUAFStage(&cr)
+		}
 		cacheHandle.Put(cacheKey, &cache.ResolvedEntry{
-			RawJSON: encoded,
-			Inputs:  cacheInputs,
+			RawJSON:     encoded,
+			Inputs:      cacheInputs,
+			TTLOverride: uafTTLOverrideForEntry(cacheInputs),
 		})
 		// 0.30.8: record the self-dep so a DELETE on this RestAction
 		// CR evicts the cached entry, and an UPDATE re-resolves it.

--- a/internal/handlers/dispatchers/uaf_shortttl.go
+++ b/internal/handlers/dispatchers/uaf_shortttl.go
@@ -29,6 +29,42 @@
 // TOGGLE (project_caching_is_provisional): UAF_RESOLVED_TTL_SECONDS default 0 =
 // DISABLED → uafTTLOverrideForEntry returns 0 → TTLOverride stays 0 → every UAF
 // cell uses the standard TTL, byte-identical to today. Cleanly removable.
+//
+// R-d-4 SITE MAP — the complete `ResolvedEntry{` Put enumeration and WHY each
+// site is or is not in (d)'s scope (reasoned, not missed). (d) caps the
+// identity-bound restactions cell that carries the per-user REFILTER OUTPUT.
+//
+// IN SCOPE — all three restactions ResolvedEntry Put sites stamp the UAF cap:
+//   - restactions.go       — customer dispatch Put.
+//   - resolve_populate.go  — refresher re-Put (CreatedAt-slides on every
+//                            data-plane refresh; the C-118-6 crux site).
+//   - phase1_pip_seed.go seedOneRestaction — boot-seed Put (seeds UAF cells
+//                            under a cohort representative identity; added after
+//                            the arch gate on 3783e65 caught the "counted 2,
+//                            there were 3" miss).
+//
+// OUT OF SCOPE BY DESIGN (the PM's open apistage question, resolved by tracing):
+//   - apistage.go:607 / cluster_list.go:417 — CacheEntryClassApistage, keyed by
+//     contentKeyInputs(gvr, ns, name): IDENTITY-FREE shared substrate, the raw
+//     pre-refilter apiserver envelope. Its staleness is DATA-plane (an informer
+//     dirty-mark on the watched GVR invalidates it), NOT RBAC-refilter-output
+//     staleness. It carries NO BindingUID and NO per-user refilter output, so an
+//     out-of-band RBAC change does not make IT stale — the identity-bound
+//     restactions cell (which holds the refilter output and IS capped above) is
+//     the one that goes stale. Both already self-stamp the CATALOG_UNSERVABLE
+//     data-plane override for their own degradation. Capping the substrate would
+//     be wrong-cell and would churn a shared hot cell for zero RBAC-freshness
+//     gain. (Traced + agreed with arch/PM; no disagreement to flag.)
+//   - partial_result_ttl.go:85 — self-stamps its OWN bounded TTLOverride for a
+//     partial-with-errors body; independent bounded-staleness mechanism. Untouched.
+//   - phase1_pip_seed.go seedOneWidget (~:1046) + widgets.go / widget_content.go
+//     / ra_full_list_store.go — widgets / widgetContent / RAFullList classes.
+//     UAF is a restactions-STAGE contract (API.UserAccessFilter). A widget whose
+//     apiRef resolves a UAF RA warms the RESTACTIONS cell via the apiref resolve
+//     path — which IS the seedOneRestaction / dispatch path now capped above — so
+//     the widget path is NOT a hole: the UAF refilter output only ever lands in a
+//     restactions-class cell, never a widget-class one. widgetContent is
+//     additionally identity-free (shared envelope, per-user serve-time filter).
 
 package dispatchers
 

--- a/internal/handlers/dispatchers/uaf_shortttl.go
+++ b/internal/handlers/dispatchers/uaf_shortttl.go
@@ -1,0 +1,72 @@
+// uaf_shortttl.go — #118 (d) interim short-TTL for userAccessFilter-bearing
+// resolved cells.
+//
+// THE DEFECT (docs/118-uaf-rbac-stale-read-design-2026-07-22.md): the resolved-
+// cache key folds a single dispatch-authorizing BindingUID, but a
+// userAccessFilter stage re-evaluates RBAC PER OBJECT, PER that object's own
+// namespace — a dependency the key never sees. An out-of-band RBAC grant/revoke
+// bumps RBACGen + rebuilds the snapshot but evicts ZERO resolved cells, so a
+// user's own now-stale UAF view (access granted-in-N not yet visible, or
+// revoked-in-N still visible) is served until the cell leaves cache. On a hot,
+// data-plane-refreshed cell the CreatedAt slides forward every refresh → the
+// standard TTL never elapses → effectively-indefinite staleness.
+//
+// THIS IS THE INTERIM (d), NOT THE FIX. It does NOT fix the key — a within-TTL
+// RBAC change is still served stale. It CAPS the exposure window at a short
+// TTLOverride on UAF-bearing cells. The durable fix is #118 (c): a per-user RBAC
+// sub-generation folded into the cache key.
+//
+// C-118-6 (THE CRUX): the override must be stamped at BOTH Put sites — the
+// customer dispatch Put (restactions.go) AND the refresher re-Put
+// (resolve_populate.go, which builds a fresh entry with zero CreatedAt and thus
+// slides the absolute TTL forward on every data-plane refresh). Stamping only
+// the first Put lets a hot churning UAF cell re-Put without the override and
+// OUTLIVE the cap. The customer path detects UAF from the resolved RESTAction CR
+// and records it on cacheInputs.HasUAF; the refresher reads the carried
+// inputs.HasUAF (it has no CR). Both sites call uafTTLOverrideForEntry, so the
+// override derivation is single-source and cannot drift between them.
+//
+// TOGGLE (project_caching_is_provisional): UAF_RESOLVED_TTL_SECONDS default 0 =
+// DISABLED → uafTTLOverrideForEntry returns 0 → TTLOverride stays 0 → every UAF
+// cell uses the standard TTL, byte-identical to today. Cleanly removable.
+
+package dispatchers
+
+import (
+	"time"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// restactionHasUAFStage reports whether any api-step of cr declares a
+// userAccessFilter (the per-object refilter contract the resolved key is blind
+// to). Each api-step is a *API and UserAccessFilter a *UserAccessFilterSpec —
+// both nil-guarded. This is a general per-entry predicate ("the entry's RA has a
+// UAF stage"), NOT a per-resource special-case (feedback_no_special_cases): it
+// keys on the presence of the UAF contract itself, uniform across every RA.
+func restactionHasUAFStage(cr *templatesv1.RESTAction) bool {
+	if cr == nil {
+		return false
+	}
+	for _, step := range cr.Spec.API {
+		if step != nil && step.UserAccessFilter != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// uafTTLOverrideForEntry returns the short UAF TTLOverride to stamp on a
+// resolved entry, or 0 (no override → standard TTL) when either the knob is
+// disabled (UAF_RESOLVED_TTL_SECONDS unset/0) OR the entry is not UAF-bearing
+// (inputs.HasUAF false / inputs nil). Called at BOTH Put sites (customer +
+// refresher) so the cap is derived identically regardless of which path writes
+// the cell (C-118-6). effectiveTTLLocked already honours the SHORTER of the
+// override and the store TTL, so this only ever TIGHTENS the bound.
+func uafTTLOverrideForEntry(inputs *cache.ResolvedKeyInputs) time.Duration {
+	if inputs == nil || !inputs.HasUAF {
+		return 0
+	}
+	return cache.UAFResolvedTTL()
+}

--- a/internal/handlers/dispatchers/uaf_shortttl_test.go
+++ b/internal/handlers/dispatchers/uaf_shortttl_test.go
@@ -21,20 +21,26 @@ import (
 	"github.com/krateoplatformops/snowplow/internal/cache"
 )
 
-// TestUAF_C118_6_BothPutSitesWired is the SOURCE-LEVEL guard that the short UAF
-// override is stamped at BOTH prod Put sites (C-118-6). The refresher re-Put
-// (resolve_populate.go) is the load-bearing one — it slides CreatedAt forward on
-// every data-plane refresh, so dropping the stamp there defeats the cap on a hot
-// cell. Guards against a future edit removing either TTLOverride stamp (which
-// would silently re-open the CreatedAt-slide defeat).
-func TestUAF_C118_6_BothPutSitesWired(t *testing.T) {
-	for _, f := range []string{"restactions.go", "resolve_populate.go"} {
+// TestUAF_C118_6_AllThreePutSitesWired is the SOURCE-LEVEL guard that the short
+// UAF override is stamped at ALL THREE prod Put sites of a restactions
+// ResolvedEntry (C-118-6, extended by the arch gate on 3783e65 which caught the
+// missing seed site):
+//   - restactions.go — the customer dispatch Put;
+//   - resolve_populate.go — the refresher re-Put (slides CreatedAt forward on
+//     every data-plane refresh → dropping the stamp defeats the cap on a hot
+//     cell);
+//   - phase1_pip_seed.go — the BOOT-SEED Put (seeds UAF cells under a cohort
+//     representative identity; uncapped until a customer /call overwrites it).
+// Guards against a future edit removing any TTLOverride stamp (silently
+// re-opening the uncapped-cell hole for that population).
+func TestUAF_C118_6_AllThreePutSitesWired(t *testing.T) {
+	for _, f := range []string{"restactions.go", "resolve_populate.go", "phase1_pip_seed.go"} {
 		src, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatalf("read %s: %v", f, err)
 		}
 		if !strings.Contains(string(src), "uafTTLOverrideForEntry(") {
-			t.Fatalf("C-118-6 wiring: %s must stamp the UAF TTLOverride via uafTTLOverrideForEntry(...) — the override MUST be stamped at BOTH the customer Put (restactions.go) AND the refresher re-Put (resolve_populate.go), else a hot UAF cell's CreatedAt-slide defeats the cap", f)
+			t.Fatalf("C-118-6 wiring: %s must stamp the UAF TTLOverride via uafTTLOverrideForEntry(...) — the override MUST be stamped at ALL THREE restactions ResolvedEntry Put sites (customer dispatch restactions.go, refresher re-Put resolve_populate.go, boot-seed phase1_pip_seed.go), else that population's UAF cells are uncapped", f)
 		}
 	}
 }
@@ -129,6 +135,34 @@ func TestUAF_C118_6_OverrideDerivedIdenticallyAtBothPutSites(t *testing.T) {
 	strippedInputs := &cache.ResolvedKeyInputs{CacheEntryClass: "restactions" /* HasUAF: false */}
 	if uafTTLOverrideForEntry(strippedInputs) != 0 {
 		t.Fatal("C-118-6 RED-control broke: an inputs without HasUAF must derive a 0 cap (proving HasUAF must be CARRIED to the refresher, else the CreatedAt-slide defeats the cap)")
+	}
+}
+
+// C-118-6 SEED PATH — a boot-seeded UAF cell carries the cap. The seed Put
+// (phase1_pip_seed.go) mirrors the customer path: set inputs.HasUAF from the
+// typed CR, then stamp TTLOverride via uafTTLOverrideForEntry. This arm drives
+// that exact derivation and asserts a seeded UAF cell gets the short cap while a
+// seeded NON-UAF cell does not. RED (the gap the arch caught on 3783e65): an
+// un-stamped seed Put → the seeded UAF cell derives 0 override → governed by the
+// long store TTL → uncapped. The RED-control below (HasUAF false / no stamp → 0)
+// proves the stamp is what caps it.
+func TestUAF_C118_6_SeedPathCapsUAFCell(t *testing.T) {
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "30")
+
+	// Seed a UAF cell: the seed sets inputs.HasUAF = restactionHasUAFStage(&cr)
+	// (cr is the typed RESTAction converted from got.Unstructured at the seed).
+	seedInputs := &cache.ResolvedKeyInputs{CacheEntryClass: "restactions"}
+	seedInputs.HasUAF = restactionHasUAFStage(uafRA())
+	if got := uafTTLOverrideForEntry(seedInputs); got != 30*time.Second {
+		t.Fatalf("C-118-6 seed: a boot-seeded UAF cell must carry the 30s cap; got %v (an un-stamped seed Put leaves it uncapped under the long store TTL — the gap the arch caught)", got)
+	}
+
+	// A seeded NON-UAF cell gets no override (standard ttl) — the seed stamp is
+	// UAF-scoped, no collateral shortening of seeded non-UAF cells.
+	plainInputs := &cache.ResolvedKeyInputs{CacheEntryClass: "restactions"}
+	plainInputs.HasUAF = restactionHasUAFStage(plainRA())
+	if got := uafTTLOverrideForEntry(plainInputs); got != 0 {
+		t.Fatalf("C-118-6 seed: a boot-seeded NON-UAF cell must get 0 override (standard ttl); got %v", got)
 	}
 }
 

--- a/internal/handlers/dispatchers/uaf_shortttl_test.go
+++ b/internal/handlers/dispatchers/uaf_shortttl_test.go
@@ -1,0 +1,155 @@
+// uaf_shortttl_test.go — #118 (d) interim short-TTL falsifiers, dispatcher level.
+//
+// C-118-6 (THE CRUX): the short UAF TTLOverride must be stamped at BOTH Put
+// sites — the customer dispatch Put AND the refresher re-Put. The refresher
+// builds a FRESH entry with zero CreatedAt, so Put stamps a NEW time.Now() and
+// the absolute TTL slides forward on every data-plane refresh. If the override
+// were stamped only on the first customer Put, a hot churning UAF cell would
+// re-Put WITHOUT the override and OUTLIVE the cap. These arms drive the REAL
+// override derivation (uafTTLOverrideForEntry at both sites) + the REAL UAF
+// predicate (restactionHasUAFStage), against a real ResolvedCacheStore.
+
+package dispatchers
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestUAF_C118_6_BothPutSitesWired is the SOURCE-LEVEL guard that the short UAF
+// override is stamped at BOTH prod Put sites (C-118-6). The refresher re-Put
+// (resolve_populate.go) is the load-bearing one — it slides CreatedAt forward on
+// every data-plane refresh, so dropping the stamp there defeats the cap on a hot
+// cell. Guards against a future edit removing either TTLOverride stamp (which
+// would silently re-open the CreatedAt-slide defeat).
+func TestUAF_C118_6_BothPutSitesWired(t *testing.T) {
+	for _, f := range []string{"restactions.go", "resolve_populate.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if !strings.Contains(string(src), "uafTTLOverrideForEntry(") {
+			t.Fatalf("C-118-6 wiring: %s must stamp the UAF TTLOverride via uafTTLOverrideForEntry(...) — the override MUST be stamped at BOTH the customer Put (restactions.go) AND the refresher re-Put (resolve_populate.go), else a hot UAF cell's CreatedAt-slide defeats the cap", f)
+		}
+	}
+}
+
+func uafRA() *templatesv1.RESTAction {
+	return &templatesv1.RESTAction{
+		Spec: templatesv1.RESTActionSpec{
+			API: []*templatesv1.API{
+				{Name: "list"},
+				{Name: "refilter", UserAccessFilter: &templatesv1.UserAccessFilterSpec{}},
+			},
+		},
+	}
+}
+
+func plainRA() *templatesv1.RESTAction {
+	return &templatesv1.RESTAction{
+		Spec: templatesv1.RESTActionSpec{
+			API: []*templatesv1.API{{Name: "list"}, {Name: "project"}},
+		},
+	}
+}
+
+// C-118-1 predicate — restactionHasUAFStage fires iff some api-step declares a
+// userAccessFilter; nil-guards each *API and *UserAccessFilterSpec.
+func TestUAF_HasUAFStagePredicate(t *testing.T) {
+	if !restactionHasUAFStage(uafRA()) {
+		t.Fatal("an RA with a userAccessFilter stage must be detected")
+	}
+	if restactionHasUAFStage(plainRA()) {
+		t.Fatal("an RA with no userAccessFilter stage must NOT be detected")
+	}
+	if restactionHasUAFStage(nil) {
+		t.Fatal("nil RA must be false")
+	}
+	// nil api-step element + nil UAF are guarded.
+	mixed := &templatesv1.RESTAction{Spec: templatesv1.RESTActionSpec{API: []*templatesv1.API{
+		nil,
+		{Name: "s", UserAccessFilter: nil},
+	}}}
+	if restactionHasUAFStage(mixed) {
+		t.Fatal("nil step + nil UAF must be false (nil-guarded)")
+	}
+}
+
+// C-118-6 — the both-Put-sites RED arm. The refresher re-Put builds a FRESH
+// entry from the CARRIED inputs (it has no RESTAction CR), so the ONLY way it
+// can re-stamp the override is by reading inputs.HasUAF that the customer
+// dispatch recorded. This arm proves BOTH Put sites derive the SAME non-zero
+// override from the SAME single-source uafTTLOverrideForEntry:
+//
+//   (1) customer dispatch: inputs.HasUAF = restactionHasUAFStage(cr) →
+//       uafTTLOverrideForEntry(inputs) is the short cap.
+//   (2) refresher re-Put: reads the CARRIED inputs (HasUAF preserved) →
+//       uafTTLOverrideForEntry(carried) yields the SAME short cap.
+//
+// GREEN: both derivations are the short cap (> 0, equal) → the cell is capped no
+// matter which path last wrote it, so the CreatedAt-slide on a hot refreshed
+// cell cannot make it outlive the bound. RED (the bug the crux guards): if the
+// refresher stamps 0 (stamp-first-Put-only), the store's TestUAFShortTTL_CapsUAFCell
+// _NotNonUAF arm shows a 0-override cell is governed by the long standard ttl →
+// the hot cell OUTLIVES the cap. Here we assert the derivation is identical and
+// non-zero at both sites (the property that makes the cap churn-proof); the RED
+// is the mutation `refresher passes a HasUAF-stripped inputs`.
+func TestUAF_C118_6_OverrideDerivedIdenticallyAtBothPutSites(t *testing.T) {
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "30") // short cap
+
+	// (1) CUSTOMER dispatch site — detect UAF from the CR, carry HasUAF.
+	custInputs := &cache.ResolvedKeyInputs{CacheEntryClass: "restactions"}
+	custInputs.HasUAF = restactionHasUAFStage(uafRA())
+	custOverride := uafTTLOverrideForEntry(custInputs)
+	if custOverride != 30*time.Second {
+		t.Fatalf("customer Put must derive the 30s UAF cap for a UAF cell; got %v", custOverride)
+	}
+
+	// (2) REFRESHER re-Put site — it only has the CARRIED inputs (no CR). The
+	// carried inputs preserve HasUAF, so the refresher re-derives the SAME cap.
+	carried := custInputs // the refresher reads ResolvedEntry.Inputs verbatim
+	refresherOverride := uafTTLOverrideForEntry(carried)
+	if refresherOverride != custOverride {
+		t.Fatalf("C-118-6 VIOLATED: refresher re-Put must derive the SAME cap as the customer Put (both single-source uafTTLOverrideForEntry over the carried HasUAF); customer=%v refresher=%v", custOverride, refresherOverride)
+	}
+	if refresherOverride == 0 {
+		t.Fatal("C-118-6: the refresher-side cap must be NON-ZERO for a UAF cell — a zero cap on the refresher re-Put is the CreatedAt-slide defeat the crux guards against")
+	}
+
+	// RED — the stamp-first-Put-only bug: the refresher builds its inputs WITHOUT
+	// carrying HasUAF (e.g. a fresh ResolvedKeyInputs, or the HasUAF stripped).
+	// Then it derives a 0 cap → the store's standard (long) ttl governs → the hot
+	// cell outlives the bound (per the cache-package store arm). This asserts the
+	// carry is load-bearing: strip HasUAF and the refresher cap collapses to 0.
+	strippedInputs := &cache.ResolvedKeyInputs{CacheEntryClass: "restactions" /* HasUAF: false */}
+	if uafTTLOverrideForEntry(strippedInputs) != 0 {
+		t.Fatal("C-118-6 RED-control broke: an inputs without HasUAF must derive a 0 cap (proving HasUAF must be CARRIED to the refresher, else the CreatedAt-slide defeats the cap)")
+	}
+}
+
+// C-118 toggle-off — with UAF_RESOLVED_TTL_SECONDS unset, uafTTLOverrideForEntry
+// returns 0 even for a UAF cell → no override → standard ttl → byte-identical to
+// today.
+func TestUAF_ToggleOff_NoOverride(t *testing.T) {
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "")
+	uafInputs := &cache.ResolvedKeyInputs{HasUAF: true}
+	if d := uafTTLOverrideForEntry(uafInputs); d != 0 {
+		t.Fatalf("toggle-off: a UAF cell must get 0 override (standard ttl); got %v", d)
+	}
+	// And with the knob ON, a NON-UAF cell still gets 0 (scoped to UAF).
+	t.Setenv("UAF_RESOLVED_TTL_SECONDS", "30")
+	if d := uafTTLOverrideForEntry(&cache.ResolvedKeyInputs{HasUAF: false}); d != 0 {
+		t.Fatalf("a non-UAF cell must get 0 override even when the knob is on; got %v", d)
+	}
+	if d := uafTTLOverrideForEntry(nil); d != 0 {
+		t.Fatalf("nil inputs must get 0 override; got %v", d)
+	}
+	if d := uafTTLOverrideForEntry(uafInputs); d != 30*time.Second {
+		t.Fatalf("a UAF cell with the knob on must get the 30s override; got %v", d)
+	}
+}


### PR DESCRIPTION
## What (interim, part 1 of 2 for #118)

Caps the exposure window of the #118 userAccessFilter (UAF) RBAC stale-read: a resolved UAF cell whose per-object refilter output depends on the user's data-plane RBAC is served stale after an RBAC change, because the cache key is blind to that dependency. This interim **short-TTL cap** bounds how long a stale UAF cell can be served; the durable key fix is **(c)** (per-user RBAC sub-generation, separate PR).

- New knob `UAF_RESOLVED_TTL_SECONDS` (default **0 = disabled → byte-identical to today**; toggle-able/removable).
- When set, any resolved cell whose RESTAction declares a `userAccessFilter` stage gets a `TTLOverride` = the short TTL. `effectiveTTL` takes the **shorter** of override/store-TTL — the cap only ever tightens, never extends.
- `HasUAF` is **bookkeeping on `ResolvedKeyInputs`, NOT folded into `ComputeKey`** (no `resolvedKeyVersion` bump) — (d) tightens TTL only, does not change the key.

## The load-bearing detail: cap stamped at ALL THREE restactions Put sites

A UAF cell is written at three `ResolvedEntry{}` sites; the cap must be stamped at all three or the CreatedAt-slide / seed populations stay un-capped:
1. **customer dispatch** (`restactions.go`)
2. **refresher re-Put** (`resolve_populate.go`) — zeroes CreatedAt every data-plane refresh, so a hot cell's absolute TTL slides forward; without the cap here a churning cell is effectively unbounded.
3. **boot-seed** (`phase1_pip_seed.go` `seedOneRestaction`) — seeded UAF cells are served to real cohort members and never get a customer Put to correct them.

A standing source-level guard (`TestUAF_C118_6_AllThreePutSitesWired`) asserts all three stamp via the single-source `uafTTLOverrideForEntry` helper — a future edit dropping any site trips it. Scoping comment in `uaf_shortttl.go` enumerates all 7 `ResolvedEntry{}` Put sites (3 in-scope capped, 4 out-of-scope with rationale: apistage/cluster_list are identity-free substrate with data-plane invalidation; partial_result_ttl self-stamps; widget-class cells aren't the UAF-restactions cell).

## Gate history

Dual-gate GREEN. Two cycles: `3783e65` (original 2-site) → arch caught a third Put site (boot-seed) uncapped → `7c8c7d2` (3-site + standing guard, dual-gate green) → `1e191c9` (R-d-4 scoping-map, comment-only). Both gaters re-derived the seed-Put and refresher REDs themselves.

## Deferred / follow-on
- **(c) durable fix** — per-user RBAC sub-generation folded into the key (a within-TTL RBAC change is still stale until (c) lands). Building now.
- On-cluster falsifier (window ≤ short TTL under refresh churn) = tester's post-deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1