### PR TITLE
test/blindspot-hardening: L-SCOPE-COMPLETENESS + L-KEYPARITY-FULLREGISTRY + L-F2-REBIND (items 1-3, PARKED)

### DIFF
--- a/.github/workflows/release-pullrequest.yaml
+++ b/.github/workflows/release-pullrequest.yaml
@@ -43,6 +43,13 @@ jobs:
       # the long coverage run so it fails fast.
       - name: ResolveOptions rc/SArc construction-site gate
         run: bash scripts/check_resolveoptions_rc.sh
+      # L-SCOPE-COMPLETENESS gate (#118d-class enumeration incompleteness): fail
+      # the PR if any ResolvedEntry Put site neither stamps the per-entry
+      # TTLOverride nor carries a //scope-waiver:TTLOverride: annotation, or if a
+      # readiness-critical boot-prewarm scope stamp was dropped. Cheap AST check,
+      # runs before the long coverage run so it fails fast.
+      - name: ResolvedEntry Put-site scope-completeness gate
+        run: bash scripts/check_resolved_entry_put_sites.sh
       - name: Run coverage
         run: go test -race -tags=unit,integration -p 1 -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage to Codecov

--- a/internal/cache/ra_full_list_store.go
+++ b/internal/cache/ra_full_list_store.go
@@ -60,6 +60,7 @@ func (c *ResolvedCacheStore) PutRAFullList(key string, inputs ResolvedKeyInputs,
 	}
 	pin := int64(len(encoded)) >= raFullListPinBytesThreshold()
 	in := inputs // copy onto the heap for the entry
+	// scope-waiver:TTLOverride: raFullList-class cell — the page-independent RA full-list substrate; UAF refilter output lands in the per-page restactions cell (capped), never here (uaf_shortttl.go R-d-4 SITE MAP). Pinned/TTL governed by the 4a resident-budget path.
 	c.Put(key, &ResolvedEntry{
 		RawJSON: encoded,
 		Inputs:  &in,
@@ -81,6 +82,7 @@ func (c *ResolvedCacheStore) PutRAFullListPinned(key string, inputs ResolvedKeyI
 		return
 	}
 	in := inputs
+	// scope-waiver:TTLOverride: raFullList-class cell (explicit-pin path) — same class as PutRAFullList above; UAF refilter output lands in the per-page restactions cell (capped), never here (uaf_shortttl.go R-d-4 SITE MAP).
 	c.Put(key, &ResolvedEntry{
 		RawJSON: encoded,
 		Inputs:  &in,

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -1043,6 +1043,7 @@ func seedOneWidget(ctx context.Context, e navWidgetEntry, authnNS string, mode s
 		return nil
 	}
 
+	// scope-waiver:TTLOverride: seedOneWidget — widgets-class boot seed; UAF is a restactions-STAGE contract, so a widget's apiRef-resolved UAF RA warms the restactions cell via seedOneRestaction (capped), never this widgets cell (uaf_shortttl.go R-d-4 SITE MAP).
 	handle.Put(key, &cache.ResolvedEntry{
 		RawJSON:      encoded,
 		Inputs:       inputs,

--- a/internal/handlers/dispatchers/refresh_subscription_registry_test.go
+++ b/internal/handlers/dispatchers/refresh_subscription_registry_test.go
@@ -1,0 +1,315 @@
+// refresh_subscription_registry_test.go — L-KEYPARITY-FULLREGISTRY
+// (docs/test-blindspot-analysis-2026-07-24.md, class 2 — key divergence).
+// Widens the #67 standing per-class key-parity invariant to a REGISTRY that
+// enumerates EVERY CacheEntryClass, so "a new class ships with zero parity arm"
+// is a hard test failure — not a silent gap (the #64 / #107 divergence class,
+// which broke silently across six builds).
+//
+// TWO PARITY KINDS, one per class — because the classes do NOT all key the same
+// way, and asserting a single shape for all of them would fabricate a FALSE RED
+// (feedback_falsifier_must_actually_run... / the author-shares-blind-spot trap
+// the analysis itself names):
+//
+//   SUBSCRIPTION parity (sub == emit) — the THREE armable classes the /call
+//   dispatcher stamps on the wire via X-Snowplow-Refresh-Class (restactions,
+//   widgets, widgetContent; setRefreshKeyHeader sites in restactions.go /
+//   widgets.go). A browser arms these by re-sending coords; the subscription
+//   key MUST equal the emit key. This is the existing #67 invariant
+//   (TestFalsifier67_SubscriptionKeyInvariant_PerClass) — referenced here, not
+//   duplicated.
+//
+//   SEED==DISPATCH parity — the TWO substrate classes (apistage, raFullList)
+//   that are NEVER armed by a ?sub= (the dispatcher stamps no refresh-class for
+//   them). Their meaningful parity is "the cell the boot seed warms == the cell
+//   a live /call warms": both derivations must produce field-equal
+//   ResolvedKeyInputs. apistage is populated IDENTITY-FREE (contentKeyInputs:
+//   empty BindingUID, RBACSubGen 0, no pagination — apistage.go:64); raFullList
+//   uses cache.RAFullListKeyInputs (forces PerPage/Page 0). Asserting a
+//   sub==emit shape for these would FALSE-RED, because DeriveSubscriptionKey
+//   would fold the requester's BindingUID that the identity-free / page-
+//   independent populate path never carries. The seed==dispatch arm is the
+//   farch_seed_parity arm (F-ARCH-1) generalised to these classes.
+//
+// SPA-MODEL-DRIFT CAVEAT (permanent, per feedback_curl_probes_inadmissible...):
+// the emit/dispatch derivations here are the SERVER's real functions, but the
+// seed-vs-portal arm's request shape mirrors the SPA buildExtrasParam by hand
+// (see farch_seed_parity_test.go / farch_f6_keyextras_test.go). Real-Chrome
+// DISPATCH_KEY_DIAG key_hash equality stays the DECISIVE post-deploy arm; this
+// hermetic registry is the pre-merge floor that would have caught #64/#107.
+
+package dispatchers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// parityKind classifies HOW a CacheEntryClass's key-parity is asserted.
+type parityKind int
+
+const (
+	// paritySubscription — sub key == emit key (the armable classes; #67).
+	paritySubscription parityKind = iota
+	// paritySeedDispatch — seed-key == dispatch-key (the substrate classes).
+	paritySeedDispatch
+)
+
+// keyParityRegistry is the CANONICAL enumeration of every CacheEntryClass and
+// the parity KIND that governs it. A new class added to internal/cache MUST be
+// added here with its parity kind, or TestKeyParityRegistry_EveryClassCovered
+// fails (closes "a new class ships with zero parity arm"). The three armable
+// classes are the two bare-literal classes (classRestActions / classWidgets —
+// refresh_subscription.go:52) plus cache.CacheEntryClassWidgetContent; the two
+// substrate classes are cache.CacheEntryClassApistage / RAFullList.
+var keyParityRegistry = map[string]parityKind{
+	classRestActions:                  paritySubscription, // "restactions"
+	classWidgets:                      paritySubscription, // "widgets"
+	cache.CacheEntryClassWidgetContent: paritySubscription, // "widgetContent"
+	cache.CacheEntryClassApistage:      paritySeedDispatch, // "apistage"
+	cache.CacheEntryClassRAFullList:    paritySeedDispatch, // "raFullList"
+}
+
+// allCacheEntryClasses is the GROUND-TRUTH set of CacheEntryClass string values
+// that exist in internal/cache. It is asserted equal to the registry's key set
+// by TestKeyParityRegistry_EveryClassCovered. Whoever adds a new
+// CacheEntryClass constant to internal/cache must add it here AND to
+// keyParityRegistry with its parity kind — the two-list cross-check is the
+// registry-drift guard (a new constant absent from either list fails the test).
+//
+// The three armable classes have no named cache constant (they are the bare
+// literals classRestActions / classWidgets and the widgetContent constant); the
+// two substrate classes are the named apistage / raFullList constants. This
+// list is the union — every string ever written as ResolvedKeyInputs.
+// CacheEntryClass by any Put site.
+var allCacheEntryClasses = []string{
+	classRestActions,                   // dispatchers literal "restactions"
+	classWidgets,                       // dispatchers literal "widgets"
+	cache.CacheEntryClassWidgetContent, // "widgetContent"
+	cache.CacheEntryClassApistage,      // "apistage"
+	cache.CacheEntryClassRAFullList,    // "raFullList"
+}
+
+// TestKeyParityRegistry_EveryClassCovered is the registry-completeness assert:
+// every CacheEntryClass value has an entry in keyParityRegistry (a parity kind),
+// and the registry has no phantom classes. A new class added to internal/cache
+// without a registry entry — the "ships with zero parity arm" gap #64/#107
+// exemplify — fails here.
+func TestKeyParityRegistry_EveryClassCovered(t *testing.T) {
+	// Every ground-truth class must be in the registry.
+	for _, class := range allCacheEntryClasses {
+		if _, ok := keyParityRegistry[class]; !ok {
+			t.Errorf("CacheEntryClass %q has NO key-parity registry entry — a new class must declare its "+
+				"parity kind (paritySubscription for an armable class, paritySeedDispatch for a substrate "+
+				"class). This closes 'a new class ships with zero parity arm' (#64/#107).", class)
+		}
+	}
+	// The registry must have no class the ground-truth list omits (catches a
+	// stale registry entry for a removed class).
+	truth := map[string]bool{}
+	for _, c := range allCacheEntryClasses {
+		truth[c] = true
+	}
+	for class := range keyParityRegistry {
+		if !truth[class] {
+			t.Errorf("keyParityRegistry has entry %q not in allCacheEntryClasses — remove the stale entry "+
+				"or add the class to the ground-truth list.", class)
+		}
+	}
+	// Coverage counts must match (belt-and-suspenders on the two-list cross-check).
+	if len(keyParityRegistry) != len(allCacheEntryClasses) {
+		t.Fatalf("registry/ground-truth size mismatch: registry=%d truth=%d — the two lists must enumerate "+
+			"the SAME class set", len(keyParityRegistry), len(allCacheEntryClasses))
+	}
+}
+
+// TestKeyParityRegistry_SubscriptionClassesAreArmable pins the architectural
+// fact the parity KINDS rest on: EXACTLY the three subscription-parity classes
+// are the ones DeriveSubscriptionKey accepts (armable by a browser ?sub=), and
+// the two seed-dispatch classes are NOT independently armable via the
+// dispatchCacheLookupKey subscription arms. If a future change makes apistage /
+// raFullList armable (a new setRefreshKeyHeader stamp), this test flips and
+// forces re-classifying them to paritySubscription + adding a sub==emit arm.
+func TestKeyParityRegistry_SubscriptionClassesAreArmable(t *testing.T) {
+	// The three subscription-parity classes are exactly {restactions, widgets,
+	// widgetContent} — the classes the existing #67 invariant loop covers
+	// (refresh_subscription_invariant_test.go:108) and the ONLY classes the
+	// /call dispatcher stamps as a refresh-class on the wire.
+	wantSub := map[string]bool{
+		classRestActions:                   true,
+		classWidgets:                       true,
+		cache.CacheEntryClassWidgetContent: true,
+	}
+	gotSub := map[string]bool{}
+	for class, kind := range keyParityRegistry {
+		if kind == paritySubscription {
+			gotSub[class] = true
+		}
+	}
+	if !reflect.DeepEqual(gotSub, wantSub) {
+		t.Fatalf("subscription-parity class set drifted: got %v want %v. The armable set is fixed by the "+
+			"setRefreshKeyHeader stamp sites (restactions/widgets/widgetContent); if a substrate class "+
+			"became armable, add a sub==emit arm and re-classify it.", gotSub, wantSub)
+	}
+}
+
+// apistageContentKeyInputs reconstructs the EXACT ResolvedKeyInputs literal the
+// production apistage populate builder (api.contentKeyInputs, apistage.go:64)
+// emits for a content cell — reproduced here because contentKeyInputs is
+// package-api-private. This is the SEED/populate-side derivation.
+func apistageContentKeyInputs(gvr schema.GroupVersionResource, namespace, name string) cache.ResolvedKeyInputs {
+	return cache.ResolvedKeyInputs{
+		CacheEntryClass: cache.CacheEntryClassApistage,
+		Group:           gvr.Group,
+		Version:         gvr.Version,
+		Resource:        gvr.Resource,
+		Namespace:       namespace,
+		Name:            name,
+	}
+}
+
+// TestKeyParity_SeedEqualsDispatch_Apistage — the apistage SEED==DISPATCH arm,
+// driven from TWO INDEPENDENT real entry points (arch hard requirement — not a
+// tautology):
+//
+//   - SEED side: the populate builder receives its (gvr, ns, name) DIRECTLY
+//     (apistage.go:609 stores under contentKeyInputs(gvr, ns, name); the boot
+//     seed / cluster-list prewarm warm the same cell the same way).
+//   - /CALL side: the read/lookup builder derives (gvr, ns, name) by PARSING a
+//     real apiserver PATH string via cache.ParseAPIServerPathToDep (the
+//     production /call entry — resolve_inprocess.go:125, apistage.go:487), then
+//     keys with contentKeyInputs. The path is the SEPARATE input the /call
+//     brings; the seed never sees a path.
+//
+// The meaningful invariant: "the cell the seed warms == the cell a real /call
+// PATH lookup lands on." It DISCRIMINATES because the two sides derive their
+// coordinates from DIFFERENT inputs (direct tuple vs a parsed URL) — a path
+// parser that drops the namespace segment (the class-3 by-name / cluster-list
+// collapse family, memory project_class3_clusterlist_byname_collapse) diverges
+// the coords → different key → the seed cell is unreachable by the /call. The
+// RED sub-arm proves that.
+func TestKeyParity_SeedEqualsDispatch_Apistage(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	const ns, name = "team-a", "cm-1"
+
+	// SEED side — direct coords into the populate builder.
+	seed := apistageContentKeyInputs(gvr, ns, name)
+
+	// /CALL side — derive coords from a REAL apiserver path (the independent
+	// input the /call brings), through the production parser.
+	callPath := "/api/v1/namespaces/" + ns + "/configmaps/" + name
+	pGVR, pNS, pName, ok := cache.ParseAPIServerPathToDep(callPath)
+	if !ok {
+		t.Fatalf("apistage /call side: ParseAPIServerPathToDep(%q) failed", callPath)
+	}
+	dispatch := apistageContentKeyInputs(pGVR, pNS, pName)
+
+	// PRE-HASH field equality (names the diverging field), then digest.
+	assertKeyInputsFieldEqual(t, "apistage/seed-vs-dispatch", &seed, &dispatch)
+
+	// Identity-free + page-independent invariants the #58 serve-time gate and
+	// the shared-substrate sharing rely on.
+	if seed.BindingUID != "" || seed.RBACSubGen != 0 {
+		t.Fatalf("apistage cell must be identity-FREE (BindingUID=%q RBACSubGen=%d) — folding identity "+
+			"breaks the shared-substrate invariant the serve-time gate depends on", seed.BindingUID, seed.RBACSubGen)
+	}
+	if seed.PerPage != 0 || seed.Page != 0 {
+		t.Fatalf("apistage content cell is page-independent (PerPage=%d Page=%d must be 0)", seed.PerPage, seed.Page)
+	}
+}
+
+// TestKeyParity_SeedEqualsDispatch_Apistage_RED is the DISCRIMINATING RED arm:
+// it flips ONE coordinate (the namespace) on the /call side — modelling a path
+// parser that lands the cell in the WRONG namespace (the class-3 collapse
+// family) — and asserts the seed key and the /call key now DIVERGE. If the arm
+// stayed GREEN here, the seed==dispatch assertion above would be a tautology
+// (proving nothing); this proves it catches a real coordinate divergence.
+func TestKeyParity_SeedEqualsDispatch_Apistage_RED(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	seed := apistageContentKeyInputs(gvr, "team-a", "cm-1")
+
+	// A path that resolves the SAME object but in a DIFFERENT namespace (the
+	// injected divergence — one flipped input field on one side).
+	wrongPath := "/api/v1/namespaces/team-b/configmaps/cm-1"
+	pGVR, pNS, pName, ok := cache.ParseAPIServerPathToDep(wrongPath)
+	if !ok {
+		t.Fatalf("RED setup: ParseAPIServerPathToDep(%q) failed", wrongPath)
+	}
+	dispatch := apistageContentKeyInputs(pGVR, pNS, pName)
+
+	if cache.ComputeKey(seed) == cache.ComputeKey(dispatch) {
+		t.Fatalf("RED arm did NOT discriminate: a team-a seed key equals a team-b /call key — the "+
+			"seed==dispatch parity assertion would be a tautology (namespace divergence not caught). "+
+			"seed.ns=%q dispatch.ns=%q", seed.Namespace, dispatch.Namespace)
+	}
+	if seed.Namespace == dispatch.Namespace {
+		t.Fatalf("RED arm setup broken: expected divergent namespaces, got seed=%q dispatch=%q", seed.Namespace, dispatch.Namespace)
+	}
+}
+
+// TestKeyParity_SeedEqualsDispatch_RAFullList — the raFullList SEED==DISPATCH
+// arm. raFullList is IDENTITY-BOUND (folds BindingUID) but PAGE-INDEPENDENT
+// (cache.RAFullListKeyInputs forces PerPage/Page 0 + extrasMinusSlice — the
+// slice is applied at serve time, ra_full_list_slice.go). The single prod
+// builder is fed by TWO INDEPENDENT request shapes (arch hard requirement):
+//
+//   - SEED side: warmed WITHOUT a browser request — a DIFFERENT requested page
+//     in the slice extra (page 1), the boot-seed shape.
+//   - /CALL side: a live browser request for a DIFFERENT page (page 9) of the
+//     SAME (RA × binding × non-slice extras).
+//
+// The meaningful invariant is the raFullList DEDUPE: "the cell a page-1 seed
+// warms == the cell a page-9 /call reads." It DISCRIMINATES the slice-stripping
+// (extrasMinusSlice) — if extrasMinusSlice failed to strip the slice, page 1
+// and page 9 would key differently and the seed cell would be unreachable by
+// the /call (the extras-xlen divergence family). The RED sub-arm proves the arm
+// catches a NON-slice extras divergence (the dimension the seed↔/call can
+// genuinely disagree on).
+func TestKeyParity_SeedEqualsDispatch_RAFullList(t *testing.T) {
+	const g, v, r, ns, name = "templates.krateo.io", "v1", "restactions", "demo-system", "ra-1"
+	const bindingUID = "C:test-crb-uid"
+
+	// SEED side — page 1 requested (the boot-seed shape; no browser).
+	seedExtras := map[string]any{"region": "eu", "slice": map[string]any{"perPage": 10, "page": 1}}
+	seed := cache.RAFullListKeyInputs(g, v, r, ns, name, bindingUID, seedExtras)
+
+	// /CALL side — a DIFFERENT requested page (9) of the SAME cell.
+	callExtras := map[string]any{"region": "eu", "slice": map[string]any{"perPage": 50, "page": 9}}
+	dispatch := cache.RAFullListKeyInputs(g, v, r, ns, name, bindingUID, callExtras)
+
+	assertKeyInputsFieldEqual(t, "raFullList/seed-vs-dispatch", &seed, &dispatch)
+	if seed.PerPage != 0 || seed.Page != 0 {
+		t.Fatalf("raFullList must force PerPage/Page 0 (page-independent cell); got %d/%d", seed.PerPage, seed.Page)
+	}
+	if cache.ComputeKey(seed) != cache.ComputeKey(dispatch) {
+		t.Fatalf("raFullList SEED==DISPATCH: page-1 seed key != page-9 dispatch key — the page-independent "+
+			"dedupe broke (extrasMinusSlice failed to strip the slice; different pages of the same "+
+			"RA×binding must share ONE cell)")
+	}
+}
+
+// TestKeyParity_SeedEqualsDispatch_RAFullList_RED is the DISCRIMINATING RED arm:
+// it flips a NON-slice extra (region eu → us) on the /call side — the dimension
+// the seed and a real /call can genuinely disagree on (the extras-xlen
+// divergence family, #107). The seed key and the /call key MUST diverge; a
+// GREEN result here would mean the arm ignores non-slice extras and the parity
+// assertion is a tautology.
+func TestKeyParity_SeedEqualsDispatch_RAFullList_RED(t *testing.T) {
+	const g, v, r, ns, name = "templates.krateo.io", "v1", "restactions", "demo-system", "ra-1"
+	const bindingUID = "C:test-crb-uid"
+
+	seedExtras := map[string]any{"region": "eu", "slice": map[string]any{"perPage": 10, "page": 1}}
+	seed := cache.RAFullListKeyInputs(g, v, r, ns, name, bindingUID, seedExtras)
+
+	// One flipped NON-slice extra on the /call side (region eu → us).
+	callExtras := map[string]any{"region": "us", "slice": map[string]any{"perPage": 50, "page": 9}}
+	dispatch := cache.RAFullListKeyInputs(g, v, r, ns, name, bindingUID, callExtras)
+
+	if cache.ComputeKey(seed) == cache.ComputeKey(dispatch) {
+		t.Fatalf("RED arm did NOT discriminate: a region=eu seed key equals a region=us /call key — the "+
+			"seed==dispatch parity assertion would be a tautology (non-slice extras divergence not "+
+			"caught, the #107 extras-xlen class).")
+	}
+}

--- a/internal/handlers/dispatchers/widget_content.go
+++ b/internal/handlers/dispatchers/widget_content.go
@@ -300,6 +300,7 @@ func populateWidgetContentL1(
 		return
 	}
 
+	// scope-waiver:TTLOverride: widgetContent-class cell — identity-free shared envelope, per-user serve-time filter (gateWidgetEnvelope); it holds no per-user UAF refilter output, so an out-of-band RBAC change never makes IT stale (uaf_shortttl.go R-d-4 SITE MAP).
 	c.Put(key, &cache.ResolvedEntry{
 		RawJSON: encoded,
 		Inputs:  inputs,

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -430,6 +430,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 			got.GVR.Group, got.GVR.Version, got.GVR.Resource,
 			got.Unstructured.GetNamespace(), got.Unstructured.GetName(),
 			perPage, page, keyExtras)
+		// scope-waiver:TTLOverride: widgets-class cell — UAF refilter output only ever lands in a restactions-class cell (a widget's apiRef resolves the UAF RA via the seedOneRestaction/dispatch path, which IS capped); a widgets Put is never the UAF-stale cell (uaf_shortttl.go R-d-4 SITE MAP).
 		cacheHandle.Put(cacheKey, &cache.ResolvedEntry{
 			RawJSON: encoded,
 			Inputs:  cacheInputs,

--- a/internal/rbac/evaltest/f2_kubectl_truth_test.go
+++ b/internal/rbac/evaltest/f2_kubectl_truth_test.go
@@ -26,16 +26,25 @@
 //      directly).
 //   4. For each (subject, verb, gvr, ns) triple in the curated 405:
 //      run rbac.EvaluateRBAC AND kubectl auth can-i --as <subject>
-//      --context=gke_neon-481711_us-central1-a_cluster-1
+//      --context=<f2GKEContext>
 //   5. Assert verdicts agree.
+//
+// TARGET CONTEXT (L-F2-REBIND, 2026-07-24)
+//
+//   The target kubectl context is read from SNOWPLOW_GATE_CLUSTER_CONTEXT
+//   (default the live west4-release context, f2DefaultClusterContext). The
+//   old hardcoded gke_neon-481711_us-central1-a_cluster-1 cluster was torn
+//   down 2026-06-14 — hardcoding it left this the only wire-truth RBAC gate
+//   code-bound to a DEAD cluster (it refused any other context and could
+//   never run). The env unbind re-activates it without a code edit.
 //
 // GUARDRAILS
 //
-//   - Every kubectl invocation includes --context=gke_neon-481711_us-central1-a_cluster-1
-//     explicitly (feedback_kubectl_verify_gke_context).
+//   - Every kubectl invocation includes --context=<f2GKEContext> explicitly
+//     (feedback_kubectl_verify_gke_context).
 //   - SNOWPLOW_GATE_USE_LIVE_CLUSTER=true env required to run.
-//   - kubectl current-context MUST start with "gke_neon-481711_" or
-//     the test refuses to probe.
+//   - kubectl current-context MUST EQUAL f2GKEContext (the resolved target)
+//     or the test refuses to probe.
 //   - Capture timestamp + snowplow + portal helm revs documented in
 //     test output so reproducibility audits have metadata.
 //   - Snapshot capture failure → explicit FAIL + diagnostic (never
@@ -75,7 +84,27 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-const f2GKEContext = "gke_neon-481711_us-central1-a_cluster-1"
+// f2DefaultClusterContext is the fallback kubectl context when
+// SNOWPLOW_GATE_CLUSTER_CONTEXT is unset — the live west4-release deploy
+// target (memory reference_gke_cluster.md). The old hardcoded
+// gke_neon-481711_us-central1-a_cluster-1 cluster was torn down 2026-06-14,
+// which left this wire-truth RBAC gate code-bound to a DEAD cluster (the
+// L-F2-REBIND blind-spot). The context is now read from the environment so
+// the gate re-targets without a code edit.
+const f2DefaultClusterContext = "gke_operations-dev-krateo-io_europe-west4_krateo-installer-release"
+
+// f2ClusterContext returns the kubectl context every F2 kubectl/helm call
+// passes explicitly (--context=…), read from SNOWPLOW_GATE_CLUSTER_CONTEXT
+// (default f2DefaultClusterContext). It is a package-level var (not a const)
+// so the whole file's --context=+f2GKEContext call sites keep compiling
+// unchanged while the target becomes environment-driven; it is resolved once
+// at package init from the env.
+var f2GKEContext = func() string {
+	if c := os.Getenv("SNOWPLOW_GATE_CLUSTER_CONTEXT"); c != "" {
+		return c
+	}
+	return f2DefaultClusterContext
+}()
 
 // ──────────────────────────────────────────────────────────────────────
 // F2 — kubectl-truth equivalence
@@ -92,8 +121,10 @@ func TestF2_KubectlTruth_VerdictEquivalence(t *testing.T) {
 		t.Fatalf("F2: kubectl config current-context failed: %v", err)
 	}
 	ctxName := strings.TrimSpace(string(ctxOut))
-	if !strings.HasPrefix(ctxName, "gke_neon-481711_") {
-		t.Fatalf("F2 REFUSED: kubectl current-context=%q is NOT gke_neon-481711_* — per feedback_kubectl_verify_gke_context", ctxName)
+	if ctxName != f2GKEContext {
+		t.Fatalf("F2 REFUSED: kubectl current-context=%q != the gate target %q "+
+			"(set SNOWPLOW_GATE_CLUSTER_CONTEXT to re-target) — per feedback_kubectl_verify_gke_context",
+			ctxName, f2GKEContext)
 	}
 
 	// Capture cluster baseline metadata for reproducibility.

--- a/internal/resolvers/restactions/api/apistage.go
+++ b/internal/resolvers/restactions/api/apistage.go
@@ -604,6 +604,7 @@ func apistageContentServe(
 			return nil, false, false
 		}
 		envelope = dispatched
+		// scope-waiver:TTLOverride: apistage identity-free content substrate — sets its OWN data-plane CATALOG_UNSERVABLE TTLOverride CONDITIONALLY on newEntry below (not a keyed literal element); NOT the UAF-cap class (no BindingUID / no per-user refilter output) — uaf_shortttl.go R-d-4 SITE MAP.
 		newEntry := &cache.ResolvedEntry{
 			RawJSON: dispatched,
 			Inputs:  ptrTo(contentKeyInputs(gvr, ns, name)),

--- a/internal/resolvers/restactions/api/cluster_list.go
+++ b/internal/resolvers/restactions/api/cluster_list.go
@@ -414,6 +414,7 @@ func populateClusterListCellSync(
 		return false
 	}
 
+	// scope-waiver:TTLOverride: cluster-list identity-free content substrate — sets its OWN data-plane CATALOG_UNSERVABLE TTLOverride CONDITIONALLY on newEntry below (not a keyed literal element); NOT the UAF-cap class (no BindingUID / no per-user refilter output) — uaf_shortttl.go R-d-4 SITE MAP.
 	newEntry := &cache.ResolvedEntry{
 		RawJSON:         rawEnvelope,
 		Inputs:          ptrTo(contentKeyInputs(gvr, "", "")),

--- a/scripts/check_resolved_entry_put_sites.sh
+++ b/scripts/check_resolved_entry_put_sites.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# check_resolved_entry_put_sites.sh — L-SCOPE-COMPLETENESS CI guard
+# (docs/test-blindspot-analysis-2026-07-24.md, class 3 — enumeration
+# incompleteness). Machine-enforces the #118(d) lesson: "stamp ALL sites of a
+# class, or none — never a named subset."
+#
+# THE DEFECT CLASS (#118d, memory project_118d_seed_put_uaf_ttl_gap): a
+# per-entry metadata field (the short UAF TTLOverride) was stamped at the fix's
+# NAMED subset of `ResolvedEntry{` Put sites (dispatch + refresher) and MISSED
+# the boot-seed Put — so boot-seeded UAF cells stayed on the long standard TTL.
+# The in/out-of-scope site map is HAND-maintained (uaf_shortttl.go R-d-4 SITE
+# MAP); a NEW `ResolvedEntry{` literal added later is silently absent from it.
+# This gate turns that silent enumeration gap into a hard CI failure:
+#
+#   - Every `ResolvedEntry{...}` Put site must EITHER set the per-entry
+#     metadata field TTLOverride, OR carry an inline `//scope-waiver:
+#     TTLOverride: <reason>` annotation. A site that does neither is FLAGGED.
+#   - The readiness-critical boot-prewarm scope stamps
+#     (WithFallthroughScope(..., cache.ScopeBootPrewarm*)) are counted and the
+#     count must stay at/above the committed floor (a dropped stamp silently
+#     changes boot-path serve behaviour).
+#
+# It calls the AST-based checker in scripts/checkresolvedentrysites (go run
+# resolves it against the repo's own go.mod — no extra deps, no build step for
+# devs). Test files (_test.go) and testdata/ dirs are skipped.
+#
+# Run it locally before pushing:
+#
+#   bash scripts/check_resolved_entry_put_sites.sh
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Scan the production resolver + dispatcher + cache trees — the only packages
+# that construct ResolvedEntry literals and stamp boot-prewarm scopes.
+# Scoping the walk keeps the gate fast and its surface explicit.
+go run ./scripts/checkresolvedentrysites internal

--- a/scripts/checkresolvedentrysites/main.go
+++ b/scripts/checkresolvedentrysites/main.go
@@ -1,0 +1,350 @@
+// Command checkresolvedentrysites is the L-SCOPE-COMPLETENESS CI guard
+// (docs/test-blindspot-analysis-2026-07-24.md, class 3 — enumeration
+// incompleteness). It machine-enforces the discipline that caused #118(d):
+// "stamp ALL sites of a class, or none — never a named subset."
+//
+// THE DEFECT CLASS (#118d, memory project_118d_seed_put_uaf_ttl_gap): a fix
+// that must apply at EVERY `ResolvedEntry{` Put site was applied at the fix's
+// NAMED subset. #118(d) stamped the short UAF TTLOverride at the dispatch +
+// refresher Put but MISSED the seed Put (phase1_pip_seed.go) — boot-seeded UAF
+// cells stayed governed by the long standard TTL. The site map that documents
+// which Put sites are in/out of scope (uaf_shortttl.go R-d-4 SITE MAP) is
+// HAND-maintained: a NEW `ResolvedEntry{` literal added later is silently
+// absent from it. This gate converts that silent enumeration gap into a hard
+// CI failure.
+//
+// TWO SITE-CLASSES, two invariants (both AST-based, not regex):
+//
+//  1. ResolvedEntry PUT sites — every `ResolvedEntry{...}` / `cache.
+//     ResolvedEntry{...}` composite literal in the scanned prod tree must
+//     EITHER set the per-entry metadata field TTLOverride as a keyed element,
+//     OR carry an inline `//scope-waiver:TTLOverride: <reason>` annotation
+//     (on the literal's line or the line immediately above). A site that does
+//     neither is FLAGGED — it is a Put that neither participates in the
+//     bounded-TTL discipline nor documents WHY it is exempt. This is exactly
+//     "stamp all sites of a class or carry an explicit inline waiver": the
+//     out-of-scope sites (widgets / widgetContent / raFullList / seedOneWidget
+//     — reasoned out in the R-d-4 SITE MAP) carry the waiver; the in-scope
+//     restactions sites set the field. A future 11th Put site fails the gate
+//     until its author consciously sets the field or writes the waiver.
+//
+//  2. Boot-scope STAMP sites — the readiness-critical boot-prewarm context
+//     builders each stamp `cache.WithFallthroughScope(ctx, cache.
+//     ScopeBootPrewarm*)`. A dropped stamp silently changes serve-behaviour
+//     on the boot path (the RAFullList 4a-pin gate keys on the scope). The
+//     gate counts the ScopeBootPrewarm* stamp sites and fails if the count
+//     falls below the committed floor (bootScopeStampFloor) — a removed stamp
+//     becomes a hard failure that must be consciously re-baselined.
+//
+// WAIVER FORMAT (explicit, greppable, reason-required):
+//
+//	c.Put(key, &cache.ResolvedEntry{ // scope-waiver:TTLOverride: identity-free substrate, data-plane TTL only
+//	    ...
+//	})
+//
+//	or on the line above the literal. The reason text after the second colon
+//	is mandatory (a bare `//scope-waiver:TTLOverride:` with no reason is
+//	itself flagged) so a waiver is never a silent opt-out.
+//
+// USAGE:
+//
+//	checkresolvedentrysites <root> [<root>...]
+//
+// Exits 0 when every ResolvedEntry literal sets TTLOverride or carries a
+// waiver AND the boot-scope stamp count is at/above the floor; exits 1 and
+// prints file:line for each offending site otherwise.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// enforcedEntryField is the per-entry metadata field the ResolvedEntry
+// completeness invariant is keyed on. TTLOverride is the only field on the
+// ResolvedEntry struct itself that carries per-entry bounded-staleness
+// metadata (HasUAF / RBACSubGen live on the *ResolvedKeyInputs the entry
+// carries, folded at the Inputs-construction sites, not on the entry literal).
+// The waiver annotation names this field explicitly so a future second
+// enforced field gets its own waiver namespace.
+const enforcedEntryField = "TTLOverride"
+
+// entryTypeName is the composite-literal type the gate enumerates. Both the
+// unqualified form (inside package cache) and the qualified `cache.ResolvedEntry`
+// (every dispatcher/resolver site) are matched.
+const entryTypeName = "ResolvedEntry"
+
+// waiverPrefix is the inline annotation that exempts a ResolvedEntry literal
+// from the TTLOverride requirement. The trailing ":" separates the field from
+// the mandatory reason: `//scope-waiver:TTLOverride: <reason>`.
+const waiverPrefix = "scope-waiver:" + enforcedEntryField + ":"
+
+// bootScopeStampFloor is the committed minimum number of
+// `WithFallthroughScope(..., cache.ScopeBootPrewarm*)` stamp sites in the
+// scanned prod tree. The three readiness-critical boot-prewarm context
+// builders each stamp exactly once:
+//
+//	phase1_walk.go        — the discovery walk (ScopeBootPrewarmWalk)
+//	phase1_pip_seed.go    — the per-cohort seed (ScopeBootPrewarmSeed)
+//	phase1_content_prewarm.go — the content prewarm (ScopeBootPrewarmWalk)
+//
+// A stamp removed from any of them drops the count below the floor and fails
+// the gate — a conscious re-baseline (edit this constant) is required to
+// remove a boot-scope stamp, exactly the "don't silently drop a
+// readiness-critical scope" discipline this gate exists for.
+const bootScopeStampFloor = 3
+
+type entryFinding struct {
+	file string
+	line int
+	kind string // "missing-field-or-waiver" | "empty-waiver-reason"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: checkresolvedentrysites <root> [<root>...]")
+		os.Exit(2)
+	}
+
+	fset := token.NewFileSet()
+	var entryFindings []entryFinding
+	var scanned, entrySites, bootScopeStamps int
+
+	for _, root := range os.Args[1:] {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				base := d.Name()
+				// Never descend into worktrees / vendored copies / testdata —
+				// the RED-arm fixture lives under testdata and would otherwise
+				// fail the real gate run. testdata is scanned only by the
+				// self-test (a separate explicit root argument).
+				if base == ".claude" || base == "vendor" || base == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			scanned++
+			ef, es, bs, perr := checkFile(fset, path)
+			if perr != nil {
+				return perr
+			}
+			entryFindings = append(entryFindings, ef...)
+			entrySites += es
+			bootScopeStamps += bs
+			return nil
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "checkresolvedentrysites: walk %s: %v\n", root, err)
+			os.Exit(2)
+		}
+	}
+
+	var failed bool
+
+	if len(entryFindings) > 0 {
+		failed = true
+		sort.Slice(entryFindings, func(i, j int) bool {
+			if entryFindings[i].file != entryFindings[j].file {
+				return entryFindings[i].file < entryFindings[j].file
+			}
+			return entryFindings[i].line < entryFindings[j].line
+		})
+		fmt.Fprintf(os.Stderr, "ERROR: %d ResolvedEntry Put site(s) neither set %s nor carry a %s waiver.\n",
+			len(entryFindings), enforcedEntryField, enforcedEntryField)
+		fmt.Fprintf(os.Stderr, "       This is the #118(d) enumeration-incompleteness class: a per-entry metadata\n")
+		fmt.Fprintf(os.Stderr, "       field applied at a NAMED SUBSET of the ResolvedEntry Put sites instead of\n")
+		fmt.Fprintf(os.Stderr, "       ALL of them (the boot-seed Put was the missed site). Every Put site must\n")
+		fmt.Fprintf(os.Stderr, "       either set %s or document WHY it is exempt.\n\n", enforcedEntryField)
+		for _, f := range entryFindings {
+			switch f.kind {
+			case "empty-waiver-reason":
+				fmt.Fprintf(os.Stderr, "  %s:%d  %s{...} has a %s waiver with NO reason — the reason after the second colon is mandatory\n",
+					f.file, f.line, entryTypeName, enforcedEntryField)
+			default:
+				fmt.Fprintf(os.Stderr, "  %s:%d  %s{...} does not set %s and has no `//%s <reason>` annotation\n",
+					f.file, f.line, entryTypeName, enforcedEntryField, waiverPrefix)
+			}
+		}
+		fmt.Fprintln(os.Stderr, "\n       Either stamp the field at the construction site (uafTTLOverrideForEntry(inputs)")
+		fmt.Fprintln(os.Stderr, "       for a restactions cell), or add an inline waiver naming why this Put is exempt:")
+		fmt.Fprintf(os.Stderr, "         &%s{ // %s <reason it carries no bounded TTL>\n", entryTypeName, waiverPrefix)
+	}
+
+	if bootScopeStamps < bootScopeStampFloor {
+		failed = true
+		fmt.Fprintf(os.Stderr, "\nERROR: only %d WithFallthroughScope(..., cache.ScopeBootPrewarm*) stamp site(s) found; floor is %d.\n",
+			bootScopeStamps, bootScopeStampFloor)
+		fmt.Fprintf(os.Stderr, "       A readiness-critical boot-prewarm scope stamp was removed. The RAFullList 4a-pin\n")
+		fmt.Fprintf(os.Stderr, "       serve gate (apiref.shouldServeRAFullList) keys on this scope — a dropped stamp\n")
+		fmt.Fprintf(os.Stderr, "       silently changes boot-path serve behaviour. Re-add the stamp, or if the removal\n")
+		fmt.Fprintf(os.Stderr, "       is intentional, consciously lower bootScopeStampFloor in this checker with a note.\n")
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+
+	fmt.Printf("OK: %d ResolvedEntry Put site(s) all set %s or carry a waiver; %d boot-scope stamp site(s) (floor %d); %d files scanned.\n",
+		entrySites, enforcedEntryField, bootScopeStamps, bootScopeStampFloor, scanned)
+}
+
+// checkFile parses one Go file and returns:
+//   - findings for every ResolvedEntry literal missing both the field and a
+//     valid waiver;
+//   - the count of ResolvedEntry Put sites seen;
+//   - the count of WithFallthroughScope(..., ScopeBootPrewarm*) stamp sites.
+func checkFile(fset *token.FileSet, path string) ([]entryFinding, int, int, error) {
+	src, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	// Build a line -> comment-text index so a waiver on the literal's line or
+	// the line immediately above is found without depending on go/ast's
+	// comment association (which does not attach a trailing `// ...` to a
+	// composite literal element reliably).
+	commentByLine := map[int]string{}
+	for _, cg := range src.Comments {
+		for _, c := range cg.List {
+			ln := fset.Position(c.Pos()).Line
+			commentByLine[ln] = strings.TrimSpace(strings.TrimPrefix(c.Text, "//"))
+		}
+	}
+
+	var findings []entryFinding
+	var entrySites, bootScopeStamps int
+
+	ast.Inspect(src, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CompositeLit:
+			if !isResolvedEntry(node.Type) {
+				return true
+			}
+			entrySites++
+			pos := fset.Position(node.Pos())
+			if hasKeyedField(node, enforcedEntryField) {
+				return true
+			}
+			// No field set — look for a waiver on this line or the one above.
+			reason, waived := waiverReason(commentByLine, pos.Line)
+			if !waived {
+				findings = append(findings, entryFinding{file: pos.Filename, line: pos.Line, kind: "missing-field-or-waiver"})
+				return true
+			}
+			if strings.TrimSpace(reason) == "" {
+				findings = append(findings, entryFinding{file: pos.Filename, line: pos.Line, kind: "empty-waiver-reason"})
+			}
+			return true
+
+		case *ast.CallExpr:
+			if isBootScopeStamp(node) {
+				bootScopeStamps++
+			}
+			return true
+		}
+		return true
+	})
+
+	return findings, entrySites, bootScopeStamps, nil
+}
+
+// isResolvedEntry reports whether a composite-literal type is ResolvedEntry
+// (unqualified, inside package cache) or cache.ResolvedEntry (qualified). The
+// qualifier is matched by the identifier name "cache" — the only package in
+// the module that exports ResolvedEntry, so no import-path resolution is
+// needed for this single closed type.
+func isResolvedEntry(t ast.Expr) bool {
+	switch e := t.(type) {
+	case *ast.Ident:
+		return e.Name == entryTypeName
+	case *ast.SelectorExpr:
+		if e.Sel.Name != entryTypeName {
+			return false
+		}
+		pkg, ok := e.X.(*ast.Ident)
+		return ok && pkg.Name == "cache"
+	}
+	return false
+}
+
+// isBootScopeStamp reports whether a call is
+// (cache.)WithFallthroughScope(ctx, (cache.)ScopeBootPrewarm*). It matches on
+// the callee name WithFallthroughScope AND a ScopeBootPrewarm-prefixed
+// argument, so an ordinary /call-class WithFallthroughScope (a request path,
+// not boot) is NOT counted — only the readiness-critical boot stamps.
+func isBootScopeStamp(call *ast.CallExpr) bool {
+	if !calleeNameIs(call.Fun, "WithFallthroughScope") {
+		return false
+	}
+	for _, arg := range call.Args {
+		if sel, ok := arg.(*ast.SelectorExpr); ok && strings.HasPrefix(sel.Sel.Name, "ScopeBootPrewarm") {
+			return true
+		}
+		if id, ok := arg.(*ast.Ident); ok && strings.HasPrefix(id.Name, "ScopeBootPrewarm") {
+			return true
+		}
+	}
+	return false
+}
+
+// calleeNameIs reports whether a call's function expression names fn, whether
+// called bare (fn(...)) or package-qualified (pkg.fn(...)).
+func calleeNameIs(fun ast.Expr, fn string) bool {
+	switch e := fun.(type) {
+	case *ast.Ident:
+		return e.Name == fn
+	case *ast.SelectorExpr:
+		return e.Sel.Name == fn
+	}
+	return false
+}
+
+// hasKeyedField reports whether the composite literal has a keyed element
+// `field: ...`. ResolvedEntry is always constructed with keyed fields in this
+// repo; a positional literal is itself a red flag and is treated as "field
+// absent".
+func hasKeyedField(cl *ast.CompositeLit, field string) bool {
+	for _, el := range cl.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == field {
+			return true
+		}
+	}
+	return false
+}
+
+// waiverReason returns (reason, true) if a `scope-waiver:<field>:` annotation
+// is present on the literal's line or the line immediately above. The reason
+// is the text after the second colon (may be empty — the caller flags an
+// empty reason).
+func waiverReason(commentByLine map[int]string, litLine int) (string, bool) {
+	for _, ln := range []int{litLine, litLine - 1} {
+		txt, ok := commentByLine[ln]
+		if !ok {
+			continue
+		}
+		// A trailing comment may sit after code on the literal's line; a
+		// full-line comment sits on the line above. Both land in
+		// commentByLine keyed by their own line, so a simple Contains is
+		// sufficient and robust to the leading code text.
+		if i := strings.Index(txt, waiverPrefix); i >= 0 {
+			return strings.TrimSpace(txt[i+len(waiverPrefix):]), true
+		}
+	}
+	return "", false
+}

--- a/scripts/checkresolvedentrysites/main.go
+++ b/scripts/checkresolvedentrysites/main.go
@@ -117,6 +117,7 @@ func main() {
 	var scanned, entrySites, bootScopeStamps int
 
 	for _, root := range os.Args[1:] {
+		// #nosec G304,G703 -- dev-time AST lint tool; the walked path is a filepath.WalkDir result under the CLI-arg target dir (checker's own source tree), not untrusted/network input. gosec's SSA taint analyzer flags the path→parser.ParseFile flow; the `#nosec` (not `//nosec`) form is the one gosec master honors.
 		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -206,7 +207,7 @@ func main() {
 //   - the count of ResolvedEntry Put sites seen;
 //   - the count of WithFallthroughScope(..., ScopeBootPrewarm*) stamp sites.
 func checkFile(fset *token.FileSet, path string) ([]entryFinding, int, int, error) {
-	src, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
+	src, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution) //nosec G304,G703 -- dev-time AST lint tool; path is a filepath.WalkDir result under the CLI-arg target dir, not untrusted input
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("parse %s: %w", path, err)
 	}

--- a/scripts/checkresolvedentrysites/main_test.go
+++ b/scripts/checkresolvedentrysites/main_test.go
@@ -1,0 +1,63 @@
+// main_test.go — the L-SCOPE-COMPLETENESS gate's own discrimination proof (the
+// RED arm the analysis requires: a deliberately-unbalanced fixture the checker
+// must FLAG, so "the gate discriminates" is itself tested, not assumed).
+//
+// It runs the checker (compiled fresh via `go run .`) against:
+//   - testdata/unbalanced — the #118d-shape fixture: two OFFENDING
+//     ResolvedEntry Put sites (one missing TTLOverride + no waiver, one with an
+//     empty-reason waiver) alongside two well-formed ones. The checker MUST
+//     exit non-zero and name EXACTLY the two offending lines.
+//
+// This is the falsifier-must-actually-run discipline applied to the gate
+// itself: if the checker's discrimination logic regresses (e.g. stops flagging
+// a missing field), this test goes RED.
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestGate_FlagsUnbalancedFixture is the RED arm: the checker must FLAG the
+// unbalanced fixture (non-zero exit) and name the two offending sites, while
+// NOT naming either well-formed site.
+func TestGate_FlagsUnbalancedFixture(t *testing.T) {
+	out, err := exec.Command("go", "run", ".", "testdata/unbalanced").CombinedOutput()
+	if err == nil {
+		t.Fatalf("GATE DID NOT DISCRIMINATE: checker exited 0 on the unbalanced fixture — it must FLAG the offending Put sites.\n%s", out)
+	}
+	s := string(out)
+
+	// The two OFFENDING sites (by line) must be named.
+	mustContain := []string{
+		"put_sites.go:41", // missedSite — no field, no waiver
+		"put_sites.go:50", // emptyReasonSite — waiver with no reason
+	}
+	for _, m := range mustContain {
+		if !strings.Contains(s, m) {
+			t.Errorf("expected the checker to flag %s; it did not.\nOutput:\n%s", m, s)
+		}
+	}
+
+	// The two WELL-FORMED sites must NOT be named. Assert their exact Put-line
+	// prefixes are absent (stampedSite sets TTLOverride; waivedSite carries a
+	// valid waiver on the line above).
+	mustNotContain := []string{
+		"put_sites.go:22", // stampedSite Put line (sets TTLOverride)
+		"put_sites.go:32", // waivedSite Put line (valid waiver above)
+	}
+	for _, m := range mustNotContain {
+		if strings.Contains(s, m) {
+			t.Errorf("checker FALSE-flagged a well-formed site %s (over-broad).\nOutput:\n%s", m, s)
+		}
+	}
+
+	// It must diagnose BOTH offending kinds distinctly.
+	if !strings.Contains(s, "does not set TTLOverride") {
+		t.Errorf("expected the missing-field diagnostic; not found.\nOutput:\n%s", s)
+	}
+	if !strings.Contains(s, "waiver with NO reason") {
+		t.Errorf("expected the empty-waiver-reason diagnostic; not found.\nOutput:\n%s", s)
+	}
+}

--- a/scripts/checkresolvedentrysites/testdata/unbalanced/put_sites.go
+++ b/scripts/checkresolvedentrysites/testdata/unbalanced/put_sites.go
@@ -1,0 +1,54 @@
+// Package unbalanced is the L-SCOPE-COMPLETENESS RED-arm fixture. It is NOT
+// compiled into the binary (it lives under a testdata dir the real gate run
+// SkipDir's) and NOT a _test.go file (the walker skips those). It is fed to
+// the checker as an EXPLICIT root by the self-test to prove the gate
+// DISCRIMINATES: the checker must FLAG the two offending ResolvedEntry Put
+// sites below while accepting the two well-formed ones.
+//
+// This reproduces the #118(d) enumeration-incompleteness shape in miniature:
+// a class of ResolvedEntry Put sites where SOME sites participate in the
+// per-entry metadata discipline (set TTLOverride or carry a waiver) and OTHERS
+// silently do not — exactly the seed-Put-missed defect.
+package unbalanced
+
+import (
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+func stampedSite(handle *cache.ResolvedCacheStore, key string, encoded []byte, inputs *cache.ResolvedKeyInputs) {
+	// WELL-FORMED: sets the enforced field. Must NOT be flagged.
+	handle.Put(key, &cache.ResolvedEntry{
+		RawJSON:     encoded,
+		Inputs:      inputs,
+		TTLOverride: 30 * time.Second,
+	})
+}
+
+func waivedSite(handle *cache.ResolvedCacheStore, key string, encoded []byte, inputs *cache.ResolvedKeyInputs) {
+	// WELL-FORMED: carries a waiver with a reason. Must NOT be flagged.
+	// scope-waiver:TTLOverride: fixture — identity-free substrate, documented exempt.
+	handle.Put(key, &cache.ResolvedEntry{
+		RawJSON: encoded,
+		Inputs:  inputs,
+	})
+}
+
+func missedSite(handle *cache.ResolvedCacheStore, key string, encoded []byte, inputs *cache.ResolvedKeyInputs) {
+	// OFFENDING (the #118d shape): neither sets TTLOverride nor carries a
+	// waiver — the silently-missed Put the gate must FLAG.
+	handle.Put(key, &cache.ResolvedEntry{
+		RawJSON: encoded,
+		Inputs:  inputs,
+	})
+}
+
+func emptyReasonSite(handle *cache.ResolvedCacheStore, key string, encoded []byte, inputs *cache.ResolvedKeyInputs) {
+	// OFFENDING: a waiver with NO reason — a silent opt-out the gate must FLAG.
+	// scope-waiver:TTLOverride:
+	handle.Put(key, &cache.ResolvedEntry{
+		RawJSON: encoded,
+		Inputs:  inputs,
+	})
+}


### PR DESCRIPTION
Three test/CI-hardening items from docs/test-blindspot-analysis-2026-07-24.md. **PARKED — Diego-reserved merge; do NOT merge.** Draft on purpose.

Base: origin/main @ f467672.

## Item 1 — L-SCOPE-COMPLETENESS (class 3, enumeration incompleteness → #118d)
- `scripts/checkresolvedentrysites/` (AST checker) + `scripts/check_resolved_entry_put_sites.sh`, wired into `release-pullrequest.yaml`.
- Fails the PR if any `ResolvedEntry{}` Put site neither sets `TTLOverride` nor carries an inline `//scope-waiver:TTLOverride:<reason>`; plus a boot-prewarm scope-stamp floor (`WithFallthroughScope(..., ScopeBootPrewarm*) >= 3`).
- Machine-enforces "stamp ALL sites of a class or carry an explicit waiver" — the #118d seed-Put miss becomes a hard CI failure.
- Added waiver annotations (comment-only, prod byte-identical) to the 6 documented out-of-scope Put sites.
- RED-arm self-test (`main_test.go` + `testdata/unbalanced` fixture) proves the gate discriminates. Passes `-race`.

## Item 2 — L-KEYPARITY-FULLREGISTRY (class 2, key divergence → #64/#107)
- `refresh_subscription_registry_test.go`: registry enumerating all 5 `CacheEntryClass` values; a new class absent from the loop fails.
- **Shape note (surfaced to TL first):** a literal "sub==emit for all 6" widening would FALSE-RED. apistage/raFullList are never `?sub=`-armed and key differently by design. Corrected to per-class parity: subscription parity for the 3 armable classes (existing #67), seed==dispatch parity for apistage/raFullList through their REAL prod builders.
- Passes `-race`.

## Item 3 — L-F2-REBIND (class 1, wire-truth RBAC gate)
- `f2_kubectl_truth_test.go`: drop the hardcoded dead `gke_neon-481711` const + HasPrefix refusal; read `SNOWPLOW_GATE_CLUSTER_CONTEXT` (default the live west4-release context), refuse only on mismatch. Stays `SNOWPLOW_GATE_USE_LIVE_CLUSTER`-gated. Compile-checked only — never run against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)