### PR TITLE
fix(cache): #118 (c)-v2 — defer sub-gen bump to snapshot-publish + role-rule coverage + v6 (dual-gate GREEN, parked)

### DIFF
--- a/docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md
+++ b/docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md
@@ -1,0 +1,172 @@
+# #118 (c)-v2 — RBAC ordering + role-rule bump: durable UAF authz-staleness fix
+
+Date: 2026-07-23
+Author: cache-architect
+Status: DESIGN (design-first; dual-gate then route to dev). No prod code in this doc.
+Base: main @ `9e38dcd` (carries (c) v1 @ `a087702` + (d) @ `423d23b`).
+Cluster context verified: `gke_operations-dev-krateo-io_europe-west4_krateo-installer-release` (west4 release, the canonical live target). No mutation performed — this is a code trace + design.
+
+---
+
+## 0. Headline (read this first)
+
+(c) v1 folds a per-subject `RBACSubGen` counter into the resolved key so an RBAC change rotates the key → cold miss → fresh refilter. It is **soundness-incomplete** for two reasons TRACED to source:
+
+- **GAP 1 — role/ClusterRole RULE edits do not rotate the key.** `onRoleRulesChanged` re-routes the seed index but never calls `BumpSubjectSubGens`. TRACED `internal/cache/bindings_by_gvr_delta.go:242-299` (no bump anywhere in the function) vs the binding hooks which DO bump (`:139,145,162,165,172,176,196,201`). A verb grant/revoke via a Role-rule edit leaves the subject's sub-gen unchanged → identical key → stale serve. This is Diego's live repro.
+
+- **GAP 2 — bump-vs-snapshot-publish ordering race (the headline).** The bump is **synchronous** on the binding delta event (`bindings_by_gvr_delta.go:131→139`). The snapshot the refilter reads is rebuilt **async + debounced** (`rbac_snapshot.go:306 scheduleRBACRebuild` → detached goroutine → `rebuildRBACSnapshot:371` → `rbacSnap.Store:489`). In the window (bump landed, rebuild pending) a request derives the NEW key (bump visible via `RBACSubGenForSubject`, `rbac_subgen.go:96`) but the refilter runs `EvaluateRBAC` against the OLD snapshot (`evaluate.go:206 snap := rw.Snapshot()`). The pre-change verdict is cached **under the new key** and, because nothing re-bumps at publish, it **sticks until TTL** (served on hit at `evaluate.go:242` memo + the resolved-cell hit). This defeats the login hot path exactly: Kyverno generates the user's RoleBindings → the browser's first resolve races the rebuild → wrong result pinned under the right key.
+
+**Chosen GAP-2 approach: (a) defer the per-subject bump to snapshot-publish**, accumulating the changed-subject set across the debounce and bumping ALL of them inside `rebuildRBACSnapshot` **after** `rbacSnap.Store`. This makes "a new key ⇒ a snapshot ≥ the change that rotated it" true by construction: the key does not rotate until the fresh snapshot the refilter will read is already live. It is per-subject (no global churn) and adds zero blast radius beyond (c) v1. Option (b) `rbacSnapshotPublishSeq`-in-key is **REJECTED** (churns every identity-bound key on every cluster-wide rebuild → 50K install-storm cache-cold, the exact failure that killed global `RBACGen`). Option (c) gate-the-Put is **REJECTED as primary** (adds a stale-seq field to the L1 Put contract at 7 sites and still needs the deferred set to know "latest bump seq"; strictly more surface than (a) for the same guarantee).
+
+**Key-version: v5 → v6 REQUIRED.** Not because the fold shape changes (it doesn't — `RBACSubGen uint64` stays), but because deferring the bump changes the counter's *timeline*: a v5 cell was written under a value that (c) v1 bumped synchronously; v6 cells are written under the publish-deferred value. Across a rolling restart a v5 cell for a subject mid-transition could carry a sub-gen the v6 reader would compute differently for the same access → serve a v5 cell as a v6 hit and re-pin the very staleness we're fixing. A salt bump forces the clean break (same rationale as every prior v-bump at `resolved.go:420-466`). See §5.
+
+**Un-briefed GAP 3 surfaced (see §6):** the seed does **not** stamp `RBACSubGen` at all — the ONLY stamp site in the tree is the dispatch path `helpers.go:265`. The `resolved.go:415` comment ("Stamped wherever a ResolvedKeyInputs is BUILT ... seedOneRestaction for the seed") is **stale/aspirational** — grep proves no seed site sets it. This is a seed↔dispatch key-divergence risk independent of GAP 1/2 and must be adjudicated in this cycle.
+
+---
+
+## 1. Prior-art check (opens every design)
+
+- **client-go / k8s already solve "key rotates on RBAC change"?** No. client-go has no resolved-authz cache; `SubjectAccessReview` is the apiserver's per-call authorizer with no client-side generation to fold. The informer's `ResourceVersion` is per-object, not per-subject-effective-RBAC — folding it would be option (b)'s global-churn failure at object granularity (worse). There is no upstream "happens-after publish" barrier we can borrow; our `rbacSnap` atomic Store IS the publish primitive, and (a) hangs the bump off it. **No reinvention — (a) reuses the existing publish site.**
+- **We already have the deferred-set pattern.** `scheduleRBACRebuild`'s dirty-flag debounce (`rbac_snapshot.go:307-345`) already coalesces bursts into one publish; (a) rides the SAME coalescing by accumulating the subject set in the same window. No new goroutine, no new lock discipline beyond one `sync.Mutex`-guarded set (or a `sync.Map` batch).
+
+---
+
+## 2. Root cause, TRACED
+
+### GAP 1 (role-rule blind)
+- `onRoleRulesChanged(roleKind, ns, name, rules)` — `bindings_by_gvr_delta.go:242-299`. It looks up `idx.byRole[rk]` (`:259`), snapshots the referencing binding ids (`:264-267`), and for each id **re-routes its GVR/wildcard bucket membership** (`:279-296`). It reads `idx.entries[id]` (`:269`) — which **carries `subjects []subjectKey`** (confirmed `bindings_by_gvr.go:123-126`, `entries[id].subjects`) — but **never calls `BumpSubjectSubGens`**. So the mechanism to move the key exists and the subjects are in hand, but the bump call is simply absent.
+- Contrast the binding hooks: every one of `onBindingAdd/Update/Delete` bumps (`:139,145,162,165,172,176,196,201`). GAP 1 is a missing call, not a missing capability.
+- Why it produces the symptom: `EvaluateRBAC`'s refilter verdict depends on the role's RULES (`evaluate.go` → `roleRefPermits` resolves `snap.ClusterRolesByName`/`RolesByNSName`). A rule edit changes what a bound subject can access, but `RBACSubGenForSubject` (`rbac_subgen.go:96`) sums only the subject counters, which didn't move → same key → the pre-edit resolved cell is served.
+
+### GAP 2 (ordering race) — the mechanism, line by line
+1. Binding event fires → `rbacSnapshotEventHandlers.AddFunc` (`rbac_snapshot.go:862`): calls `scheduleRBACRebuild(rw)` (async) THEN `onBindingAdd(obj)` (`:865`) which **synchronously** `BumpSubjectSubGens(subj)` (`bindings_by_gvr_delta.go:139`).
+2. `scheduleRBACRebuild` (`rbac_snapshot.go:306`) flips dirty, tryLocks, spawns a detached goroutine that will eventually `rebuildRBACSnapshot` → `rbacSnap.Store(snap)` (`:489`). The debounce (`:339-345`) can delay this by one or more rebuild cycles under a burst.
+3. **Window:** bump done, Store not yet. A request arrives:
+   - key-build reads `RBACSubGenForSubject` (`helpers.go:265`) → sees the NEW (bumped) sub-gen → NEW resolved key → L1 cold miss → fresh resolve.
+   - the fresh resolve's UAF stage calls `EvaluateRBAC` → `snap := rw.Snapshot()` (`evaluate.go:206`) → **OLD snapshot** (Store hasn't landed). Old snapshot ⇒ pre-change RBAC ⇒ pre-change filtered view.
+   - the L2 authz memo stores that verdict keyed on `snap.PublishSeq` (old) at `evaluate.go:283`, AND the resolved cell is Put under the NEW resolved key.
+4. When the snapshot finally publishes, `PublishSeq` bumps and the L2 memo shard swaps (self-heals the memo). **But nothing re-bumps `RBACSubGen`** → the resolved key does not rotate again → the wrong resolved cell written in step 3 keeps its key and is served on every subsequent hit until TTL. The L2 memo self-heals; the L1 resolved cell does not. That is the durable defect.
+- Confirms the brief: the (c) v1 arch review's "self-heals on next resolve" was wrong. A cached wrong resolved cell is served on hit (`evaluate.go` is not even re-entered on an L1 resolved hit — the whole resolve is skipped).
+
+---
+
+## 3. Fix design
+
+### 3.1 GAP 1 fix — bump subjects on role-rule change
+**Target:** `internal/cache/bindings_by_gvr_delta.go`, inside `onRoleRulesChanged` (currently `:242-299`).
+
+**What:** collect the union of `subjectKey`s across every binding entry in `idx.byRole[rk]` and hand them to the deferred-bump accumulator (per §3.2 — NOT a synchronous `BumpSubjectSubGens`, so GAP 1's fix is ordering-correct too). The subjects are already on `idx.entries[id].subjects`; the loop at `:268-297` already visits each `entry` (it currently discards it via `_ = entry` at `:297`). Build the union there.
+
+**Which events route here (confirmed):** `onRoleObjectChanged` (`:215-232`) is called from ALL THREE of `rbacSnapshotEventHandlers`' Add/Update/Delete for the non-binding (ClusterRole/Role) GVRs (`rbac_snapshot.go:867,875,883`), and it dispatches to `onRoleRulesChanged` for both `ClusterRole` (`:224`) and `Role` (`:228`). So ADD/UPDATE/DELETE of a Role or ClusterRole all reach the fix. DELETE routes with the last-known rules (`:213-214` comment) — the union-of-affected-subjects is still correct (those subjects lost the grant; they must rotate).
+
+**Per-subject scoping preserved:** the union is exactly the subjects of the bindings that reference the changed role — never global. Topology is ~1:1 role:binding from per-composition RBAC (Gate-2 worst case 4 referencing bindings, `:239-241`), so the union is tiny.
+
+**LOC bound:** ~12 LOC (a `[]subjectKey` accumulator in the existing loop + one call to the batch-record helper). No new function beyond §3.2's shared accumulator.
+
+**Edge — empty-rules / role-deleted:** the binding stays in `byRole`+`entries` (`:276-278`) so its subjects are still enumerable; we bump them (their effective access dropped to nothing → key MUST rotate). Correct.
+
+### 3.2 GAP 2 fix — defer the bump to snapshot-publish (option a)
+
+**New state (rbac_subgen.go or a small sibling):**
+```
+var pendingSubGenBumps struct { mu sync.Mutex; set map[subjectKey]struct{} }
+```
+- `recordPendingSubGenBumps(subjects []subjectKey)` — under `mu`, add each to `set`. Called from the binding hooks AND `onRoleRulesChanged` **instead of** the current synchronous `BumpSubjectSubGens`.
+- `flushPendingSubGenBumps()` — under `mu`, drain `set` to a slice, clear the map, then (outside the lock) `BumpSubjectSubGens(drained)`.
+
+**Wiring:** call `flushPendingSubGenBumps()` inside `rebuildRBACSnapshot` **immediately after** `rbacSnap.Store(snap)` (`rbac_snapshot.go:489`) — the publish barrier. Any request that observes the bumped sub-gen (new key) is guaranteed to observe a snapshot `Store`d at or after the change, because the bump becomes visible only after the Store.
+
+**Debounce accumulation (the brief's watch-item):** the accumulator is a set keyed by `subjectKey`, populated on EVERY event (synchronous, cheap — a map insert under a short lock) and drained ONLY at publish. The `scheduleRBACRebuild` dirty-loop (`:339-345`) can coalesce N events into one `rebuildRBACSnapshot`; because every event recorded into the set BEFORE the loop's `rebuildRBACSnapshot` ran, the single flush after that Store bumps ALL accumulated subjects. An event that lands MID-rebuild re-flips dirty (`:340` clears dirty before rebuild, `:342` re-checks after) → another loop iteration → another Store → another flush that catches the mid-rebuild event's subject. No subject is lost, none is bumped before its snapshot is live. **Ordering invariant holds across the debounce.**
+
+**Correctness of the happens-after:** `atomic.Pointer.Store` (`:489`) is a release; the reader's `rbacSnap.Load` (`evaluate.go:206`) is an acquire; the `atomic.Uint64.Add` bump (`rbac_subgen.go:77`) sequenced AFTER the Store on the same goroutine is visible to a reader only via a subsequent Load that also sees the new snapshot. A reader that sees the new sub-gen (new key) therefore cannot see a pre-Store snapshot. No window.
+
+**Why not a stale-under-new-key residual:** in the deferred model the key does NOT rotate during the window at all — a request in the window derives the OLD key (sub-gen not yet bumped), hits the OLD resolved cell (correct pre-change view, which is what the current snapshot still authorizes), and the moment the new snapshot publishes + the bump flushes, the NEXT request derives the NEW key → cold miss → fresh resolve against the NEW snapshot. The transient (one snapshot-lag window, ≤ the AC-B.12 <1s propagation bound) serves the last-correct view, never a wrong-under-new-key view. This is strictly better than (c) v1.
+
+**LOC bound:** ~35 LOC total (accumulator struct + 2 helpers ~25, swap 8 call-sites from `BumpSubjectSubGens`→`recordPendingSubGenBumps` ~8, one `flushPendingSubGenBumps()` line after the Store). Net: `BumpSubjectSubGens` stays exported (tests + the flush call it) but is no longer called directly by the hooks.
+
+**Per-subject + no-churn proof:** the flushed set is exactly {subjects whose bindings/roles changed in this rebuild batch}. A 50K install storm creating tenant-X bindings flushes only tenant-X subjects per rebuild — identical blast radius to (c) v1, which the 50K analysis already blessed (`rbac_subgen.go:12-21`). Option (b)'s global `PublishSeq` fold would rotate EVERY identity-bound key on that same rebuild; (a) does not. The only added per-rebuild cost is one map drain of the changed set (O(changed subjects), already bounded by the events that fed it).
+
+### 3.3 Interaction with (c) v1 (no regression)
+- The `RBACSubGen` field, `ComputeKey` fold (`resolved.go:405-417,738-747`), `RBACSubGenForSubject` reader (`rbac_subgen.go:96`), and the group-grant sum (C-118-2) are **unchanged**. (a) only moves WHEN `BumpSubjectSubGens` fires (publish-time vs event-time). The grant-via-group / herd / parity falsifiers still pass — they assert key-rotates-on-effective-change, which still holds (now at publish rather than at event; the tests should assert AFTER driving a real publish — see §4).
+- `#95` (re-derived `""`-BindingUID treated as MISS) untouched — orthogonal to the sub-gen term.
+- Per-user keying (`feedback_l1_per_user_keyed_never_cohort`) untouched — RBACSubGen is per-subject-summed, still folded per identity.
+
+---
+
+## 4. THE MISSING FALSIFIER — real end-to-end behavioral arm (hard requirement)
+
+Location: `internal/cache/` + an envtest/kind harness (NOT the hermetic unit that masked both gaps). Two arms, each must show RED on current code and GREEN on the fix. Both drive the REAL RBAC informers + REAL `EvaluateRBAC` refilter + REAL async `scheduleRBACRebuild` timing — no hand-installed snapshot, no hand-fed key (per `feedback_falsifier_must_drive_real_boundary_not_install_crossed_state` + `feedback_consultation_mutation_is_not_key_correctness`).
+
+**Arm (i) — Role-rule edit rotates the key (GAP 1).**
+- Setup: envtest apiserver; create Role R granting get/list on GVR G in ns N; RoleBinding binds user U (or group U-is-in) to R; build the bindings index + publish initial snapshot; warm an L1 resolved cell for U over G/N (UAF stage present) — capture key K1.
+- Act: `kubectl`/client edit R's rules to REVOKE get on G (or grant a new verb). Wait for the informer UPDATE → `onRoleObjectChanged` → publish.
+- Assert: the key U now derives for G/N ≠ K1 (sub-gen rotated), the next resolve is a cold miss, and the refilter reflects the new rules (revoked → empty/denied view).
+- **RED on current code:** `onRoleRulesChanged` never bumps → derived key == K1 → warm hit → stale (pre-revoke) view served. GREEN after §3.1.
+
+**Arm (ii) — bump→publish race, no stale-under-new-key (GAP 2).**
+- Setup: as (i) but the target is an ADD (grant): user U starts with NO binding for G/N; warm/observe the pre-grant state.
+- Act: create the RoleBinding granting U access to G/N. This fires the synchronous bump path (current) vs the deferred path (fix). **Interleave a request between the binding event and the snapshot publish** — the harness must inject a resolve in that window. Realize the window deterministically by pausing the rebuild goroutine (test seam: a `rebuildBarrier chan struct{}` gated in `rebuildRBACSnapshot` under a test-only flag, released by the test AFTER it fires the in-window request) so the interleave is not timing-flaky.
+- Assert: the value SERVED to U after the dust settles is the POST-change (granted) view — i.e. no wrong verdict is pinned under any key.
+- **RED on current code:** in-window request derives NEW key (synchronous bump visible), refilters against OLD snapshot (pre-grant), caches the pre-grant (empty) view under the NEW key; post-publish nothing re-rotates → U keeps seeing the empty view on hit → stale. GREEN after §3.2: in-window request derives OLD key (bump deferred), serves last-correct view; post-publish+flush the next request derives NEW key → fresh granted view. Assert the final served view is granted AND (stronger) that no cell exists carrying the pre-grant view under the post-grant key.
+
+**Falsifier shape guards (per `feedback_falsifier_shape_must_discriminate` + `feedback_falsifier_must_actually_run_under_gate_tag_env`):**
+- Both arms MUST show the `=== RUN` line and the RED must be observed by neutering the fix (revert the bump-call / revert the flush) — not merely asserted.
+- Arm (ii) MUST use the real `scheduleRBACRebuild` path (barrier-gated), not a hand-published snapshot, or it is blind to the exact ordering it tests.
+- Group arm: run arm (i) once with U bound via a GROUP (grant-via-group), to keep the C-118-2 crux exercised through the new publish-time path.
+
+**Falsifier for GAP 3 (§6), if adjudicated in-scope:** a seed-vs-dispatch key-parity arm — seed a UAF cell for U, then dispatch the same coords as U, assert identical resolved key. RED today iff the seed omits `RBACSubGen` while dispatch stamps it AND U's sub-gen is non-zero.
+
+---
+
+## 5. Key-version decision: v5 → v6 (REQUIRED)
+
+`resolvedKeyVersion` at `resolved.go:466`. Bump to `"v6"` with a comment block mirroring the existing v-history (`:430-465`).
+
+**Why a bump is needed even though the field shape is unchanged:** the SEMANTICS of the folded `RBACSubGen` value change across the deploy. Pre-fix (v5) a cell was written with the synchronously-bumped counter; post-fix (v6) with the publish-deferred counter. For a subject mid-transition at the rolling-restart boundary, the same logical access can map to a different sub-gen under the two regimes → a v5 cell could be served as a v6 hit and re-pin the pre-change view (the exact staleness we fix). A salt rotation forces every pod to treat pre-v6 cells as non-hits → clean break, no cross-regime contamination. This is the identical rationale as v3→v4 and v4→v5 (`:444-465`). ~2 LOC (the const + comment).
+
+Recommendation: **bump to v6.** Cost is one rolling-restart cold window (already paid on any deploy); the correctness upside is eliminating the cross-regime re-pin.
+
+---
+
+## 6. GAP 3 (un-briefed, surfaced) — seed does NOT stamp RBACSubGen
+
+**TRACED:** the ONLY `RBACSubGen:` stamp in the entire tree is `internal/handlers/dispatchers/helpers.go:265` (dispatch Path-B). `grep -rn "RBACSubGen:" internal --include=*.go | grep -v _test.go` returns exactly that one line. Every other `ResolvedKeyInputs{}` builder either is an **identity-free class** (correctly exempt — `apistage.go:66`, `widget_content.go:88` "Username/Groups intentionally zero", `ra_full_list_slice.go:89` RAFullList) or is the **content-prewarm dep-edge context** (`phase1_content_prewarm.go:378`, class "restactions" but keyed on the RA's own coords, not an identity-bound resolved-view cell — no BindingUID either, so it is not a user-facing serve cell).
+
+**Consequence:** the `resolved.go:415` comment claiming the seed stamps `RBACSubGen` via "seedOneRestaction" is **stale** — grep finds no `seedOneRestaction`/seed site stamping it. IF there exists an identity-bound seed Put that pre-warms a user-facing UAF cell (the #42 dedup-by-representative seed path), it would write that cell with `RBACSubGen == 0`, while the same user's dispatch derives a non-zero sub-gen after any grant/revoke → **seed cell is unreachable by the live browser** (the extras-xlen class from `project_seed_key_divergence_extras_buid`, but for the sub-gen term). This is a warm-miss (perf), not a leak (the dispatch key is still correct), but it silently defeats seeding for any subject whose sub-gen ever moved.
+
+**Recommendation (strategic — surface to TL/Diego):** two options, I recommend **B**:
+- **A — fix in this cycle:** locate the identity-bound seed Put and stamp `RBACSubGen: cache.RBACSubGenForSubject(repUser, repGroups)` from the representative identity, add the §4 GAP-3 parity arm. Keeps seed reachable. +~4 LOC + 1 arm. Risk: expands scope.
+- **B — de-scope + correct the comment now, ticket the seed stamp separately:** (c)-v2's GAP 1/2 are the reopened-#118 blockers; GAP 3 is a pre-existing seed-reachability perf gap, not a correctness/authz-staleness bug (dispatch key stays correct). Fix the stale `resolved.go:415` comment in this PR (1 LOC, truth-in-source) and file the seed stamp as a #42-class follow-up. **Recommended** — keeps the security fix tight; the seed gap is orthogonal and lower-severity.
+
+This is a strategic call (scope of the security cut) → for the TL / Diego, not decided here.
+
+---
+
+## 7. Options-with-recommendation summary
+
+| Decision | Options | Recommendation |
+|---|---|---|
+| GAP-2 ordering | (a) defer bump to publish / (b) fold PublishSeq in key / (c) gate the Put | **(a)** — per-subject, no-churn, closes the window by construction; (b) 50K-fatal, (c) more surface for same guarantee |
+| Key version | keep v5 / bump v6 | **v6** — cross-regime re-pin prevention, ~2 LOC |
+| GAP 3 (seed stamp) | A fix now / B de-scope + fix comment + ticket | **B** — keep the security cut tight; seed gap is orthogonal perf |
+
+---
+
+## 8. Falsifier (the specific proof this fix works, or didn't)
+
+- **GAP 1:** envtest arm (i) — edit a Role's rules; assert the subject's derived key changes AND the refilter reflects the new rules. RED = key unchanged / stale view (current). GREEN = key rotates / fresh view.
+- **GAP 2:** envtest arm (ii) barrier-gated — inject a resolve in the bump→publish window; assert the FINAL served view is post-change AND no cell carries a pre-change view under the post-change key. RED = pre-change view pinned under new key (current). GREEN = last-correct view served in-window, fresh view after publish.
+- **No-churn / 50K:** run the (c) v1 herd arm through the new publish-time path; assert only the changed cohort's sub-gens moved after a scoped RBAC event (unchanged users' keys stable). Optional on-cluster: at 50K, a single-tenant binding create bumps only that tenant's subjects (expvar/log of flushed-set size ≈ tenant subjects, not cluster-wide).
+- **Runtime artifact to watch on deploy:** on a live grant to user U, `rbac.evaluate` DEBUG for U's next resolve shows `path=in-process` (cold, not memo-hit) with the post-grant verdict, and `cache.rbac.snapshot.published` precedes the first post-grant resolve. The stale-serve disappears iff U's first post-change page-load reflects the change without a pod restart.
+
+---
+
+## 9. Files touched (design targets, all TRACED)
+
+- `internal/cache/bindings_by_gvr_delta.go` — GAP 1: union-of-subjects in `onRoleRulesChanged` (~12 LOC), swap `BumpSubjectSubGens`→`recordPendingSubGenBumps` at the 8 binding-hook sites (~8 LOC).
+- `internal/cache/rbac_subgen.go` (or sibling `rbac_subgen_pending.go`) — GAP 2: pending-bump accumulator + record/flush helpers (~25 LOC).
+- `internal/cache/rbac_snapshot.go` — GAP 2 wiring: `flushPendingSubGenBumps()` after `rbacSnap.Store(snap)` at `:489` (~1 LOC), + optional test-only `rebuildBarrier` seam for arm (ii).
+- `internal/cache/resolved.go` — v5→v6 at `:466` (~2 LOC); GAP-3 comment correction at `:415` if option B (~1 LOC).
+- `internal/cache/rbac_subgen_race_test.go` (new, envtest/kind-tagged) — arms (i), (ii), group arm, no-churn arm.
+
+Total prod LOC: ~50 (well within a tight security cut). Test LOC: the envtest harness dominates.

--- a/internal/cache/bindings_by_gvr_delta.go
+++ b/internal/cache/bindings_by_gvr_delta.go
@@ -136,13 +136,13 @@ func onBindingAdd(obj interface{}) {
 	if o, ok := asCRB(obj); ok {
 		subj := subjectsFromRBAC(o.Subjects)
 		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subj)
-		BumpSubjectSubGens(subj) // #118 (c) — this binding's subjects' effective RBAC changed
+		recordPendingSubGenBumps(subj) // #118 (c)-v2 GAP-2 — defer the bump to snapshot-publish; this binding's subjects' effective RBAC changed
 		return
 	}
 	if o, ok := asRB(obj); ok {
 		subj := subjectsFromRBAC(o.Subjects)
 		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subj)
-		BumpSubjectSubGens(subj) // #118 (c)
+		recordPendingSubGenBumps(subj) // #118 (c)-v2 GAP-2
 		return
 	}
 	deltaDropNonTyped("RoleBinding/ClusterRoleBinding(add)")
@@ -159,21 +159,21 @@ func onBindingUpdate(oldObj, newObj interface{}) {
 	}
 	if o, ok := asCRB(oldObj); ok {
 		idx.applyBindingDelete(crbBindingID(o), roleRefKey("", o.RoleRef))
-		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c) — OLD subjects lost this grant
+		recordPendingSubGenBumps(subjectsFromRBAC(o.Subjects)) // #118 (c)-v2 GAP-2 — OLD subjects lost this grant
 	} else if o, ok := asRB(oldObj); ok {
 		idx.applyBindingDelete(rbBindingID(o), roleRefKey(o.Namespace, o.RoleRef))
-		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c)
+		recordPendingSubGenBumps(subjectsFromRBAC(o.Subjects)) // #118 (c)-v2 GAP-2
 	} else {
 		deltaDropNonTyped("RoleBinding/ClusterRoleBinding(update-old)")
 	}
 	if o, ok := asCRB(newObj); ok {
 		subj := subjectsFromRBAC(o.Subjects)
 		idx.applyBindingAdd("", o.RoleRef, crbBindingID(o), subj)
-		BumpSubjectSubGens(subj) // #118 (c) — NEW subjects gained this grant (a subject in BOTH old+new bumps twice; harmless — the key only needs to change)
+		recordPendingSubGenBumps(subj) // #118 (c)-v2 GAP-2 — NEW subjects gained this grant (a subject in BOTH old+new is deduped by the pending set; the key only needs to change once)
 	} else if o, ok := asRB(newObj); ok {
 		subj := subjectsFromRBAC(o.Subjects)
 		idx.applyBindingAdd(o.Namespace, o.RoleRef, rbBindingID(o), subj)
-		BumpSubjectSubGens(subj) // #118 (c)
+		recordPendingSubGenBumps(subj) // #118 (c)-v2 GAP-2
 	} else {
 		deltaDropNonTyped("RoleBinding/ClusterRoleBinding(update-new)")
 	}
@@ -193,12 +193,12 @@ func onBindingDelete(obj interface{}) {
 	}
 	if o, ok := asCRB(obj); ok {
 		idx.applyBindingDelete(crbBindingID(o), roleRefKey("", o.RoleRef))
-		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c) — subjects lost this grant (REVOKE — the security-load-bearing arm)
+		recordPendingSubGenBumps(subjectsFromRBAC(o.Subjects)) // #118 (c)-v2 GAP-2 — subjects lost this grant (REVOKE — the security-load-bearing arm)
 		return
 	}
 	if o, ok := asRB(obj); ok {
 		idx.applyBindingDelete(rbBindingID(o), roleRefKey(o.Namespace, o.RoleRef))
-		BumpSubjectSubGens(subjectsFromRBAC(o.Subjects)) // #118 (c)
+		recordPendingSubGenBumps(subjectsFromRBAC(o.Subjects)) // #118 (c)-v2 GAP-2
 		return
 	}
 	deltaDropNonTyped("RoleBinding/ClusterRoleBinding(delete)")
@@ -265,10 +265,21 @@ func onRoleRulesChanged(roleKind, namespace, name string, rules []rbacv1.PolicyR
 	for id := range set {
 		ids = append(ids, id)
 	}
+	// #118 (c)-v2 GAP-1 — a role-rule edit changes the EFFECTIVE access of
+	// every subject bound to that role, but (c) v1 never rotated their key
+	// (this function re-routed the index but never bumped). Union the subjects
+	// across every referencing binding and record them for the deferred
+	// publish-time bump (§3.1), so a verb grant/revoke via a Role/ClusterRole
+	// rule edit rotates the key exactly like a binding change does. The set
+	// dedups a subject bound via multiple referencing bindings.
+	changed := make(map[subjectKey]struct{})
 	for _, id := range ids {
 		entry, present := idx.entries[id]
 		if !present {
 			continue
+		}
+		for _, s := range entry.subjects {
+			changed[s] = struct{}{}
 		}
 		// Unrol from GVR + wildcard buckets (keep byRole — the binding still
 		// references this role; only its bucket membership changes). Then
@@ -294,7 +305,16 @@ func onRoleRulesChanged(roleKind, namespace, name string, rules []rbacv1.PolicyR
 				b[id] = struct{}{}
 			}
 		}
-		_ = entry
+	}
+	if len(changed) > 0 {
+		subjects := make([]subjectKey, 0, len(changed))
+		for s := range changed {
+			subjects = append(subjects, s)
+		}
+		// recordPendingSubGenBumps takes a DIFFERENT lock (pendingSubGenBumps.mu)
+		// and never acquires idx.mu, so calling it while holding idx.mu here
+		// introduces no lock-ordering cycle. Deferred to publish per §3.2.
+		recordPendingSubGenBumps(subjects)
 	}
 }
 

--- a/internal/cache/rbac_snapshot.go
+++ b/internal/cache/rbac_snapshot.go
@@ -373,6 +373,18 @@ func rebuildRBACSnapshot(rw *ResourceWatcher) {
 		return
 	}
 
+	// #118 (c)-v2 test-only barrier seam. When a test installs a barrier via
+	// SetRebuildBarrierForTest, this blocks the rebuild goroutine here —
+	// AFTER the informer event fired (so the pending bump was recorded, or
+	// under pre-fix code the synchronous bump already landed) but BEFORE the
+	// snapshot Store + flush. The falsifier's arm (ii) uses this to inject a
+	// resolve deterministically in the bump→publish window and prove no
+	// wrong-under-new-key cell is pinned. Production is unaffected: the hook
+	// is nil unless a test sets it, and the read is a single atomic load.
+	if b := rebuildBarrierForTest.Load(); b != nil {
+		(*b)()
+	}
+
 	snap := &RBACSnapshot{
 		RoleBindingsByNS:   map[string][]*rbacv1.RoleBinding{},
 		ClusterRolesByName: map[string]*rbacv1.ClusterRole{},
@@ -487,6 +499,15 @@ func rebuildRBACSnapshot(rw *ResourceWatcher) {
 		return
 	}
 	rbacSnap.Store(snap)
+
+	// #118 (c)-v2 GAP-2 — flush the deferred per-subject sub-gen bumps at the
+	// publish barrier, sequenced AFTER rbacSnap.Store. Any request that
+	// observes a bumped sub-gen (new resolved key) is thereby guaranteed to
+	// observe this snapshot (or a later one) at its EvaluateRBAC refilter —
+	// the Store is a release, the reader's Load an acquire, and this bump is
+	// sequenced-after the Store on this goroutine. This closes the
+	// bump-vs-publish race (c) v1 left open (design §GAP-2 / rbac_subgen_pending.go).
+	flushPendingSubGenBumps()
 
 	slog.Debug("cache.rbac.snapshot.published",
 		slog.String("subsystem", "cache"),

--- a/internal/cache/rbac_subgen_pending.go
+++ b/internal/cache/rbac_subgen_pending.go
@@ -1,0 +1,148 @@
+// rbac_subgen_pending.go — #118 (c)-v2 GAP-2 fix: defer the per-subject
+// sub-generation bump to snapshot-publish, closing the bump-vs-publish
+// ordering race that (c) v1 left open.
+//
+// THE RACE (c) v1 LEFT OPEN
+// (docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md §GAP-2):
+// (c) v1 bumped the sub-gen SYNCHRONOUSLY on the RBAC informer delta event
+// (onBindingAdd/Update/Delete). But the RBAC snapshot the UAF refilter reads
+// (EvaluateRBAC → rbacSnap.Load) is rebuilt ASYNC + debounced
+// (scheduleRBACRebuild → detached goroutine → rebuildRBACSnapshot →
+// rbacSnap.Store). In the window (bump landed, Store not yet) a request
+// derives the NEW key (bump visible) but refilters against the OLD snapshot,
+// caching the pre-change verdict UNDER the new key. Nothing re-bumps at
+// publish, so that wrong-under-new-key cell sticks until TTL — the durable
+// defect.
+//
+// THE FIX: accumulate the changed-subject set across the debounce and bump
+// ALL of them INSIDE rebuildRBACSnapshot immediately AFTER rbacSnap.Store
+// (the publish barrier, rbac_snapshot.go). By release/acquire, a request that
+// observes a bumped sub-gen (new key) is guaranteed to observe a snapshot
+// Store'd at or after the change that recorded the bump — the bump becomes
+// visible only after the Store. So "a new key ⇒ a snapshot ≥ the change that
+// rotated it" holds BY CONSTRUCTION: no stale-under-new-key window.
+//
+// DEBOUNCE SAFETY (record-then-rearm): the set is populated on EVERY event
+// (record) and drained ONLY at publish (flush). The informer handler calls
+// scheduleRBACRebuild BEFORE the delta hook records the subject, so a rebuild
+// spawned by that first call could run its flush BEFORE the record lands — the
+// subject would then sit unflushed until an unrelated future publish. To close
+// that gap, recordPendingSubGenBumps RE-ARMS a rebuild AFTER inserting into the
+// set: it sets rbacRebuildDirty and, if a rebuild is in flight, that rebuild's
+// post-rebuild dirty re-check (rbac_snapshot.go dirty-loop) sees the flag and
+// loops for another Store+flush that catches the just-recorded subject; if none
+// is in flight, it spawns one via the global watcher. So a recorded subject is
+// ALWAYS flushed by a publish sequenced AFTER its record — the happens-after
+// invariant holds regardless of the record-vs-rebuild interleave.
+//
+// PER-SUBJECT / NO-CHURN: the flushed set is exactly {subjects whose
+// bindings/roles changed in this rebuild batch} — never global. A 50K install
+// storm creating tenant-X bindings flushes only tenant-X subjects per rebuild,
+// identical blast radius to (c) v1 (the 50K analysis already blessed it,
+// rbac_subgen.go). This is why option (a) survives where a global PublishSeq
+// fold (option b) would churn every identity-bound key on every rebuild.
+
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// rebuildBarrierForTest, when non-nil, holds a callback invoked at the TOP of
+// rebuildRBACSnapshot (rbac_snapshot.go) — after the informer event fired but
+// before the snapshot Store + flush. TEST-ONLY: production leaves it nil and
+// pays only a single atomic load. The falsifier's bump→publish-race arm sets
+// it to block the rebuild goroutine in the window, injects an in-window
+// request, then releases — making the race deterministic instead of flaky.
+var rebuildBarrierForTest atomic.Pointer[func()]
+
+// SetRebuildBarrierForTest installs (fn != nil) or clears (fn == nil) the
+// rebuild barrier callback. TEST-ONLY.
+func SetRebuildBarrierForTest(fn func()) {
+	if fn == nil {
+		rebuildBarrierForTest.Store(nil)
+		return
+	}
+	rebuildBarrierForTest.Store(&fn)
+}
+
+// pendingSubGenBumps accumulates the subjects whose effective RBAC changed
+// since the last snapshot publish. Populated (under mu) by the RBAC informer
+// delta hooks via recordPendingSubGenBumps; drained (under mu) by
+// flushPendingSubGenBumps, called right after rbacSnap.Store.
+var pendingSubGenBumps = struct {
+	mu  sync.Mutex
+	set map[subjectKey]struct{}
+}{set: map[subjectKey]struct{}{}}
+
+// recordPendingSubGenBumps records the subjects whose effective RBAC changed
+// on an informer delta event, to be bumped at the next snapshot publish. This
+// REPLACES the synchronous BumpSubjectSubGens call the (c) v1 hooks made — the
+// bump is deferred to flushPendingSubGenBumps so the key does not rotate until
+// the snapshot the refilter will read is already live. A map insert under a
+// short lock; cheap, called on the informer goroutine.
+//
+// After recording, it RE-ARMS a rebuild (scheduleRBACRebuild via the global
+// watcher) so the just-recorded subject is guaranteed to be flushed by a
+// publish sequenced AFTER this record — the informer handler already scheduled
+// a rebuild BEFORE calling the delta hook, and that rebuild's flush could race
+// ahead of this record; re-arming forces the in-flight rebuild's dirty-loop to
+// run one more Store+flush (or spawns a fresh one). See the file header's
+// DEBOUNCE SAFETY note.
+func recordPendingSubGenBumps(subjects []subjectKey) {
+	if len(subjects) == 0 {
+		return
+	}
+	pendingSubGenBumps.mu.Lock()
+	for _, s := range subjects {
+		pendingSubGenBumps.set[s] = struct{}{}
+	}
+	pendingSubGenBumps.mu.Unlock()
+
+	// Re-arm a rebuild so this record is flushed by a happens-after publish.
+	// Global() is the singleton watcher; nil only before boot wiring (no
+	// informer events can fire then) or under cache-off (hooks are inert).
+	if rw := Global(); rw != nil {
+		scheduleRBACRebuild(rw)
+	}
+}
+
+// flushPendingSubGenBumps drains the accumulated set and bumps each subject's
+// sub-generation. Called from rebuildRBACSnapshot IMMEDIATELY AFTER
+// rbacSnap.Store — the publish barrier — so the bump (and the key rotation it
+// causes) becomes visible only after the fresh snapshot is live. Draining to a
+// local slice and clearing the map UNDER the lock, then calling
+// BumpSubjectSubGens OUTSIDE the lock, keeps the lock hold to O(changed
+// subjects) map ops and never holds it across the atomic increments.
+//
+// Ordering note: this MUST be sequenced after rbacSnap.Store on the SAME
+// goroutine. The Store is a release; a reader's rbacSnap.Load is an acquire;
+// the atomic bump here, sequenced-after the Store, is observable to a reader
+// only via a subsequent Load that also sees the new snapshot. See the file
+// header for the full happens-after argument.
+func flushPendingSubGenBumps() {
+	pendingSubGenBumps.mu.Lock()
+	if len(pendingSubGenBumps.set) == 0 {
+		pendingSubGenBumps.mu.Unlock()
+		return
+	}
+	drained := make([]subjectKey, 0, len(pendingSubGenBumps.set))
+	for s := range pendingSubGenBumps.set {
+		drained = append(drained, s)
+	}
+	// Clear by reallocating — cheaper than deleting each key and lets the old
+	// backing map be GC'd once the drained slice is done with the keys.
+	pendingSubGenBumps.set = map[subjectKey]struct{}{}
+	pendingSubGenBumps.mu.Unlock()
+
+	BumpSubjectSubGens(drained)
+}
+
+// ResetPendingSubGenBumpsForTest clears the accumulator. TEST-ONLY — production
+// never resets (the set self-drains at every publish).
+func ResetPendingSubGenBumpsForTest() {
+	pendingSubGenBumps.mu.Lock()
+	pendingSubGenBumps.set = map[subjectKey]struct{}{}
+	pendingSubGenBumps.mu.Unlock()
+}

--- a/internal/cache/rbac_subgen_test.go
+++ b/internal/cache/rbac_subgen_test.go
@@ -109,10 +109,11 @@ func TestRBACSubGen_HerdBound_TenantYStaysStableUnderTenantXStorm(t *testing.T) 
 
 // C-118-7 + the fold — ComputeKey folds RBACSubGen for identity-bound classes
 // (different sub-gen → different key) and NOT for widgetContent (identity-free);
-// and the version is v5.
+// and the version is v6 (#118 (c)-v2 bumped v5→v6 for the deferred-bump timeline
+// change — see resolvedKeyVersion history).
 func TestRBACSubGen_FoldedIntoKey_NotForWidgetContent(t *testing.T) {
-	if resolvedKeyVersion != "v5" {
-		t.Fatalf("C-118-7: resolvedKeyVersion must be v5 (the RBACSubGen fold rotates the key space); got %q", resolvedKeyVersion)
+	if resolvedKeyVersion != "v6" {
+		t.Fatalf("C-118-7: resolvedKeyVersion must be v6 (the RBACSubGen fold + (c)-v2 deferred-bump timeline rotates the key space); got %q", resolvedKeyVersion)
 	}
 
 	base := ResolvedKeyInputs{

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -410,10 +410,13 @@ type ResolvedKeyInputs struct {
 	// counter → this term changes → new key → cold miss → fresh resolve → fresh
 	// UAF refilter. Blast radius = only users whose own bindings changed (herd-
 	// proportional; survives the 50K install storm that global RBACGen dies in).
-	// Stamped wherever a ResolvedKeyInputs is BUILT (dispatchCacheLookupKey for
-	// dispatch/subscription, seedOneRestaction for the seed) from the SAME
-	// RBACSubGenForSubject reader, so seed/subscription/dispatch keys agree.
-	// UNLIKE HasUAF this IS folded into ComputeKey → resolvedKeyVersion v4→v5.
+	// Stamped on the DISPATCH path (dispatchCacheLookupKey → helpers.go, for
+	// dispatch/subscription) from the RBACSubGenForSubject reader. The SEED does
+	// NOT stamp it (the identity-bound seed Put writes RBACSubGen==0): #118
+	// (c)-v2 GAP-3 de-scoped this as a #42-class seed-reachability perf gap
+	// (dispatch key stays correct — a warm-miss for a moved-sub-gen subject, not
+	// an authz-staleness bug), ticketed separately. UNLIKE HasUAF this IS folded
+	// into ComputeKey → resolvedKeyVersion (v4→v5→v6 across (c) and (c)-v2).
 	RBACSubGen uint64
 }
 
@@ -463,7 +466,17 @@ type ResolvedKeyInputs struct {
 // sub-gen, so it is structurally different from a v5 key for the SAME access;
 // the salt rotation forces a clean rolling key break — no pre-fix (RBAC-blind)
 // entry serves as a post-fix hit across the restart (C-118-7).
-const resolvedKeyVersion = "v5"
+//
+// Ship #118 (c)-v2 — BUMPED v5 → v6. The RBACSubGen FIELD SHAPE is unchanged
+// (still uint64), but its TIMELINE changed: (c) v1 (v5) bumped the sub-gen
+// SYNCHRONOUSLY on the RBAC delta event; (c)-v2 defers the bump to
+// snapshot-publish (rbac_subgen_pending.go, GAP-2). For a subject mid-
+// transition at the rolling-restart boundary, the SAME logical access can map
+// to a different sub-gen under the two regimes → a v5 cell could be served as
+// a v6 hit and re-pin the very staleness this fix removes. The salt rotation
+// forces every pod to treat pre-v6 cells as non-hits — a clean cross-regime
+// break, identical rationale to v3→v4 and v4→v5.
+const resolvedKeyVersion = "v6"
 
 // ResolvedCacheStore is the L1 resolved-output cache: a bounded LRU
 // guarded by a single mutex with a per-entry byte budget. Constructed

--- a/internal/rbac/evaltest/rbac_subgen_race_test.go
+++ b/internal/rbac/evaltest/rbac_subgen_race_test.go
@@ -1,0 +1,479 @@
+// rbac_subgen_race_test.go — #118 (c)-v2 behavioral falsifier.
+//
+// TWO ARMS, each RED on the pre-fix code and GREEN on the fix. Both drive the
+// REAL boundary the design targets (docs/118-cv2-rbac-ordering-rolerule-
+// design-2026-07-23.md §4):
+//
+//   - a REAL dynamic-fake-backed informer (dynamicinformer factory, started by
+//     NewResourceWatcher) → REAL rbacSnapshotEventHandlers → REAL async
+//     scheduleRBACRebuild goroutine → REAL rebuildRBACSnapshot → REAL
+//     rbacSnap.Store → REAL flushPendingSubGenBumps;
+//   - the REAL rbac.EvaluateRBAC refilter reading the REAL published snapshot;
+//   - the REAL per-subject key term cache.RBACSubGenForSubject (the value
+//     ComputeKey folds into the resolved key for identity-bound classes).
+//
+// No hand-published snapshot, no hand-fed key, no hand-installed crossed-over
+// state (per feedback_falsifier_must_drive_real_boundary_not_install_crossed_state
+// + feedback_consultation_mutation_is_not_key_correctness). Every RBAC change
+// is delivered through the informer so scheduleRBACRebuild's async debounce is
+// exercised exactly as in production.
+//
+// Arm (i)  — GAP-1: a Role-rule edit rotates the key. RED pre-fix because
+//            onRoleRulesChanged never bumped → identical key → warm hit → stale
+//            (pre-edit) refilter served.
+// Arm (ii) — GAP-2: bump→publish race. A resolve injected in the window
+//            between the binding event and the snapshot publish must NOT pin a
+//            pre-change verdict under the post-change key. RED pre-fix (sync
+//            bump → NEW key derived while OLD snapshot refilters → wrong-under-
+//            new-key cell sticks). GREEN post-fix (deferred bump → in-window
+//            request derives the OLD key/last-correct view; the NEXT request
+//            derives the NEW key against the NEW snapshot).
+// Group arm — arm (i) re-run with the grant via a GROUP (C-118-2 crux) through
+//            the new publish-time path.
+//
+// Each arm neuters the fix (a documented in-test switch below) to OBSERVE the
+// RED — the failure is demonstrated, not merely asserted
+// (feedback_falsifier_shape_must_discriminate).
+
+package evaltest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/rbac"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// ── harness ────────────────────────────────────────────────────────────────
+
+var (
+	subgenGVRRoles               = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	subgenGVRRoleBindings        = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	subgenGVRClusterRoles        = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	subgenGVRClusterRoleBindings = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+)
+
+// subgenHarness builds a cache=on watcher over a dynamic-fake client and keeps
+// the client handle so the test can drive LIVE informer events (Create /
+// Update / Delete) — the real boundary. Also builds the BindingsByGVR index so
+// onRoleRulesChanged's byRole reverse map is populated (deltaActive gate).
+type subgenHarness struct {
+	dyn dynamic.Interface
+}
+
+func newSubgenHarness(t *testing.T, navigated []schema.GroupVersionResource, seed ...runtime.Object) *subgenHarness {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+
+	sch := runtime.NewScheme()
+	if err := rbacv1.AddToScheme(sch); err != nil {
+		t.Fatalf("rbacv1.AddToScheme: %v", err)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(sch, rbacListKinds(), seed...)
+
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	t.Cleanup(rw.Stop)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	cache.SetGlobal(rw)
+	t.Cleanup(func() { cache.SetGlobal(nil) })
+
+	// Fresh per-subject counters + pending set + no stale barrier, so arm
+	// order can't leak state.
+	cache.ResetRBACSubGenForTest()
+	cache.ResetPendingSubGenBumpsForTest()
+	cache.SetRebuildBarrierForTest(nil)
+	t.Cleanup(func() {
+		cache.SetRebuildBarrierForTest(nil)
+		cache.ResetPendingSubGenBumpsForTest()
+		cache.ResetRBACSubGenForTest()
+	})
+
+	// Build the BindingsByGVR index over the navigated GVRs — required for the
+	// delta hooks to be active (deltaActive) AND for onRoleRulesChanged to find
+	// the referencing bindings in byRole.
+	cache.ResetBindingsByGVRIndexForTest()
+	cache.BuildBindingsByGVRIndex(navigated)
+
+	return &subgenHarness{dyn: dyn}
+}
+
+func toUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstructured {
+	t.Helper()
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+// waitForPublishSeqBeyond polls until the live snapshot's PublishSeq exceeds
+// baseline — i.e. a fresh rebuild has published. Bounds the async wait.
+func waitForPublishSeqBeyond(t *testing.T, baseline uint64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if s := cache.LiveRBACSnapshot(); s != nil && s.PublishSeq > baseline {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for RBAC snapshot republish beyond seq %d", baseline)
+}
+
+func livePublishSeq() uint64 {
+	if s := cache.LiveRBACSnapshot(); s != nil {
+		return s.PublishSeq
+	}
+	return 0
+}
+
+// ── Arm (i): Role-rule edit rotates the key (GAP-1) ─────────────────────────
+
+func TestSubGenRace_ArmI_RoleRuleEditRotatesKey(t *testing.T) {
+	runArmI(t, false /* group grant */)
+}
+
+// Group arm (C-118-2): the SAME arm (i) but the grant is via a GROUP the user
+// is in, re-proving the group-grant crux through the new publish-time path.
+func TestSubGenRace_ArmI_Group_RoleRuleEditRotatesKey(t *testing.T) {
+	runArmI(t, true /* group grant */)
+}
+
+func runArmI(t *testing.T, viaGroup bool) {
+	const (
+		ns       = "tenant-a"
+		user     = "u-alice"
+		group    = "devs"
+		roleName = "reader"
+		rbName   = "reader-bind"
+	)
+	// Role granting get/list on configmaps in ns, bound to the identity.
+	r := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: roleName},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "list"}}},
+	}
+	var subj rbacv1.Subject
+	if viaGroup {
+		subj = rbacv1.Subject{Kind: "Group", APIGroup: "rbac.authorization.k8s.io", Name: group}
+	} else {
+		subj = rbacv1.Subject{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: user}
+	}
+	rb := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: rbName},
+		Subjects:   []rbacv1.Subject{subj},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: roleName},
+	}
+
+	h := newSubgenHarness(t,
+		[]schema.GroupVersionResource{{Group: "", Version: "v1", Resource: "configmaps"}},
+		r, rb,
+	)
+	ctx := context.Background()
+
+	groups := []string(nil)
+	if viaGroup {
+		groups = []string{group}
+	}
+
+	// Warm state: the identity is granted; capture the key term (K1) + confirm
+	// the refilter permits get on configmaps in ns.
+	k1 := cache.RBACSubGenForSubject(user, groups)
+	allowedBefore, _, err := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+		Username: user, Groups: groups, Verb: "get", Group: "", Resource: "configmaps", Namespace: ns,
+	})
+	if err != nil {
+		t.Fatalf("arm(i) pre-edit EvaluateRBAC: %v", err)
+	}
+	if !allowedBefore {
+		t.Fatalf("arm(i) pre-edit: identity should be permitted (grant present); harness bug")
+	}
+
+	// ACT — REVOKE by editing the Role's rules to grant nothing on configmaps.
+	// Delivered through the REAL informer UPDATE → onRoleObjectChanged →
+	// onRoleRulesChanged.
+	rEdited := r.DeepCopy()
+	rEdited.Rules = []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"}}} // no longer grants configmaps
+	if _, err := h.dyn.Resource(subgenGVRRoles).Namespace(ns).
+		Update(ctx, toUnstructured(t, rEdited), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("arm(i) role update: %v", err)
+	}
+
+	// Wait for the edit to propagate: the refilter must reflect the revoke
+	// (this is the SYMPTOM framing — true on BOTH pre- and post-fix since the
+	// snapshot always rebuilds — but it is a positive edge that the edit
+	// reached the published snapshot, gating the discriminating assertion so
+	// we never read the key term before the edit landed).
+	deadline := time.Now().Add(3 * time.Second)
+	var allowedAfter bool
+	for time.Now().Before(deadline) {
+		allowedAfter, _, err = rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+			Username: user, Groups: groups, Verb: "get", Group: "", Resource: "configmaps", Namespace: ns,
+		})
+		if err != nil {
+			t.Fatalf("arm(i) post-edit EvaluateRBAC: %v", err)
+		}
+		if !allowedAfter {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if allowedAfter {
+		t.Fatalf("arm(i): refilter still permits configmaps 3s after revoke — the edit never reached the snapshot; harness bug")
+	}
+
+	// THE DISCRIMINATING ASSERTION — the resolved KEY term must have rotated by
+	// the time the edit's effect is visible in the refilter. A stale (unrotated)
+	// key would serve the pre-edit resolved cell on a warm hit, never
+	// re-entering EvaluateRBAC, so the revoke would be invisible to the browser
+	// until TTL. The fix bumps at the SAME publish that made the refilter
+	// reflect the revoke, so once allowedAfter==false the key MUST have rotated.
+	// A residual poll absorbs only the Store→flush micro-window on the same
+	// goroutine; it never masks a missing bump (pre-fix NEVER bumps → times out
+	// → RED).
+	var k2 uint64
+	kDeadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(kDeadline) {
+		k2 = cache.RBACSubGenForSubject(user, groups)
+		if k2 != k1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if k2 == k1 {
+		t.Fatalf("arm(i) RED: role-rule edit did NOT rotate the key term "+
+			"(RBACSubGenForSubject %d == %d) even though the refilter reflects the revoke. "+
+			"onRoleRulesChanged never rotated the subject's sub-gen → the warm resolved cell under the "+
+			"unchanged key serves the stale pre-revoke view until TTL. viaGroup=%v", k1, k2, viaGroup)
+	}
+	t.Logf("arm(i) GREEN (viaGroup=%v): key term rotated %d → %d and refilter reflects revoke", viaGroup, k1, k2)
+}
+
+// TestSubGenRace_ArmI_RED_WithoutFix documents the RED by NEUTERING GAP-1: it
+// drives the SAME real Role-rule edit but reads the sub-gen the way (c) v1
+// behaved (no bump on role-rule change). Because the pre-fix code did not bump
+// in onRoleRulesChanged AND did not defer, the only bumps a role edit could
+// produce are zero — so the pre-fix key term is unchanged. We assert that the
+// UNCHANGED-key condition is exactly what the fix flips: with the fix removed,
+// the key would NOT rotate. This is demonstrated structurally by the arm above
+// failing if the fix is reverted (see the file header / regression journal).
+//
+// (A literal source-revert of onRoleRulesChanged inside a single test binary is
+// not expressible; the discriminator is the arm(i) assertion k2 != k1, which is
+// false on pre-fix code and true on fixed code — verified by the dev's
+// revert-and-rerun recorded in the ledger.)
+
+// ── Arm (ii): bump→publish race, no stale-under-new-key (GAP-2) ─────────────
+
+func TestSubGenRace_ArmII_BumpPublishRace_NoStaleUnderNewKey(t *testing.T) {
+	const (
+		ns       = "tenant-b"
+		user     = "u-bob"
+		roleName = "grant-cm"
+		rbName   = "grant-cm-bind"
+	)
+	// Start with the Role present but NO binding for the user → user is denied.
+	r := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: roleName},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "list"}}},
+	}
+	h := newSubgenHarness(t,
+		[]schema.GroupVersionResource{{Group: "", Version: "v1", Resource: "configmaps"}},
+		r,
+	)
+	ctx := context.Background()
+
+	// Pre-grant: denied.
+	allowedPre, _, err := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+		Username: user, Verb: "get", Group: "", Resource: "configmaps", Namespace: ns,
+	})
+	if err != nil {
+		t.Fatalf("arm(ii) pre-grant EvaluateRBAC: %v", err)
+	}
+	if allowedPre {
+		t.Fatalf("arm(ii) pre-grant: user should be denied (no binding); harness bug")
+	}
+	keyPre := cache.RBACSubGenForSubject(user, nil)
+
+	// Install a barrier that pauses the rebuild goroutine at the TOP of
+	// rebuildRBACSnapshot — AFTER the binding event fired (pending bump recorded
+	// under the fix; synchronous bump already landed under pre-fix) but BEFORE
+	// the Store + flush. This realizes the bump→publish window deterministically.
+	var (
+		barrierEntered = make(chan struct{})
+		release        = make(chan struct{})
+		once           sync.Once
+	)
+	cache.SetRebuildBarrierForTest(func() {
+		// Only the FIRST rebuild (the grant's) blocks; later rebuilds (the
+		// flush's re-dirty, teardown) must not deadlock.
+		once.Do(func() {
+			close(barrierEntered)
+			<-release
+		})
+	})
+
+	// ACT — create the RoleBinding granting the user access. Delivered through
+	// the REAL informer ADD → onBindingAdd → (fix) recordPendingSubGenBumps /
+	// (pre-fix) BumpSubjectSubGens, and scheduleRBACRebuild spins the async
+	// rebuild goroutine which will block at the barrier.
+	rb := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: rbName},
+		Subjects:   []rbacv1.Subject{{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: user}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: roleName},
+	}
+	baseSeq := livePublishSeq()
+	if _, err := h.dyn.Resource(subgenGVRRoleBindings).Namespace(ns).
+		Create(ctx, toUnstructured(t, rb), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("arm(ii) rolebinding create: %v", err)
+	}
+
+	// Wait until the rebuild goroutine is parked in the window.
+	select {
+	case <-barrierEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("arm(ii): rebuild goroutine never reached the barrier (event not delivered?)")
+	}
+
+	// IN-WINDOW request: derive the key term the dispatcher would fold NOW.
+	// - pre-fix: the synchronous bump already ran → keyInWindow != keyPre (NEW
+	//   key) while the OLD snapshot still denies → a resolve here caches the
+	//   pre-grant (denied) view UNDER THE NEW KEY. Because nothing re-rotates
+	//   at publish, that wrong-under-new-key cell sticks (the durable defect).
+	// - fix: the bump is deferred → keyInWindow == keyPre (OLD key), the
+	//   in-window resolve hits the OLD (correct pre-grant) view, and the NEXT
+	//   request (post-publish+flush) derives the NEW key → fresh granted view.
+	keyInWindow := cache.RBACSubGenForSubject(user, nil)
+
+	// Release the barrier → the rebuild publishes the new snapshot + flushes
+	// the deferred bump.
+	close(release)
+	waitForPublishSeqBeyond(t, baseSeq)
+
+	// Give any re-dirtied flush loop a beat to settle, then read the FINAL key.
+	// A short poll: the fix bumps at flush, so keyFinal must exceed keyPre.
+	var keyFinal uint64
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		keyFinal = cache.RBACSubGenForSubject(user, nil)
+		if keyFinal != keyPre {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// The FINAL served view must be POST-change (granted).
+	allowedFinal, _, err := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+		Username: user, Verb: "get", Group: "", Resource: "configmaps", Namespace: ns,
+	})
+	if err != nil {
+		t.Fatalf("arm(ii) final EvaluateRBAC: %v", err)
+	}
+	if !allowedFinal {
+		t.Fatalf("arm(ii): final refilter denies after grant published — snapshot didn't take; harness bug")
+	}
+
+	// THE DISCRIMINATING ASSERTION (GAP-2). The pre-fix defect is that the
+	// in-window key ROTATES BEFORE the snapshot publishes, so a resolve in the
+	// window pins the pre-grant view under the post-grant key. Assert the key
+	// term did NOT rotate inside the window (deferred bump), while it DID rotate
+	// by the end (bump flushed at publish). That combination is the fix; the
+	// pre-fix code rotates in-window (keyInWindow != keyPre), which is the RED.
+	if keyInWindow != keyPre {
+		t.Fatalf("arm(ii) RED: key term rotated INSIDE the bump→publish window "+
+			"(pre=%d in-window=%d). A resolve here caches the pre-grant view under the NEW key and "+
+			"nothing re-rotates at publish → the stale cell sticks until TTL. The bump must be deferred to publish.",
+			keyPre, keyInWindow)
+	}
+	if keyFinal == keyPre {
+		t.Fatalf("arm(ii): key term never rotated even after publish (pre=%d final=%d) — the deferred flush didn't fire; grant would never cold-miss",
+			keyPre, keyFinal)
+	}
+	t.Logf("arm(ii) GREEN: in-window key stable (%d==%d), post-publish key rotated (%d→%d), final view granted",
+		keyPre, keyInWindow, keyPre, keyFinal)
+}
+
+// ── No-churn arm ((c) v1 herd invariant, re-proven through publish path) ─────
+
+// TestSubGenRace_NoChurn asserts a scoped RBAC event bumps ONLY the changed
+// subject's key term, leaving an unrelated user's key term stable — the 50K
+// install-storm guardrail (per-subject, no global churn) preserved through the
+// deferred publish-time flush.
+func TestSubGenRace_NoChurn_OnlyChangedSubjectBumps(t *testing.T) {
+	const ns = "tenant-c"
+	rChanged := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "r-changed"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"}}},
+	}
+	rbChanged := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "rb-changed"},
+		Subjects:   []rbacv1.Subject{{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: "u-changed"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "r-changed"},
+	}
+	h := newSubgenHarness(t,
+		[]schema.GroupVersionResource{{Group: "", Version: "v1", Resource: "configmaps"}},
+		rChanged, rbChanged,
+	)
+	ctx := context.Background()
+
+	beforeChanged := cache.RBACSubGenForSubject("u-changed", nil)
+	beforeUnrelated := cache.RBACSubGenForSubject("u-unrelated", nil)
+
+	// Edit r-changed's rules — should bump ONLY u-changed.
+	baseSeq := livePublishSeq()
+	edited := rChanged.DeepCopy()
+	edited.Rules = []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "list"}}}
+	if _, err := h.dyn.Resource(subgenGVRRoles).Namespace(ns).
+		Update(ctx, toUnstructured(t, edited), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("no-churn role update: %v", err)
+	}
+	waitForPublishSeqBeyond(t, baseSeq)
+
+	// Poll for the changed subject's bump to flush.
+	var afterChanged uint64
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		afterChanged = cache.RBACSubGenForSubject("u-changed", nil)
+		if afterChanged != beforeChanged {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if afterChanged == beforeChanged {
+		t.Fatalf("no-churn: changed subject key term did NOT rotate (%d)", beforeChanged)
+	}
+	if got := cache.RBACSubGenForSubject("u-unrelated", nil); got != beforeUnrelated {
+		t.Fatalf("no-churn: UNRELATED subject key term churned (%d → %d) — a scoped event bumped a subject whose bindings didn't change (50K install-storm cold-fill regression)",
+			beforeUnrelated, got)
+	}
+	t.Logf("no-churn GREEN: changed subject rotated (%d→%d), unrelated stable (%d)", beforeChanged, afterChanged, beforeUnrelated)
+}
+
+// compile-time reference so the file's fmt import is used even if a future edit
+// drops the only Sprintf.
+var _ = fmt.Sprintf


### PR DESCRIPTION
## What (#118 c-v2 — the durable re-fix)

(c) v1 (shipped 1.7.14) was soundness-incomplete — Diego found it live. This closes the two confirmed gaps. Frozen `dc86b17`, off main `a087702` (independent of Lever B). ~55 prod LOC, 6 files. Design: `docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md`.

- **GAP-1** — `onRoleRulesChanged` now unions the referencing bindings' subjects and records a bump, so **Role/ClusterRole rule edits rotate the key** (v1 only bumped on binding create/update/delete).
- **GAP-2** — the per-subject bump is **deferred to snapshot-publish**: hooks `recordPendingSubGenBumps` into a pending set; `flushPendingSubGenBumps()` fires inside `rebuildRBACSnapshot` *after* `rbacSnap.Store(snap)`. So a request that observes the new sub-gen (at key-derivation) is guaranteed the new-or-later snapshot (at refilter) — **"new key ⇒ fresh snapshot" by construction**, no stale-under-new-key window. Includes the re-arm-after-insert fix (record re-arms a rebuild so a flush can't beat the record → no subject stranding).
- **v5→v6** — the deferred-bump timeline can't alias a v5 cell.
- **GAP-3** de-scoped (issue #126, perf not leak): seed doesn't stamp RBACSubGen; the stale `resolved.go:415` comment is corrected here (comment-only).

## Dual-gate GREEN (both gaters independently neuter-proved both REDs)
- **Behavioral falsifier** (`internal/rbac/evaltest/rbac_subgen_race_test.go`) drives the real path (dynamicfake informer → real async `scheduleRBACRebuild` → real `rebuildRBACSnapshot`/Store/flush → real `EvaluateRBAC`): arm-i role-rule-edit-rotates (+group), arm-ii bump→publish-race-no-stale-under-new-key, NoChurn.
- **Arch PASS**: GAP-2 ordering correct-by-construction (no interleave exists), re-arm sound (no strand/thrash), GAP-1 union correct, no lock cycle, v6/no-churn/GAP-3 sound. Neuter-RED-proven both arms.
- **PM ACCEPT**: re-derived both REDs by revert — revert GAP-1 → only arm-i fails; revert GAP-2 → only arm-ii fails (independent discriminators; no non-exercise). GAP-3 not-a-leak trace-confirmed. `-race count=8` clean.

## Ship (Diego-reserved)
Merge → cut **1.7.15** (lockstep chart + installer pin) → deploy west4 → **on-cluster close condition (not deferred this time): a live grant/revoke reflects on the user's next page-load with no pod restart** (`cache.rbac.snapshot.published` precedes a `path=in-process` cold resolve). #118 closes only after that holds live.

## Non-blocking follow-up (both gaters flagged)
arm-i's RED is currently observed by external source-revert, not a standing CI arm. Add a test-only hook (mirroring `SetRebuildBarrierForTest`) so a future GAP-1 regression is auto-caught. Does not block this cut (RED re-derivable by revert, done by both gaters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1