### PR TITLE
fix(cache): #118 (c) durable — per-user RBAC sub-generation folded into the resolved key (v5)

### DIFF
--- a/internal/cache/bindings_by_gvr_delta.go
+++ b/internal/cache/bindings_by_gvr_delta.go
@@ -134,11 +134,15 @@ func onBindingAdd(obj interface{}) {
 		return
 	}
 	if o, ok := asCRB(obj); ok {
-		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subjectsFromRBAC(o.Subjects))
+		subj := subjectsFromRBAC(o.Subjects)
+		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subj)
+		BumpSubjectSubGens(subj) // #118 (c) — this binding's subjects' effective RBAC changed
 		return
 	}
 	if o, ok := asRB(obj); ok {
-		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subjectsFromRBAC(o.Subjects))
+		subj := subjectsFromRBAC(o.Subjects)
+		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subj)
+		BumpSubjectSubGens(subj) // #118 (c)
 		return
 	}
 	deltaDropNonTyped("RoleBinding/ClusterRoleBinding(add)")
@@ -155,15 +159,21 @@ func onBindingUpdate(oldObj, newObj interface{}) {
 	}
 	if o, ok := asCRB(oldObj); ok {
 		idx.applyBindingDelete(crbBindingID(o), roleRefKey("", o.RoleRef))
+		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c) — OLD subjects lost this grant
 	} else if o, ok := asRB(oldObj); ok {
 		idx.applyBindingDelete(rbBindingID(o), roleRefKey(o.Namespace, o.RoleRef))
+		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c)
 	} else {
 		deltaDropNonTyped("RoleBinding/ClusterRoleBinding(update-old)")
 	}
 	if o, ok := asCRB(newObj); ok {
-		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subjectsFromRBAC(o.Subjects))
+		subj := subjectsFromRBAC(o.Subjects)
+		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subj)
+		BumpSubjectSubGens(subj) // #118 (c) — NEW subjects gained this grant (a subject in BOTH old+new bumps twice; harmless — the key only needs to change)
 	} else if o, ok := asRB(newObj); ok {
-		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subjectsFromRBAC(o.Subjects))
+		subj := subjectsFromRBAC(o.Subjects)
+		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subj)
+		BumpSubjectSubGens(subj) // #118 (c)
 	} else {
 		deltaDropNonTyped("RoleBinding/ClusterRoleBinding(update-new)")
 	}
@@ -183,10 +193,12 @@ func onBindingDelete(obj interface{}) {
 	}
 	if o, ok := asCRB(obj); ok {
 		idx.applyBindingDelete(crbBindingID(o), roleRefKey("", o.RoleRef))
+		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c) — subjects lost this grant (REVOKE — the security-load-bearing arm)
 		return
 	}
 	if o, ok := asRB(obj); ok {
 		idx.applyBindingDelete(rbBindingID(o), roleRefKey(o.Namespace, o.RoleRef))
+		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c)
 		return
 	}
 	deltaDropNonTyped("RoleBinding/ClusterRoleBinding(delete)")

--- a/internal/cache/rbac_subgen.go
+++ b/internal/cache/rbac_subgen.go
@@ -1,0 +1,163 @@
+// rbac_subgen.go — #118 (c) DURABLE fix: per-subject RBAC sub-generation.
+//
+// THE DEFECT (docs/118-uaf-rbac-stale-read-design-2026-07-22.md §root-cause):
+// the resolved-cache key folds one dispatch-authorizing BindingUID and NO RBAC
+// generation, while a userAccessFilter stage re-evaluates RBAC per object per
+// per-object-namespace — a dependency the key never sees. An out-of-band RBAC
+// grant/revoke bumps RBACGen + rebuilds the snapshot but evicts ZERO resolved
+// cells, so a user's own now-stale UAF view is served until the cell leaves
+// cache. (d) capped the WINDOW; (c) fixes the KEY.
+//
+// THE FIX: a PER-SUBJECT sub-generation counter that bumps ONLY when THAT
+// subject's effective bindings change, folded into the cache key. Blast radius =
+// exactly the users whose OWN bindings changed — a composition-install binding
+// for tenant-X bumps only tenant-X's subjects, leaving every other user's cells
+// hot (this is what makes (c) survive the 50K install storm that global RBACGen
+// (option a) dies in).
+//
+// WHY per-SUBJECT, not global (option a) — the 50K install storm creates RBAC
+// bindings continuously; a global gen would rotate the WHOLE identity-bound key
+// space on every one, keeping L1 permanently cold. Per-subject bounds the herd
+// to the change (design §fix-options (c) vs (a)).
+//
+// GROUP-GRANT CRUX (C-118-2): a binding can grant via a GROUP the requesting
+// user is in. RBACSubGenForSubject therefore folds over the user counter AND
+// every presented group's counter (and the SA counter when the identity is a
+// ServiceAccount) — so a group-scoped grant/revoke moves the user's effective
+// sub-gen. Folding only the user counter is BLIND to group grants (the RED arm).
+//
+// CONCURRENCY: a sync.Map[subjectKey]*atomic.Uint64. Bumps come from the RBAC
+// informer hooks (onBindingAdd/Update/Delete, single informer goroutine but the
+// atomic makes it race-safe regardless); reads are lock-free on the hot /call
+// path (LoadOrStore is amortized-O(1), the atomic Load is wait-free) — mirrors
+// RBACGen's single-atomic-load discipline, just sharded per subject. No new
+// informer, no per-request binding-set walk (the design's feasibility guardrail):
+// the bump reuses the subjects the onBinding* hooks ALREADY have in hand
+// (subjectsFromRBAC(o.Subjects)); the reader does O(user's group count) map
+// reads.
+
+package cache
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// rbacSubGen holds the per-subject sub-generation counters. Keyed by subjectKey
+// (the SAME comparable {Kind,Name,Namespace} the binding indexes use), value is
+// a *atomic.Uint64 so a bump and a read never lock. A subject absent from the
+// map reads as 0 (never granted/revoked yet) — the zero value is correct.
+var rbacSubGen sync.Map // subjectKey -> *atomic.Uint64
+
+// subGenCounterFor returns the (creating if absent) atomic counter for subj.
+// LoadOrStore is the single amortized-O(1) map op; the returned pointer is
+// stable for the process lifetime so a bump and a concurrent read share it.
+func subGenCounterFor(subj subjectKey) *atomic.Uint64 {
+	if v, ok := rbacSubGen.Load(subj); ok {
+		return v.(*atomic.Uint64)
+	}
+	v, _ := rbacSubGen.LoadOrStore(subj, new(atomic.Uint64))
+	return v.(*atomic.Uint64)
+}
+
+// BumpSubjectSubGens increments the sub-generation of each subject whose
+// effective bindings just changed. Called from the RBAC informer hooks
+// (onBindingAdd/Update/Delete) with the binding's subjects already in hand
+// (subjectsFromRBAC(o.Subjects)) — so NO new informer and NO binding-set walk.
+// An Update deletes-old-then-adds-new; the hook calls this for BOTH the old
+// subject set (on the delete leg) and the new (on the add leg), so a
+// subject-list edit that drops user U and adds user V bumps both U (its grant
+// changed: removed) and V (added). Idempotent-safe: every call is a monotonic
+// +1, and the key only needs to CHANGE on any relevant RBAC event, not carry a
+// meaningful absolute value.
+func BumpSubjectSubGens(subjects []subjectKey) {
+	for _, s := range subjects {
+		subGenCounterFor(s).Add(1)
+	}
+}
+
+// RBACSubGenForSubject returns the requesting identity's EFFECTIVE RBAC
+// sub-generation: the sum over the identity's own subject counter(s) — the User
+// counter, every presented Group's counter, and (when the username is a
+// ServiceAccount) the SA counter. A sum means ANY relevant subject's bump
+// changes the total, so the folded key rotates on a grant/revoke via the user
+// OR any of its groups OR (for an SA) the SA identity — the C-118-2 group-grant
+// crux. Lock-free (a handful of atomic Loads). O(len(groups)) map reads on the
+// hot path; a user has O(10) groups (design INFERRED bound, pinned by the herd
+// arm). Returns 0 for an identity none of whose subjects has ever been touched
+// (correct: nothing changed → no key rotation).
+//
+// The subjectKey mapping mirrors subjectsFromRBAC exactly: a User is
+// {Kind:"User",Name:username}; a Group is {Kind:"Group",Name:g}; a
+// ServiceAccount username "system:serviceaccount:<ns>:<name>" folds the SA
+// subject {Kind:"ServiceAccount",Name:<name>,Namespace:<ns>} so a binding whose
+// subject is that SA (which onBinding* recorded as an SA subjectKey) bumps it.
+func RBACSubGenForSubject(username string, groups []string) uint64 {
+	var sum uint64
+	if username != "" {
+		if ns, name, ok := parseServiceAccountUsername(username); ok {
+			// The identity is a ServiceAccount: fold the SA subject counter (the
+			// shape onBinding* recorded), NOT a User counter — a binding granting
+			// this SA is indexed under the SA subjectKey.
+			sum += subGenValue(subjectKey{Kind: subjectKindServiceAccount, Name: name, Namespace: ns})
+		} else {
+			// A human/user identity: fold the User subject counter.
+			sum += subGenValue(subjectKey{Kind: subjectKindUser, Name: username})
+		}
+	}
+	for _, g := range groups {
+		if g == "" {
+			continue
+		}
+		sum += subGenValue(subjectKey{Kind: subjectKindGroup, Name: g})
+	}
+	return sum
+}
+
+// subGenValue reads a subject's counter WITHOUT creating it — an untouched
+// subject reads 0 (no map entry, no allocation). Keeping the read side
+// allocation-free means a /call for a never-granted-since-boot identity does not
+// grow the map.
+func subGenValue(subj subjectKey) uint64 {
+	if v, ok := rbacSubGen.Load(subj); ok {
+		return v.(*atomic.Uint64).Load()
+	}
+	return 0
+}
+
+// subjectKind constants — the rbacv1.Subject.Kind string values, named here so
+// the reader's subjectKey construction cannot drift from subjectsFromRBAC's.
+const (
+	subjectKindUser           = "User"
+	subjectKindGroup          = "Group"
+	subjectKindServiceAccount = "ServiceAccount"
+)
+
+// serviceAccountUsernamePrefix is the canonical prefix a ServiceAccount presents
+// as its username on the request (system:serviceaccount:<ns>:<name>).
+const serviceAccountUsernamePrefix = "system:serviceaccount:"
+
+// parseServiceAccountUsername splits a canonical SA username into (namespace,
+// name). Returns ok=false for a non-SA username (a human user), which the caller
+// then folds as a User subject. Mirrors f3SubjectFor / the k8s canonical form.
+func parseServiceAccountUsername(username string) (namespace, name string, ok bool) {
+	rest, found := strings.CutPrefix(username, serviceAccountUsernamePrefix)
+	if !found {
+		return "", "", false
+	}
+	ns, nm, hasColon := strings.Cut(rest, ":")
+	if !hasColon || ns == "" || nm == "" {
+		return "", "", false
+	}
+	return ns, nm, true
+}
+
+// ResetRBACSubGenForTest clears all per-subject counters. TEST-ONLY — production
+// never resets (the counters are monotonic for the process lifetime).
+func ResetRBACSubGenForTest() {
+	rbacSubGen.Range(func(k, _ any) bool {
+		rbacSubGen.Delete(k)
+		return true
+	})
+}

--- a/internal/cache/rbac_subgen_test.go
+++ b/internal/cache/rbac_subgen_test.go
@@ -1,0 +1,164 @@
+// rbac_subgen_test.go — #118 (c) per-user RBAC sub-generation falsifiers
+// (cache-package arms: the counter mechanics + the key fold).
+//
+// The durable fix folds RBACSubGenForSubject into ComputeKey so an out-of-band
+// RBAC change that touches THIS user's own bindings rotates the key (cold miss →
+// fresh UAF refilter), while leaving other users' cells hot (herd-proportional,
+// survives the 50K install storm). These arms pin: the group-grant crux
+// (C-118-2), per-user isolation (C-118-3), the v5 fold (C-118-7), and the 50K
+// herd bound proxy (C-118-5). C-118-1 (revoke→drop CONTENT) is on-cluster; the
+// hermetic proxy here is "a bump changes the key" (cold miss forces refilter).
+
+package cache
+
+import "testing"
+
+// bump helpers mirror the onBinding* subjectKey shapes.
+func userSubj(name string) subjectKey {
+	return subjectKey{Kind: subjectKindUser, Name: name}
+}
+func groupSubj(name string) subjectKey {
+	return subjectKey{Kind: subjectKindGroup, Name: name}
+}
+
+// C-118-2 (GRANT-VIA-GROUP crux) — a bump of a GROUP the user presents must move
+// the user's effective sub-gen. The RED is a fold over {user} ONLY (blind to
+// groups); this arm proves the prod fold includes groups by bumping ONLY a group
+// counter and asserting the user's effective sub-gen changes.
+func TestRBACSubGen_GroupGrantBumpsUserEffective(t *testing.T) {
+	ResetRBACSubGenForTest()
+	t.Cleanup(ResetRBACSubGenForTest)
+
+	const user = "alice"
+	groups := []string{"devs", "on-call"}
+
+	before := RBACSubGenForSubject(user, groups)
+
+	// A grant/revoke via the "devs" GROUP (not the user directly) — the hook
+	// bumps the group's subject counter.
+	BumpSubjectSubGens([]subjectKey{groupSubj("devs")})
+
+	after := RBACSubGenForSubject(user, groups)
+	if after == before {
+		t.Fatalf("C-118-2 VIOLATED: a grant via GROUP 'devs' did NOT move alice's effective sub-gen (before=%d after=%d) — the fold is blind to groups (folds {user} only). A group-scoped grant/revoke would then serve stale until TTL.", before, after)
+	}
+
+	// RED-control (the {user}-only mis-fold): a bump of a group the user is NOT
+	// in must NOT move her sub-gen (isolation the other way — proves the fold is
+	// scoped to HER groups, not global).
+	mid := RBACSubGenForSubject(user, groups)
+	BumpSubjectSubGens([]subjectKey{groupSubj("some-other-team")})
+	if RBACSubGenForSubject(user, groups) != mid {
+		t.Fatal("C-118-2: a bump of a group alice is NOT in must not move her effective sub-gen")
+	}
+}
+
+// C-118-3 (per-user isolation) — U1's grant change bumps U1's effective sub-gen
+// but NOT U2's (they share no subject). Preserves feedback_l1_per_user_keyed_
+// never_cohort: per-subject blast radius, not a global rotation.
+func TestRBACSubGen_PerUserIsolation(t *testing.T) {
+	ResetRBACSubGenForTest()
+	t.Cleanup(ResetRBACSubGenForTest)
+
+	u1before := RBACSubGenForSubject("u1", []string{"team-a"})
+	u2before := RBACSubGenForSubject("u2", []string{"team-b"})
+
+	// A binding change touching ONLY u1 (its own User subject).
+	BumpSubjectSubGens([]subjectKey{userSubj("u1")})
+
+	if RBACSubGenForSubject("u1", []string{"team-a"}) == u1before {
+		t.Fatal("C-118-3: u1's own grant change must move u1's effective sub-gen")
+	}
+	if got := RBACSubGenForSubject("u2", []string{"team-b"}); got != u2before {
+		t.Fatalf("C-118-3 VIOLATED: u1's grant change moved u2's effective sub-gen (before=%d after=%d) — per-user isolation broken; this is the global-rotation (option a) herd, not per-subject (c)", u2before, got)
+	}
+}
+
+// C-118-5 (50K HERD, ≥2 tenants) — a stream of binding changes for tenant-X
+// subjects must NOT move tenant-Y's effective sub-gen. This is the arm that
+// discriminates (c) from (a): under global RBACGen every bump rotates ALL keys
+// (Y goes cold); under per-subject (c), Y's sub-gen is untouched (Y stays HIT).
+// ≥2 tenants REQUIRED (a single-tenant arm can't tell per-subject from global).
+func TestRBACSubGen_HerdBound_TenantYStaysStableUnderTenantXStorm(t *testing.T) {
+	ResetRBACSubGenForTest()
+	t.Cleanup(ResetRBACSubGenForTest)
+
+	// Tenant-Y user, its sub-gen captured before the storm.
+	yBefore := RBACSubGenForSubject("y-user", []string{"tenant-y"})
+
+	// Simulate a tenant-X composition-install RBAC-binding stream: many bindings,
+	// each granting tenant-X subjects (users + the tenant-x group). This is the
+	// 50K install storm shape.
+	for i := 0; i < 1000; i++ {
+		BumpSubjectSubGens([]subjectKey{
+			userSubj("x-user"),
+			groupSubj("tenant-x"),
+		})
+	}
+
+	// Tenant-Y's effective sub-gen is UNCHANGED — Y's cells stay hot through the
+	// entire tenant-X storm. Under global RBACGen this would have rotated 1000×.
+	if got := RBACSubGenForSubject("y-user", []string{"tenant-y"}); got != yBefore {
+		t.Fatalf("C-118-5 VIOLATED: a 1000-binding tenant-X install storm moved tenant-Y's sub-gen (before=%d after=%d) — (c) collapsed to (a)'s global herd; Y's cells would go cold under every unrelated install", yBefore, got)
+	}
+	// Sanity: tenant-X's OWN sub-gen DID move (the storm is real, not a no-op).
+	if RBACSubGenForSubject("x-user", []string{"tenant-x"}) == 0 {
+		t.Fatal("C-118-5 setup: tenant-X's sub-gen must have moved (the storm must actually bump)")
+	}
+}
+
+// C-118-7 + the fold — ComputeKey folds RBACSubGen for identity-bound classes
+// (different sub-gen → different key) and NOT for widgetContent (identity-free);
+// and the version is v5.
+func TestRBACSubGen_FoldedIntoKey_NotForWidgetContent(t *testing.T) {
+	if resolvedKeyVersion != "v5" {
+		t.Fatalf("C-118-7: resolvedKeyVersion must be v5 (the RBACSubGen fold rotates the key space); got %q", resolvedKeyVersion)
+	}
+
+	base := ResolvedKeyInputs{
+		CacheEntryClass: "restactions",
+		Group:           "templates.krateo.io", Version: "v1", Resource: "restactions",
+		Namespace: "ns", Name: "ra", BindingUID: "C:b1",
+	}
+	k0 := ComputeKey(base)
+	bumped := base
+	bumped.RBACSubGen = 7
+	k1 := ComputeKey(bumped)
+	if k0 == k1 {
+		t.Fatal("C-118-7 VIOLATED: an identity-bound (restactions) key did NOT change when RBACSubGen changed — the sub-gen is not folded, so an RBAC change would serve the stale cell")
+	}
+
+	// widgetContent is identity-free — RBACSubGen must NOT affect its key (folding
+	// identity there breaks the shared-content invariant; design §key-parity).
+	wc := ResolvedKeyInputs{
+		CacheEntryClass: CacheEntryClassWidgetContent,
+		Group:           "widgets.templates.krateo.io", Version: "v1beta1", Resource: "widgets",
+		Namespace: "ns", Name: "w",
+	}
+	wc0 := ComputeKey(wc)
+	wcBumped := wc
+	wcBumped.RBACSubGen = 42
+	if ComputeKey(wcBumped) != wc0 {
+		t.Fatal("C-118-7: widgetContent is identity-free — RBACSubGen must NOT change its key (shared-content invariant)")
+	}
+}
+
+// SA-identity fold — a ServiceAccount username folds the SA subject counter, so a
+// binding granting that SA (recorded by onBinding* as an SA subjectKey) moves the
+// SA identity's effective sub-gen.
+func TestRBACSubGen_ServiceAccountIdentity(t *testing.T) {
+	ResetRBACSubGenForTest()
+	t.Cleanup(ResetRBACSubGenForTest)
+
+	const saUser = "system:serviceaccount:ns-x:runner"
+	before := RBACSubGenForSubject(saUser, nil)
+	// A binding granting the SA — the hook records the SA subjectKey.
+	BumpSubjectSubGens([]subjectKey{{Kind: subjectKindServiceAccount, Name: "runner", Namespace: "ns-x"}})
+	if RBACSubGenForSubject(saUser, nil) == before {
+		t.Fatal("SA identity: a grant to the SA must move the SA username's effective sub-gen (parseServiceAccountUsername → SA subjectKey)")
+	}
+	// A human user with the same trailing name must NOT be affected (different Kind).
+	if RBACSubGenForSubject("runner", nil) != 0 {
+		t.Fatal("SA identity: a User named 'runner' must not inherit the SA 'runner' counter (Kind-scoped)")
+	}
+}

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -29,6 +29,7 @@ package cache
 import (
 	"container/list"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -400,6 +401,20 @@ type ResolvedKeyInputs struct {
 	// hash it, so adding it does NOT shift the key space (no resolvedKeyVersion
 	// bump) and a UAF cell keeps the SAME key as before, only a shorter TTL.
 	HasUAF bool
+
+	// RBACSubGen — #118 (c) DURABLE fix. The requesting identity's EFFECTIVE
+	// per-subject RBAC sub-generation (RBACSubGenForSubject over the user +
+	// groups (+ SA) counters), FOLDED INTO ComputeKey for every identity-bound
+	// class (like BindingUID; EXCLUDED for widgetContent, which is identity-free).
+	// A grant/revoke that touches this user's OWN bindings bumps a subject
+	// counter → this term changes → new key → cold miss → fresh resolve → fresh
+	// UAF refilter. Blast radius = only users whose own bindings changed (herd-
+	// proportional; survives the 50K install storm that global RBACGen dies in).
+	// Stamped wherever a ResolvedKeyInputs is BUILT (dispatchCacheLookupKey for
+	// dispatch/subscription, seedOneRestaction for the seed) from the SAME
+	// RBACSubGenForSubject reader, so seed/subscription/dispatch keys agree.
+	// UNLIKE HasUAF this IS folded into ComputeKey → resolvedKeyVersion v4→v5.
+	RBACSubGen uint64
 }
 
 // resolvedKeyVersion is folded into every key hash so a key-schema
@@ -442,7 +457,13 @@ type ResolvedKeyInputs struct {
 // The cohort-gate-memo apparatus is deleted (design §3.4). Pre-v4
 // apistage entries CANNOT serve as v4 hits even under the same identity
 // because the v3 key did not encode identity.
-const resolvedKeyVersion = "v4"
+// Ship #118 (c) — BUMPED v4 → v5. ComputeKey now folds RBACSubGen (the
+// requesting identity's per-subject RBAC sub-generation) alongside BindingUID
+// for every identity-bound class. A pre-v5 cell's key did not encode the
+// sub-gen, so it is structurally different from a v5 key for the SAME access;
+// the salt rotation forces a clean rolling key break — no pre-fix (RBAC-blind)
+// entry serves as a post-fix hit across the restart (C-118-7).
+const resolvedKeyVersion = "v5"
 
 // ResolvedCacheStore is the L1 resolved-output cache: a bounded LRU
 // guarded by a single mutex with a per-entry byte budget. Constructed
@@ -711,6 +732,21 @@ func ComputeKey(in ResolvedKeyInputs) string {
 	if in.CacheEntryClass != CacheEntryClassWidgetContent {
 		h.Write([]byte(in.BindingUID))
 		h.Write([]byte{0xff}) // identity terminator
+		// #118 (c) v4→v5: fold the requesting identity's per-subject RBAC
+		// sub-generation alongside BindingUID for every identity-bound class.
+		// The BindingUID captures WHICH binding authorised THIS layer's GET;
+		// RBACSubGen captures "did anything about this user's effective RBAC
+		// change" (incl a per-namespace grant/revoke the single dispatch-GET
+		// BindingUID is blind to — the userAccessFilter refilter dependency,
+		// #118 defect 1). A change to the user's own bindings bumps a subject
+		// counter → this fold changes → new key → cold miss → fresh refilter.
+		// widgetContent is excluded (identity-free shared envelope) exactly as
+		// for BindingUID — folding identity there would break the shared-content
+		// invariant (design §key-parity-surface). uint64 LE, then a terminator.
+		var subgen [8]byte
+		binary.LittleEndian.PutUint64(subgen[:], in.RBACSubGen)
+		h.Write(subgen[:])
+		h.Write([]byte{0xfe}) // sub-gen terminator (distinct from the 0xff identity terminator)
 	}
 
 	h.Write([]byte(strconv.Itoa(in.PerPage)))

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -254,6 +254,15 @@ func dispatchCacheLookupKey(ctx context.Context, handlerKind, group, version, re
 		Namespace:       namespace,
 		Name:            name,
 		BindingUID:      bindingUID,
+		// #118 (c) — the requesting identity's EFFECTIVE per-subject RBAC
+		// sub-generation, folded into ComputeKey (identity-bound classes) so an
+		// out-of-band grant/revoke touching THIS user's own bindings rotates the
+		// key → cold miss → fresh UAF refilter. RBACSubGenForSubject folds the
+		// user + every presented group (+ SA) counter (C-118-2 group-grant
+		// crux). ui.Username/ui.Groups are already in hand here (the same tuple
+		// EvaluateRBAC read above), so this is a handful of lock-free map reads,
+		// no extra walk.
+		RBACSubGen: cache.RBACSubGenForSubject(ui.Username, ui.Groups),
 		// Representative identity for the refresher's re-resolve.
 		// Carried on Inputs but NOT folded into ComputeKey (the cell
 		// is keyed by BindingUID, not by the literal name). The first

--- a/internal/handlers/dispatchers/refresh_subscription_invariant_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_invariant_test.go
@@ -175,6 +175,15 @@ func assertKeyInputsFieldEqual(t *testing.T, class string, a, b *cache.ResolvedK
 	if a.Stage != b.Stage {
 		t.Fatalf("%s field Stage: %q != %q", class, a.Stage, b.Stage)
 	}
+	// #118 (c) C-118-4 — the per-user RBAC sub-generation must be pre-hash
+	// field-equal across arming↔serve (both derive it via the SAME
+	// dispatchCacheLookupKey → RBACSubGenForSubject). A divergence here means a
+	// subscription armed a different sub-gen than the emit stamped → the armed
+	// key would never match after a grant/revoke rotated one side only (the #64
+	// desync class at the RBAC-freshness dimension). Extends the #67 invariant.
+	if a.RBACSubGen != b.RBACSubGen {
+		t.Fatalf("%s field RBACSubGen: %d != %d — arming↔serve RBAC sub-gen desync (a grant/revoke would rotate one side's key only)", class, a.RBACSubGen, b.RBACSubGen)
+	}
 	if cache.ComputeKey(*a) != cache.ComputeKey(*b) {
 		t.Fatalf("%s: digests differ despite field-equal scalars — Extras canonicalisation divergence?", class)
 	}


### PR DESCRIPTION
## What (durable fix, part 2 of 2 for #118)

The **durable** close-out of the #118 userAccessFilter (UAF) authz-staleness bug: the resolved-cache key was blind to the per-user data-plane RBAC that a UAF stage's refilter output depends on, so after an RBAC change a user was served a **stale-authorized** cell (the old refilter result) until TTL/restart. (d) — PR #121 — caps the *window*; **(c) fixes the key** so an RBAC change forces a cold miss → fresh refilter immediately.

## Mechanism (~200 LOC, reuses existing subject indexes + onBinding hooks — no new informer, no per-request walk)

- **`internal/cache/rbac_subgen.go` (new):** `sync.Map[subjectKey]*atomic.Uint64` (lock-free). `BumpSubjectSubGens` increments per-subject counters; `RBACSubGenForSubject(user, groups)` folds `user + Σgroups (+SA)` into one monotone term.
- **`bindings_by_gvr_delta.go`:** `BumpSubjectSubGens` wired into `onBindingAdd/Update/Delete` — **Update bumps OLD ∪ NEW subjects** (so revoke-by-subject-removal invalidates), reusing `subjectsFromRBAC(o.Subjects)` already in hand.
- **`resolved.go`:** `RBACSubGen` on `ResolvedKeyInputs`, **folded in `ComputeKey` for identity-bound classes only** (alongside `BindingUID`, distinct `0xfe` terminator; `widgetContent` excluded — identity-free). `resolvedKeyVersion` **v4→v5**.
- **`helpers.go` `dispatchCacheLookupKey`:** stamps `RBACSubGen`. Seed (`seedOneRestaction`) + subscription (`DeriveSubscriptionKey`) inherit the term because both route through this **one** function — no parallel derivation (the #64/#66 drift-proof property).

## Why the sum is correct (gate-adjudicated)

The combine is an additive sum, not a hash-of-pairs. Both gaters ruled this **sound**: the required invariant is *monotone-per-identity*, which a sum satisfies — every relevant bump is +1 to one of the identity's own counters, so the identity's fold strictly increases and can never alias back to a prior value (grant→revoke→grant = 2→3→4). Cross-identity sum collisions are irrelevant because the key also folds username-derived `BindingUID`. (A lossy xor *would* alias; the code uses sum.)

## Residual (not a regression, gate-characterized)

The bump fires from the informer handler; there's a sub-second informer-propagation window — the same lag every data-plane dep-invalidation already lives with — during which a request may still derive the old key. **(d)'s TTL cap is the belt** for that window. No unbounded/stale-serve hazard: the sub-gen bump is synchronous and lands *before* the new RBAC is observable via `EvaluateRBAC`.

## Falsifiers (all `=== RUN` + PASS 3× -race; both gaters re-derived the key REDs independently)

- **C-118-2 grant-via-group** (granularity crux): fold `{user}`-only → group-grant fails to move alice → arm FAILS. GREEN folds `{user}∪{groups}`.
- **C-118-5 50K herd** (discriminates (c) from rejected (a)): global counter → a 1000-binding tenant-X storm moves tenant-Y → arm FAILS. GREEN: per-subject leaves tenant-Y untouched.
- **C-118-4 parity** (standing guard): `assertKeyInputsFieldEqual` now asserts `RBACSubGen` pre-hash field-equality across arming↔serve for **every** class (extends the #67/F-ARCH invariant) — a dispatch-only fold trips the whole family pre-deploy.
- Plus per-user isolation, widgetContent-exclusion, SA-identity fold, v5.
- **C-118-1 revoke→content-drop** = on-cluster acceptance (live refilter, tester post-deploy). Code-level proxy in the set: revoke bumps sub-gen → different key → cold miss.

## Preserves
Per-user keying (never cohort), #95 `""`-BindingUID serve-as-MISS (folded *inside* the identity-bound branch, never resurrects a `""`-cell), blast-radius = only users whose own bindings changed (survives the 50K install storm global `RBACGen` dies in).

## Merge order (stacked on (d))
This branch is stacked on **(d) PR #121** (branched off its tip `1e191c9`), so this PR currently shows the (d) commits + the (c) commit. **Merge #121 (d) first**; I'll then rebase this branch onto `main` so its diff narrows to the 6 (c)-specific files, ready for merge.

## Gate
Dual-gate GREEN: arch soundness PASS (combine monotone-per-identity, bump-before-observe safe ordering, seed/subscription parity verified, concurrency/#95/per-user preserved) + PM final-accept (C-118-1..8, three key REDs self-re-derived in an isolated worktree). Frozen SHA `84cbd22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1