### PR TITLE
fix(cache): #119 skip informers for authoritatively-unserved API groups (PARKED — Diego-reserved merge)

### DIFF
--- a/internal/cache/servable.go
+++ b/internal/cache/servable.go
@@ -29,6 +29,8 @@ package cache
 import (
 	"context"
 	"log/slog"
+	"os"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -549,6 +551,158 @@ func groupVersionString(gvr schema.GroupVersionResource) string {
 		return gvr.Version
 	}
 	return gvr.Group + "/" + gvr.Version
+}
+
+// --- #119 unserved-GROUP pre-check ----------------------------------------
+//
+// Reclassified #119 residual: an informer registered for an API GROUP the
+// apiserver does NOT serve (a dead/typo'd apiGroup in an RBAC/RESTAction ref,
+// or a group left over from an uninstalled operator) has a HasSynced that
+// never flips → conjunct 2 never true → never servable → every dispatch falls
+// through to a live apiserver 404, and the reflector's ListAndWatch churns 404
+// forever (boot latency + perpetual watch-404 churn). The pre-check skips
+// spawning that informer.
+//
+// GROUP granularity, NOT resource granularity (architect adjudication,
+// docs/followup-119): a resource-level "not served right now" skip would
+// regress the S4/stale-delete post-startup-CRD design (#50/#116), which
+// DELIBERATELY registers a GVR whose RESOURCE type the apiserver does not yet
+// serve and relies on the ~30s confirm-ticker (RefreshDiscovery) to heal it
+// once the CRD lands. A dead group and a mid-install post-startup CRD are
+// indistinguishable at a single RESOURCE-level snapshot — but a dead group is
+// entirely ABSENT from ServerGroups(), whereas a Krateo post-startup CRD lands
+// under a group that is ALREADY served (its siblings are served). So the
+// unserved-GROUP boundary skips the churniest real case while leaving the
+// register-then-confirm heal path intact for resource/version-level pending
+// CRDs. The skip is NON-TERMINAL: a brand-new group's first CRD (group briefly
+// absent from ServerGroups at first-touch) is recovered by the next dispatch's
+// EnsureResourceType re-touch, which re-checks fresh discovery and registers
+// once the group appears.
+
+// envSkipUnservedGroupInformers gates the pre-check. Default ON — flips both
+// ways (SkipUnservedGroupInformers).
+const envSkipUnservedGroupInformers = "SKIP_UNSERVED_GROUP_INFORMERS"
+
+// SkipUnservedGroupInformers reports whether the #119 unserved-group pre-check
+// is active. Default ON; set SKIP_UNSERVED_GROUP_INFORMERS to false/0/no to
+// restore the pre-#119 register-unconditionally behaviour. Read fresh per
+// registration (cheap os.Getenv) so a deployer can flip it at pod start,
+// matching the RefreshSSEEnabled string-toggle idiom.
+func SkipUnservedGroupInformers() bool {
+	switch os.Getenv(envSkipUnservedGroupInformers) {
+	case "false", "0", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// serverGroupsLister is the NARROW discovery surface the group-absent pre-check
+// needs. It is a SEPARATE interface from ResourceTypeDiscovery (which the
+// confirm path uses) so the pre-check does NOT widen that shared interface —
+// every existing ResourceTypeDiscovery double keeps compiling untouched, and a
+// disco that does not implement ServerGroups simply fails the type assertion in
+// groupAuthoritativelyAbsent → the pre-check fails safe open (registers). The
+// production raw *discovery.DiscoveryClient (main.go) satisfies it directly.
+type serverGroupsLister interface {
+	ServerGroups() (*metav1.APIGroupList, error)
+}
+
+// servedGroupsMemoTTL bounds the freshness of the cached served-group set the
+// pre-check consults. A newly-installed group is skipped for at most this
+// window before the memo re-reads and admits it (then the dispatch re-touch
+// registers it). Mirrors the confirm-ticker cadence so the skip window matches
+// the heal window.
+const servedGroupsMemoTTL = discoveryRefreshInterval
+
+// servedGroupsMemo caches the set of group names ServerGroups() reported, with
+// a short TTL. The pre-check reads the RAW disco (never the memcache-cached
+// client — that client's event-driven global Invalidate can leave it
+// stale-ABSENT on an un-served→served transition, which for a SKIP decision is
+// a PERMANENT false-skip = data dropped forever; the confirm path tolerates
+// staleness because it only falls through to apiserver, but a skip does not).
+// This in-process memo bounds the raw round-trip cost to ~one ServerGroups per
+// TTL window across all registration misses, WITHOUT the cached client's unsafe
+// staleness semantics.
+var (
+	servedGroupsMu        sync.Mutex
+	servedGroupsSet       map[string]struct{}
+	servedGroupsFetchedAt time.Time
+)
+
+// ResetServedGroupsMemoForTest clears the served-group memo so each test reads
+// its freshly-installed discovery double. TEST-ONLY. Mirrors the exported
+// Reset*ForTest convention (ResetNavigationDiscoveredGroupsForTest et al.).
+func ResetServedGroupsMemoForTest() {
+	servedGroupsMu.Lock()
+	servedGroupsSet = nil
+	servedGroupsFetchedAt = time.Time{}
+	servedGroupsMu.Unlock()
+}
+
+// groupAuthoritativelyAbsent is the #119 pre-check's THREE-STATE predicate. It
+// returns true ONLY when a SUCCESSFUL ServerGroups() response definitively
+// lacks gvr's GROUP — the authoritative "this group is not served" signal.
+// Every form of UNCERTAINTY fails SAFE OPEN (returns false → register):
+//
+//   - the core group ("")                        → never skip (always served)
+//   - disco does not implement ServerGroups       → NOT authoritative (register)
+//   - ServerGroups() errors                        → NOT authoritative (register)
+//   - it returns a nil list                        → NOT authoritative (register)
+//   - group PRESENT in the served set              → served (register)
+//   - group ABSENT from a successful served set    → AUTHORITATIVE absent (SKIP)
+//
+// A false-skip of a genuinely-served-but-slow-to-discover group would silently
+// drop real data forever (strictly worse than churn), so uncertainty NEVER
+// skips. The served-group set is memoised with a short TTL (servedGroupsMemoTTL)
+// off the RAW disco — see servedGroupsMemo.
+func groupAuthoritativelyAbsent(disco ResourceTypeDiscovery, group string) bool {
+	if group == "" {
+		return false // core group is always served — never skip
+	}
+	lister, ok := disco.(serverGroupsLister)
+	if !ok || lister == nil {
+		return false // no ServerGroups surface — fail-safe open (register)
+	}
+	set, ok := servedGroupsSnapshot(lister)
+	if !ok {
+		return false // discovery unavailable/errored — fail-safe open (register)
+	}
+	_, present := set[group]
+	return !present // absent from a SUCCESSFUL served set → authoritative absent
+}
+
+// servedGroupsSnapshot returns the memoised served-group name set, refreshing it
+// from lister.ServerGroups() when the memo is empty or older than
+// servedGroupsMemoTTL. Returns (set, true) on success; (nil, false) when the
+// (refresh) ServerGroups() call errors or returns nil AND no prior good snapshot
+// exists — the fail-safe-open signal. A refresh error with a prior good snapshot
+// keeps serving the prior snapshot (bounded staleness beats a false-skip storm).
+func servedGroupsSnapshot(lister serverGroupsLister) (map[string]struct{}, bool) {
+	servedGroupsMu.Lock()
+	defer servedGroupsMu.Unlock()
+
+	if servedGroupsSet != nil && time.Since(servedGroupsFetchedAt) < servedGroupsMemoTTL {
+		return servedGroupsSet, true
+	}
+
+	groups, err := lister.ServerGroups()
+	if err != nil || groups == nil {
+		if servedGroupsSet != nil {
+			// Transient refresh failure — keep the prior good snapshot rather
+			// than fail-open every GVR (which would DEFEAT the pre-check for
+			// the whole window). Bounded staleness, never a false-skip.
+			return servedGroupsSet, true
+		}
+		return nil, false // no signal at all — fail-safe open
+	}
+	set := make(map[string]struct{}, len(groups.Groups))
+	for _, g := range groups.Groups {
+		set[g.Name] = struct{}{}
+	}
+	servedGroupsSet = set
+	servedGroupsFetchedAt = time.Now()
+	return set, true
 }
 
 // StartDiscoveryRefresher launches the conjunct-4 discovery-refresh

--- a/internal/cache/skip_unserved_group_119_test.go
+++ b/internal/cache/skip_unserved_group_119_test.go
@@ -1,0 +1,467 @@
+// skip_unserved_group_119_test.go — #119 unserved-GROUP pre-check falsifier.
+//
+// #119 reclassified residual: an informer registered for an API GROUP the
+// apiserver does NOT serve (a dead/typo'd apiGroup, or a group from an
+// uninstalled operator) has a HasSynced that never flips → conjunct 2 never
+// true → never servable → every dispatch falls through to a live apiserver
+// 404, and the reflector's ListAndWatch churns 404 forever (boot latency +
+// perpetual refresher-404 churn). The fix is an unserved-GROUP pre-check
+// inside EnsureResourceType (the single spawn-site funnel): before spawning an
+// informer, consult ServerGroups() and SKIP registration when the GROUP is
+// entirely absent. Gated by SKIP_UNSERVED_GROUP_INFORMERS (default ON).
+//
+// GROUP granularity, NOT resource granularity (architect adjudication). A
+// resource-level skip would regress the S4/stale-delete post-startup-CRD design
+// (#50/#116), which DELIBERATELY registers a GVR whose RESOURCE type is not yet
+// served and relies on the ~30s confirm-ticker to heal it. A post-startup CRD
+// lands under a group that is ALREADY served, so the group-level check does NOT
+// skip it → it registers + heals. Only a group entirely absent from
+// ServerGroups() (a dead group) is skipped. The skip is NON-TERMINAL: a
+// brand-new group's first CRD (group briefly absent at first-touch) is
+// recovered by the next dispatch's EnsureResourceType re-touch.
+//
+// THE CRUX — fail-safe open on uncertainty. groupAuthoritativelyAbsent is
+// THREE-STATE: it skips ONLY on a SUCCESSFUL ServerGroups() response that
+// definitively lacks the group. A ServerGroups ERROR, no-ServerGroups-surface,
+// a nil list, or the core group "" ALL register (never skip). A false-skip of a
+// genuinely-served group would silently drop real data forever.
+//
+// Falsifier shape (feedback_falsifier_shape_must_discriminate): K>1 groups
+// under ONE discovery double, so the arms discriminate PER-GROUP decisions, not
+// a global flag; plus a brand-new-group RECOVERY arm that drives the real
+// boundary ≥2× (feedback_falsifier_must_drive_real_boundary).
+
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// skip119ServedGVR is a GVR under a SERVED group (secrets/core — always in the
+// fake dynamic scheme). NOTE: the core group "" is never skipped, so we use a
+// custom served GROUP for the discrimination arms below (skip119ServedCustom).
+var skip119ServedGVR = servableTestGVR
+
+// skip119ServedCustom is a GVR under a served CUSTOM group. Its group is
+// reported present by the double's ServerGroups(); its List kind is registered
+// so its informer LIST does not panic when it registers.
+var skip119ServedCustom = schema.GroupVersionResource{
+	Group: "served.krateo.io", Version: "v1", Resource: "servedthings",
+}
+
+// skip119UnservedGVR is a GVR under an UNSERVED (dead/typo'd) group. Its group
+// is absent from the double's ServerGroups(). In the GREEN case it is skipped
+// (never registers); its List kind is registered for the RED (flag-off) path.
+var skip119UnservedGVR = schema.GroupVersionResource{
+	Group: "dead.krateo.io", Version: "v1", Resource: "widgets",
+}
+
+// skip119PendingResourceGVR is a GVR whose GROUP is served but whose RESOURCE
+// is not yet in the served set — the S4 post-startup-CRD shape. It MUST
+// register (group-level check does not skip it) so the confirm-ticker can heal.
+var skip119PendingResourceGVR = schema.GroupVersionResource{
+	Group: "served.krateo.io", Version: "v1", Resource: "pendingcrd",
+}
+
+func skip119ListKinds() map[schema.GroupVersionResource]string {
+	m := servableListKinds()
+	m[skip119ServedCustom] = "ServedThingList"
+	m[skip119UnservedGVR] = "WidgetList"
+	m[skip119PendingResourceGVR] = "PendingCRDList"
+	return m
+}
+
+// skip119Disco is the discovery double. It satisfies cache.ResourceTypeDiscovery
+// (ServerResourcesForGroupVersion) AND the pre-check's serverGroupsLister
+// (ServerGroups). Two INDEPENDENT axes, which is the whole point of the
+// group-level boundary:
+//   - servedGroups (group name -> served) drives the #119 GROUP-level pre-check
+//     (ServerGroups). groupsErr makes ServerGroups return an error (fail-safe-
+//     open guard).
+//   - servedResources (gv -> set of resource names) drives the RESOURCE-level
+//     confirm path (ServerResourcesForGroupVersion) that flips conjunct-4
+//     typeConfirmed and thus IsServable. A resource can be absent here while its
+//     GROUP is present in servedGroups — the post-startup-CRD shape.
+type skip119Disco struct {
+	mu              sync.Mutex
+	servedGroups    map[string]bool            // group name -> served (drives ServerGroups)
+	servedResources map[string]map[string]bool // gv -> resourceName -> served (drives confirm)
+	groupsErr       error                      // when non-nil, ServerGroups returns it
+	groupsCalls     int
+	resourcesCalls  int
+}
+
+func (d *skip119Disco) ServerGroups() (*metav1.APIGroupList, error) {
+	d.mu.Lock()
+	d.groupsCalls++
+	err := d.groupsErr
+	names := make([]string, 0, len(d.servedGroups))
+	for name, served := range d.servedGroups {
+		if served {
+			names = append(names, name)
+		}
+	}
+	d.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	list := &metav1.APIGroupList{}
+	for _, name := range names {
+		list.Groups = append(list.Groups, metav1.APIGroup{Name: name})
+	}
+	return list, nil
+}
+
+func (d *skip119Disco) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	d.mu.Lock()
+	d.resourcesCalls++
+	res := d.servedResources[gv]
+	d.mu.Unlock()
+
+	// The confirm path (resourceTypeServed) reads this: a resource name present
+	// here flips conjunct-4 typeConfirmed → servable. Absent (or empty) → the
+	// GVR stays unconfirmed → not servable (the pre-heal post-startup-CRD state).
+	list := &metav1.APIResourceList{GroupVersion: gv}
+	for name, served := range res {
+		if served {
+			list.APIResources = append(list.APIResources, metav1.APIResource{
+				Name: name, Namespaced: true, Kind: "X",
+			})
+		}
+	}
+	return list, nil
+}
+
+func (d *skip119Disco) setGroupServed(name string, served bool) {
+	d.mu.Lock()
+	if d.servedGroups == nil {
+		d.servedGroups = map[string]bool{}
+	}
+	d.servedGroups[name] = served
+	d.mu.Unlock()
+}
+
+func (d *skip119Disco) setResourceServed(gv, resource string, served bool) {
+	d.mu.Lock()
+	if d.servedResources == nil {
+		d.servedResources = map[string]map[string]bool{}
+	}
+	if d.servedResources[gv] == nil {
+		d.servedResources[gv] = map[string]bool{}
+	}
+	d.servedResources[gv][resource] = served
+	d.mu.Unlock()
+}
+
+func newSkip119Watcher(t *testing.T) *cache.ResourceWatcher {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	// The served-group memo is process-global; reset so each test reads its own
+	// freshly-installed double (not a prior test's snapshot).
+	cache.ResetServedGroupsMemoForTest()
+	t.Cleanup(cache.ResetServedGroupsMemoForTest)
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		newTestScheme(), skip119ListKinds())
+	rw, err := cache.NewResourceWatcher(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	if rw == nil {
+		t.Fatalf("expected non-nil watcher under CACHE_ENABLED=true")
+	}
+	t.Cleanup(func() {
+		rw.Stop()
+		time.Sleep(50 * time.Millisecond)
+	})
+	return rw
+}
+
+// gvKey renders a GVR's group/version the way discovery keys it.
+func gvKey(gvr schema.GroupVersionResource) string {
+	if gvr.Group == "" {
+		return gvr.Version
+	}
+	return gvr.Group + "/" + gvr.Version
+}
+
+// TestSkip119_GREEN_UnservedGroupSkipped is the GREEN arm. With the pre-check
+// active (default ON), an EnsureResourceType for a GVR under a GROUP absent from
+// ServerGroups() returns added=false and does NOT register — no informer, no
+// watch-404 churn. A GVR under a SERVED custom group in the same test registers
+// (per-GROUP discrimination, K>1).
+func TestSkip119_GREEN_UnservedGroupSkipped(t *testing.T) {
+	rw := newSkip119Watcher(t) // default ON
+
+	disco := &skip119Disco{servedGroups: map[string]bool{
+		"served.krateo.io": true,
+		"dead.krateo.io":   false,
+	}}
+	rw.SetDiscoveryClient(disco)
+
+	// Served custom group → registers.
+	addedServed, _ := rw.EnsureResourceType(skip119ServedCustom)
+	if !addedServed {
+		t.Fatalf("served-group GVR: want added=true")
+	}
+	if !rw.IsRegistered(skip119ServedCustom) {
+		t.Fatalf("served-group GVR: want IsRegistered=true")
+	}
+
+	// Dead group → SKIPPED.
+	addedDead, syncCh := rw.EnsureResourceType(skip119UnservedGVR)
+	if addedDead {
+		t.Fatalf("dead-group GVR: want added=false (pre-check must skip a group " +
+			"absent from ServerGroups()), got added=true")
+	}
+	if rw.IsRegistered(skip119UnservedGVR) {
+		t.Fatalf("dead-group GVR: want IsRegistered=false — the informer must NOT " +
+			"spawn for an unserved group (no perpetual watch-404 churn)")
+	}
+	select {
+	case <-syncCh:
+	default:
+		t.Fatalf("dead-group GVR: skip must return a pre-closed sync channel")
+	}
+	t.Logf("GREEN: served-group %s registered; dead-group %s skipped (no churn)",
+		skip119ServedCustom.Group, skip119UnservedGVR.Group)
+}
+
+// TestSkip119_S4NonRegression_ServedGroupResourceHeals is the S4/stale-delete
+// non-regression arm — THE collision the group-level boundary resolves, and it
+// asserts the FULL register-then-CONFIRM-then-HEAL cycle, NOT merely "not
+// skipped" (per the TL hard guard: a weakened S4 test laundered through #119 is
+// the anti-pattern). A GVR whose GROUP is served but whose RESOURCE is not yet
+// in the served set (a post-startup CRD mid-install) must, WITH the #119
+// pre-check ACTIVE:
+//
+//  1. REGISTER (added=true) — the group-level pre-check does not skip it (its
+//     group is present in ServerGroups()). added=false here = the pre-check
+//     wrongly regressed to RESOURCE granularity = S4/stale-delete regression.
+//  2. stay NOT-SERVABLE while the resource type is unconfirmed (conjunct 4) —
+//     exactly the S4 gate that stops the pivot serving [] for a not-yet-served
+//     post-startup CRD.
+//  3. HEAL to servable once the apiserver serves the RESOURCE type and the
+//     confirm-ticker (RefreshDiscovery) observes it.
+//
+// This arm RED-fails if #119 skips the post-startup CRD (step 1: not registered
+// → never heals) OR if the S4 confirm gate is broken (step 2 servable-too-early
+// or step 3 never-heals). It is the exact discriminator the TL required: it
+// cannot pass on a "merely not skipped" implementation because it drives the
+// full heal.
+func TestSkip119_S4NonRegression_ServedGroupResourceHeals(t *testing.T) {
+	rw := newSkip119Watcher(t) // #119 pre-check ACTIVE (default ON)
+
+	gv := gvKey(skip119PendingResourceGVR)
+	// GROUP served (so #119 does not skip) but the RESOURCE type not yet served
+	// (so the S4 confirm gate keeps it unconfirmed) — the post-startup-CRD shape.
+	disco := &skip119Disco{
+		servedGroups:    map[string]bool{"served.krateo.io": true},
+		servedResources: map[string]map[string]bool{gv: {skip119PendingResourceGVR.Resource: false}},
+	}
+	rw.SetDiscoveryClient(disco)
+
+	// Step 1 — REGISTERS despite the resource being unserved (group-level skip
+	// does not fire). The informer syncs over the empty fake apiserver.
+	added, syncCh := rw.EnsureResourceType(skip119PendingResourceGVR)
+	if !added {
+		t.Fatalf("S4 step 1: want added=true — a post-startup CRD (group served, " +
+			"resource not-yet-served) MUST register so the confirm-ticker can heal it; " +
+			"added=false means #119 wrongly skipped at RESOURCE granularity = " +
+			"S4/stale-delete regression (this is the TL hard-guard failure)")
+	}
+	if !rw.IsRegistered(skip119PendingResourceGVR) {
+		t.Fatalf("S4 step 1: want IsRegistered=true")
+	}
+	select {
+	case <-syncCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("S4 step 1: informer did not sync within 5s")
+	}
+
+	// Step 2 — confirm pass against the resource-UNSERVED state: conjunct 4
+	// typeConfirmed is false → MUST NOT be servable, even though registered +
+	// synced both hold. This is the S4 gate the fix must not weaken.
+	rw.RefreshDiscovery(context.Background())
+	if rw.IsServable(skip119PendingResourceGVR) {
+		t.Fatalf("S4 step 2: a registered+synced post-startup CRD whose RESOURCE " +
+			"type is not yet served MUST stay NOT servable (conjunct 4 unconfirmed); " +
+			"servable-too-early = the S4 bug the confirm gate exists to stop")
+	}
+
+	// Step 3 — the CRD installs: the apiserver now serves the RESOURCE type. The
+	// confirm-ticker observes it → HEALS to servable.
+	disco.setResourceServed(gv, skip119PendingResourceGVR.Resource, true)
+	rw.RefreshDiscovery(context.Background())
+	if !rw.IsServable(skip119PendingResourceGVR) {
+		t.Fatalf("S4 step 3: once the apiserver serves the resource type, the " +
+			"confirm-ticker MUST heal the GVR to servable; it did not — the " +
+			"register-then-heal path is broken (S4/stale-delete regression)")
+	}
+	if _, servable := rw.ListObjectsServable(skip119PendingResourceGVR, ""); !servable {
+		t.Fatalf("S4 step 3: healed GVR must be servable via ListObjectsServable too")
+	}
+	t.Logf("S4 NON-REGRESSION: post-startup CRD registered (step1) → not-servable-while-unconfirmed " +
+		"(step2) → healed to servable after resource served (step3) — full heal proven under active #119")
+}
+
+// TestSkip119_RED_FlagOffRegistersUnserved is the RED arm. With the pre-check
+// DISABLED (SKIP_UNSERVED_GROUP_INFORMERS=false), the SAME dead-group call
+// registers + spawns the informer — reproducing the pre-#119 churn state.
+// Proves the pre-check (not another guard) is what skips the registration.
+func TestSkip119_RED_FlagOffRegistersUnserved(t *testing.T) {
+	t.Setenv("SKIP_UNSERVED_GROUP_INFORMERS", "false")
+	rw := newSkip119Watcher(t)
+
+	disco := &skip119Disco{servedGroups: map[string]bool{"dead.krateo.io": false}}
+	rw.SetDiscoveryClient(disco)
+
+	added, _ := rw.EnsureResourceType(skip119UnservedGVR)
+	if !added {
+		t.Fatalf("RED (flag off): want added=true — with the pre-check disabled the " +
+			"dead group must register (pre-#119 behaviour), got added=false")
+	}
+	if !rw.IsRegistered(skip119UnservedGVR) {
+		t.Fatalf("RED (flag off): want IsRegistered=true — proves the pre-check does " +
+			"the skipping, not some other guard")
+	}
+	t.Logf("RED: flag off → dead-group %s REGISTERED (churn reproduced)", skip119UnservedGVR.Group)
+}
+
+// TestSkip119_BrandNewGroupRecovery is the C-specific NON-TERMINAL arm. It
+// drives the real boundary ≥2×: a GVR whose group is initially absent is
+// skipped; the double's ServerGroups() then flips to include the group (the
+// operator's first CRD lands); a re-invocation of EnsureResourceType now
+// REGISTERS it. Proves the skip is non-terminal and the dispatch re-touch
+// recovers a brand-new group — no permanent false-skip.
+func TestSkip119_BrandNewGroupRecovery(t *testing.T) {
+	rw := newSkip119Watcher(t) // default ON
+
+	disco := &skip119Disco{servedGroups: map[string]bool{"served.krateo.io": false}}
+	rw.SetDiscoveryClient(disco)
+
+	// Pass 1: group absent → skipped.
+	added1, _ := rw.EnsureResourceType(skip119ServedCustom)
+	if added1 || rw.IsRegistered(skip119ServedCustom) {
+		t.Fatalf("recovery pass 1: group absent must skip (added=%v registered=%v)",
+			added1, rw.IsRegistered(skip119ServedCustom))
+	}
+
+	// The operator installs — the group now appears in ServerGroups(). Expire
+	// the memo so the next check re-reads.
+	disco.setGroupServed("served.krateo.io", true)
+	cache.ResetServedGroupsMemoForTest()
+
+	// Pass 2: re-touch → now registers (recovery via re-invocation).
+	added2, _ := rw.EnsureResourceType(skip119ServedCustom)
+	if !added2 {
+		t.Fatalf("recovery pass 2: want added=true — once the group appears in " +
+			"ServerGroups(), the re-touch must register it (skip is NON-terminal); " +
+			"added=false means a permanent false-skip")
+	}
+	if !rw.IsRegistered(skip119ServedCustom) {
+		t.Fatalf("recovery pass 2: want IsRegistered=true after the group is served")
+	}
+	t.Logf("RECOVERY: group absent→skip (pass 1), group served→register (pass 2) — non-terminal")
+}
+
+// TestSkip119_FalseSkipGuard_ServerGroupsError is THE CRUX arm. A group that IS
+// genuinely served but whose ServerGroups() is MOMENTARILY ERRORING (and no
+// prior good snapshot exists) must NOT be skipped — it must register. Fails if
+// the impl skips on uncertainty.
+func TestSkip119_FalseSkipGuard_ServerGroupsError(t *testing.T) {
+	rw := newSkip119Watcher(t) // pre-check ON
+
+	disco := &skip119Disco{
+		servedGroups: map[string]bool{"served.krateo.io": true},
+		groupsErr:    context.DeadlineExceeded, // ServerGroups errors right now
+	}
+	rw.SetDiscoveryClient(disco)
+
+	added, _ := rw.EnsureResourceType(skip119ServedCustom)
+	if !added {
+		t.Fatalf("FALSE-SKIP GUARD (ServerGroups error): want added=true — a " +
+			"ServerGroups() error with no prior snapshot MUST NOT skip (fail-safe open). " +
+			"added=false means the impl skipped on uncertainty = the false-skip defect.")
+	}
+	if !rw.IsRegistered(skip119ServedCustom) {
+		t.Fatalf("FALSE-SKIP GUARD (ServerGroups error): want IsRegistered=true")
+	}
+	t.Logf("FALSE-SKIP GUARD (ServerGroups error): registered (fail-safe open)")
+}
+
+// TestSkip119_FalseSkipGuard_NilDiscovery: with NO discovery client wired
+// (rw.disco==nil — degraded S4 mode), the pre-check has no ServerGroups surface
+// and MUST register (never skip).
+func TestSkip119_FalseSkipGuard_NilDiscovery(t *testing.T) {
+	rw := newSkip119Watcher(t) // pre-check ON, no SetDiscoveryClient
+
+	added, _ := rw.EnsureResourceType(skip119UnservedGVR)
+	if !added {
+		t.Fatalf("FALSE-SKIP GUARD (nil disco): want added=true — with no discovery " +
+			"client the pre-check has no authoritative signal and must register")
+	}
+	if !rw.IsRegistered(skip119UnservedGVR) {
+		t.Fatalf("FALSE-SKIP GUARD (nil disco): want IsRegistered=true")
+	}
+	t.Logf("FALSE-SKIP GUARD (nil disco): registered (fail-safe open)")
+}
+
+// TestSkip119_CoreGroupNeverSkipped: the core group ("") is always served and
+// must never be skipped even if the double's ServerGroups() omits it (a double
+// that does not list core).
+func TestSkip119_CoreGroupNeverSkipped(t *testing.T) {
+	rw := newSkip119Watcher(t) // pre-check ON
+
+	// ServerGroups() lists only a custom group — core "" is NOT listed. The
+	// core-group short-circuit must still register the core GVR.
+	disco := &skip119Disco{servedGroups: map[string]bool{"served.krateo.io": true}}
+	rw.SetDiscoveryClient(disco)
+
+	added, _ := rw.EnsureResourceType(skip119ServedGVR) // secrets, core group ""
+	if !added || !rw.IsRegistered(skip119ServedGVR) {
+		t.Fatalf("core group must never be skipped (added=%v registered=%v)",
+			added, rw.IsRegistered(skip119ServedGVR))
+	}
+	t.Logf("core group never skipped: %s registered", skip119ServedGVR)
+}
+
+// TestSkip119_MixedK_Concurrent_Race is the mixed-K + -race arm. Concurrent
+// EnsureResourceType of a served-group GVR + a dead-group GVR under one double,
+// asserting per-group discrimination holds under concurrency with no data race
+// on the shared disco read + served-group memo + informers write.
+func TestSkip119_MixedK_Concurrent_Race(t *testing.T) {
+	rw := newSkip119Watcher(t) // pre-check ON
+
+	disco := &skip119Disco{servedGroups: map[string]bool{
+		"served.krateo.io": true,
+		"dead.krateo.io":   false,
+	}}
+	rw.SetDiscoveryClient(disco)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); rw.EnsureResourceType(skip119ServedCustom) }()
+		go func() { defer wg.Done(); rw.EnsureResourceType(skip119UnservedGVR) }()
+	}
+	wg.Wait()
+
+	if !rw.IsRegistered(skip119ServedCustom) {
+		t.Fatalf("mixed-K race: served-group GVR must be registered")
+	}
+	if rw.IsRegistered(skip119UnservedGVR) {
+		t.Fatalf("mixed-K race: dead-group GVR must NOT be registered (skipped under concurrency)")
+	}
+	t.Logf("mixed-K race: served-group registered + dead-group skipped under 16 concurrent EnsureResourceType")
+}

--- a/internal/cache/watcher.go
+++ b/internal/cache/watcher.go
@@ -636,7 +636,58 @@ func (rw *ResourceWatcher) EnsureResourceType(gvr schema.GroupVersionResource) (
 		close(closed)
 		return false, closed
 	}
+	disco := rw.disco
 	rw.mu.RUnlock()
+
+	// #119 unserved-GROUP pre-check. A miss is confirmed — this call would
+	// register + spawn an informer for gvr. Before it does, consult discovery:
+	// if the apiserver AUTHORITATIVELY does not serve gvr's GROUP at all (a
+	// dead/typo'd apiGroup, or a group from an uninstalled operator), DO NOT
+	// register it. Such an informer's HasSynced never flips → conjunct 2 never
+	// true → never servable → every dispatch falls through to a live apiserver
+	// 404, and the reflector's ListAndWatch churns 404 forever (the #119
+	// boot-latency + perpetual-refresher-404 residual). This is the ONLY
+	// spawn-site funnel (all path-derived callers — resolve.go:1788,
+	// informer_dispatch.go:359, apistage.go:585, objects/get.go:113,
+	// deps_extract.go:156 — route here), so gating once here needs no
+	// per-caller special-case (feedback_no_special_cases).
+	//
+	// GROUP granularity, NOT resource granularity — this is the architect-ruled
+	// boundary that keeps the S4/stale-delete post-startup-CRD heal path
+	// intact. A post-startup CRD lands under a group that is ALREADY served, so
+	// groupAuthoritativelyAbsent is false for it → it registers and the
+	// confirm-ticker heals it once its resource type appears. Only a group
+	// entirely absent from ServerGroups() is skipped. See
+	// groupAuthoritativelyAbsent (servable.go).
+	//
+	// FAIL-SAFE OPEN ON UNCERTAINTY (the crux): groupAuthoritativelyAbsent is
+	// THREE-STATE — it returns true ONLY on a SUCCESSFUL ServerGroups() response
+	// that definitively lacks the group. disco==nil / no ServerGroups surface /
+	// a ServerGroups error / a nil list ALL register (never skip); the core
+	// group ("") never skips. A false-skip of a genuinely-served group would
+	// silently drop real data forever — strictly worse than the churn — so
+	// uncertainty NEVER skips.
+	//
+	// NON-TERMINAL: the skip does not register anything, so a brand-new group's
+	// first CRD (group briefly absent at first-touch) is recovered by the next
+	// dispatch's EnsureResourceType re-touch against fresh discovery. The
+	// dispatch still serves live via httpcall.Do apiserver fall-through
+	// meanwhile, exactly as an unregistered GVR does today.
+	//
+	// Gated by SkipUnservedGroupInformers() (default ON, flips both ways);
+	// flag-off restores register-unconditionally.
+	if SkipUnservedGroupInformers() && groupAuthoritativelyAbsent(disco, gvr.Group) {
+		closed := make(chan struct{})
+		close(closed)
+		slog.Info("cache.lazy_register.skipped_unserved_group",
+			slog.String("subsystem", "cache"),
+			slog.String("gvr", gvr.String()),
+			slog.String("group", gvr.Group),
+			slog.String("reason", "apiserver ServerGroups() authoritatively does not serve this group"),
+			slog.String("effect", "informer NOT registered — no perpetual watch-404 churn; dispatch falls through to live apiserver; re-touch recovers if the group is later served"),
+		)
+		return false, closed
+	}
 
 	// Miss confirmed under RLock — upgrade to writer Lock. The
 	// addResourceType*Locked helpers re-check the informers map (line


### PR DESCRIPTION
## ⛔ PARKED — Diego-reserved merge. Do NOT merge.

Closes the #119 residual. Base frozen off `origin/main` tip `cf09811` (carries #120's phase1_walk.go). Frozen SHA `7a6c949`.

### Reclassified problem
The issue-as-filed ("pod stuck 0/1 forever") is **not** the live behavior — Fix 1b's quiescence latch + 900s ceiling already bound the readiness hang. The real residual is (a) boot **latency** and (b) **perpetual WATCH-404 churn** on an **unserved API group**: an informer registered for a group the apiserver doesn't serve has a `HasSynced` that never flips → conjunct 2 never true → never servable → every dispatch falls through to a live apiserver 404, and the reflector's `ListAndWatch` churns 404 forever.

### Fix
An **unserved-GROUP pre-check** inside `EnsureResourceType` — the single spawn-site funnel all 5 path-derived callers route through (`resolve.go`, `informer_dispatch.go`, `apistage.go`, `objects/get.go`, `deps_extract.go`). Before spawning an informer, consult `ServerGroups()`: if the group is authoritatively absent, skip registration. No informer → no reflector → no 404 loop. Gated by `SKIP_UNSERVED_GROUP_INFORMERS` (default **ON**, flips both ways; `=false` is the kill-switch).

### GROUP granularity, not resource granularity (the key design decision)
A resource-level "not served right now" skip would regress the S4/stale-delete post-startup-CRD heal path (#50/#116), which deliberately registers a GVR whose *resource* type is not yet served and relies on the ~30s confirm-ticker to heal it. A post-startup CRD lands under a group that is **already served**, so the group-level check does not skip it → it registers + heals. Only a group entirely absent from `ServerGroups()` (a dead/typo'd apiGroup) is skipped. This was surfaced falsifier-first (a resource-level cut broke 6 existing S4/F1b tests) and adjudicated by the architect.

### Fail-safe open on uncertainty (the crux)
`groupAuthoritativelyAbsent` is **three-state** — it skips **only** on a *successful* `ServerGroups()` response that definitively lacks the group. The core group `""`, `disco==nil`, no `ServerGroups` surface, a `ServerGroups` error, or a nil list **all register** (never skip). A false-skip of a genuinely-served group would silently drop real data forever — strictly worse than the churn — so uncertainty never skips.

### Non-terminal skip
The skip registers nothing, so a brand-new group's first CRD (group briefly absent at first-touch) is recovered by the next dispatch's `EnsureResourceType` re-touch. The served-group set is memoised off the **raw** discovery client with a ~30s TTL — **not** the memcache-cached client, whose event-driven global `Invalidate` can leave it stale-absent on an un-served→served transition = a permanent false-skip.

### Falsifier (`skip_unserved_group_119_test.go`, 8 arms, `-race`)
- **GREEN** — unserved-group informer skipped (no churn)
- **S4-non-regression** — served-group / resource-absent registers + heals (the collision-resolution guard)
- **RED** — flag off → dead group registers (proves the pre-check does the work)
- **brand-new-group RECOVERY** — skip → group appears → re-touch registers (drives the boundary ≥2×; non-terminal proof)
- **false-skip guard ×2** — `ServerGroups()` error + nil disco both register (the crux)
- **core-group-never-skipped**
- **mixed-K concurrent** — served registered + dead skipped under 16 concurrent `EnsureResourceType`

Full `internal/cache` package green under `-race`.

### Gate
Dual-gate GREEN: **architect PASS** (as-built faithful to the group-level Option C ruling; memo keep-prior-on-error sound; narrow-interface non-widening sound; recovery arm sufficient) + **PM ACCEPT** (symptom disappears; falsifier sufficient; default-ON safe via fail-safe-open; kill-switch clean). PM on-deploy conditions C-1 (skipped_unserved_group INFO + zero reflector watch-404 for a dead group), C-2 (post-boot CRD heal intact), C-3 (50K north-star ledger row) — post-merge, not pre-merge blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhyREULHkpkfEiuKkvto1
