### PR TITLE
fix(prewarm): un-throttle the Phase-1 roots-read client (#120)

### DIFF
--- a/internal/handlers/dispatchers/phase1_roots_unthrottled_test.go
+++ b/internal/handlers/dispatchers/phase1_roots_unthrottled_test.go
@@ -1,0 +1,186 @@
+// phase1_roots_unthrottled_test.go — #120 falsifier for the boot-critical
+// navigation-roots read.
+//
+// ROOT CAUSE (#120): the roots-read dynamic client at phase1_walk.go was
+// built directly from the shared rc (main.go's rest.InClusterConfig()),
+// which carries no QPS / RateLimiter — so client-go synthesises its default
+// 5-QPS / 10-burst token-bucket limiter for it. On a slow-apiserver boot the
+// very first roots read (the frontend-config ConfigMap Get) can lose its
+// tryThrottle Wait to the startupProbe ctx deadline BEFORE the request is
+// sent — no nav roots, no recursive walk, proactive informer registration
+// starved.
+//
+// FIX (#120): rootsReadRESTConfig(rc) returns a shallow copy of rc with
+// QPS=-1 / Burst=0, so the roots client's limiter is nil (client-go only
+// builds a bucket when qps > 0) and tryThrottleWithInfo returns immediately
+// — the boot-critical roots path can never deadline on the throttle.
+//
+// These are HERMETIC unit tests: they drive the REAL client-go throttle path
+// (dynamic.NewForConfig → Request.tryThrottle → RateLimiter.Wait) against an
+// httptest apiserver, exercising the exact production helper
+// rootsReadRESTConfig. No cluster.
+//
+// ARMS:
+//   - RED (pre-fix posture): the client built from the UN-tuned rc with a
+//     PRE-DRAINED token bucket (the boot condition) + a tight ctx — the read
+//     DEADLINES in tryThrottle, proving the limiter is the cause.
+//   - GREEN (with fix): the SAME drained-bucket rc passed through
+//     rootsReadRESTConfig — the limiter is dropped, so the SAME tight-ctx read
+//     COMPLETES.
+//   - NON-MUTATION: rootsReadRESTConfig(rc) does NOT mutate the shared rc's
+//     QPS / Burst / RateLimiter — the shared-rc safety invariant the fix
+//     depends on (rc also backs the informer/metadata/discovery/config-vars/
+//     secrets/controller-health clients).
+
+package dispatchers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sdynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// configMapReplyServer is a minimal apiserver that answers the roots
+// ConfigMap Get with a valid (empty) ConfigMap object. It records whether the
+// HTTP handler was ever reached — the discriminator between "throttle
+// deadlined before the request left client-go" and "the request actually ran".
+type configMapReplyServer struct {
+	*httptest.Server
+	reached bool
+}
+
+func newConfigMapReplyServer(t *testing.T) *configMapReplyServer {
+	t.Helper()
+	s := &configMapReplyServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.reached = true
+		w.Header().Set("Content-Type", "application/json")
+		// A well-formed ConfigMap so the dynamic Get decodes cleanly. The
+		// test only cares that the read COMPLETES vs deadlines, not the body.
+		_, _ = w.Write([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"x","namespace":"krateo-system"},"data":{"config.json":"{}"}}`))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// drainedBucketConfig builds a *rest.Config pointed at srv whose RateLimiter
+// is a real token bucket with its single token already consumed — the
+// slow-boot condition where the next Wait must block for a refill. This is
+// the client-go default-limiter posture (a bucket that gates requests), made
+// deterministic by pre-draining rather than depending on wall-clock QPS.
+func drainedBucketConfig(t *testing.T, srv *configMapReplyServer) *rest.Config {
+	t.Helper()
+	rl := flowcontrol.NewTokenBucketRateLimiter(1, 1)
+	if !rl.TryAccept() {
+		t.Fatalf("precondition: fresh burst-1 bucket should grant its first token")
+	}
+	// Bucket now empty; the next Wait blocks ~1s for a refill at QPS=1.
+	return &rest.Config{
+		Host:        srv.URL,
+		RateLimiter: rl,
+	}
+}
+
+// getRootsConfigMap performs the SAME dynamic ConfigMap Get the roots read
+// uses (readFrontendConfig → dynCli.Resource(configMapGVR).Get), through the
+// real client-go throttle path, under the given ctx. dynCfg is the config the
+// dynamic client is built from — the arm under test.
+func getRootsConfigMap(ctx context.Context, dynCfg *rest.Config) error {
+	cli, err := k8sdynamic.NewForConfig(dynCfg)
+	if err != nil {
+		return err
+	}
+	_, err = cli.Resource(configMapGVR).Namespace("krateo-system").Get(ctx, "x", metav1.GetOptions{})
+	return err
+}
+
+// TestRootsRead_DrainedLimiter_DeadlinesWithoutFix is the RED arm: the pre-fix
+// posture (un-tuned rc + drained default-style bucket) under a tight ctx
+// DEADLINES in the client-side throttle before the request is sent.
+func TestRootsRead_DrainedLimiter_DeadlinesWithoutFix(t *testing.T) {
+	srv := newConfigMapReplyServer(t)
+	rc := drainedBucketConfig(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := getRootsConfigMap(ctx, rc) // NO fix: rc used as-is
+	if err == nil {
+		t.Fatalf("RED arm expected the roots read to fail (throttle should deadline), got nil error")
+	}
+	// client-go wraps the throttle-time ctx-deadline as a rate-limiter error.
+	if !strings.Contains(err.Error(), "rate limiter Wait") {
+		t.Fatalf("RED arm expected a client rate-limiter Wait deadline error, got: %v", err)
+	}
+	if srv.reached {
+		t.Fatalf("RED arm: the HTTP request should NEVER have left client-go (throttle deadlined first), but the apiserver handler was reached")
+	}
+}
+
+// TestRootsRead_Unthrottled_CompletesWithFix is the GREEN arm: the SAME
+// drained-bucket rc, once passed through rootsReadRESTConfig (the fix), has no
+// limiter — so the SAME tight-ctx read COMPLETES and reaches the apiserver.
+func TestRootsRead_Unthrottled_CompletesWithFix(t *testing.T) {
+	srv := newConfigMapReplyServer(t)
+	rc := drainedBucketConfig(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := getRootsConfigMap(ctx, rootsReadRESTConfig(rc)) // fix applied
+	if err != nil {
+		t.Fatalf("GREEN arm expected the roots read to complete under the fix, got: %v", err)
+	}
+	if !srv.reached {
+		t.Fatalf("GREEN arm: the apiserver handler should have been reached (no throttle to deadline)")
+	}
+}
+
+// TestRootsReadRESTConfig_DoesNotMutateSharedConfig pins the load-bearing
+// safety invariant: the fix COPIES rc before tuning, so the shared rc — which
+// also backs the informer factory, metadata, discovery, config-vars-watch,
+// secrets and controller-health clients — keeps its throttling untouched.
+func TestRootsReadRESTConfig_DoesNotMutateSharedConfig(t *testing.T) {
+	origLimiter := flowcontrol.NewTokenBucketRateLimiter(5, 10)
+	rc := &rest.Config{
+		Host:        "https://example.invalid",
+		QPS:         5,
+		Burst:       10,
+		RateLimiter: origLimiter,
+	}
+
+	got := rootsReadRESTConfig(rc)
+
+	// The COPY carries the un-throttled posture.
+	if got.QPS != -1 {
+		t.Errorf("roots config QPS = %v, want -1", got.QPS)
+	}
+	if got.Burst != 0 {
+		t.Errorf("roots config Burst = %v, want 0", got.Burst)
+	}
+	if got.RateLimiter != nil {
+		t.Errorf("roots config RateLimiter = %v, want nil (QPS<=0 only disables throttling when RateLimiter is nil)", got.RateLimiter)
+	}
+	if got == rc {
+		t.Errorf("rootsReadRESTConfig returned the SAME pointer as rc; must be a copy")
+	}
+
+	// The shared rc is UNTOUCHED — the whole point of copying.
+	if rc.QPS != 5 {
+		t.Errorf("shared rc.QPS mutated to %v, want 5 (unchanged)", rc.QPS)
+	}
+	if rc.Burst != 10 {
+		t.Errorf("shared rc.Burst mutated to %v, want 10 (unchanged)", rc.Burst)
+	}
+	if rc.RateLimiter != origLimiter {
+		t.Errorf("shared rc.RateLimiter changed; want the original limiter pointer preserved")
+	}
+}

--- a/internal/handlers/dispatchers/phase1_walk.go
+++ b/internal/handlers/dispatchers/phase1_walk.go
@@ -319,7 +319,25 @@ func Phase1Warmup(ctx context.Context, rc *rest.Config, authnNS string) error {
 		return saErr
 	}
 
-	dynCli, dynErr := k8sdynamic.NewForConfig(rc)
+	// #120: build the roots-read client from an UN-THROTTLED shallow copy of
+	// rc. The shared rc carries client-go's default client-side rate limiter
+	// (QPS 5 / Burst 10) — main.go's rest.InClusterConfig() sets neither QPS
+	// nor RateLimiter, so NewForConfig synthesises the 5/10 token bucket
+	// (client-go rest/config.go:373-382). On a slow-apiserver boot the very
+	// first roots read (the frontend-config ConfigMap Get in
+	// listNavigationRootsFromConfigMap) can lose its tryThrottle Wait to the
+	// startupProbe ctx deadline BEFORE the request is ever sent — no nav
+	// roots, no recursive walk, proactive informer registration starved.
+	// Disabling the limiter (QPS=-1/Burst=0) makes tryThrottleWithInfo return
+	// nil immediately (rest/request.go:667 nil-limiter short-circuit; -1 QPS
+	// leaves RateLimiter nil at config.go:380 `qps > 0`), so the boot-critical
+	// roots path can never deadline on the throttle. Server-side API Priority
+	// & Fairness remains authoritative. This mirrors the SA-client posture
+	// (internal/dynamic/sa_client.go:170-171). rootsReadRESTConfig copies rc
+	// (rest.CopyConfig) before tuning so the shared rc — which also backs the
+	// informer factory, metadata, discovery, config-vars-watch, secrets and
+	// controller-health clients — keeps its throttling untouched.
+	dynCli, dynErr := k8sdynamic.NewForConfig(rootsReadRESTConfig(rc))
 	if dynErr != nil {
 		log.Warn("phase1.warmup.no_dyn_client",
 			slog.String("subsystem", "cache"),
@@ -988,6 +1006,44 @@ func rootKey(root *unstructured.Unstructured) string {
 // pathological CR graph that the visited-set somehow fails to dedupe. It
 // is NOT a per-resource policy — it is a uniform recursion-safety bound.
 const phase1MaxWalkDepth = 32
+
+// rootsReadRESTConfig returns a shallow copy of rc with the client-side
+// rate limiter disabled (QPS=-1 / Burst=0), for the boot-critical
+// navigation-roots read only.
+//
+// #120: the shared rc (main.go's rest.InClusterConfig()) has no QPS /
+// RateLimiter set, so k8sdynamic.NewForConfig gives it client-go's default
+// 5-QPS / 10-burst token bucket. On a slow-apiserver boot the roots
+// ConfigMap Get can lose its tryThrottle Wait to the startupProbe ctx
+// deadline before the request is sent — starving the recursive walk and the
+// proactive informer registration it drives. QPS<=0 leaves the copy's
+// RateLimiter nil (client-go rest/config.go:373-382 only builds a bucket
+// when qps > 0), so tryThrottleWithInfo returns nil immediately
+// (rest/request.go:667). Server-side API Priority & Fairness stays
+// authoritative. Mirrors the SA-client posture (internal/dynamic/
+// sa_client.go:170-171).
+//
+// The COPY is load-bearing: the caller passes the SAME rc to the informer
+// factory, metadata / discovery, config-vars-watch, secrets and
+// controller-health clients; mutating rc in place would strip throttling
+// from all of them. rest.CopyConfig duplicates the config by value (QPS and
+// Burst are scalars), so tuning the copy leaves rc untouched.
+//
+// RateLimiter is cleared on the COPY: CopyConfig duplicates RateLimiter by
+// POINTER, and NewForConfig honours a non-nil RateLimiter verbatim — QPS<=0
+// only takes effect when RateLimiter is nil (client-go rest/config.go:370).
+// In production rc.RateLimiter is nil (rest.InClusterConfig leaves it unset,
+// as sa_client.go likewise assumes) so this is a no-op there; clearing it
+// makes the un-throttled posture hold unconditionally even if rc ever
+// carries a pre-built limiter, and keeps the shared rc's limiter untouched
+// (we clear the field on our private copy, not the shared limiter object).
+func rootsReadRESTConfig(rc *rest.Config) *rest.Config {
+	c := rest.CopyConfig(rc)
+	c.QPS = -1
+	c.Burst = 0
+	c.RateLimiter = nil
+	return c
+}
 
 // resolveNavigationRoot resolves one navigation-root CR through the
 // STANDARD widget resolver under the snowplow SA identity, then


### PR DESCRIPTION
## PARKED — DRAFT, Diego-reserved merge. Do NOT merge; awaiting dual-review gate.

### Problem (#120)
Phase-1's boot-critical navigation-roots read (the frontend-config ConfigMap `Get` in `listNavigationRootsFromConfigMap`) was issued through a dynamic client built directly from the shared `rc` (`main.go`'s `rest.InClusterConfig()`). That `rc` sets neither `QPS` nor `RateLimiter`, so client-go synthesises its **default client-side rate limiter (QPS 5 / Burst 10)** for the roots client. On a slow-apiserver boot the read's `tryThrottle` `Wait` can lose to the startupProbe ctx deadline **before the request is ever sent** → no navigation roots → the recursive widget walk never runs → the proactive informer registration it drives is starved.

### Fix (Option A — one file, ~6 LOC + doc)
New helper `rootsReadRESTConfig(rc)` returns `rest.CopyConfig(rc)` with `QPS=-1`, `Burst=0`, `RateLimiter=nil`; the call site at `phase1_walk.go` becomes `k8sdynamic.NewForConfig(rootsReadRESTConfig(rc))`.

- `QPS<=0` makes `NewForConfig` leave the limiter nil (client-go `rest/config.go:373-382` only builds a bucket when `qps > 0`) → `tryThrottleWithInfo` returns immediately (`rest/request.go:667`) → the roots path can never deadline on the throttle.
- Server-side API Priority & Fairness stays authoritative. Mirrors the SA-client posture (`internal/dynamic/sa_client.go:170-171`).
- **The copy is load-bearing**: the shared `rc` also backs the informer factory, metadata, discovery, config-vars-watch, secrets and controller-health clients — mutating it in place would strip throttling from all of them. `rest.CopyConfig` duplicates by value, so tuning the copy leaves `rc` untouched.
- `RateLimiter=nil` on the copy: `CopyConfig` duplicates `RateLimiter` by pointer and `NewForConfig` honours a non-nil limiter verbatim (`QPS<=0` only takes effect when it's nil). In production `rc.RateLimiter` is nil so this is a no-op, but it makes the un-throttled posture hold unconditionally and never touches the shared limiter object.

### Falsifier (hermetic, no cluster — drives the real client-go throttle path against an `httptest` apiserver)
- **RED** `TestRootsRead_DrainedLimiter_DeadlinesWithoutFix`: pre-fix posture (drained bucket + tight ctx) deadlines in `tryThrottle`, apiserver never reached.
- **GREEN** `TestRootsRead_Unthrottled_CompletesWithFix`: the same drained-bucket `rc` through `rootsReadRESTConfig` has no limiter → same tight-ctx read completes.
- **non-mutation** `TestRootsReadRESTConfig_DoesNotMutateSharedConfig`: shared `rc`'s `QPS`/`Burst`/`RateLimiter` unchanged.

All three `--- PASS` under `-race -count=1`. Discrimination-verified: neutering the fix flips GREEN + non-mutation red.

### Scope
Only the roots-read client. The broader boot-client limiter-posture audit (config-vars-watch / secrets / controller-health / eager-register clients, same 5/10 default) is a **separate follow-up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1