### PR TITLE
feat(prewarm): #135 F4b Lever B — reuse discovery snapshot on boot resume (arch-gated, real-boundary falsifiers)

### DIFF
--- a/docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md
+++ b/docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md
@@ -1,0 +1,161 @@
+# F4b Lever B — reuse the harvested discovery snapshot on boot RESUME passes (#135)
+
+Date: 2026-07-22
+Author: cache-architect
+Repo: main
+Source design: `docs/f4b-seed-overshoot-design-2026-07-14.md` §"Lever B" (~:105), §6, §7, falsifiers 4+5 (~:127-128).
+Prior ship (context, do NOT re-scope): Lever A landed 1.7.12 (#132) — engine-lived declined-external set, `declined_external_keys=63` live.
+
+---
+
+## HEADLINE VERDICTS (read these first)
+
+**1. Invalidation-seam verdict: SOUND, and it is ALREADY WIRED — Lever B needs NO new invalidation code.**
+The load-bearing worry ("a resume after a topology change seeds a stale target set") does not arise, for a reason the source design did not fully account for: the `navWidgetHarvester` + `contentPrewarmHarvester` are **already process-lived, monotonic, first-write-wins accumulators** shared by reference across every walk pass (they are NEVER cleared in production — TRACED below). Lever B does not add a new cached snapshot; it **stops re-driving `walk()` on resume** and reads the harvester the walk already filled. The only genuine question is: on a real config-vars INIT change, does the resume re-walk so the NEW nav set is discovered? Answer: **yes, for free** — a config-vars redrive is NOT a `NumRequeues>0` resume; it is a fresh `enqueueScope` with backoff reset, so the `attempt==0` gate re-walks it. The seam is a one-line `NumRequeues(s)==0` read of state client-go already tracks, not a new invalidation subscription. **Recommend: BUILD.**
+
+**2. #123-framing verdict: Lever B does NOT widen the #123 margin. It hardens aggregate boot convergence under resume-thrash only.**
+Lever B removes ~255s of rewalk from RESUME passes. Pass 1 (the #123 ceiling, 459.6s of per-cohort seed jq, latch at 376s) has `attempt==0` so it STILL walks — Lever B touches zero of pass-1's cost. The true #123 reducer is the §6 per-cohort-baseline split (resolve the `allCompositions` substrate once, filter per cohort). **Recommend: book that as its own task (#123/#136), higher #123 leverage, out of scope here.** Lever B is worth shipping regardless because Lever A alone does NOT remove the rewalk (see §3.3) — a resume pass that Lever A shrank to ~0 seed still pays 255s of rewalk, so aggregate resume passes stay ~255s each and the boot scope keeps burning the requeue budget on rediscovery.
+
+---
+
+## 1. Root cause (TRACED)
+
+`rePrewarmBootScoped` (`internal/handlers/dispatchers/prewarm_engine_boot.go:228`) runs the FULL discovery re-walk on EVERY invocation, including every F.4 deadline-cut resume:
+
+- **The re-walk loop** — `prewarm_engine_boot.go:291-328`: `deps.navHarv.BeginWalk()` then per-root a FRESH `newPhase1Walker` + `w.walk(...)`. This is the 253-261s `rewalk_complete elapsed_ms` (source design §1.1 table).
+- **`rewalk_complete` emitted** — `prewarm_engine_boot.go:364-371`, AFTER the walk, reporting `widgets:191 restactions:34` identical every pass.
+- **The resume path that re-enters it** — `processScope` (`prewarm_engine.go:571`) → on `err!=nil` with live ctx → `queue.AddRateLimited(s)` (`:621`) → worker re-`Get`s → `processScope` → `scopeHandler` → `rePrewarmBoot` → `rePrewarmBootScoped`. Every resume re-runs the whole function top-to-bottom, walk included.
+
+**Why the walk output is identical across resume passes (the reuse is provably safe):** the harvesters are process-lived accumulators, not per-pass state.
+
+- `newNavWidgetHarvester()` is called EXACTLY ONCE in production — `phase1_walk.go:379` inside `Phase1Warmup`. The instance is stored on `rePrewarmDeps.navHarv` (`phase1_walk.go:426`) and closed into the boot-scope handler; `deps` outlives every pass.
+- `harvestNavWidget` (`phase1_pip_seed.go:300`) is **first-write-wins** (`:308` `if _, seen := h.entries[key]; seen { return }`). Entries are never deleted.
+- **There is NO clear/reset of `h.entries` anywhere in production code** (verified: grep for `h.entries =` / `delete(h.entries` / `clear(` returns only the constructor at `phase1_pip_seed.go:244`). `BeginWalk`/`BeginRoot` reset only `curRoot` (the RootIndex stamp counter), NOT the entry map.
+- `snapshot()` (`phase1_pip_seed.go:387`) returns a copy of the accumulated map.
+
+So on resume pass N, `deps.navHarv.snapshot()` already returns the union of every widget harvested on passes 0..N — the re-walk on pass N adds nothing new (first-write-wins drops every re-harvest). **The re-walk on a resume pass is 255s of pure waste: it re-discovers a set the shared harvester already holds.** `contentPrewarmHarvester` (the RA harvester, `deps.harvester`) has the identical process-lived first-write-wins shape.
+
+This is the root cause: `rePrewarmBootScoped` unconditionally re-drives `walk()` even when the harvester it feeds is already fully populated from a prior pass of the same live boot scope.
+
+---
+
+## 2. Design + placement
+
+**Gate the re-walk (and the two post-walk settle/index steps that depend on it) on `attempt == 0`; on a resume pass, skip straight to the seed over the already-populated harvester snapshot.**
+
+- **Placement:** `rePrewarmBootScoped` (`prewarm_engine_boot.go:228`), guarding the block `:254-345` (the `BeginWalk`/per-root `walk()` loop `:291-328`, `settleRegisteredSet` `:333`, and `BuildBindingsByGVRIndex` `:340`). The seed block `:347-391` (snapshot → `seedScopeYielding`) runs UNCHANGED on both first and resume passes — it already reads the shared harvester's `snapshot()`, which on a resume is the accumulated set.
+- **The attempt signal (no new state):** the workqueue already tracks per-item requeue count. `processScope` reads it today at `prewarm_engine.go:626` (`e.queue.NumRequeues(s)` for the `scope_requeued attempt:` log). Thread it into the scope handler. Cleanest seam: compute `attempt := e.queue.NumRequeues(s)` in `processScope` BEFORE calling the handler and carry it on `scopeCtx` via a new tiny `cache.WithBootResumeAttempt(ctx, attempt)` (mirror the existing `WithSeedDeclinedExternalSet` install at `prewarm_engine.go:602-604`, boot-scope-only). `rePrewarmBootScoped` reads it: `attempt == 0` (or absent → 0) walks; `attempt > 0` reuses.
+  - Alternative seam (no ctx plumbing): a `bool walk` parameter on `rePrewarmBootScoped`, set by a new `makeBootScopeHandler` branch that inspects `NumRequeues`. Ctx-carry is preferred — it mirrors the Lever A install pattern already in `processScope` and keeps the handler signature stable.
+- **Reuse-branch behavior on a resume pass:**
+  - SKIP `BeginWalk` + the per-root `walk()` loop (the 255s).
+  - `settleRegisteredSet` (`:333`) and `BuildBindingsByGVRIndex` (`:340`): these depend on the walk's discovered GVRs. On a resume, the GVRs were already registered + indexed on pass 0, and the informer set only grows. **Keep `BuildBindingsByGVRIndex` on resume** (it is cheap — an index rebuild over already-registered GVRs, source design measures the 255s as the WALK, not the index; the index build logs its own `index_built` line separately) OR skip it as a further optimization once measured. **Recommend: keep both settle+index on resume for pass-0 parity of the substrate the seed reads; only skip the `walk()` loop.** This is the minimal, provably-safe cut — the 255s is the walk, and skipping only the walk removes the entire measured cost with zero risk to the informer/index substrate.
+  - RUN the seed (`:347-391`) exactly as today over `deps.navHarv.snapshot()` — now the accumulated set.
+- **feedback_no_special_cases CLEAN (verdict 4):** the reused snapshot is the WALK'S OWN output (`deps.navHarv.snapshot()`), harvested from live config.json roots — not a hardcoded target list, no resource/name/path literal. The `attempt` gate is a data-derived requeue count from client-go, not a magic number. This is a pure "don't recompute an idempotent result" reuse, structurally identical to the F4 memo (`seedScopeYielding:499`) and to the harvester's own first-write-wins dedup. No special case introduced.
+
+---
+
+## 3. The invalidation seam — soundness resolution (THE CRUX)
+
+### 3.1 The two ways the boot scope re-enters, and how they differ
+
+There are exactly two paths that cause `rePrewarmBootScoped` to run again for the `"boot"` key:
+
+**(A) F.4 deadline-cut RESUME** — `processScope:621` `queue.AddRateLimited(s)`. This INCREMENTS `NumRequeues(s)` (client-go's rate-limiter tracks per-item requeues). So the resume pass sees `attempt > 0` → REUSE snapshot. Correct: a deadline-cut is the SAME topology, just an unfinished seed tail; re-discovering the identical set is the waste Lever B kills.
+
+**(B) config-vars redrive (genuine topology change)** — `enqueueBootReDrive` (`phase1_configvars_watch.go:181`) → `enqueueScope(bootScope)` → `queue.Add(s)` (`prewarm_engine.go:357`, the IMMEDIATE add, NOT `AddRateLimited`). Critically: on the PRIOR scope's genuine completion, `processScope:637` called `queue.Forget(s)`, which **resets `NumRequeues(s)` to 0**. And even mid-flight, a config-vars change fires `clearDeclinedExternalSet` + a fresh `Add` — the new dequeue of the boot scope is `attempt == 0` unless it is itself subsequently deadline-cut. So a config-vars redrive re-walks the NEW config.json roots → discovers the new nav set → first-write-wins ADDS the new widgets to the harvester → seed covers them. **The new topology is walked, exactly as required by falsifier 5.**
+
+**This is the seam, and it is already correct by construction of the existing queue semantics** — `Forget`-on-success (`:637`) and immediate-`Add` (not rate-limited) for config-vars redrive (`:357`) mean the requeue counter distinguishes "deadline-cut resume of the same topology" (counter > 0) from "genuine redrive" (counter reset to 0 by the prior Forget). Lever B keys on exactly that distinction.
+
+### 3.2 The ONE residual edge — a config-vars change DURING an unfinished (already-requeued) boot scope
+
+Consider: pass 0 deadline-cuts → `AddRateLimited` → `NumRequeues==1`. Before the resume runs, config.json changes → `enqueueBootReDrive` → `queue.Add(boot)`. Because the boot key is already in the queue (coalesces), the pending item still carries `NumRequeues==1`. The resume then runs with `attempt==1` → REUSE → **would seed the OLD nav set, missing the new topology until the next genuine completion+redrive.** This is the stale-snapshot risk the source design flagged as "the load-bearing correctness condition."
+
+**Resolution — two options, recommend (i):**
+
+**(i) RECOMMENDED — clear the requeue counter on config-vars redrive (1 line, reuses the pattern Lever A already established at the same call site).** `enqueueBootReDrive` ALREADY does `prewarmEngineSingleton().clearDeclinedExternalSet(bootScope.key(), "config-vars-redrive")` at `phase1_configvars_watch.go:192` — for exactly the analogous reason (Lever A's set must be dropped on a topology change). Add a sibling `prewarmEngineSingleton().queue.Forget(bootScope)` (or a thin `e.resetBootAttempt(key)` wrapper) BEFORE the `enqueueScope`. `Forget` resets `NumRequeues` to 0, so the coalesced pending boot item is re-dequeued as `attempt==0` → RE-WALKS the new config. This is byte-for-byte the same "clear-on-redrive" hardening Lever A required, in the same function, and it composes: the config-vars watcher becomes the single invalidation point for BOTH Lever A's declined set AND Lever B's walk-skip. Clean, no new subscription, one line.
+  - Caveat to verify in impl: `workqueue.Forget` on an item currently in the queue (not being processed) is safe (it only touches the rate-limiter's failure map, not queue membership) — confirm against the client-go version; if `Forget` semantics on a queued-but-not-processing item are ambiguous, use option (ii).
+
+**(ii) Fallback — snapshot-generation counter.** Bump an engine-lived `bootTopologyGen atomic.Uint64` in `enqueueBootReDrive`; stamp the gen the walk-skip is valid for; reuse only if `attempt>0 AND gen unchanged since the last walk`. More explicit but adds a counter + a compare; (i) reuses existing queue state and the existing clear-on-redrive call site, so it is strictly less surface.
+
+### 3.3 Interaction with the existing self-heal (`TestBootRace_ConfigVarsInformerDrivesReWalk`)
+
+The self-heal falsifier (`phase1_boot_race_selfheal_falsifier_test.go`) drives: config-vars ABSENT → boot scope gives up (`roots_list_failed`, returns error at `prewarm_engine_boot.go:277`) → later the ConfigMap appears → AddFunc → `enqueueBootReDrive` → boot re-walk finds roots. Two facts make Lever B compatible:
+
+- The give-up on absent config returns an ERROR at `:271-278` (`roots_list_failed`) — that is BEFORE the walk. Under Lever B, an `attempt>0` resume would try to reuse an EMPTY harvester (nothing was ever walked). **Guard: reuse ONLY when the harvester snapshot is non-empty** (`len(deps.navHarv.snapshot()) > 0`); an empty snapshot means pass 0 never successfully harvested (config was absent / walk failed) → fall through to a real walk regardless of `attempt`. This makes the give-up→appear→heal sequence still re-walk on the config-vars AddFunc (option (i) resets attempt to 0 anyway; the non-empty guard is defense-in-depth for the deadline-cut-before-any-harvest corner).
+- The AddFunc path uses `queue.Add` (immediate) and, with option (i), `Forget` first — so the self-heal re-walk is always `attempt==0` → walks. The falsifier's `bootRuns>=2` assertion (t0 give-up + self-heal re-walk) holds; both runs walk.
+
+**Verdict on the seam: SOUND.** The distinction Lever B needs (resume-of-same-topology vs genuine-redrive) is already materialized in the queue's `NumRequeues`/`Forget` semantics; the one residual edge (§3.2) is closed by a 1-line `Forget`-on-redrive that mirrors Lever A's existing clear-on-redrive at the identical call site; the non-empty-snapshot guard makes the boot-race give-up path re-walk safely. No new invalidation subscription, no new watcher, no topology-diff logic.
+
+---
+
+## 4. Lifetime / ownership
+
+The snapshot Lever B reuses is NOT a new field — it is the existing `deps.navHarv` (+ `deps.harvester`), which is:
+
+- **Created once** (`phase1_walk.go:379`), **engine/deps-lived** (closed into the boot handler via `rePrewarmDeps`), REUSED across every requeue and every config-vars redrive.
+- **Grows monotonically** (first-write-wins, never cleared). A config-vars redrive that walks a NEW config ADDS the new roots' widgets to the SAME harvester (correct — a superset seed is safe; the seed's per-target RBAC scoping filters, and over-inclusion is benign per the existing `unionProactiveRARefs` no-special-case note at `prewarm_engine_boot.go:1129`). A widget that DISAPPEARS from the new config remains in the harvester and is re-seeded (a harmless stale seed of a now-unreferenced widget — its cell is per-user-keyed and simply unused; NOT a correctness or leak issue). If a future requirement needs the harvester to SHRINK on topology change, that is a separate concern that predates and is orthogonal to Lever B (today's harvester never shrinks either).
+- **The only NEW lifetime element** is the per-scope `attempt` read, which is:
+  - OWNED by the workqueue (client-go), not by Lever B — Lever B only reads `NumRequeues`.
+  - Reset on genuine completion (`Forget` at `prewarm_engine.go:637`) and, per §3.2 option (i), on config-vars redrive (`enqueueBootReDrive`). So a fresh boot / new topology re-walks once, exactly mirroring how Lever A's declined set is cleared on completion + redrive (`prewarm_engine.go:644` + `phase1_configvars_watch.go:192`).
+
+Ownership summary: no engine-held snapshot field is added (unlike Lever A's `declinedExtSets` map — the harvester already IS the engine-lived accumulator). The clear-on-completion + clear-on-redrive points are the SAME two points Lever A uses, so the two levers share one invalidation story.
+
+---
+
+## 5. Falsifier set (PM-gateable, each ties to a runtime artifact / real re-invocation)
+
+**B-symptom (positive) — `rewalk_complete` fires ONCE per boot scope, not per attempt.**
+- Runtime: re-boot the fixed image at 50K; grep `prewarm.engine.boot.rewalk_complete` bucketed against `scope_requeued attempt:` lines. Pre-fix: 6+ `rewalk_complete` lines (one per pass), each `elapsed_ms:253000-261000`. Post-fix: exactly 1 `rewalk_complete` (pass 0) + N `boot.complete` lines whose gap to their `scope_requeued` predecessor is dominated by SEED not rewalk (resume `boot.complete elapsed_ms` collapses from ~340-383s toward the resume seed cost alone, low tens of seconds once Lever A also elides the whale re-seed).
+- Corollary: a NEW `prewarm.engine.boot.rewalk_reused` (or a field on `boot.complete`, e.g. `walked:false attempt:N`) INFO line on resume passes, so the skip is greppable and the count of skips == number of resume passes.
+
+**B-safety (load-bearing, RED-blocking) — config-vars INIT change DURING a boot resume → the next seed pass uses the NEW target set (re-walks); driven through the REAL ≥2× resume boundary.**
+Per `feedback_falsifier_must_drive_real_boundary_not_install_crossed_state`: the arm MUST drive the actual resume re-invocation twice with a genuine config-vars change between — NOT hand-install a stale snapshot.
+- Harness (extends `phase1_boot_race_selfheal_falsifier_test.go`'s real-informer + real-engine pattern): 
+  1. Config-vars present with roots {A}. Drive boot scope pass 0 (`attempt==0`) → walks → harvester holds {A}. Force a deadline-cut (via `prewarmScopeTimeoutFn` test seam, `prewarm_engine.go:522`) so `processScope` `AddRateLimited`s → `NumRequeues==1`.
+  2. **Genuine config-vars change**: update the ConfigMap Data to roots {A,B} → REAL UpdateFunc → `configVarsDataChanged==true` → `enqueueBootReDrive` (with §3.2 option (i): `Forget` resets attempt to 0).
+  3. Drive the NEXT dequeue through the REAL worker/`processScope`. Assert: it WALKED (`rewalk_complete` fired again) and the harvester/seed now covers {B} (new root). 
+  - **RED arm** = remove the §3.2 `Forget`-on-redrive (or the non-empty guard): the resume runs at `attempt==1` → REUSE → seeds only {A} → B is missing → assert-B-seeded FAILS. This discriminates the stale-snapshot bug precisely.
+  - Second RED arm (the pure symptom guard): with NO config change, drive pass 0 (walk) → deadline-cut → resume: assert the resume did NOT call `walk()` (a `walkCalled` counter via the existing `deps.lister`/walker seam stays at 1). RED = gate always-walks → counter==2.
+
+**B-safety corollary — boot-race give-up path still self-heals under Lever B.** Reuse `TestBootRace_ConfigVarsInformerDrivesReWalk` unchanged: config absent → give-up (empty harvester) → ConfigMap appears → AddFunc → re-walk. Assert `rewalk_complete` fires on the self-heal pass (non-empty guard + attempt-reset both force the walk). RED = a naive `attempt>0→reuse` with no non-empty guard would try to reuse the empty harvester and seed nothing → `roots>0` assertion (`selfheal_falsifier_test.go:241`) fails.
+
+**Aggregate milestone (unchanged from source §5.6):** `boot.complete` for the boot scope converges (no `scope_requeued attempt≥2` churn over 10 min); `first_nav.latch` still fires via `segment-complete` on pass 0 (Lever B does not touch pass-0 latch timing — pass 0 walks). 50K canonical bar (warm 911 / cold 2053 / conv ~24s per `project_current_state`) must not regress.
+
+---
+
+## 6. Implementation LOC estimate
+
+~25-40 LOC:
+- `rePrewarmBootScoped` gate: read attempt off ctx, `if attempt==0 || len(navHarv.snapshot())==0 { walk block } else { skip-walk, log rewalk_reused }` — ~12 LOC (wrap `:254-333`, keep `:340` index build).
+- `processScope` (`prewarm_engine.go:602-604` area): compute `attempt := e.queue.NumRequeues(s)` and `scopeCtx = cache.WithBootResumeAttempt(scopeCtx, attempt)` in the boot-scope branch — ~3 LOC.
+- `cache.WithBootResumeAttempt` / `BootResumeAttemptFromContext` (mirror `WithSeedDeclinedExternalSet`) — ~10 LOC in `internal/cache`.
+- `enqueueBootReDrive` §3.2 fix: `prewarmEngineSingleton().queue.Forget(bootScope)` (or `e.resetBootAttempt`) before `enqueueScope` — ~1-3 LOC, adjacent to the existing `clearDeclinedExternalSet` call at `phase1_configvars_watch.go:192`.
+- New `rewalk_reused` log line — ~5 LOC.
+
+No production code written here (design only). This is well inside the source design's ~40-60 LOC estimate; it comes in LOWER because the harvester reuse is free (no new snapshot field) — the source design assumed a new cached-snapshot field that turned out to be redundant with the existing accumulator.
+
+---
+
+## 7. #123 framing verdict (explicit, data-driven) + per-cohort-baseline recommendation
+
+**Does Lever B widen the #123 margin? NO.** #123 is the pass-1 seed ceiling: 459.6s of per-cohort seed jq, `first_nav.latch` at 376s (< 480s — it fit), scale-linear in cohort count (source §2, §7; #136 re-grounds cohort count at ~20 not 6). Pass 1 runs at `attempt==0` → Lever B walks it → Lever B removes ZERO of pass-1's cost. Lever B removes ~255s of rewalk from RESUME passes only. So Lever B's contribution is **aggregate boot convergence under resume-thrash**, not #123 margin: with the rewalk gone AND Lever A's whale re-seed gone, a resume pass drops from ~340s to the seed-tail cost, so the F.4 cost-proportional resume actually converges the deadline-cut tail instead of each requeue paying 255s of rediscovery and re-thrashing. That is real and worth shipping (it is what makes the boot scope stop requeuing), but it must not be sold as a #123 fix.
+
+**The true #123 reducer (§6 of the source design): resolve the `allCompositions` substrate ONCE across cohorts, filter per cohort.** Source §2 traces the pass-1 mid-mass (259s) to the per-cohort `allCompositions`-over-29-GVRs double-pass floor (`stage=allCompositions iter_calls:29`), paid once per (widget × cohort). The informer-served substrate bytes are cohort-INDEPENDENT; only the RBAC filter is per-cohort. A "resolve substrate once, filter N times" split attacks the dominant pass-1 term directly and scales sub-linearly in cohort count — exactly the lever #123/#136 need. It is a larger design (touches the resolve stage's substrate/filter boundary, cache-key implications, RBAC-filter correctness under a shared substrate) and is genuinely the higher-leverage #123 item.
+
+**Recommendation to TL/Diego:** ship Lever B for resume-thrash hardening (it is the necessary complement to Lever A — A alone leaves 255s of rewalk on every resume, so the boot scope keeps churning). **Book the per-cohort-baseline substrate-share as its own design task under #123/#136** — it is the real pass-1/#123 reducer and should be surfaced to Diego as the next boot-budget item, NOT folded into Lever B. Sequencing (source §7): A shipped → B (this) → then the substrate-share design if the on-cluster cohort count (#136, ~20) pushes pass-1 toward 480s.
+
+---
+
+## Appendix — file:line index (all TRACED against current main)
+
+- Re-walk loop + `rewalk_complete`: `prewarm_engine_boot.go:254-371` (gate target).
+- Seed block (unchanged by Lever B): `prewarm_engine_boot.go:347-391`.
+- Resume re-entry (AddRateLimited): `prewarm_engine.go:609-632`; `Forget`-on-success (attempt reset): `:637`.
+- Attempt signal source: `prewarm_engine.go:626` `e.queue.NumRequeues(s)`.
+- Lever A install pattern to mirror: `prewarm_engine.go:602-604` (`WithSeedDeclinedExternalSet`, boot-scope-only).
+- config-vars redrive (invalidation call site + existing Lever A clear): `phase1_configvars_watch.go:181-200`, esp. `:192`.
+- config-vars DATA-change gate (#106): `phase1_configvars_watch.go:163-171`, `:283-299`.
+- Harvester single-construction: `phase1_walk.go:379`; stored on deps `:426`.
+- Harvester first-write-wins (never cleared): `phase1_pip_seed.go:300-344`; snapshot `:387`.
+- Boot-race self-heal falsifier (compat + reuse): `phase1_boot_race_selfheal_falsifier_test.go` (esp. `:241` roots>0 assert, `:272` bootRuns>=2).
+- Deadline-cut test seam (drive resume without a live cluster): `prewarm_engine.go:522` `prewarmScopeTimeoutFn`.

--- a/internal/cache/boot_resume_attempt.go
+++ b/internal/cache/boot_resume_attempt.go
@@ -1,0 +1,64 @@
+// boot_resume_attempt.go — #135 F4b Lever B boot-scope resume-attempt marker.
+//
+// Lever B stops re-driving the discovery walk() on a boot RESUME pass. The
+// navWidgetHarvester + contentPrewarmHarvester are already process-lived,
+// monotonic, first-write-wins accumulators (never cleared in production), so on
+// a resume pass their snapshot() already returns the union of every prior pass —
+// re-walking rediscovers a set the shared harvester already holds (~255s of pure
+// waste per resume, docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md
+// §1). This marker carries the workqueue's per-item requeue count
+// (NumRequeues(s)) from processScope onto the boot scope ctx so rePrewarmBootScoped
+// can distinguish pass 0 (attempt==0 → WALK) from an F.4 deadline-cut resume
+// (attempt>0 → REUSE the snapshot, skip the walk).
+//
+// WHY THE ATTEMPT COUNT IS THE RIGHT SIGNAL (design §3): the queue's
+// NumRequeues/Forget semantics already materialize the distinction Lever B needs.
+// An F.4 deadline-cut resume goes through AddRateLimited → NumRequeues>0. A
+// genuine config-vars redrive (topology change) goes through Forget (resets
+// NumRequeues to 0) + immediate Add + a sibling Forget in enqueueBootReDrive
+// (§3.2), so it re-dequeues at attempt==0 → RE-WALKS the new config. The reuse is
+// additionally guarded by a non-empty-snapshot check in rePrewarmBootScoped so
+// the boot-race give-up→appear→self-heal path (empty harvester) always re-walks.
+//
+// This is NOT a new invalidation subscription — it is a read of state client-go
+// already tracks (feedback_no_special_cases: attempt is the requeue count, not a
+// magic number). Installed ONLY on the boot scope ctx in processScope, mirroring
+// the Lever A WithSeedDeclinedExternalSet install; absent → 0 → WALK (the safe
+// default, so any non-boot / uninstrumented path always walks).
+
+package cache
+
+import "context"
+
+// ctxKeyBootResumeAttemptType is the typed empty-struct context key for the
+// boot-scope resume-attempt count. Distinct unexported type — no cross-package
+// raw-string-key collision (mirrors ctxKeySeedDeclinedExternalSetType).
+type ctxKeyBootResumeAttemptType struct{}
+
+var ctxKeyBootResumeAttempt = ctxKeyBootResumeAttemptType{}
+
+// WithBootResumeAttempt returns a child context carrying the boot scope's
+// workqueue requeue count (attempt). Installed ONLY by processScope on the boot
+// scope ctx (boot-scope-only, mirroring WithSeedDeclinedExternalSet). attempt==0
+// is pass 0 (fresh enqueue or Forget-reset genuine redrive); attempt>0 is an F.4
+// deadline-cut resume of the same topology. Inert under Disabled() (a cache-off
+// process never runs the prewarm engine, so this is never consulted there).
+func WithBootResumeAttempt(ctx context.Context, attempt int) context.Context {
+	if ctx == nil || Disabled() {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyBootResumeAttempt, attempt)
+}
+
+// BootResumeAttemptFromContext returns the boot resume-attempt count installed on
+// ctx, or 0 when none is present. A 0 return MUST be treated as "pass 0 — WALK"
+// (the safe default): any path that did not install the marker re-walks, so Lever
+// B can never skip a walk it wasn't explicitly told is a resume of a
+// still-populated boot scope.
+func BootResumeAttemptFromContext(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+	v, _ := ctx.Value(ctxKeyBootResumeAttempt).(int)
+	return v
+}

--- a/internal/cache/boot_resume_attempt_test.go
+++ b/internal/cache/boot_resume_attempt_test.go
@@ -1,0 +1,65 @@
+// boot_resume_attempt_test.go — #135 F4b Lever B C3: the ctx-marker unit.
+//
+// WithBootResumeAttempt / BootResumeAttemptFromContext carry the boot scope's
+// workqueue requeue count (NumRequeues) from processScope onto the boot scope
+// ctx so rePrewarmBootScoped can distinguish pass 0 (attempt==0 → WALK) from an
+// F.4 deadline-cut resume (attempt>0 → REUSE). Mirrors the WithSeedResolveMemo /
+// WithSeedDeclinedExternalSet ctx-marker units in this package:
+//   - round-trip (set N → read N),
+//   - Disabled() → ctx unchanged → read 0 (inert, the cache-off posture),
+//   - absent / nil ctx → 0 default (the safe "pass 0 — WALK" default: any path
+//     that never installed the marker re-walks).
+
+package cache
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBootResumeAttempt_RoundTripAndDefaults(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true") // not Disabled() → the install is live
+
+	// ── round-trip: set N → read N (a few representative attempts incl. 0).
+	for _, n := range []int{0, 1, 5, 42} {
+		ctx := WithBootResumeAttempt(context.Background(), n)
+		if got := BootResumeAttemptFromContext(ctx); got != n {
+			t.Fatalf("round-trip: WithBootResumeAttempt(%d) → read %d; want %d", n, got, n)
+		}
+	}
+
+	// ── absent marker on a live base ctx → 0 (the safe "pass 0 — WALK" default).
+	if got := BootResumeAttemptFromContext(context.Background()); got != 0 {
+		t.Fatalf("absent marker must read 0 (pass-0/WALK default); got %d", got)
+	}
+
+	// ── nil ctx → 0 (BootResumeAttemptFromContext is nil-safe).
+	//nolint:staticcheck // SA1012: intentionally passing a nil ctx to prove nil-safety.
+	if got := BootResumeAttemptFromContext(nil); got != 0 {
+		t.Fatalf("nil ctx must read 0; got %d", got)
+	}
+	// WithBootResumeAttempt on a nil ctx must not panic and must return nil.
+	//nolint:staticcheck // SA1012: intentionally passing a nil ctx to prove nil-safety.
+	if ctx := WithBootResumeAttempt(nil, 3); ctx != nil {
+		t.Fatalf("WithBootResumeAttempt(nil, 3) must return the nil ctx unchanged; got non-nil")
+	}
+}
+
+// TestBootResumeAttempt_DisabledInert — Disabled() (CACHE_ENABLED=false) →
+// WithBootResumeAttempt returns the ctx UNCHANGED, so no marker is installed and
+// a read is the 0 default (byte-identical to pre-Lever-B). A cache-off process
+// never runs the prewarm engine, so the marker is never consulted there.
+func TestBootResumeAttempt_DisabledInert(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+	if !Disabled() {
+		t.Fatal("premise broken: CACHE_ENABLED=false must make Disabled() true")
+	}
+	base := context.Background()
+	ctx := WithBootResumeAttempt(base, 7)
+	if ctx != base {
+		t.Fatal("Disabled(): WithBootResumeAttempt must return the ctx UNCHANGED (inert install)")
+	}
+	if got := BootResumeAttemptFromContext(ctx); got != 0 {
+		t.Fatalf("Disabled(): the marker must be inert → read 0; got %d", got)
+	}
+}

--- a/internal/handlers/dispatchers/phase1_configvars_watch.go
+++ b/internal/handlers/dispatchers/phase1_configvars_watch.go
@@ -198,6 +198,18 @@ func enqueueBootReDrive(reason string) {
 	// than a stale prior. A plain F.4 deadline-cut requeue does NOT come through
 	// here (it keeps the state) — only a genuine config change clears.
 	prewarmEngineSingleton().clearBootConvergenceState(bootScope.key())
+	// #135 F4b Lever B — RESET the boot scope's workqueue requeue count so this
+	// genuine topology change re-dequeues at attempt==0 → rePrewarmBootScoped
+	// WALKS the new config.json nav set instead of REUSING the prior topology's
+	// harvester snapshot. MUST precede enqueueScope (a plain queue.Add that does
+	// NOT reset NumRequeues): without it, a redrive landing mid-F.4-requeue-streak
+	// (NumRequeues>0) leaves attempt>0 → Lever B reuses the STALE nav set across
+	// the topology change. A plain F.4 deadline-cut resume does NOT come through
+	// here (it AddRateLimited's in processScope), so its attempt>0 fast-path reuse
+	// is preserved — only a genuine config change forces the re-walk. Paired with
+	// clearBootConvergenceState above: a topology change resets BOTH the #105
+	// convergence sets AND the #135 requeue-attempt count on the same event.
+	prewarmEngineSingleton().forgetScope(bootScope)
 	prewarmEngineSingleton().enqueueScope(bootScope)
 	slog.Info("prewarm.configvars.boot_redrive_enqueued",
 		slog.String("subsystem", "cache"),

--- a/internal/handlers/dispatchers/prewarm_engine.go
+++ b/internal/handlers/dispatchers/prewarm_engine.go
@@ -368,6 +368,22 @@ func (e *prewarmEngine) enqueueScope(s prewarmScope) {
 	e.enqueuedTotal.Add(1)
 }
 
+// forgetScope resets the workqueue's rate-limit / requeue history for s
+// (NumRequeues(s) → 0) WITHOUT processing it. #135 F4b Lever B: a config-vars
+// redrive is a GENUINE TOPOLOGY CHANGE, so the boot scope must re-dequeue at
+// attempt==0 → rePrewarmBootScoped WALKS the new nav set instead of REUSING the
+// prior topology's harvester snapshot. enqueueScope alone is a plain queue.Add,
+// which does NOT reset NumRequeues; a redrive arriving while an F.4 deadline-cut
+// requeue streak is in flight (NumRequeues>0) would otherwise keep attempt>0 and
+// wrongly reuse the stale snapshot. enqueueBootReDrive pairs forgetScope +
+// enqueueScope so the redrive re-walks. A plain F.4 deadline-cut does NOT call
+// this — it AddRateLimited's inside processScope and keeps its NumRequeues
+// (attempt>0 → reuse, the intended fast path). Never blocks (workqueue.Forget is
+// a mutex critical section).
+func (e *prewarmEngine) forgetScope(s prewarmScope) {
+	e.queue.Forget(s)
+}
+
 // declinedExternalSetFor returns the engine-lived declined-external marker set
 // for scope key, creating it on first use. REUSED across the scope's
 // AddRateLimited requeues (so a boot resume pass consults the SAME set the prior
@@ -662,6 +678,14 @@ func (e *prewarmEngine) processScope(ctx context.Context, s prewarmScope) {
 		bootConv = e.bootConvergenceStateForKey(s.key())
 		scopeCtx = cache.WithBootSeededSet(scopeCtx, bootConv.seeded)
 		scopeCtx = withBootConvergenceState(scopeCtx, bootConv)
+		// #135 F4b Lever B — carry the workqueue's per-item requeue count onto the
+		// boot scope ctx so rePrewarmBootScoped can distinguish pass 0
+		// (attempt==0 → WALK) from an F.4 deadline-cut resume (attempt>0 → REUSE
+		// the already-populated harvester snapshot, skip the ~255s re-walk). This
+		// is the SAME NumRequeues the scope_requeued log reads below; Forget-on-
+		// success (:637) + the config-vars-redrive Forget (phase1_configvars_watch.go)
+		// reset it to 0 so a genuine topology change re-walks. Boot scope ONLY.
+		scopeCtx = cache.WithBootResumeAttempt(scopeCtx, e.queue.NumRequeues(s))
 	}
 	err := e.scopeHandler(scopeCtx, s)
 	scopeCancel()

--- a/internal/handlers/dispatchers/prewarm_engine_boot.go
+++ b/internal/handlers/dispatchers/prewarm_engine_boot.go
@@ -225,6 +225,23 @@ func rePrewarmGVRDiscoveredSeed(ctx context.Context, deps rePrewarmDeps) error {
 	return rePrewarmBootScoped(ctx, deps, seedModeGVRDiscovered)
 }
 
+// bootShouldWalk is the #135 F4b Lever B reuse predicate — the SINGLE source of
+// the walk-vs-reuse decision (rePrewarmBootScoped calls this; the falsifier calls
+// the SAME function, never a copy, so the test can't drift from prod — the #64/#66
+// anti-shadow-drift lesson). Returns true = re-walk discovery, false = reuse the
+// process-lived harvester snapshot.
+//
+//   - attempt==0  → pass 0: a fresh enqueue OR a genuine config-vars redrive that
+//     reset the requeue count via forgetScope (enqueueBootReDrive). WALK.
+//   - attempt>0   → an F.4 deadline-cut resume of the SAME topology. REUSE — UNLESS
+//     harvestedCount==0 (a resume whose pass 0 never harvested: boot-race give-up
+//     on absent config, or a cut before any harvest). An empty harvester has
+//     nothing to reuse, so it must WALK (keeps the give-up→appear self-heal path
+//     re-walking).
+func bootShouldWalk(attempt, harvestedCount int) bool {
+	return attempt == 0 || harvestedCount == 0
+}
+
 func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, mode seedScopeMode) error {
 	log := slog.Default()
 	start := time.Now()
@@ -267,28 +284,72 @@ func rePrewarmBootScoped(ctx context.Context, deps rePrewarmDeps, mode seedScope
 	// cache.WithBackgroundResolve.
 	ctx = cache.WithBackgroundResolve(ctx)
 	rctx := withPhase1SAContext(ctx, deps.saEP, deps.saRC)
-	roots, listErr := deps.lister(rctx)
-	if listErr != nil {
-		log.Warn("prewarm.engine.boot.roots_list_failed",
-			slog.String("subsystem", "cache"),
-			slog.Any("err", listErr),
-			slog.String("effect", "boot re-walk has no roots; first /call per cohort falls back to per-user resolve"),
-		)
-		return listErr
-	}
 
+	// #135 F4b Lever B — SKIP the discovery re-walk on an F.4 deadline-cut RESUME
+	// pass. The navWidgetHarvester + contentPrewarmHarvester are process-lived,
+	// monotonic, first-write-wins accumulators (never cleared in prod), so on a
+	// resume pass their snapshot() already holds the UNION of every prior pass —
+	// re-walking rediscovers a set the shared harvester already has (~255s of pure
+	// waste). Gate on attempt (the workqueue requeue count carried by processScope):
+	//   - attempt==0 → pass 0 (fresh enqueue, OR a Forget-reset genuine config-vars
+	//     redrive) → WALK the current config.json roots.
+	//   - attempt>0 → deadline-cut resume of the SAME topology → REUSE the snapshot.
+	// GUARD len(snapshot)==0: a resume whose pass 0 never harvested (boot-race
+	// give-up on absent config, or a deadline-cut before ANY harvest) MUST still
+	// walk — an empty harvester has nothing to reuse. This keeps the
+	// give-up→appear→self-heal path (TestBootRace_ConfigVarsInformerDrivesReWalk)
+	// re-walking. A genuine config-vars redrive resets attempt to 0 (Forget in
+	// enqueueBootReDrive), so the NEW topology is always walked (design §3).
+	attempt := cache.BootResumeAttemptFromContext(ctx)
+	doWalk := bootShouldWalk(attempt, len(deps.navHarv.snapshot()))
+
+	var roots []navigationRoot
 	rewalked := 0
-	// #99b Fix 2 — reset the harvester's config-root index to -1 at the top of
-	// this walk PASS so the per-root BeginRoot() below stamps RootIndex 0..N-1
-	// in config.json order, exactly like the boot walk (phase1_walk.go:401).
-	// WITHOUT the reset the re-walk would resume from the boot walk's final
-	// curRoot=N-1 and a widget FIRST harvested only during this re-walk (the
-	// 50K+ common case, where the effective harvest comes from the config-vars
-	// redrive) would stamp N..2N-1, so its RootIndex would never be 0 → the
-	// first-nav latch zero-fires (multi-root). First-write-wins dedupe
-	// preserves any boot-walk stamp. Nil-safe. Inert on single-root config
-	// (curRoot pinned 0 after the first BeginRoot); required for multi-root.
-	deps.navHarv.BeginWalk()
+	if doWalk {
+		var listErr error
+		roots, listErr = deps.lister(rctx)
+		if listErr != nil {
+			log.Warn("prewarm.engine.boot.roots_list_failed",
+				slog.String("subsystem", "cache"),
+				slog.Any("err", listErr),
+				slog.String("effect", "boot re-walk has no roots; first /call per cohort falls back to per-user resolve"),
+			)
+			return listErr
+		}
+		// #99b Fix 2 — reset the harvester's config-root index to -1 at the top of
+		// this walk PASS so the per-root BeginRoot() below stamps RootIndex 0..N-1
+		// in config.json order, exactly like the boot walk (phase1_walk.go:401).
+		// WITHOUT the reset the re-walk would resume from the boot walk's final
+		// curRoot=N-1 and a widget FIRST harvested only during this re-walk (the
+		// 50K+ common case, where the effective harvest comes from the config-vars
+		// redrive) would stamp N..2N-1, so its RootIndex would never be 0 → the
+		// first-nav latch zero-fires (multi-root). First-write-wins dedupe
+		// preserves any boot-walk stamp. Nil-safe. Inert on single-root config
+		// (curRoot pinned 0 after the first BeginRoot); required for multi-root.
+		//
+		// #135 F4b Lever B — BeginWalk() lives INSIDE the walk branch: a reuse pass
+		// does no BeginRoot(), so resetting curRoot to -1 (with nothing to re-stamp)
+		// would only strand the index at -1. The existing RootIndex stamps must
+		// stand; the seed drains the already-populated snapshot unchanged.
+		deps.navHarv.BeginWalk()
+	} else {
+		// #135 F4b Lever B — F.4 RESUME pass: SKIP the ~255s discovery re-walk and
+		// REUSE the process-lived harvester snapshot (already the UNION of every
+		// prior pass — navWidgetHarvester is monotonic / first-write-wins / never
+		// cleared in prod). `roots` stays nil → the walk loop below is a no-op →
+		// step (4) seeds from deps.harvester.snapshot() + deps.navHarv.snapshot(),
+		// which hold the accumulated targets. A genuine config-vars topology change
+		// resets attempt→0 (forgetScope in enqueueBootReDrive), taking the doWalk
+		// branch above and re-walking the new set; the len(snapshot)==0 guard in
+		// doWalk keeps the boot-race give-up→appear self-heal path re-walking.
+		log.Info("prewarm.engine.boot.rewalk_reused",
+			slog.String("subsystem", "cache"),
+			slog.Int("attempt", attempt),
+			slog.Int("harvested_widgets", len(deps.navHarv.snapshot())),
+			slog.String("effect", "#135 Lever B — F.4 resume reused the harvester snapshot instead of "+
+				"re-walking discovery (~255s/pass saved); config-vars redrive resets attempt→0 to force a fresh walk"),
+		)
+	}
 	for _, root := range roots {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/internal/handlers/dispatchers/prewarm_leverb_realboundary_test.go
+++ b/internal/handlers/dispatchers/prewarm_leverb_realboundary_test.go
@@ -1,0 +1,501 @@
+// prewarm_leverb_realboundary_test.go — #135 F4b Lever B REAL-BOUNDARY arms.
+//
+// These upgrade the predicate-level LB-1/LB-2 (prewarm_leverb_rewalk_reuse_test.go,
+// which hand-compute bootShouldWalk on a bare queue) to DRIVE THE ACTUAL
+// processScope → rePrewarmBootScoped walk-vs-reuse decision ≥2× through a real
+// local engine worker — per feedback_falsifier_must_drive_real_boundary_not_
+// install_crossed_state (the exact lesson the shipped LB test under-delivered on:
+// it never re-invoked the real resume boundary; it evaluated the pure predicate).
+//
+// THE REAL BOUNDARY. e.scopeHandler = makeBootScopeHandler(deps) with a real
+// rePrewarmDeps whose discovery WALK is instrumented by a WALK-COUNTING seam:
+// deps.lister (rootsLister) is invoked by rePrewarmBootScoped ONLY inside its
+// `if doWalk` branch (prewarm_engine_boot.go:308-334). Each invocation
+//   (a) increments a walk counter,
+//   (b) records the roots it "walked" (the CURRENT topology), and
+//   (c) harvests that topology into the SAME process-lived deps.navHarv via the
+//       REAL harvestNavWidget primitive (first-write-wins, monotonic — the exact
+//       accumulator prod reuses), then returns ZERO navigationRoots so the
+//       cluster-bound w.walk/widgets.Resolve loop is a hermetic no-op.
+// So walk-count == the number of times the real reuse decision chose WALK, and
+// deps.navHarv.snapshot() is the real accumulated seed source rePrewarmBootScoped
+// drains — no shadow copy, no hand-installed crossed-over state.
+//
+// The scope is driven ≥2× through the REAL e.processScope (NOT an inlined copy),
+// so the REAL cache.WithBootResumeAttempt(scopeCtx, NumRequeues(s)) install +
+// the REAL Forget-on-success / AddRateLimited-on-cut requeue plumbing are what
+// feed bootShouldWalk. The ONLY stubbed surfaces are the seed OUTCOME seams
+// (seedOneWidgetFn / enumeratePrewarmTargetsForGVRFn) + prewarmScopeTimeoutFn —
+// the same named injection points the #105 and F.4 harnesses use.
+//
+// Hermetic, -race, seams + a real client-go-fake-backed ResourceWatcher only
+// (buildP0Watcher). Serializes on engineLatchTestMu (shared counters + the
+// process singleton is untouched here — every arm drives a LOCAL newTestEngine()).
+// Never touches ./internal/rbac.
+
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// ── the WALK-COUNTING seam ────────────────────────────────────────────────
+//
+// walkCountingLister is a rootsLister test double closed over a live-topology
+// pointer + a counter. rePrewarmBootScoped calls it ONLY when it decides to WALK
+// (the `if doWalk` branch), so:
+//   - calls == the count of real WALK decisions,
+//   - it harvests the CURRENT topology into the shared deps.navHarv via the REAL
+//     harvestNavWidget (so the seed source is the genuine accumulator), and
+//   - returns nil roots → the per-root cluster walk loop is a hermetic no-op.
+type walkCountingLister struct {
+	mu       sync.Mutex
+	calls    int        // times the real reuse decision chose WALK
+	walked   [][]string // per-walk: the widget names harvested that pass
+	topology []string   // the CURRENT topology (widget names), swappable between passes
+	navHarv  *navWidgetHarvester
+}
+
+func newWalkCountingLister(navHarv *navWidgetHarvester, initial ...string) *walkCountingLister {
+	return &walkCountingLister{navHarv: navHarv, topology: append([]string(nil), initial...)}
+}
+
+// setTopology swaps the live topology the NEXT walk will harvest (a genuine
+// config-vars change: new nav set).
+func (l *walkCountingLister) setTopology(names ...string) {
+	l.mu.Lock()
+	l.topology = append([]string(nil), names...)
+	l.mu.Unlock()
+}
+
+// lister is the rootsLister rePrewarmBootScoped invokes. It harvests the current
+// topology into the shared navHarv via the REAL harvestNavWidget, then returns
+// zero roots (the cluster walk loop no-ops).
+func (l *walkCountingLister) lister(_ context.Context) ([]navigationRoot, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls++
+	// The real walk pass resets the harvester's root index (BeginWalk) then
+	// stamps per root — mirror the prod pass shape so first-write-wins dedupe
+	// and RootIndex stamping behave exactly as production.
+	l.navHarv.BeginWalk()
+	l.navHarv.BeginRoot()
+	names := append([]string(nil), l.topology...)
+	for _, name := range names {
+		w := &unstructured.Unstructured{}
+		w.SetNamespace("krateo-system")
+		w.SetName(name)
+		w.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: engineSeedWidgetGVR.Group, Version: engineSeedWidgetGVR.Version, Kind: "Table",
+		})
+		// REAL harvest primitive (first-write-wins) into the shared accumulator.
+		l.navHarv.harvestNavWidget(w, engineSeedWidgetGVR, -1, 1, -1, -1)
+	}
+	l.walked = append(l.walked, names)
+	// Return NO roots → the cluster-bound per-root w.walk loop is a no-op.
+	return nil, nil
+}
+
+func (l *walkCountingLister) walkCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// leverBRealDeps builds a rePrewarmDeps whose discovery walk is the walk-counting
+// seam and whose rw is a real client-go-fake-backed ResourceWatcher (so
+// settleRegisteredSet + RegisteredGVRs run for real). Returns deps + the seam.
+func leverBRealDeps(t *testing.T) (rePrewarmDeps, *walkCountingLister, *navWidgetHarvester) {
+	t.Helper()
+	rw, _ := buildP0Watcher(t) // CACHE_ENABLED=true; real informer-backed watcher
+	navHarv := newNavWidgetHarvester()
+	harv := newContentPrewarmHarvester()
+	lister := newWalkCountingLister(navHarv, "widget-A")
+	deps := rePrewarmDeps{
+		rw:        rw,
+		lister:    lister.lister,
+		harvester: harv,
+		navHarv:   navHarv,
+		saEP:      endpoints.Endpoint{},
+		saRC:      nil, // no root is ever walked (lister returns zero roots) → rc never consumed
+		authnNS:   "krateo-system",
+	}
+	return deps, lister, navHarv
+}
+
+// leverBSeedSeams installs the seed OUTCOME seams for a real-boundary boot pass:
+// enumeratePrewarmTargetsForGVRFn → one cohort; seedOneWidgetFn → the per-target
+// behavior fn (Marks the BootSeededSet on success so #105's set-delta works,
+// exactly like the #105 harness). prewarmScopeTimeoutFn → never-deadline unless
+// the caller overrides. Also silences the first-nav latch (nil under these
+// tests) and zeroes the customer-inflight gate. Returns a *bytes.Buffer of the
+// captured JSON logs.
+func leverBSeedSeams(t *testing.T, seedFn func(ctx context.Context, e navWidgetEntry) error) *bytes.Buffer {
+	t.Helper()
+	zeroCustomerInFlight()
+	resetFirstNavLatchForTest()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	prevTO := prewarmScopeTimeoutFn
+	prewarmScopeTimeoutFn = func(prewarmScope) time.Duration { return time.Hour }
+	t.Cleanup(func() { prewarmScopeTimeoutFn = prevTO })
+
+	prevEnum := enumeratePrewarmTargetsForGVRFn
+	enumeratePrewarmTargetsForGVRFn = func(schema.GroupVersionResource, string) []cache.PrewarmTarget {
+		return makeTargets(1)
+	}
+	t.Cleanup(func() { enumeratePrewarmTargetsForGVRFn = prevEnum })
+
+	prevSeed := seedOneWidgetFn
+	seedOneWidgetFn = func(ctx context.Context, e navWidgetEntry, _ string, _ seedScopeMode) error {
+		return seedFn(ctx, e)
+	}
+	t.Cleanup(func() { seedOneWidgetFn = prevSeed })
+
+	return &buf
+}
+
+// leverBWaitReady pulls a rate-limited (AddRateLimited-deferred) item forward:
+// the stock controller backoff base is 5ms, so poll briefly until the queue has
+// a ready item (mirrors the F.4 boot-resume harness).
+func leverBWaitReady(e *prewarmEngine) {
+	deadline := time.Now().Add(3 * time.Second)
+	for e.queue.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// ── C1 (LOAD-BEARING) — real-boundary forget-race ─────────────────────────
+//
+// Drives the ACTUAL processScope → rePrewarmBootScoped reuse decision ≥2× via a
+// real local worker. Sequence (design §5 "B-safety (LOAD-BEARING)"):
+//  1. pass 0: attempt==0 → assert the walk RAN (walk-count==1); harvester holds
+//     root {widget-A} → seeded {widget-A}.
+//  2. force an F.4 deadline-cut requeue (AddRateLimited) → NumRequeues>0.
+//  3. invoke the REAL redrive sequence for a NEW topology {widget-A, widget-B}
+//     (genuine config-vars change): forgetScope THEN enqueueScope (exactly
+//     enqueueBootReDrive's Lever B seam, parameterized on the local engine).
+//  4. next real dequeue → assert it WALKED (walk-count==2) and seeded {widget-B}.
+//
+// RED arm: the pre-fix WIP dropped forgetScope from the redrive (plain
+// enqueueScope only). NumRequeues persists >0 → attempt>0 → the resume REUSES
+// (walk-count stays 1) → {widget-B} never harvested → missing. Proven RED then
+// the real path GREEN. The RED mutation is expressed test-locally (call
+// enqueueScope only) — NO prod seam.
+func TestLeverB_C1_RealBoundary_ForgetRace_ReWalksNewTopology(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	// run drives the full 2-pass boundary; withForget selects GREEN (prod
+	// redrive: forgetScope+enqueueScope) vs RED (enqueueScope only, the WIP).
+	run := func(t *testing.T, withForget bool) (walkAfterPass0, walkAfterRedrive int, seededAfterPass0, seededAfterRedrive []string, logText string) {
+		deps, lister, _ := leverBRealDeps(t)
+
+		var seededMu sync.Mutex
+		seeded := map[string]struct{}{}
+		buf := leverBSeedSeams(t, func(ctx context.Context, e navWidgetEntry) error {
+			// Model the real success site: Mark the BootSeededSet (so #105's
+			// set-delta sees growth) + record the widget name we seeded.
+			cache.BootSeededSetFromContext(ctx).Mark(stableSeededKey(ctx, e.W.GetName()))
+			seededMu.Lock()
+			seeded[e.W.GetName()] = struct{}{}
+			seededMu.Unlock()
+			return nil
+		})
+		seededSnapshot := func() []string {
+			seededMu.Lock()
+			defer seededMu.Unlock()
+			out := make([]string, 0, len(seeded))
+			for k := range seeded {
+				out = append(out, k)
+			}
+			sort.Strings(out)
+			return out
+		}
+
+		e := newTestEngine()
+		e.yieldPoll = 2 * time.Millisecond
+		e.scopeHandler = makeBootScopeHandler(deps)
+
+		boot := prewarmScope{kind: scopeKindBoot}
+		ctx := context.Background()
+
+		// ── PASS 0 (attempt==0 → WALK) via REAL processScope.
+		e.enqueueScope(boot)
+		s0, _ := e.queue.Get()
+		e.processScope(ctx, s0) // REAL: installs WithBootResumeAttempt(NumRequeues==0)
+		walkAfterPass0 = lister.walkCount()
+		seededAfterPass0 = seededSnapshot()
+
+		// ── FORCE the F.4 deadline-cut requeue: AddRateLimited bumps NumRequeues
+		// (this is exactly what processScope does on a deadline-cut, and what the
+		// design §5 step 2 specifies: "force an F.4 deadline-cut requeue
+		// (AddRateLimited) → NumRequeues>0").
+		e.queue.AddRateLimited(boot)
+		if n := e.queue.NumRequeues(boot); n == 0 {
+			t.Fatalf("C1 setup: AddRateLimited must bump the boot requeue count; NumRequeues=%d", n)
+		}
+
+		// ── GENUINE config-vars change: new topology {widget-A, widget-B}.
+		lister.setTopology("widget-A", "widget-B")
+
+		// ── REDRIVE. GREEN = the prod Lever B seam (forgetScope THEN enqueueScope,
+		// exactly enqueueBootReDrive:212-213 on the local engine). RED = the pre-fix
+		// WIP (drop forgetScope; plain enqueueScope only).
+		if withForget {
+			e.forgetScope(boot) // <-- the #135 Lever B invalidation seam
+		}
+		e.enqueueScope(boot)
+
+		// ── NEXT real dequeue → REAL processScope. GREEN: NumRequeues reset to 0
+		// → attempt==0 → WALK the new topology. RED: NumRequeues persists >0 →
+		// attempt>0 + non-empty harvester → REUSE (stale).
+		leverBWaitReady(e)
+		s1, _ := e.queue.Get()
+		e.processScope(ctx, s1)
+		walkAfterRedrive = lister.walkCount()
+		seededAfterRedrive = seededSnapshot()
+		return walkAfterPass0, walkAfterRedrive, seededAfterPass0, seededAfterRedrive, buf.String()
+	}
+
+	// ── GREEN — the real prod path.
+	gW0, gW1, gS0, gS1, gLog := run(t, true /*withForget*/)
+	if gW0 != 1 {
+		t.Fatalf("C1 GREEN pass 0: attempt==0 MUST walk exactly once; walk-count=%d", gW0)
+	}
+	if !containsName(gS0, "widget-A") {
+		t.Fatalf("C1 GREEN pass 0: must seed {widget-A}; seeded=%v", gS0)
+	}
+	// Liveness sanity only: the real rePrewarmBootScoped ran to its seed-source
+	// summary. NOTE: rewalk_complete fires on EVERY pass (walk AND reuse — it is
+	// post-branch at prewarm_engine_boot.go:425), so it is NOT the walk
+	// discriminator; the walk discriminator is the walk-count seam (gW0==1 /
+	// gW1==2 vs the RED rW1==1) asserted above and below.
+	if !strings.Contains(gLog, "prewarm.engine.boot.rewalk_complete") {
+		t.Fatalf("C1 GREEN: pass 0 must run to rewalk_complete (liveness); logs:\n%s", gLog)
+	}
+	if gW1 != 2 {
+		t.Fatalf("C1 GREEN redrive: forgetScope reset attempt→0 → the new topology MUST re-WALK "+
+			"(walk-count 1→2); got walk-count=%d. logs:\n%s", gW1, gLog)
+	}
+	if !containsName(gS1, "widget-B") {
+		t.Fatalf("C1 GREEN redrive: the re-walk MUST discover+seed the NEW root {widget-B}; seeded=%v", gS1)
+	}
+
+	// ── RED — the pre-fix WIP (drop forgetScope).
+	rW0, rW1, _, rS1, rLog := run(t, false /*withForget → RED*/)
+	if rW0 != 1 {
+		t.Fatalf("C1 RED pass 0: attempt==0 MUST still walk once; walk-count=%d", rW0)
+	}
+	if rW1 != 1 {
+		t.Fatalf("C1 RED (LOAD-BEARING): without forgetScope the requeue count persists >0 → attempt>0 → "+
+			"the redrive MUST REUSE the stale snapshot (walk-count STAYS 1); got walk-count=%d — if it walked, "+
+			"the seam is not what discriminates. logs:\n%s", rW1, rLog)
+	}
+	if containsName(rS1, "widget-B") {
+		t.Fatalf("C1 RED: the stale-reuse WIP must NOT seed the new root {widget-B} (it never re-walked); "+
+			"seeded=%v", rS1)
+	}
+
+	// The discriminator: the forgetScope seam FLIPS the real re-walk decision.
+	if gW1 == rW1 {
+		t.Fatalf("C1: forgetScope must CHANGE the real re-walk outcome — GREEN re-walked (walk-count=%d) but "+
+			"RED must reuse (walk-count=%d); they did not discriminate", gW1, rW1)
+	}
+
+	leverBArtifact(t, "c1_realboundary_forget_race.txt", fmt.Sprintf(
+		"REAL processScope→rePrewarmBootScoped driven 2×.\n"+
+			"GREEN (forgetScope+enqueueScope): pass0 walk-count=%d seeded=%v; after redrive walk-count=%d seeded=%v (new root widget-B re-walked+seeded).\n"+
+			"RED (enqueueScope only, pre-fix WIP): pass0 walk-count=%d; after redrive walk-count=%d seeded=%v (STALE reuse — widget-B missing).\n"+
+			"Discriminator: forgetScope flips the real re-walk (GREEN 2 vs RED 1).\n",
+		gW0, gS0, gW1, gS1, rW0, rW1, rS1))
+}
+
+// ── C2 — compose #105 × #135 through the real gate ─────────────────────────
+//
+// e.scopeHandler = makeBootScopeHandler(deps) (real rePrewarmBootScoped, real
+// bootShouldWalk), a DETERMINISTIC FAILER target present, driven ≥
+// bootMaxNoProgressPasses+1 passes via real processScope. Asserts BOTH:
+//
+//	(a) pass 0 WALKED; the F.4 RESUME passes REUSED (rewalk_reused emitted;
+//	    walk-count stays 1 across the resume passes);
+//	(b) #105 still trips → converged_with_skips with the failer given up (no
+//	    further re-enqueue).
+//
+// Proves the Lever B walk-skip does NOT perturb #105's set-delta bound and the
+// bound still fires under reuse — the exact auto-merge semantic risk.
+//
+// THE RESUME MECHANISM (the load-bearing subtlety, established by driving the
+// REAL boundary — see the C2 note appended to the ledger). Lever B reuse keys on
+// NumRequeues>0, which the F.4 deadline-cut path (AddRateLimited, no Forget)
+// sets. The #105 pass-tail re-enqueue is a NIL-return + plain Add, so its own
+// resumes are Forget-reset to attempt==0 → they WALK (Lever B never reuses a
+// #105 re-enqueue). The composition that genuinely exercises BOTH is therefore
+// an F.4-deadline-cut-then-resume sequence that ALSO carries the #105 failer:
+// each resume is driven at attempt>0 (AddRateLimited) so bootShouldWalk REUSES,
+// yet runs its seed loop to a CLEAN nil tail so finalizeBootReEnqueue evaluates
+// the set-delta over the REUSED snapshot. We drive that shape directly: before
+// each resume Get we forget+AddRateLimited the boot key (the F.4 attempt>0
+// posture) and drain the #105 plain-Add coalesce, so every resume is a REUSE
+// pass whose failer still lands in the pass failedSet. The set-delta accumulates
+// across the REUSE passes and trips at bootMaxNoProgressPasses.
+func TestLeverB_C2_Compose105_ReuseDoesNotPerturbSetDeltaBound(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	deps, lister, _ := leverBRealDeps(t)
+	// Topology: a healthy target + a deterministic failer (both harvested on the
+	// pass-0 walk; reused on every resume).
+	lister.setTopology("healthy-w", "det-failer-w")
+
+	buf := leverBSeedSeams(t, func(ctx context.Context, e navWidgetEntry) error {
+		switch e.W.GetName() {
+		case "det-failer-w":
+			// Deterministic non-apierror/non-ctx failure every pass (the #105
+			// marketplace-detail class) → recorded into the pass failedSet.
+			return detFailErr("det-failer-w")
+		default:
+			// Healthy: Mark the STABLE (widget,cohort) key every pass — grows the
+			// seeded set on pass 0, no growth after (the set-delta crux).
+			cache.BootSeededSetFromContext(ctx).Mark(stableSeededKey(ctx, e.W.GetName()))
+			return nil
+		}
+	})
+
+	e := newTestEngine()
+	e.yieldPoll = 2 * time.Millisecond
+	e.scopeHandler = makeBootScopeHandler(deps)
+
+	boot := prewarmScope{kind: scopeKindBoot}
+	ctx := context.Background()
+
+	// drainBoot pops+Done+Forgets any pending boot scope (the #105 tail's plain
+	// Add) so the next pass's attempt is set solely by our AddRateLimited below —
+	// modeling "the F.4 deadline-cut resume path is the one running each resume."
+	drainBoot := func() {
+		for e.queue.Len() > 0 {
+			s, shut := e.queue.Get()
+			if shut {
+				return
+			}
+			e.queue.Done(s)
+			e.queue.Forget(s)
+		}
+	}
+
+	// ── PASS 0 (attempt==0 → WALK) via REAL processScope.
+	e.enqueueScope(boot)
+	s0, _ := e.queue.Get()
+	e.processScope(ctx, s0)
+	passes := 1
+	if lister.walkCount() != 1 {
+		t.Fatalf("C2 pass 0: attempt==0 MUST walk exactly once; walk-count=%d", lister.walkCount())
+	}
+
+	// ── F.4 RESUME passes at attempt>0 (REUSE), each running its seed to a clean
+	// nil tail so the #105 set-delta evaluates over the reused snapshot. Loop
+	// until converged_with_skips fires (or a safety cap for a non-converging RED).
+	const maxResumes = 10
+	for r := 0; r < maxResumes; r++ {
+		if strings.Contains(buf.String(), "prewarm.engine.boot.converged_with_skips") {
+			break
+		}
+		drainBoot()                  // drop the #105 plain-Add (attempt-0 posture)
+		e.queue.AddRateLimited(boot) // F.4 posture: NumRequeues>0 → Lever B REUSE
+		if e.queue.NumRequeues(boot) == 0 {
+			t.Fatalf("C2 resume setup: AddRateLimited must set NumRequeues>0 for the reuse posture")
+		}
+		leverBWaitReady(e)
+		s, shut := e.queue.Get()
+		if shut {
+			break
+		}
+		e.processScope(ctx, s) // REAL: attempt>0 → bootShouldWalk REUSE; clean tail → #105 eval
+		passes++
+	}
+
+	logText := buf.String()
+
+	// (a) Lever B: pass 0 WALKED exactly once; every resume REUSED (walk-count
+	// stays 1). The resume passes must have emitted rewalk_reused.
+	if lister.walkCount() != 1 {
+		t.Fatalf("C2 (a): only pass 0 must WALK; resume passes must REUSE the harvester snapshot — "+
+			"walk-count MUST stay 1, got %d. passes=%d logs:\n%s", lister.walkCount(), passes, logText)
+	}
+	if passes < bootMaxNoProgressPasses+1 {
+		t.Fatalf("C2: expected ≥%d passes (≥1 resume so the set-delta bound can trip under reuse); got %d",
+			bootMaxNoProgressPasses+1, passes)
+	}
+	// rewalk_reused is the reuse marker — emitted ONLY on the walk-SKIP branch.
+	// It must fire on every F.4 resume (== passes-1). (rewalk_complete, by
+	// contrast, fires on EVERY pass regardless of walk-vs-reuse — it is the
+	// boot.complete-adjacent seed-source summary, not the walk discriminator; the
+	// discriminator is the walk-count seam + rewalk_reused.)
+	reusedCount := strings.Count(logText, "prewarm.engine.boot.rewalk_reused")
+	if reusedCount != passes-1 {
+		t.Fatalf("C2 (a): every F.4 resume must emit prewarm.engine.boot.rewalk_reused (walk skipped); "+
+			"got %d, want passes-1=%d. logs:\n%s", reusedCount, passes-1, logText)
+	}
+
+	// (b) #105 STILL trips under reuse: converged_with_skips with EXACTLY the
+	// deterministic failer given up, and no further re-enqueue (queue drained).
+	rec := findLogRecord(t, logText, "prewarm.engine.boot.converged_with_skips")
+	if rec == nil {
+		t.Fatalf("C2 (b): #105 set-delta bound must STILL trip under Lever B reuse — "+
+			"converged_with_skips must fire. passes=%d walk-count=%d logs:\n%s", passes, lister.walkCount(), logText)
+	}
+	var givenUp []string
+	if gu, ok := rec["given_up_targets"].([]any); ok {
+		for _, v := range gu {
+			if s, ok := v.(string); ok {
+				givenUp = append(givenUp, s)
+			}
+		}
+	}
+	if len(givenUp) != 1 || givenUp[0] != "widget/krateo-system/det-failer-w" {
+		t.Fatalf("C2 (b): given_up_targets must be EXACTLY [widget/krateo-system/det-failer-w] "+
+			"(healthy seeded, only the deterministic failer given up); got %v", givenUp)
+	}
+	if p, ok := rec["passes"].(float64); ok && int(p) != bootMaxNoProgressPasses {
+		t.Fatalf("C2 (b): converged_with_skips passes field = %v; want %d", p, bootMaxNoProgressPasses)
+	}
+	// No further re-enqueue after convergence (the terminal pass returned nil →
+	// Forget; the queue is drained).
+	if e.queue.Len() != 0 {
+		t.Fatalf("C2 (b): after convergence the boot scope must NOT re-enqueue itself; queue depth=%d", e.queue.Len())
+	}
+
+	leverBArtifact(t, "c2_compose_105x135.txt", fmt.Sprintf(
+		"REAL processScope over %d passes.\n"+
+			"(a) Lever B: walk-count=%d (pass 0 only); rewalk_reused emitted %d× on the F.4 resumes (== passes-1).\n"+
+			"(b) #105 STILL trips under reuse: converged_with_skips givenUp=%v passes=%v; no further re-enqueue.\n"+
+			"→ the walk-skip does not perturb the set-delta bound; the bound still fires under reuse.\n",
+		passes, lister.walkCount(), reusedCount, givenUp, rec["passes"]))
+}

--- a/internal/handlers/dispatchers/prewarm_leverb_rewalk_reuse_test.go
+++ b/internal/handlers/dispatchers/prewarm_leverb_rewalk_reuse_test.go
@@ -1,0 +1,157 @@
+// prewarm_leverb_rewalk_reuse_test.go — #135 F4b Lever B falsifiers
+// (docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md).
+//
+// Lever B skips the ~255s discovery re-walk on an F.4 deadline-cut RESUME pass
+// and reuses the process-lived (monotonic / first-write-wins / never-cleared)
+// harvester snapshot. Two arms, both driving the REAL prod decision surface — no
+// shadow copy (the #64/#66 anti-drift lesson):
+//
+//   LB-1 SYMPTOM — the reuse predicate. bootShouldWalk is the SINGLE source of
+//     the walk-vs-reuse decision rePrewarmBootScoped uses. Truth table over a
+//     REAL harvester snapshot count:
+//       attempt==0             → WALK (pass 0 / a Forget-reset config-vars redrive)
+//       attempt>0, snapshot>0  → REUSE (F.4 resume, same topology — the ~255s save)
+//       attempt>0, snapshot==0 → WALK  (boot-race give-up guard: nothing to reuse)
+//     An "always-reuse-on-attempt>0" predicate (drop the empty-guard) is RED on
+//     the (1,0) case.
+//
+//   LB-2 SAFETY (LOAD-BEARING) — the invalidation seam. A genuine config-vars
+//     redrive MUST reset the boot scope's workqueue requeue count to 0 so it
+//     re-dequeues at attempt==0 → bootShouldWalk WALKS the new topology.
+//       GREEN = the prod redrive sequence (forgetScope THEN enqueueScope, exactly
+//         enqueueBootReDrive): NumRequeues→0 → bootShouldWalk(0, N>0)==WALK.
+//       RED (mutation = drop forgetScope, plain enqueueScope only — the pre-fix
+//         WIP): NumRequeues stays >0 → bootShouldWalk(k, N>0)==REUSE → the redrive
+//         reuses the STALE nav set across the topology change. This is the exact
+//         bug the WIP shipped before the seam.
+//
+// Hermetic, -race, engine/queue + real harvester only. No apiserver, no
+// ./internal/rbac. LB-2 serializes on engineLatchTestMu (engine convention).
+
+package dispatchers
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func leverBArtifact(t *testing.T, name, body string) {
+	t.Helper()
+	_ = os.MkdirAll("/tmp/leverb", 0o755)
+	_ = os.WriteFile("/tmp/leverb/"+name, []byte(body), 0o644)
+}
+
+// leverBHarvestN builds a navWidgetHarvester holding n distinct widgets through
+// the REAL harvestNavWidget, so the count fed to bootShouldWalk is the production
+// snapshot() length — not a literal.
+func leverBHarvestN(n int) *navWidgetHarvester {
+	h := newNavWidgetHarvester()
+	gvr := engineSeedWidgetGVR
+	h.BeginWalk()
+	h.BeginRoot()
+	for i := 0; i < n; i++ {
+		w := &unstructured.Unstructured{}
+		w.SetNamespace("krateo-system")
+		w.SetName(fmt.Sprintf("w%d", i))
+		w.SetGroupVersionKind(schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: "W"})
+		h.harvestNavWidget(w, gvr, -1, 1, -1, -1)
+	}
+	return h
+}
+
+// LB-1 — the reuse predicate (B-symptom), over a REAL harvester snapshot count.
+func TestLeverB_ReusePredicate_WalkVsReuse(t *testing.T) {
+	full := leverBHarvestN(3)
+	if got := len(full.snapshot()); got != 3 {
+		t.Fatalf("setup: expected 3 harvested widgets; snapshot len=%d", got)
+	}
+	empty := newNavWidgetHarvester()
+	if got := len(empty.snapshot()); got != 0 {
+		t.Fatalf("setup: expected empty harvester; snapshot len=%d", got)
+	}
+
+	// pass 0 (fresh enqueue / Forget-reset config-vars redrive) → WALK.
+	if !bootShouldWalk(0, len(full.snapshot())) {
+		t.Fatal("LB-1: attempt==0 MUST walk")
+	}
+	if !bootShouldWalk(0, len(empty.snapshot())) {
+		t.Fatal("LB-1: attempt==0 MUST walk even with an empty harvester")
+	}
+	// F.4 resume (attempt>0) with a populated harvester → REUSE (the ~255s save).
+	if bootShouldWalk(1, len(full.snapshot())) {
+		t.Fatal("LB-1: attempt>0 with a populated harvester MUST reuse (skip the re-walk)")
+	}
+	if bootShouldWalk(5, len(full.snapshot())) {
+		t.Fatal("LB-1: any attempt>0 with a populated harvester MUST reuse")
+	}
+	// GUARD: attempt>0 but EMPTY harvester → WALK (boot-race give-up self-heal).
+	if !bootShouldWalk(1, len(empty.snapshot())) {
+		t.Fatal("LB-1 GUARD: attempt>0 with an EMPTY harvester MUST walk (nothing to reuse; the give-up→appear self-heal path). An always-reuse-on-attempt>0 predicate is RED here.")
+	}
+	leverBArtifact(t, "lb1_reuse_predicate.txt",
+		"bootShouldWalk: (0,3)=walk (0,0)=walk (1,3)=reuse (5,3)=reuse (1,0)=WALK-guard. Mutation (drop empty-guard) → (1,0) reuses empty → RED.")
+}
+
+// LB-2 — the invalidation seam (B-safety, LOAD-BEARING).
+func TestLeverB_ConfigVarsRedrive_ResetsAttemptSoNewTopologyReWalks(t *testing.T) {
+	engineLatchTestMu.Lock()
+	defer engineLatchTestMu.Unlock()
+
+	boot := prewarmScope{kind: scopeKindBoot}
+	const harvested = 3 // a populated harvester = the PRIOR topology's nav set
+
+	// Model an in-flight F.4 deadline-cut requeue streak: each AddRateLimited
+	// bumps the rate limiter's failure count (NumRequeues), independent of the
+	// delay-queue timing.
+	streak := func(e *prewarmEngine) int {
+		e.queue.AddRateLimited(boot)
+		e.queue.AddRateLimited(boot)
+		return e.queue.NumRequeues(boot)
+	}
+
+	// GREEN — the PROD redrive sequence (enqueueBootReDrive): forgetScope THEN
+	// enqueueScope → NumRequeues reset to 0 → next dequeue is attempt==0 → WALK.
+	eg := newTestEngine()
+	if n := streak(eg); n == 0 {
+		t.Fatalf("LB-2 setup: expected a non-zero requeue streak before the redrive; NumRequeues=%d", n)
+	}
+	eg.forgetScope(boot)  // <-- the Lever B invalidation seam
+	eg.enqueueScope(boot) // plain Add — does NOT touch NumRequeues
+	greenAttempt := eg.queue.NumRequeues(boot)
+	if greenAttempt != 0 {
+		t.Fatalf("LB-2 GREEN: forgetScope must reset the boot requeue count to 0; NumRequeues=%d", greenAttempt)
+	}
+	if !bootShouldWalk(greenAttempt, harvested) {
+		t.Fatalf("LB-2 GREEN: after the redrive's forgetScope, attempt=%d + populated harvester MUST re-WALK the new topology", greenAttempt)
+	}
+
+	// RED — the MUTATION (drop forgetScope; the pre-fix WIP): plain enqueueScope
+	// only. NumRequeues persists >0 → attempt>0 → bootShouldWalk REUSES the stale
+	// nav set across the topology change (the bug).
+	er := newTestEngine()
+	if n := streak(er); n == 0 {
+		t.Fatalf("LB-2 RED setup: expected a non-zero requeue streak; NumRequeues=%d", n)
+	}
+	// (no forgetScope — the mutation)
+	er.enqueueScope(boot)
+	redAttempt := er.queue.NumRequeues(boot)
+	if redAttempt == 0 {
+		t.Fatalf("LB-2 RED: without forgetScope the requeue count MUST persist (>0); NumRequeues=%d — if enqueueScope reset it, the seam would be unnecessary", redAttempt)
+	}
+	if bootShouldWalk(redAttempt, harvested) {
+		t.Fatalf("LB-2 RED: the mutation must REUSE the stale set (bootShouldWalk==false), but it walked; attempt=%d", redAttempt)
+	}
+
+	// The discriminator: the forgetScope seam FLIPS the decision — GREEN walks,
+	// RED reuses. If both agree, the seam did not discriminate.
+	if bootShouldWalk(greenAttempt, harvested) == bootShouldWalk(redAttempt, harvested) {
+		t.Fatal("LB-2: the forgetScope seam must CHANGE the walk decision (GREEN walk vs RED reuse); it did not discriminate")
+	}
+	leverBArtifact(t, "lb2_invalidation_seam.txt",
+		fmt.Sprintf("GREEN redrive (forgetScope+enqueueScope): NumRequeues=%d walk=%v (new topology re-walked).\nRED mutation (enqueueScope only): NumRequeues=%d walk=%v (STALE reuse — the bug the seam prevents).",
+			greenAttempt, bootShouldWalk(greenAttempt, harvested), redAttempt, bootShouldWalk(redAttempt, harvested)))
+}


### PR DESCRIPTION
## What (#135 F4b Lever B)

On an **F.4 deadline-cut boot RESUME** pass, skip the ~255s discovery re-walk and reuse the process-lived `navWidgetHarvester` snapshot (monotonic / first-write-wins / never cleared in prod — it already holds the union of every prior pass). Pass 0 still walks; a genuine config-vars topology change re-walks the new set. ~+90 LOC (6 files). Design: `docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md`.

## Mechanism
- `cache.WithBootResumeAttempt` / `BootResumeAttemptFromContext` — carry the workqueue requeue count onto the boot scope ctx (`processScope`, boot-only, mirrors the Lever A install).
- `bootShouldWalk(attempt, harvestedCount)` — **single-source** reuse predicate (`attempt==0 || snapshot empty → walk`); `rePrewarmBootScoped` gates the walk on it (falsifier calls the SAME func — anti-shadow-drift, the #64/#66 lesson). `BeginWalk()` moved inside the walk branch; reuse emits `rewalk_reused`.
- **Invalidation seam (load-bearing):** `forgetScope()` resets `NumRequeues`; wired into `enqueueBootReDrive` **before** `enqueueScope` so a config-vars redrive re-dequeues at `attempt==0` → re-walks the new topology.

## ⚠️ Finding while building (why this wasn't a trivial WIP finish)
The prior WIP had the reuse gate but **omitted the invalidation seam**, and the design's assumption that the redrive already resets `NumRequeues` was **false** — `enqueueScope` is a plain `queue.Add` (no reset). Without the added `forgetScope`, a config-vars change landing mid-requeue-streak keeps `attempt>0` → Lever B would reuse the **stale nav set** across a topology change. That's the exact bug the falsifier's RED arm reproduces.

Residual (documented): a config change during an *in-flight failing* pass can race one stale-reuse pass before the next success-Forget (bounded, self-correcting, not permanent). The robust alternative is a topology-gen counter — **arch's call at the gate.**

## Falsifiers (`prewarm_leverb_rewalk_reuse_test.go`, `-race` green; full pkg suites green)
- **LB-1** reuse predicate truth table over a REAL harvester snapshot (incl. the empty-guard: `attempt>0 + empty → walk`).
- **LB-2** invalidation seam: GREEN (`forgetScope`+`enqueueScope`) → NumRequeues 0 → **walk** new topology; RED (`enqueueScope` only = the WIP) → NumRequeues 2 → **stale reuse**. The seam flips the decision.

## Gate status
**NOT dual-gated.** Built + self-verified + falsifier-proven solo (team stood down). This is an **always-on change to the live boot path** — the invalidation-seam soundness (Forget-race vs topology-gen) **owes an arch soundness pass** before merge/deploy. **PARKED, Diego-reserved.** Do not merge until gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1