### PR TITLE
feat(prewarm): boot-seed external-fetch wall-clock bound (Approach B, 3 scopes) [PARKED — Diego-reserved merge]

### DIFF
--- a/internal/handlers/dispatchers/external_seed_bound_marker_liveness_test.go
+++ b/internal/handlers/dispatchers/external_seed_bound_marker_liveness_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+// +build unit
+
+// external_seed_bound_marker_liveness_test.go — MARKER-LIVENESS falsifier for
+// the boot-seed external-fetch wall-clock bound
+// (docs/boot-seed-external-fetch-bound-design-2026-07-24.md).
+//
+// PROVES the bound fires under ALL THREE readiness-critical vectors — the
+// per-cohort SEED, the discovery WALK, and the content-prewarm PASS — by
+// driving the REAL PRODUCTION context builders (withCohortSeedContext,
+// withPhase1SAContext, withContentPrewarmSAContext) and handing each produced
+// ctx to the REAL gating predicate api.ExternalSeedFetchBounded (which is the
+// single source of truth for resolve.go:1106's wrap decision).
+//
+// This is NOT a hand-stamped ctx: each arm re-invokes the production builder
+// end-to-end and asserts the boundary is bounded through the SAME predicate
+// production uses (feedback_falsifier_must_drive_real_boundary_not_install_crossed_state).
+// The CONTENT-PASS ARM is the load-bearing one — it is the exact vector the PM
+// caught (withContentPrewarmSAContext carried no scope before this fix, so the
+// bound would no-op on it and leave it unbounded to overrun 480s). A test green
+// on seed+walk but blind to the content pass would be INADMISSIBLE.
+
+package dispatchers
+
+import (
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
+)
+
+// TestMarkerLiveness_AllThreeReadinessVectorsBounded — the three real prod
+// context builders each produce a ctx that the external-fetch bound wraps at
+// resolve.go:1106. Default (5000ms) bound is ON.
+func TestMarkerLiveness_AllThreeReadinessVectorsBounded(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true") // else WithFallthroughScope is a no-op (Disabled())
+	// Leave RESOLVER_SEED_EXTERNAL_FETCH_TIMEOUT_MS unset → default 5000 → bound ON.
+
+	// The base ctx production hands the builders: the discovery-walk-scoped
+	// parent that rePrewarmBootScoped threads into the seed, exactly as in prod
+	// (withPhase1SAContext stamps it, then the seed builder runs under it).
+	base := xcontext.BuildContext(t.Context())
+
+	t.Run("seed_ctx_real_withCohortSeedContext", func(t *testing.T) {
+		// The seed runs under the walk-scoped parent (rePrewarmBootScoped handoff).
+		walkScoped := cache.WithFallthroughScope(base, cache.ScopeBootPrewarmWalk)
+		seedCtx := withCohortSeedContext(walkScoped, seedTarget{Username: "admin"}, endpoints.Endpoint{}, nil)
+
+		if fs := cache.FallthroughScope(seedCtx); fs == nil || fs.Path != cache.ScopeBootPrewarmSeed {
+			t.Fatalf("premise: seed ctx scope = %v, want ScopeBootPrewarmSeed", fs)
+		}
+		if !api.ExternalSeedFetchBounded(seedCtx) {
+			t.Fatal("RED: the REAL seed ctx (withCohortSeedContext) is NOT bounded at resolve.go:1106 — a degraded external widget in the seed loop stays unbounded (up to ~120s/unit) and overruns the 480s readiness budget.")
+		}
+	})
+
+	t.Run("walk_ctx_real_withPhase1SAContext", func(t *testing.T) {
+		walkCtx := withPhase1SAContext(base, endpoints.Endpoint{}, nil)
+
+		if fs := cache.FallthroughScope(walkCtx); fs == nil || fs.Path != cache.ScopeBootPrewarmWalk {
+			t.Fatalf("premise: walk ctx scope = %v, want ScopeBootPrewarmWalk", fs)
+		}
+		if !api.ExternalSeedFetchBounded(walkCtx) {
+			t.Fatal("RED: the REAL discovery-walk ctx (withPhase1SAContext) is NOT bounded — the pre-latch SA discovery walk resolves external widgets before MarkPhase1Done and would pay an unbounded round-trip per external widget.")
+		}
+	})
+
+	t.Run("content_pass_ctx_real_withContentPrewarmSAContext_THE_PM_CAUGHT_VECTOR", func(t *testing.T) {
+		contentCtx := withContentPrewarmSAContext(base, endpoints.Endpoint{}, nil)
+
+		fs := cache.FallthroughScope(contentCtx)
+		if fs == nil {
+			t.Fatal("RED (the PM-caught defect): the content-prewarm pass ctx (withContentPrewarmSAContext) carries NO fallthrough scope — the external-fetch bound no-ops on it, so the content pass (which resolves the obs-* ClickHouse apiRef data sources BEFORE MarkPhase1Done) stays UNBOUNDED and can overrun the 480s backstop alone. withContentPrewarmSAContext must stamp a boot-readiness scope.")
+		}
+		if !api.ExternalSeedFetchBounded(contentCtx) {
+			t.Fatalf("RED (the PM-caught defect): the content-prewarm pass ctx carries scope %q but the external-fetch bound does NOT wrap it — that scope is not in the readiness-critical gated set. The content-pass external fetch stays unbounded.", fs.Path)
+		}
+	})
+}

--- a/internal/handlers/dispatchers/phase1_content_prewarm.go
+++ b/internal/handlers/dispatchers/phase1_content_prewarm.go
@@ -235,6 +235,33 @@ func withContentPrewarmSAContext(ctx context.Context, saEP endpoints.Endpoint, s
 	// CACHE_ENABLED=false → WithServeWatcher returns ctx unchanged → the live LIST
 	// runs as today).
 	rctx = cache.WithServeWatcher(rctx, cache.Global())
+	// Boot-readiness external-fetch wall-clock bound (external_seed_bound.go /
+	// resolve.go:1106) — stamp the SAME boot-prewarm-walk scope the discovery
+	// walk carries (withPhase1SAContext, phase1_walk.go:1084). The content pass
+	// resolves the obs-* apiRef data sources (external ClickHouse widgets)
+	// SERIALLY BEFORE MarkPhase1Done, so without a scope marker the
+	// external-fetch bound would no-op on this vector and it could overrun the
+	// 480s readiness budget alone. Reusing the walk scope (rather than a new
+	// constant) is behavior-neutral for the content pass: the ONLY behavioral
+	// consumer of ScopeBootPrewarmWalk is apiref.shouldServeRAFullList
+	// (widgets/apiref/resolve.go:89), which reads the scope ONLY on a PAGINATED
+	// resolve (perPage>0 && page>0). The content pass resolves at PerPage:-1/
+	// Page:-1 (prewarmOneRESTAction, :394), and that -1/-1 pagination propagates
+	// VERBATIM down the nested-widget path it CAN reach shouldServeRAFullList
+	// through (restactions.Resolve → maybeResolveInProcess resolve_inprocess.go:174
+	// → ResolveNestedCall nested_call.go:251 → widgets.Resolve widgets/resolve.go:253
+	// → apiref.Resolve), so every resolve arrives as shouldServeRAFullList(ctx,-1,-1)
+	// → IsPaginatedResolve(-1,-1)==false → short-circuits at the FIRST conjunct
+	// BEFORE the scope is ever read. The walk-scope stamp therefore cannot alter
+	// any content-pass behavior other than engaging the external-fetch bound it
+	// is added for. (One benign non-behavioral side effect: the content pass now
+	// records apiserver-fallthrough metrics under the boot-prewarm-walk label —
+	// RecordApiserverFallthrough is "NO BEHAVIOUR CHANGE", a metrics-attribution
+	// shift onto a label the discovery walk already emits.) Structural (an
+	// existing scope constant, no host/name literal — feedback_no_special_cases).
+	// nil-safe / inert under cache-off (WithFallthroughScope returns rctx
+	// unchanged when Disabled()).
+	rctx = cache.WithFallthroughScope(rctx, cache.ScopeBootPrewarmWalk)
 	return rctx
 }
 

--- a/internal/resolvers/restactions/api/external_seed_bound.go
+++ b/internal/resolvers/restactions/api/external_seed_bound.go
@@ -1,0 +1,122 @@
+// external_seed_bound.go — boot-readiness external-fetch wall-clock bound
+// (#129-adjacent; origin: live west4-release 1.7.15 boot
+// `readyz.backstop.fired reason=seed_incomplete elapsed_ms=480001`).
+//
+// ROOT CAUSE. The single external GET dispatch at resolve.go:1106-1107
+// (httpFetchAllowingNonJSON) is bounded ONLY by the ctx deadline. On the
+// boot-readiness paths that deadline is the 120s cohort timeout — no
+// http.Client.Timeout is set, and util.NewRetryClient retries idempotent
+// GETs with exponential backoff. So one degraded external endpoint (e.g. a
+// ClickHouse obs-* data source) blocks up to ~120s per (external-widget ×
+// cohort) unit, and N such units overrun pipGlobalTimeout=480s → the seed
+// returns DeadlineExceeded → the readiness backstop fires.
+//
+// FIX. externalSeedFetchCtx wraps the fetch ctx with a per-fetch wall-clock
+// deadline D, but ONLY on the boot readiness-critical paths (seed / discovery
+// walk / content-prewarm pass), keyed on the EXISTING structural
+// FallthroughScope constant — no host/name/resource literal
+// (feedback_no_special_cases). Because the request is built with
+// http.NewRequestWithContext and util.RetryClient.Do honors req.Context() at
+// EVERY retry boundary (limiter wait, per-attempt clone, and the
+// inter-attempt backoff sleeps), a context.WithTimeout truncates the WHOLE
+// retry envelope — strictly stronger than a bare http.Client.Timeout, which
+// would not bound the backoff sleeps between attempts.
+//
+// SCOPE ISOLATION. A /call (ScopeCallGeneric / ScopeCallRestactions / …) or a
+// refresher resolve is NOT one of the gated scopes, so this returns the
+// parent ctx + a no-op cancel and the external fetch on those paths stays
+// byte-identical (no latency ceiling on a customer /call to a slow external
+// widget). The internal informer-backed / apistage / internal-rest-config
+// dispatch branches all return BEFORE resolve.go:1106, so their ctx is never
+// wrapped — #130 first-nav internal warming is structurally untouched.
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// envSeedExternalFetchTimeoutMS is the string-typed installer knob
+// (installer plumbing is string-only per
+// project_installer_config_plumbing_is_string_only — env.Int coerces the
+// string to an int in-runtime, no chart-boolean). Default 5000 (5s) means
+// the bound is ON by default: a degraded external endpoint on the boot
+// readiness path is cut at 5s, not ~120s. A value <= 0 disables the bound
+// (restores the pre-fix unbounded behavior — reproduces the outage; NOT the
+// shipped default). Toggle both ways per project_caching_is_provisional.
+const envSeedExternalFetchTimeoutMS = "RESOLVER_SEED_EXTERNAL_FETCH_TIMEOUT_MS"
+
+const defaultSeedExternalFetchTimeoutMS = 5000
+
+// bootReadinessFetchScopes is the closed set of FallthroughScope paths on
+// which the external-fetch wall-clock bound fires — every readiness-critical
+// vector that resolves external widgets BEFORE MarkPhase1Done:
+//
+//   - ScopeBootPrewarmSeed  — per-cohort seed (withCohortSeedContext).
+//   - ScopeBootPrewarmWalk  — discovery walk (withPhase1SAContext) AND the
+//     content-prewarm pass (withContentPrewarmSAContext, which reuses the
+//     walk scope — see phase1_content_prewarm.go). The content pass resolves
+//     the obs-* apiRef data sources at PerPage:-1, so its resolves never
+//     reach shouldServeRAFullList's paginated branch; the shared walk scope
+//     therefore bounds its fetch without altering any other content-pass
+//     behavior.
+var bootReadinessFetchScopes = map[string]struct{}{
+	cache.ScopeBootPrewarmSeed: {},
+	cache.ScopeBootPrewarmWalk: {},
+}
+
+// externalSeedFetchCtx returns a ctx + cancel to wrap the external fetch at
+// resolve.go:1106-1107. On a non-boot-readiness scope, or when the bound is
+// disabled (D <= 0), it returns (ctx, no-op) so the fetch is byte-identical
+// to the pre-fix path. On a boot-readiness scope with D > 0 it returns a
+// context.WithTimeout(ctx, D) that truncates the whole retry envelope.
+//
+// The caller MUST `defer cancel()` in all cases (the no-op cancel is a real
+// func so the call site is uniform).
+func externalSeedFetchCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	ms := env.Int(envSeedExternalFetchTimeoutMS, defaultSeedExternalFetchTimeoutMS)
+	if ms <= 0 {
+		// Disabled — pre-fix unbounded behavior.
+		return ctx, func() {}
+	}
+
+	fs := cache.FallthroughScope(ctx)
+	if fs == nil {
+		// No scope marker — /call-class handlers always stamp one, so a nil
+		// scope here is a background/non-readiness path (or cache-off, where
+		// WithFallthroughScope no-ops). Leave the fetch unbounded.
+		return ctx, func() {}
+	}
+	if _, gated := bootReadinessFetchScopes[fs.Path]; !gated {
+		// A /call or refresher scope — NOT readiness-critical. Byte-identical.
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, time.Duration(ms)*time.Millisecond)
+}
+
+// ExternalSeedFetchBounded reports whether externalSeedFetchCtx would apply a
+// wall-clock deadline to a fetch under ctx — i.e. whether ctx's
+// FallthroughScope is one of the boot-readiness scopes AND the bound is
+// enabled (D > 0). It is the SINGLE SOURCE OF TRUTH for the gating decision,
+// exported so a marker-liveness test in the dispatchers package can drive the
+// REAL production seed / walk / content-prewarm context builders (which live
+// there) all the way into THIS predicate, rather than re-asserting a
+// hand-copied scope-set that could drift
+// (feedback_falsifier_must_drive_real_boundary_not_install_crossed_state).
+//
+// It derives its answer by actually invoking externalSeedFetchCtx and checking
+// that the returned ctx is a DIFFERENT ctx value than the input — the bounded
+// path returns a fresh context.WithTimeout child, the no-op path returns the
+// parent ctx unchanged. This discriminates the helper's OWN wrapping and does
+// NOT give a false positive when the parent already carries an (inherited)
+// deadline, so the test can never pass against a helper that silently stopped
+// wrapping.
+func ExternalSeedFetchBounded(ctx context.Context) bool {
+	fctx, cancel := externalSeedFetchCtx(ctx)
+	defer cancel()
+	return fctx != ctx
+}

--- a/internal/resolvers/restactions/api/external_seed_bound_falsifier_test.go
+++ b/internal/resolvers/restactions/api/external_seed_bound_falsifier_test.go
@@ -1,0 +1,247 @@
+//go:build unit
+// +build unit
+
+// external_seed_bound_falsifier_test.go — fetch-level falsifiers for the
+// boot-seed external-fetch wall-clock bound
+// (docs/boot-seed-external-fetch-bound-design-2026-07-24.md).
+//
+// These drive the REAL production dispatch wrap — externalSeedFetchCtx +
+// httpFetchAllowingNonJSON exactly as resolve.go:1106-1107 calls them —
+// against an httptest.Server, so they exercise the real plumbing
+// RetryClient/backoff envelope, not a stub of it.
+//
+// Arms:
+//   - RED / discriminating (K>1×M>1): a production set MISSING one member
+//     leaves that vector's fetch UNBOUNDED (~D+backoff); the full set bounds
+//     every vector at ~D. Proves the scope set is COMPLETE + each member
+//     load-bearing (feedback_falsifier_shape_must_discriminate). Mutates the
+//     REAL production set (bootReadinessFetchScopes), not a shadow copy.
+//   - Retry-envelope truncation: a 5xx-always stub returns in ~D, NOT
+//     ~D+Σbackoff — proves ctx.WithTimeout truncates the WHOLE retry envelope
+//     (limiter + per-attempt + backoff sleeps), strictly stronger than a bare
+//     http.Client.Timeout.
+//   - Scope isolation: a /call (ScopeCallGeneric) scope is NOT cut at D — a
+//     slow external under a customer /call runs to completion, byte-identical.
+//   - Default / toggle: env unset → 5000ms active; env=0 → disabled (pre-fix).
+//
+// No kubeconfig, no kind cluster (feedback_no_go_test_against_remote_kubeconfig).
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	httpcall "github.com/krateoplatformops/plumbing/http/request"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// slowOrFailingServer returns an httptest.Server whose handler either sleeps
+// `bodyDelay` before a 200 (slow-but-eventually-OK) or always 5xx (retry
+// amplifier). It records the number of inbound attempts so the retry-envelope
+// arm can confirm >1 attempt actually occurred.
+func slowOrFailingServer(t *testing.T, status int, bodyDelay time.Duration) (url string, attempts *int64) {
+	t.Helper()
+	var n int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&n, 1)
+		if bodyDelay > 0 {
+			select {
+			case <-time.After(bodyDelay):
+			case <-r.Context().Done():
+				// The request ctx was cut (the wall-clock bound) — abandon.
+				return
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &n
+}
+
+// fetchUnderScope stamps `scope` (if non-empty) on a cache-enabled ctx, wraps
+// it with the PRODUCTION externalSeedFetchCtx exactly as resolve.go:1106 does,
+// then runs the REAL httpFetchAllowingNonJSON against serverURL. Returns the
+// wall-clock elapsed.
+func fetchUnderScope(t *testing.T, scope, serverURL string) time.Duration {
+	t.Helper()
+	ctx := xcontext.BuildContext(t.Context())
+	if scope != "" {
+		ctx = cache.WithFallthroughScope(ctx, scope)
+	}
+
+	fctx, fcancel := externalSeedFetchCtx(ctx)
+	defer fcancel()
+
+	verb := http.MethodGet
+	endpoint := endpoints.Endpoint{ServerURL: serverURL}
+	call := httpcall.RequestOptions{
+		RequestInfo: httpcall.RequestInfo{Verb: &verb},
+		Endpoint:    &endpoint,
+	}
+	start := time.Now()
+	_, _, _, _ = httpFetchAllowingNonJSON(fctx, call)
+	return time.Since(start)
+}
+
+// TestBound_DiscriminatingRED_EachScopeMemberIsLoadBearing — for each of the
+// two readiness scopes, a production set MISSING that member leaves ITS vector
+// UNBOUNDED (fetch runs to the slow server's full delay), while the full set
+// bounds it at ~D. K=2 scopes × M=2 set-configs (full vs missing-one).
+func TestBound_DiscriminatingRED_EachScopeMemberIsLoadBearing(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	// Tight bound so "bounded" (~150ms) is unambiguously below the slow
+	// server's 1200ms delay.
+	t.Setenv(envSeedExternalFetchTimeoutMS, "150")
+	const D = 150 * time.Millisecond
+	const slow = 1200 * time.Millisecond
+
+	url, _ := slowOrFailingServer(t, http.StatusOK, slow)
+
+	// Save + restore the REAL production set (no shadow copy — drift-proof).
+	orig := bootReadinessFetchScopes
+	t.Cleanup(func() { bootReadinessFetchScopes = orig })
+
+	for _, member := range []string{cache.ScopeBootPrewarmSeed, cache.ScopeBootPrewarmWalk} {
+		member := member
+		t.Run("full_set_bounds_"+member, func(t *testing.T) {
+			bootReadinessFetchScopes = map[string]struct{}{
+				cache.ScopeBootPrewarmSeed: {},
+				cache.ScopeBootPrewarmWalk: {},
+			}
+			el := fetchUnderScope(t, member, url)
+			if el >= slow {
+				t.Fatalf("full set: %s fetch NOT bounded (elapsed %v ≥ slow %v)", member, el, slow)
+			}
+			if el > D+800*time.Millisecond {
+				t.Fatalf("full set: %s fetch elapsed %v, expected ~D=%v (bounded)", member, el, D)
+			}
+		})
+		t.Run("set_missing_"+member+"_leaves_it_UNBOUNDED_RED", func(t *testing.T) {
+			// Drop exactly this member — the discriminating RED.
+			bootReadinessFetchScopes = map[string]struct{}{
+				cache.ScopeBootPrewarmSeed: {},
+				cache.ScopeBootPrewarmWalk: {},
+			}
+			delete(bootReadinessFetchScopes, member)
+
+			el := fetchUnderScope(t, member, url)
+			if el < slow {
+				t.Fatalf("RED FAILED TO DISCRIMINATE: %s fetch was bounded (elapsed %v < slow %v) even though its scope was DROPPED from the set — the bound does not actually key on this member, so the falsifier cannot prove the member is load-bearing.", member, el, slow)
+			}
+		})
+	}
+}
+
+// TestBound_RetryEnvelopeTruncation — a 5xx-always endpoint (retry amplifier)
+// under a boot-readiness scope returns in ~D, NOT ~D + Σbackoff. Proves the
+// ctx.WithTimeout truncates the WHOLE retry envelope (including the
+// inter-attempt backoff sleeps), which a bare http.Client.Timeout would not.
+func TestBound_RetryEnvelopeTruncation(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv(envSeedExternalFetchTimeoutMS, "250")
+	const D = 250 * time.Millisecond
+	// Force multiple retry attempts with a real backoff so, absent the ctx
+	// bound, the envelope would run far past D. base 200ms × several attempts.
+	t.Setenv("CLIENT_MAX_RETRIES", "5")
+	t.Setenv("CLIENT_BASE_BACKOFF", "200ms")
+	t.Setenv("CLIENT_MAX_BACKOFF", "5s")
+
+	url, attempts := slowOrFailingServer(t, http.StatusInternalServerError, 0)
+
+	el := fetchUnderScope(t, cache.ScopeBootPrewarmSeed, url)
+
+	// Bounded: must be well under the un-truncated envelope
+	// (200+400+800+1600ms ≈ 3s of backoff alone).
+	if el > 1500*time.Millisecond {
+		t.Fatalf("RED: 5xx retry envelope NOT truncated — elapsed %v, expected ~D=%v. The ctx deadline is not cutting the inter-attempt backoff sleeps (a bare http.Client.Timeout would leave them running).", el, D)
+	}
+	// The retry loop must actually have engaged (>1 attempt) or the truncation
+	// claim is vacuous.
+	if n := atomic.LoadInt64(attempts); n < 2 {
+		t.Fatalf("premise: only %d attempt(s) reached the 5xx server — the retry loop did not engage, so the retry-envelope-truncation claim is not exercised (raise CLIENT_MAX_RETRIES / lower backoff).", n)
+	}
+}
+
+// TestBound_ScopeIsolation_CallGenericNotCut — a slow external widget under a
+// /call scope (ScopeCallGeneric) is NOT cut at D: the customer /call runs to
+// completion, byte-identical to the pre-fix path.
+func TestBound_ScopeIsolation_CallGenericNotCut(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv(envSeedExternalFetchTimeoutMS, "150")
+	const slow = 600 * time.Millisecond
+
+	url, _ := slowOrFailingServer(t, http.StatusOK, slow)
+
+	el := fetchUnderScope(t, cache.ScopeCallGeneric, url)
+	if el < slow {
+		t.Fatalf("RED: a /call (ScopeCallGeneric) external fetch was CUT at D (elapsed %v < slow %v) — the bound must NOT touch customer /call scopes; a slow external widget on /call must run to completion.", el, slow)
+	}
+}
+
+// TestBound_DefaultAndToggle — env unset → 5000ms bound ACTIVE on a boot scope;
+// env=0 → disabled (pre-fix unbounded). Also asserts the shipped default is ON,
+// not off (a default-off flag would not fix the live backstop).
+func TestBound_DefaultAndToggle(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	t.Run("env_unset_default_5000_bound_ON", func(t *testing.T) {
+		// Explicitly ensure unset.
+		t.Setenv(envSeedExternalFetchTimeoutMS, "")
+		ctx := cache.WithFallthroughScope(xcontext.BuildContext(t.Context()), cache.ScopeBootPrewarmSeed)
+		fctx, cancel := externalSeedFetchCtx(ctx)
+		defer cancel()
+		dl, ok := fctx.Deadline()
+		if !ok {
+			t.Fatal("RED: env unset must default to a 5000ms bound (ON), but the ctx carries no deadline — the shipped default is NOT bounded. A default-off flag does not fix the live backstop.")
+		}
+		// Deadline should be ~5s out (allow slack).
+		if until := time.Until(dl); until <= 0 || until > 6*time.Second {
+			t.Fatalf("default deadline is %v out, expected ~5s (defaultSeedExternalFetchTimeoutMS=%d)", until, defaultSeedExternalFetchTimeoutMS)
+		}
+	})
+
+	t.Run("env_zero_disabled_prefix_behavior", func(t *testing.T) {
+		t.Setenv(envSeedExternalFetchTimeoutMS, "0")
+		ctx := cache.WithFallthroughScope(xcontext.BuildContext(t.Context()), cache.ScopeBootPrewarmSeed)
+		fctx, cancel := externalSeedFetchCtx(ctx)
+		defer cancel()
+		if _, ok := fctx.Deadline(); ok {
+			t.Fatal("RED: env=0 must DISABLE the bound (pre-fix unbounded behavior), but the ctx carries a deadline.")
+		}
+		if fctx != ctx {
+			t.Fatal("RED: env=0 must return the parent ctx unchanged (byte-identical no-op).")
+		}
+	})
+}
+
+// TestBound_Internal130NonRegression — an internal (non-external) resolve never
+// reaches resolve.go:1106, so its ctx is never handed to externalSeedFetchCtx.
+// We assert the wrap decision itself is byte-identical flag-ON vs flag-OFF for a
+// ctx with NO fallthrough scope (the shape a background/non-readiness caller
+// carries): the helper is a no-op either way, so no latch / L1-key is touched.
+func TestBound_Internal130NonRegression(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+
+	noScope := xcontext.BuildContext(t.Context())
+
+	for _, ms := range []string{"5000", "0"} {
+		t.Setenv(envSeedExternalFetchTimeoutMS, ms)
+		fctx, cancel := externalSeedFetchCtx(noScope)
+		if fctx != noScope {
+			cancel()
+			t.Fatalf("RED (#130): a no-scope (internal / background) ctx was WRAPPED at MS=%s — the bound must no-op when there is no boot-readiness scope, so internal informer-backed first-nav warming is byte-identical.", ms)
+		}
+		if _, ok := fctx.Deadline(); ok {
+			cancel()
+			t.Fatalf("RED (#130): a no-scope ctx acquired a deadline at MS=%s — must stay unbounded.", ms)
+		}
+		cancel()
+	}
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -1104,7 +1104,18 @@ func (r *resolveRun) dispatchOneCall(sc *stageCtx, i int) error {
 	// external data is re-fetched LIVE every /call and never persisted under a
 	// TTL it has no dep edge to invalidate.
 	cache.ExternalTouchedSinkFromContext(gctx).Bump()
-	res, jsonBytes, _, fetchErr := httpFetchAllowingNonJSON(gctx, call)
+	// Boot-readiness external-fetch wall-clock bound (external_seed_bound.go).
+	// The Bump() STAYS before the wrap so a timed-out fetch still records the
+	// external touch → the L1 Put is still declined → uniform with the
+	// refresher. On a boot readiness-critical scope (seed / discovery walk /
+	// content-prewarm pass) fctx carries a per-fetch deadline that truncates
+	// the WHOLE retry envelope (util.RetryClient honors req.Context() at every
+	// retry/backoff boundary); on /call + refresher scopes it is the parent
+	// gctx + a no-op cancel, so the fetch is byte-identical to the pre-fix
+	// path.
+	fctx, fcancel := externalSeedFetchCtx(gctx)
+	defer fcancel()
+	res, jsonBytes, _, fetchErr := httpFetchAllowingNonJSON(fctx, call)
 	if fetchErr != nil {
 		// A non-nil go error mirrors httpcall.Do's response.New(500, err)
 		// transport/build faults. res already carries the same 500 Failure


### PR DESCRIPTION
## PARKED — do NOT merge (Diego-reserved).

Boot-readiness external-fetch wall-clock bound. Origin: live west4-release 1.7.15 boot `readyz.backstop.fired reason=seed_incomplete elapsed_ms=480001`. Design: `docs/boot-seed-external-fetch-bound-design-2026-07-24.md`.

### Root cause
The single external GET dispatch at `resolve.go:1106-1107` is bounded only by the ctx deadline (120s cohort). No `http.Client.Timeout` is set and `util.RetryClient` retries idempotent GETs with exponential backoff, so one degraded external endpoint (obs-* ClickHouse) blocks ~120s per (widget × cohort) unit; N units overrun `pipGlobalTimeout=480s` → the seed returns `DeadlineExceeded` → the readiness backstop fires.

### Fix (additive; default BOUNDED at 5000ms — NOT default-off)
1. **New `externalSeedFetchCtx(ctx)`** (`internal/resolvers/restactions/api/external_seed_bound.go`): reads `RESOLVER_SEED_EXTERNAL_FETCH_TIMEOUT_MS` (string→ms→Duration, default **5000**); `<=0` disables (reproduces pre-fix outage); wraps `context.WithTimeout` ONLY when `FallthroughScope.Path ∈ {ScopeBootPrewarmSeed, ScopeBootPrewarmWalk}`, else returns `(ctx, no-op)` so `/call` + refresher are byte-identical. `context.WithTimeout` truncates the **whole** `RetryClient` envelope (limiter + per-attempt + backoff sleeps all honor `req.Context()`), strictly stronger than `http.Client.Timeout`.
2. **Wrap `resolve.go:1106`**: `Bump()` stays before the wrap (timed-out fetch still declines the L1 Put → uniform with refresher).
3. **Content-prewarm scope stamp** (`phase1_content_prewarm.go`): stamps `ScopeBootPrewarmWalk` on `withContentPrewarmSAContext` so the content-prewarm pass (obs-* apiRef resolves before `MarkPhase1Done`) is bounded. Behavior-neutral reuse (no new constant): the content pass resolves at `PerPage:-1`, which propagates verbatim down the nested-widget path to `shouldServeRAFullList` and short-circuits `IsPaginatedResolve(-1,-1)` before the scope is read.

### Default is BOUNDED/ON
`RESOLVER_SEED_EXTERNAL_FETCH_TIMEOUT_MS` defaults to **5000ms** when unset → the bound is live out of the box. `env=0` disables it (reproduces the outage). A default-off flag would NOT fix the live backstop.

### Falsifiers (all `-race`, RUN+PASS; content-pass arm RED-proven by neutering the stamp)
- Marker-liveness — 3 real prod ctx builders (`withCohortSeedContext` / `withPhase1SAContext` / `withContentPrewarmSAContext`) → real `ExternalSeedFetchBounded` predicate.
- K=2×M=2 discriminating RED — each scope member load-bearing (drop it → its vector unbounded).
- Retry-envelope truncation — 5xx-always stub returns ~D not ~D+Σbackoff.
- Scope-isolation — `/call` (ScopeCallGeneric) NOT cut at D.
- Default/toggle — unset→5000 ON, env=0→disabled.
- #130 non-regression — no-scope ctx wrap decision byte-identical flag-ON vs OFF.

### Dual-gate GREEN (against frozen SHA)
- **Architect: PASS** — all 6 items TRACED; walk-scope reuse confirmed behavior-neutral (content pass reaches `shouldServeRAFullList` transitively but `-1/-1` short-circuits).
- **PM: ACCEPT** — 5000ms default ratified, scope-isolation RED-proven, content-pass arm independently neuter-RED re-verified, symptom-disappearance traced.

### Chart (handled at cut, NOT here)
Snowplow chart needs `RESOLVER_SEED_EXTERNAL_FETCH_TIMEOUT_MS` exposed as a string env in values+configmap for toggle-ability. Code default 5000 works without it.

### Owed downstream (not this parked-PR gate)
On-cluster decisive proof: degraded ClickHouse on west4, flag ON → `readyz.backstop.fired` absent + latch ≪ 480s; RED control flag-OFF/pre-fix → still ~480001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1