### PR TITLE
fix(rbac): #123 name-aware userAccessFilter refilter — honor resourceNames-scoped grants (PARKED)

### DIFF
--- a/apis/templates/v1/core.go
+++ b/apis/templates/v1/core.go
@@ -196,6 +196,34 @@ type UserAccessFilterSpec struct {
 	// +optional
 	// +kubebuilder:default=".metadata.namespace"
 	NamespaceFrom string `json:"namespaceFrom,omitempty"`
+	// NameFrom is a JQ path expression evaluated against each returned
+	// object to derive the per-object NAME for the EvaluateRBAC call.
+	// Symmetric with NamespaceFrom (which derives the per-object
+	// namespace): NameFrom derives the per-object name so a
+	// resourceNames-scoped RBAC grant (a Role/ClusterRole rule with a
+	// non-empty resourceNames, valid only for name-specific verbs —
+	// get/update/patch/delete) is honoured. Typical values:
+	//   - ".metadata.name" (the default) for a K8s object.
+	//   - "." when the items are bare name strings (the namespaces-stage
+	//     post-filter shape — the projected item IS the name).
+	//
+	// Optional with a default of ".metadata.name": when the field is
+	// ABSENT the refilter evaluates ".metadata.name" against each object.
+	// Without the derived name the EvaluateRBAC call carries an empty
+	// Name, and a resourceNames-scoped grant (which requires the request
+	// name to appear in rule.resourceNames) matches NOTHING — every named
+	// object is silently dropped (issue #123: under-serve / fail-closed).
+	// The default only fires when the field is omitted; an explicit "."
+	// still overrides it verbatim.
+	//
+	// Note: NameFrom has NO effect on collection verbs
+	// (list/watch/create/deletecollection): the RBAC evaluator scopes
+	// resourceNames to name-specific verbs only, so a plain list grant is
+	// evaluated identically whether or not a Name is threaded.
+	//
+	// +optional
+	// +kubebuilder:default=".metadata.name"
+	NameFrom string `json:"nameFrom,omitempty"`
 }
 
 // ObjectReference is a reference to a named object in a specified namespace.

--- a/crds/templates.krateo.io_restactions.yaml
+++ b/crds/templates.krateo.io_restactions.yaml
@@ -168,6 +168,34 @@ spec:
                             Group is the API group of the checked resource. Empty string
                             = core group. Required (use "" explicitly for core).
                           type: string
+                        nameFrom:
+                          default: .metadata.name
+                          description: |-
+                            NameFrom is a JQ path expression evaluated against each returned
+                            object to derive the per-object NAME for the EvaluateRBAC call.
+                            Symmetric with NamespaceFrom (which derives the per-object
+                            namespace): NameFrom derives the per-object name so a
+                            resourceNames-scoped RBAC grant (a Role/ClusterRole rule with a
+                            non-empty resourceNames, valid only for name-specific verbs —
+                            get/update/patch/delete) is honoured. Typical values:
+                              - ".metadata.name" (the default) for a K8s object.
+                              - "." when the items are bare name strings (the namespaces-stage
+                                post-filter shape — the projected item IS the name).
+
+                            Optional with a default of ".metadata.name": when the field is
+                            ABSENT the refilter evaluates ".metadata.name" against each object.
+                            Without the derived name the EvaluateRBAC call carries an empty
+                            Name, and a resourceNames-scoped grant (which requires the request
+                            name to appear in rule.resourceNames) matches NOTHING — every named
+                            object is silently dropped (issue #123: under-serve / fail-closed).
+                            The default only fires when the field is omitted; an explicit "."
+                            still overrides it verbatim.
+
+                            Note: NameFrom has NO effect on collection verbs
+                            (list/watch/create/deletecollection): the RBAC evaluator scopes
+                            resourceNames to name-specific verbs only, so a plain list grant is
+                            evaluated identically whether or not a Name is threaded.
+                          type: string
                         namespaceFrom:
                           default: .metadata.namespace
                           description: |-

--- a/internal/rbac/evaluate.go
+++ b/internal/rbac/evaluate.go
@@ -628,6 +628,21 @@ var nameSpecificVerbs = map[string]struct{}{
 	"delete": {},
 }
 
+// IsNameSpecificVerb reports whether verb acts on a single named object —
+// i.e. whether a resourceNames-scoped rule (and therefore the request's
+// object Name) can EVER matter for this verb. It is the exact predicate
+// resourceNameMatches uses internally, exported so callers that derive a
+// per-object Name (e.g. the userAccessFilter refilter's NameFrom, #123) can
+// skip that derivation for collection verbs — where the Name is never
+// consulted — rather than fail-closed on a Name-derivation error that would
+// be irrelevant to the grant. The "*" verb wildcard on a request is not a
+// real request verb (requests carry a concrete verb), so it is not listed;
+// resourceNameMatches handles the rule-side wildcard separately.
+func IsNameSpecificVerb(verb string) bool {
+	_, ok := nameSpecificVerbs[verb]
+	return ok
+}
+
 // resourceNameMatches implements Kubernetes `ResourceNameMatches`
 // semantics for a single PolicyRule (0.30.109, G1):
 //

--- a/internal/resolvers/restactions/api/jqvalue_test.go
+++ b/internal/resolvers/restactions/api/jqvalue_test.go
@@ -506,8 +506,9 @@ func TestSite3_NamespaceFrom_Consumer(t *testing.T) {
 			Resource:      "compositions",
 		}
 		nsExpr, nsCode := compileNamespaceFrom(uaf)
+		nameExpr, nameCode := compileNameFrom(uaf)
 		permitted := evalSingle(context.Background(), log, "alice", nil, uaf,
-			[]string{"compositions"}, item, nsExpr, nsCode)
+			[]string{"compositions"}, item, nsExpr, nsCode, nameExpr, nameCode)
 		if permitted {
 			t.Errorf("multi-yield NamespaceFrom permitted the item; want denied (fail-closed)")
 		}
@@ -527,8 +528,9 @@ func TestSite3_NamespaceFrom_Consumer(t *testing.T) {
 		if nsCode != nil {
 			t.Fatalf("parse-error NamespaceFrom %q must fail to compile (nsCode==nil)", uaf.NamespaceFrom)
 		}
+		nameExpr, nameCode := compileNameFrom(uaf)
 		permitted := evalSingle(context.Background(), log, "alice", nil, uaf,
-			[]string{"compositions"}, item, nsExpr, nsCode)
+			[]string{"compositions"}, item, nsExpr, nsCode, nameExpr, nameCode)
 		if permitted {
 			t.Errorf("parse-error NamespaceFrom permitted the item; want denied")
 		}

--- a/internal/resolvers/restactions/api/refilter.go
+++ b/internal/resolvers/restactions/api/refilter.go
@@ -120,9 +120,10 @@ func applyUserAccessFilter(ctx context.Context, dict map[string]any, apiCall *te
 			// wrapper (cluster-scoped GET-by-name). Treat the whole
 			// map as the single object. #121 1b — compile the
 			// NamespaceFrom expression once (single item, but shares the
-			// hoisted signature).
+			// hoisted signature). #123 — compile NameFrom too.
 			nsExpr, nsCode := compileNamespaceFrom(uaf)
-			permitted := evalSingle(ctx, log, user.Username, user.Groups, uaf, resources, v, nsExpr, nsCode)
+			nameExpr, nameCode := compileNameFrom(uaf)
+			permitted := evalSingle(ctx, log, user.Username, user.Groups, uaf, resources, v, nsExpr, nsCode, nameExpr, nameCode)
 			res.EvaluateRBACCalls++
 			if permitted {
 				res.Kept++
@@ -207,13 +208,25 @@ func refilterSlice(ctx context.Context, log *slog.Logger, username string, group
 	// compile-error branch did per item.
 	nsExpr, nsCode := compileNamespaceFrom(uaf)
 
+	// #123 — compile the per-item NameFrom expression ONCE for the whole
+	// slice, symmetric with NamespaceFrom above. NameFrom derives each
+	// object's NAME, threaded into EvaluateOptions.Name so that a
+	// resourceNames-scoped RBAC grant (Role/ClusterRole rule with a
+	// non-empty resourceNames, valid only for name-specific verbs) is
+	// honoured. Pre-#123 the serve path passed no Name → every
+	// resourceNames-scoped grant matched nothing → all named objects were
+	// silently dropped (under-serve / fail-closed). Same hoist-once
+	// mechanism and fail-closed contract as nsCode: a compile error yields
+	// nameCode==nil → evalSingle denies the item.
+	nameExpr, nameCode := compileNameFrom(uaf)
+
 	for _, item := range items {
 		switch item.(type) {
 		case map[string]any, string:
 			// Object OR bare scalar — both reach the evaluator. evalSingle
-			// resolves NamespaceFrom against the item (jq handles a string
-			// receiver fine) and calls EvaluateRBAC.
-			permitted := evalSingle(ctx, log, username, groups, uaf, resources, item, nsExpr, nsCode)
+			// resolves NamespaceFrom + NameFrom against the item (jq handles a
+			// string receiver fine) and calls EvaluateRBAC.
+			permitted := evalSingle(ctx, log, username, groups, uaf, resources, item, nsExpr, nsCode, nameExpr, nameCode)
 			calls++
 			if permitted {
 				kept = append(kept, item)
@@ -247,7 +260,7 @@ func refilterSlice(ctx context.Context, log *slog.Logger, username string, group
 //
 // JQ-eval errors and RBAC errors both fail closed. An EMPTY `resources`
 // set denies (no resource to grant against) — never allow-all.
-func evalSingle(ctx context.Context, log *slog.Logger, username string, groups []string, uaf *templates.UserAccessFilterSpec, resources []string, item any, nsExpr string, nsCode *gojq.Code) bool {
+func evalSingle(ctx context.Context, log *slog.Logger, username string, groups []string, uaf *templates.UserAccessFilterSpec, resources []string, item any, nsExpr string, nsCode *gojq.Code, nameExpr string, nameCode *gojq.Code) bool {
 	// #121 1b — nsExpr + nsCode are the ONCE-compiled NamespaceFrom
 	// expression, hoisted out of the per-item loop by the caller
 	// (compileNamespaceFrom). nsExpr is kept for error/log fidelity; nsCode
@@ -270,6 +283,41 @@ func evalSingle(ctx context.Context, log *slog.Logger, username string, groups [
 	}
 	namespace := ns
 
+	// #123 — derive the per-object NAME so a resourceNames-scoped grant is
+	// honoured. The name only ever matters for a NAME-SPECIFIC verb
+	// (get/update/patch/delete): the RBAC evaluator scopes resourceNames to
+	// exactly those verbs (rbac.IsNameSpecificVerb, the same predicate
+	// resourceNameMatches uses), so for a COLLECTION verb (list/watch/…) the
+	// Name is never consulted. We therefore evaluate NameFrom ONLY for
+	// name-specific verbs; for collection verbs Name stays "" — byte-identical
+	// to the pre-#123 serve path (which passed no Name), and, critically,
+	// avoids fail-closing on a NameFrom JQ error that would be IRRELEVANT to a
+	// list grant (e.g. the namespaces-stage bare-string shape where the item
+	// is a name string, not an object with .metadata.name). This is not a
+	// resource/path special-case — it is the evaluator's own verb contract.
+	name := ""
+	if rbac.IsNameSpecificVerb(uaf.Verb) {
+		// nameExpr + nameCode are the ONCE-compiled NameFrom expression,
+		// hoisted by the caller (compileNameFrom), symmetric with nsExpr/nsCode.
+		// A nil nameCode means the expression failed to compile — fail-closed
+		// (deny the item), identical to the NamespaceFrom compile-error branch.
+		if nameCode == nil {
+			log.Warn("userAccessFilter: NameFrom JQ compile failed; treating item as denied",
+				slog.String("expr", nameExpr),
+			)
+			return false
+		}
+		n, err := evalJQStringCompiled(ctx, nameCode, item)
+		if err != nil {
+			log.Warn("userAccessFilter: NameFrom JQ eval failed; treating item as denied",
+				slog.String("expr", nameExpr),
+				slog.Any("err", err),
+			)
+			return false
+		}
+		name = n
+	}
+
 	// OR semantics: keep the item iff the user is permitted on ANY
 	// resource in the set. An empty set yields no iterations -> false
 	// (fail-closed — an unresolvable / empty resource set never permits).
@@ -283,6 +331,12 @@ func evalSingle(ctx context.Context, log *slog.Logger, username string, groups [
 			Group:     uaf.Group,
 			Resource:  resource,
 			Namespace: namespace,
+			// #123 — thread the per-object name so a resourceNames-scoped
+			// grant (name-specific verb only) matches the named object.
+			// Empty for collection verbs is harmless: the evaluator scopes
+			// resourceNames to name-specific verbs, so a plain list grant is
+			// evaluated identically whether or not Name is set (INERTNESS).
+			Name: name,
 			// Ship L1 (0.30.252): per-item caller discards
 			// matchedBindingUID — skip the CRB/RB stable-sort.
 			SkipBindingUID: true,
@@ -294,6 +348,7 @@ func evalSingle(ctx context.Context, log *slog.Logger, username string, groups [
 				slog.String("group", uaf.Group),
 				slog.String("resource", resource),
 				slog.String("namespace", namespace),
+				slog.String("name", name),
 				slog.Any("err", err),
 			)
 			continue // a transient evaluator error on one resource must
@@ -336,6 +391,40 @@ func compileNamespaceFrom(uaf *templates.UserAccessFilterSpec) (string, *gojq.Co
 		return nsExpr, nil
 	}
 	return nsExpr, code
+}
+
+// compileNameFrom resolves the effective NameFrom expression for a UAF and
+// compiles it ONCE (#123), returning (expr, code). Symmetric with
+// compileNamespaceFrom: it centralises the default so the per-item loop and
+// the single-object branches share one derivation — the expression is
+// item-independent, so it is compiled here, before any item is evaluated,
+// and reused across every item.
+//
+// #123 — an absent/empty NameFrom defaults to ".metadata.name" (the
+// dominant K8s-object shape). The derived name is threaded into
+// EvaluateOptions.Name so a resourceNames-scoped RBAC grant (a rule with a
+// non-empty resourceNames, valid only for name-specific verbs —
+// get/update/patch/delete) is honoured. Pre-#123 the serve path passed no
+// Name → every resourceNames-scoped grant matched nothing → all named
+// objects were silently dropped (under-serve / fail-closed). The CRD-level
+// +kubebuilder:default fills this for stored RESTAction CRs; this in-code
+// default is the belt-and-suspenders for pre-default CRs and any caller
+// passing a UAF with an empty NameFrom directly. An explicit "." (the
+// namespaces-stage bare-name-string shape) still overrides verbatim.
+//
+// A compile error returns (expr, nil): evalSingle then fails closed (deny),
+// identical to the compileNamespaceFrom compile-error branch. The
+// ModuleLoader matches the NamespaceFrom compile (jqsupport.ModuleLoader()).
+func compileNameFrom(uaf *templates.UserAccessFilterSpec) (string, *gojq.Code) {
+	nameExpr := uaf.NameFrom
+	if nameExpr == "" {
+		nameExpr = ".metadata.name"
+	}
+	code, err := CompileJQ(nameExpr, jqsupport.ModuleLoader())
+	if err != nil {
+		return nameExpr, nil
+	}
+	return nameExpr, code
 }
 
 // resolveUAFResources resolves the RBAC resource-plural set for a UAF
@@ -548,8 +637,10 @@ func applyUserAccessFilterOnPig(ctx context.Context, pig map[string]any, dict ma
 		if !hasItems {
 			// Single-object shape (GET-by-name). #121 1b — compile the
 			// NamespaceFrom expression once (shares the hoisted signature).
+			// #123 — compile NameFrom too.
 			nsExpr, nsCode := compileNamespaceFrom(uaf)
-			permitted := evalSingle(ctx, log, user.Username, user.Groups, uaf, resources, v, nsExpr, nsCode)
+			nameExpr, nameCode := compileNameFrom(uaf)
+			permitted := evalSingle(ctx, log, user.Username, user.Groups, uaf, resources, v, nsExpr, nsCode, nameExpr, nameCode)
 			res.EvaluateRBACCalls++
 			if permitted {
 				res.Kept++

--- a/internal/resolvers/restactions/api/refilter_compile_once_falsifier_test.go
+++ b/internal/resolvers/restactions/api/refilter_compile_once_falsifier_test.go
@@ -80,15 +80,23 @@ func TestRefilter1b_CompileOncePerFilter_C3(t *testing.T) {
 		items = append(items, nsItem(deniedNS(i)))
 	}
 
-	// (a) DISCRIMINATING ARM — compile-count delta == 1 across all N items.
+	// (a) DISCRIMINATING ARM — compile-count delta == 2 across all N items.
+	// 2 hoisted per-filter compiles since #123 (ns + name); per-item recompile
+	// would be ~2*N. Both compileNamespaceFrom and compileNameFrom are hoisted
+	// ABOVE the item loop in refilterSlice, so the count is a FIXED 2
+	// independent of len(items) — the compile-once-per-filter property the
+	// #121-1b gate guards is intact. Keeping the EXACT-count assertion (== 2,
+	// not <=) means a real per-item-recompile regression still RED-fails at
+	// N=25 (delta would jump to ~2*25).
 	before := JQCompileCountForTest()
 	kept, dropped, calls := refilterSlice(ctx, discardLogger(),
 		"cyberjoker", []string{"devs"}, uaf, []string{"compositions"}, items)
 	delta := JQCompileCountForTest() - before
 
-	if delta != 1 {
-		t.Fatalf("CompileJQ delta = %d across %d items; want exactly 1 (compile-once-per-filter). "+
-			"delta==N would be the pre-1b per-item recompile RED.", delta, len(items))
+	if delta != 2 {
+		t.Fatalf("CompileJQ delta = %d across %d items; want exactly 2 (compile-once-per-filter, "+
+			"NamespaceFrom + NameFrom since #123, both hoisted). delta==~2*N would be the "+
+			"per-item recompile RED.", delta, len(items))
 	}
 
 	// (b) SECURITY-BOUNDARY ARM — the kept subset is EXACTLY the permitted set,

--- a/internal/resolvers/restactions/api/refilter_name_aware_falsifier_test.go
+++ b/internal/resolvers/restactions/api/refilter_name_aware_falsifier_test.go
@@ -1,0 +1,219 @@
+// refilter_name_aware_falsifier_test.go — #123 falsifier: the UAF refilter
+// serve path must be NAME-aware so a resourceNames-scoped RBAC grant
+// (a Role/ClusterRole rule with a non-empty resourceNames, valid only for
+// name-specific verbs — get/update/patch/delete) is honoured.
+//
+// Root cause (#123): pre-fix the refilter built EvaluateOptions WITHOUT the
+// object's Name (refilter.go evalSingle passed no Name → ""). The evaluator
+// core (internal/rbac/evaluate.go resourceNameMatches) requires opts.Name ∈
+// rule.ResourceNames for a resourceNames-scoped rule; with Name=="" every
+// resourceNames-scoped grant matches NOTHING → all named objects are silently
+// dropped (UNDER-serve / fail-closed). The fix derives the per-object name via
+// the additive UAFSpec.NameFrom JQ (default ".metadata.name") and threads it
+// into EvaluateOptions.Name — symmetric with the existing NamespaceFrom path.
+//
+// Arms:
+//   - GREEN: a resourceNames-scoped get grant + K>1 distinct-name items → the
+//     refilter returns EXACTLY the named object(s), drops the rest.
+//   - RED: the pre-fix posture (Name unresolved → "") reproduced by pointing
+//     NameFrom at a field the objects don't carry (yields null → "") → the
+//     named-object grant drops ALL items (kept:0), proving the Name plumbing
+//     is what honours the grant.
+//   - INERTNESS: a plain LIST grant (a collection verb, which the evaluator
+//     scopes resourceNames AWAY from) still returns all items — Name threading
+//     must not change collection-verb behaviour (guards against over-narrowing).
+
+package api
+
+import (
+	"testing"
+
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// resourceNamesReaderRBAC builds a namespace-scoped Role + RoleBinding that
+// grants the "devs" group get/watch on a SINGLE named object of the given
+// resource (resourceNames: [name]). cyberjoker is a "devs" member. This is
+// the production-shaped narrow grant that #123 was silently dropping.
+func resourceNamesReaderRBAC(group, resource, ns, name string) (*rbacv1.Role, *rbacv1.RoleBinding) {
+	role := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Name: "named-reader", Namespace: ns},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"get", "watch"},
+				APIGroups:     []string{group},
+				Resources:     []string{resource},
+				ResourceNames: []string{name}, // <-- the scoped grant
+			},
+		},
+	}
+	binding := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Name: "named-reader-binding", Namespace: ns},
+		Subjects: []rbacv1.Subject{
+			{Kind: "Group", APIGroup: "rbac.authorization.k8s.io", Name: "devs"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "named-reader",
+		},
+	}
+	return role, binding
+}
+
+// nameAwareItems returns K>1 distinct-named objects in the given namespace,
+// one of which is the granted name. Object shape carries .metadata.name +
+// .metadata.namespace so the default NameFrom (".metadata.name") and
+// NamespaceFrom (".metadata.namespace") resolve.
+func nameAwareItems(ns string, names ...string) []any {
+	out := make([]any, 0, len(names))
+	for _, n := range names {
+		out = append(out, map[string]any{
+			"metadata": map[string]any{"name": n, "namespace": ns},
+		})
+	}
+	return out
+}
+
+// TestRefilterNameAware_GREEN — a resourceNames-scoped GET grant keeps EXACTLY
+// the named object and drops the rest. K=3 distinct names, grant scoped to one.
+func TestRefilterNameAware_GREEN(t *testing.T) {
+	const ns = "bench-ns-01"
+	role, binding := resourceNamesReaderRBAC("apps", "deployments", ns, "selfservice-krateo")
+	newRefilterTestWatcher(t, role, binding)
+
+	apiCall := &templates.API{
+		Name: "deployments",
+		UserAccessFilter: &templates.UserAccessFilterSpec{
+			Verb:     "get",
+			Group:    "apps",
+			Resource: "deployments",
+			// NameFrom + NamespaceFrom omitted → CRD/in-code defaults
+			// (.metadata.name / .metadata.namespace) fire.
+		},
+	}
+	dict := map[string]any{
+		"deployments": map[string]any{
+			"kind":       "DeploymentList",
+			"apiVersion": "apps/v1",
+			"items":      nameAwareItems(ns, "selfservice-krateo", "other-a", "other-b"),
+		},
+	}
+
+	res := applyUserAccessFilter(ctxWithUser("cyberjoker", "devs"), dict, apiCall)
+
+	if res.Kept != 1 {
+		t.Errorf("GREEN: kept = %d; want 1 (only the resourceNames-granted object)", res.Kept)
+	}
+	if res.Dropped != 2 {
+		t.Errorf("GREEN: dropped = %d; want 2", res.Dropped)
+	}
+	if res.EvaluateRBACCalls != 3 {
+		t.Errorf("GREEN: evaluate_rbac_calls = %d; want 3 (one per object)", res.EvaluateRBACCalls)
+	}
+	items := dict["deployments"].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("GREEN: retained items = %d; want 1", len(items))
+	}
+	got := items[0].(map[string]any)["metadata"].(map[string]any)["name"]
+	if got != "selfservice-krateo" {
+		t.Errorf("GREEN: retained name = %v; want selfservice-krateo", got)
+	}
+}
+
+// TestRefilterNameAware_RED — reproduces the PRE-FIX posture: when the derived
+// Name is empty (NameFrom points at a field the objects don't carry → jq
+// yields null → ""), the resourceNames-scoped grant matches NOTHING and the
+// refilter drops ALL items. This is the exact #123 symptom (under-serve /
+// fail-closed) and proves the Name plumbing is load-bearing: the ONLY
+// difference vs the GREEN arm is that Name resolves to "" instead of the
+// object's real name.
+//
+// If a future refactor drops the Name from EvaluateOptions, the GREEN arm
+// collapses to THIS behaviour for every object → GREEN turns red, catching the
+// regression.
+func TestRefilterNameAware_RED_EmptyNameDropsGrantedObject(t *testing.T) {
+	const ns = "bench-ns-01"
+	role, binding := resourceNamesReaderRBAC("apps", "deployments", ns, "selfservice-krateo")
+	newRefilterTestWatcher(t, role, binding)
+
+	apiCall := &templates.API{
+		Name: "deployments",
+		UserAccessFilter: &templates.UserAccessFilterSpec{
+			Verb:     "get",
+			Group:    "apps",
+			Resource: "deployments",
+			// Force the pre-fix Name="" posture: a path the objects don't
+			// carry yields null → "" (identical to no-Name-plumbed).
+			NameFrom: ".metadata.thisFieldDoesNotExist",
+		},
+	}
+	dict := map[string]any{
+		"deployments": map[string]any{
+			"kind":       "DeploymentList",
+			"apiVersion": "apps/v1",
+			"items":      nameAwareItems(ns, "selfservice-krateo", "other-a", "other-b"),
+		},
+	}
+
+	res := applyUserAccessFilter(ctxWithUser("cyberjoker", "devs"), dict, apiCall)
+
+	if res.Kept != 0 {
+		t.Errorf("RED: kept = %d; want 0 — an empty derived Name must drop even the granted object (the #123 defect)", res.Kept)
+	}
+	if res.Dropped != 3 {
+		t.Errorf("RED: dropped = %d; want 3 (all items dropped)", res.Dropped)
+	}
+}
+
+// TestRefilterNameAware_INERTNESS_ListGrantUnaffected — a plain LIST grant
+// (no resourceNames; collection verb) must return ALL items regardless of the
+// threaded Name. The evaluator scopes resourceNames to name-specific verbs
+// only, so threading a name into a list-verb check is inert. This guards
+// against Name threading over-narrowing collection-verb behaviour.
+func TestRefilterNameAware_INERTNESS_ListGrantUnaffected(t *testing.T) {
+	const ns = "bench-ns-01"
+	// UNSCOPED list grant: no resourceNames → matches every object.
+	role := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Name: "list-reader", Namespace: ns},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"list"}, APIGroups: []string{"apps"}, Resources: []string{"deployments"}},
+		},
+	}
+	binding := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Name: "list-reader-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "Group", APIGroup: "rbac.authorization.k8s.io", Name: "devs"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "list-reader"},
+	}
+	newRefilterTestWatcher(t, role, binding)
+
+	apiCall := &templates.API{
+		Name: "deployments",
+		UserAccessFilter: &templates.UserAccessFilterSpec{
+			Verb:     "list", // collection verb — resourceNames does not scope it
+			Group:    "apps",
+			Resource: "deployments",
+		},
+	}
+	dict := map[string]any{
+		"deployments": map[string]any{
+			"kind":       "DeploymentList",
+			"apiVersion": "apps/v1",
+			"items":      nameAwareItems(ns, "d-a", "d-b", "d-c"),
+		},
+	}
+
+	res := applyUserAccessFilter(ctxWithUser("cyberjoker", "devs"), dict, apiCall)
+
+	if res.Kept != 3 {
+		t.Errorf("INERTNESS: kept = %d; want 3 — a plain list grant must return all items (Name threading is inert for collection verbs)", res.Kept)
+	}
+	if res.Dropped != 0 {
+		t.Errorf("INERTNESS: dropped = %d; want 0", res.Dropped)
+	}
+}

--- a/internal/resolvers/restactions/api/refilter_test.go
+++ b/internal/resolvers/restactions/api/refilter_test.go
@@ -484,8 +484,9 @@ func TestResourcesFrom_FailClosed(t *testing.T) {
 	}
 	emptyResUAF := &templates.UserAccessFilterSpec{Verb: "list"}
 	emptyResExpr, emptyResCode := compileNamespaceFrom(emptyResUAF)
+	emptyResNameExpr, emptyResNameCode := compileNameFrom(emptyResUAF)
 	if evalSingle(context.Background(), log, "u", []string{"g"},
-		emptyResUAF, nil, "ns-a", emptyResExpr, emptyResCode) {
+		emptyResUAF, nil, "ns-a", emptyResExpr, emptyResCode, emptyResNameExpr, emptyResNameCode) {
 		t.Errorf("fail-closed: evalSingle with an empty resource set must DENY")
 	}
 }


### PR DESCRIPTION
## PARKED — Diego-reserved merge. Do NOT merge.

Fixes #123. The `userAccessFilter` refilter serve path was NOT name-aware: a
`resourceNames`-scoped RBAC grant silently dropped ALL its objects
(under-serve / fail-closed).

### Root cause
`internal/resolvers/restactions/api/refilter.go` `evalSingle` built
`rbac.EvaluateOptions` WITHOUT the object's `Name` → `Name==""`. The evaluator
core `internal/rbac/evaluate.go` `resourceNameMatches` requires
`opts.Name ∈ rule.ResourceNames` for a `resourceNames`-scoped rule (name-specific
verbs only). With `Name==""` every such grant matched nothing → all named
objects dropped. `refilterSlice` derived only the namespace per item, never the name.

### Fix (additive CRD field + JQ, symmetric with the existing `NamespaceFrom` — no hardcoded special-case)
1. `apis/templates/v1/core.go`: add `UAFSpec.NameFrom` (JQ path,
   `+optional +kubebuilder:default=".metadata.name"`), mirroring `NamespaceFrom`.
2. `refilter.go`: `compileNameFrom()` hoists the compile once; `evalSingle`
   derives the per-object name and threads it into `EvaluateOptions.Name`, for
   BOTH UAF entrypoints (`applyUserAccessFilter` + the live shim
   `applyUserAccessFilterOnPig`, both via `refilterSlice`→`evalSingle`).
3. NameFrom derivation is gated on `rbac.IsNameSpecificVerb(uaf.Verb)`
   (exported): for a COLLECTION verb (list/watch/…) `Name` stays `""` —
   byte-identical to the pre-#123 path, and no fail-close on a NameFrom JQ error
   that is irrelevant to a list grant (e.g. the namespaces-stage bare-string
   item shape).
4. `make generate`: regenerated RestActions CRD with the `nameFrom` field.

### Falsifier (hermetic, dynamicfake — `refilter_name_aware_falsifier_test.go`)
- **GREEN**: resourceNames-scoped `get` grant + K=3 distinct-name items → keeps
  exactly the named object, drops the rest.
- **RED**: pre-fix `Name==""` posture (NameFrom→"") → the named grant drops ALL
  items (kept:0). **Neuter-verified**: forcing `EvaluateOptions.Name=""` turns
  the GREEN arm RED (`kept:0/dropped:3`) while INERTNESS stays green.
- **INERTNESS**: a plain `list` grant still returns all items (Name threading is
  inert for collection verbs; guards against over-narrowing).

All arms `--- PASS` under `-race -count=1`; full UAF/refilter suite green.

### Deploy-order note
snowplow's own RestActions CRD ships `NameFrom` FIRST (this PR); THEN portal-chart
RestAction stanzas may set `nameFrom` — no portal CRD schema change (NameFrom is on
snowplow's RestAction; portal-owned CRDs unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1