### PR TITLE
test: extensive feature-coverage suite (Waves 1+2 — full audit gap list) [PARKED]

### DIFF
--- a/.github/workflows/release-pullrequest.yaml
+++ b/.github/workflows/release-pullrequest.yaml
@@ -50,6 +50,22 @@ jobs:
       # runs before the long coverage run so it fails fast.
       - name: ResolvedEntry Put-site scope-completeness gate
         run: bash scripts/check_resolved_entry_put_sites.sh
+      # H6 (SEC-adj forgery single-source): the AST lints under scripts/lint/
+      # are //go:build ignore standalone programs that no workflow invoked, so
+      # a BindingUID derivation reintroduced OUTSIDE the match_subject.go single
+      # source of truth would NOT fail CI. This step runs the lint over the
+      # production tree and fails the PR on any parallel derivation. Cheap AST
+      # check, runs before the long coverage run so it fails fast.
+      - name: BindingUID single-source (no parallel derivation) gate
+        run: bash scripts/check_no_parallel_binding_derivation.sh
+      # H6 companion: the Ship 0.30.233 defect class — a raw
+      # obj.(*unstructured.Unstructured) content-assert inside a literal
+      # informer event-handler body — silently drops every CRD event post-H5
+      # (delivery shape is *bytesObject). This step runs the orphaned lint over
+      # internal/cache and fails the PR on any unchecked assert. Cheap AST
+      # check, runs before the long coverage run so it fails fast.
+      - name: No unchecked *unstructured.Unstructured assert in informer handlers gate
+        run: bash scripts/check_no_unchecked_unstructured_assert.sh
       - name: Run coverage
         run: go test -race -tags=unit,integration -p 1 -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage to Codecov

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,9 @@
+# gitleaks false-positive allowlist (fingerprints: commit:file:rule:line).
+#
+# The resolvedKeyVersion golden anchor is a 64-char SHA-256 hex constant
+# (ComputeKey output captured empirically for the L3 key-version test). gitleaks'
+# generic-api-key rule flags it as a credential because the identifier contains
+# "Key". It is a test fixture, not a secret. The source line also carries an
+# inline //gitleaks:allow (covers the post-squash-merge scan on main, new SHA);
+# this fingerprint covers the PR-branch scan of the introducing commit's diff.
+dada1521fa9ea4bcaa7a6dd15fe313b6afe903a1:internal/cache/resolved_key_version_golden_test.go:generic-api-key:50

--- a/docs/test-coverage-audit-2026-07-30.md
+++ b/docs/test-coverage-audit-2026-07-30.md
@@ -1,0 +1,107 @@
+# Snowplow Test-Coverage Audit — 2026-07-30
+
+Feature × existing-coverage × gap inventory across all packages, produced to drive an extensive
+test-suite build. Full per-feature matrix (131 rows) is in the workflow output
+(`wwdxzny7r`); this doc carries the actionable parts: summary, prioritized gap list, and the
+conflict-free suite-organization plan.
+
+## Summary
+
+- Features audited: **131**
+- Covered — discriminating (RED/neuter arm, -race): **89**
+- Covered — shallow (happy-path only): **26**
+- Uncovered (no test): **16**
+- Standing CI gates: 1 wired (`-race` suite in `release-pullrequest.yaml`); 1 **orphaned** (the
+  `scripts/lint/*` AST gates — present but NOT invoked by any workflow).
+
+**8 of the top-10 gaps are security** (RBAC / identity / cross-user-leak / forgery). The
+dispatcher serve path and the identity/key-derivation seams carry the most under-tested
+correctness-critical surface.
+
+## Prioritized gap list
+
+### HIGH
+- **H1** [SEC cross-user] — RESTAction & Widget `ServeHTTP` end-to-end orchestration. No httptest
+  drives the branch ordering (RBAC before L1 Get; serve-eligible before Get; Put only on genuine
+  else-if; stage-error/external precedence). Arms a–k incl warm≡cache-off, RBAC-deny→Get-never-called,
+  RBAC-sensitive-widget skips content cell, both Put-gates. RED: L1-serve-before-RBAC / reads shared
+  content cell for RBAC-sensitive widget / Puts regardless of sink.Count().
+- **H2** [SEC cross-user] — `resolveWidgetData` #69 fail-soft: read-error must return STATIC src, build
+  NO cross-ns aggregate. RED: on read-error proceeds to build SA-maximal aggregate.
+- **H3** [SEC stale-permit] — L2 authz-memo invalidation on **role-RULE edit** (not just binding-set).
+  RED: memo keyed only on binding-set / rule Update fails to bump PublishSeq → serves stale allow.
+- **H4** [SEC forgery/arming] — CORS `ExposedHeaders` wiring: `X-Snowplow-Refresh-Key`/`-Class` must be
+  exposed cross-origin (the whole #48/#67 arming contract). RED: drop either header.
+- **H5** [SEC under-grant] — `/rbac` handler non-auth contracts: 422 partial-read-set refusal
+  (`formatUnresolved`, zero coverage), 400 missing param, `[]` not null. RED: partial read-set as 200.
+- **H6** [SEC-adjacent forgery-single-source] — orphaned AST lint gates (`no_parallel_binding_derivation`,
+  `no_unchecked_unstructured_assert`) not in CI → a BindingUID derivation outside the match_subject
+  allowlist would not fail. Wire into CI + regression fixture.
+
+### MEDIUM
+- **M1** [SEC/mem] — `Representative*` EXCLUDED from ComputeKey (per-binding equivalence unpinned).
+- **M2** [SEC] — widgetContent OMITS BindingUID / other 4 classes fold it.
+- **M3** [SEC identity] — `GetIdentityContext` D1 enum filter (drops displayName/typo/non-string).
+- **M5** [SEC fail-closed] — `checkDispatchRBAC` direct table (fail-closed on UserInfo/eval error).
+- **M6** [SEC stale-forever] — external-touched skip on RA full-list serve surface (#4).
+- **M7** — `/readyz` C2 backstop via injected panicking/blocking/erroring `pipSeedFn`.
+- **M8** — L2 authz-memo cap-breach (16384) REFUSE path (not LRU-evict; correct verdict on refused).
+- **M9** [SEC-adjacent] — `canonicalGroupsHash` isolated unit (length-prefix anti-alias, no in-place sort).
+- **M10** — `WidgetContentL1Enabled` gate truth table.
+- **M11** — `SeededAtBoot` seed→traffic re-classification on re-Put.
+- **M12** — SA transport capture at construction + out-of-cluster nil-guard (#18/#19).
+- **M13** — `HashExtras` direct + parity with ComputeKey (single-derivation anti-drift).
+- **M14** — Seed footprint budget PROD branch (ERROR+counter+proceed, no panic).
+- **M15** — `hasTemplatedEndpointRef` seed-skip (no truncated no-extras Put).
+- **M16** — X-Snowplow-Refresh-Class stamped-class AST scan (serve-site literal ∈ allowlist).
+- **M17** [SEC auth] — RefreshAuth cookie-name override + **no-token-in-URL** + expired→401.
+- **M18** [SEC-adjacent DoS] — /refreshes URL-safe base64 (EventSource path) + 512-cap + informer-only skip.
+- **M19** — delivery dep-edges list-scope path (RecordList `*`) + action-ref skip.
+- **M20** — widgets.Resolve orchestration hermetic unit + rrt-extras fold timing (rrt key must not leak
+  into widgetData jq).
+
+### LOW
+L1 inlineParentIdentityForKey partial-identity shapes [SEC]; L2 Extras marshal-failure fallback;
+L3 resolvedKeyVersion golden anchor; L4 SeedDeclinedExternalSet cache-pkg direct; L5 cache=off SAR
+permit branch [SEC]; L6 authn Token -race + clock-skew; L7 SA synthetic-groups probe→assertion;
+L8 Stats widgetContent/raFullList evict-pressure; L9 /debug/refreshes structural aggregate-only guard
+[SEC-adjacent]; L10 /debug/servable handler; L11 refresh coalesce-window disable; L12 F6 undeclared-extra
+reaches resolve-INPUT-not-key; L13 UAF refilter -race + SA-endpoint fail-closed + multi-yield; L14
+beginPerCall / emitDispatchCacheKeyDiag diagnostics.
+
+## Suite organization (conflict-free; one coherent new file per concern, by owning package)
+
+**internal/handlers/dispatchers/**: `servehttp_orchestration_test.go` (H1), `check_dispatch_rbac_test.go`
+(M5), `sa_transport_capture_test.go` (M12), `phase1_readyz_backstop_test.go` (M7),
+`refresh_class_stamp_ast_test.go` (M16), `inline_parent_identity_key_test.go` (L1),
+`f6_resolve_input_reach_test.go` (L12), + extend templated-endpointref (M15).
+
+**internal/cache/**: `compute_key_identity_invariants_test.go` (M1+M2), `hash_extras_test.go` (M13+L2),
+`gates_widget_content_test.go` (M10), `seeded_at_boot_test.go` (M11),
+`seed_assert_prod_mode_test.go` (M14), `resolved_key_version_golden_test.go` (L3),
+`seed_declined_external_set_test.go` (L4), stats extension (L8), refresh_broadcaster coalesce (L11).
+
+**internal/resolvers/widgets/**: `resolve_orchestration_test.go` (M20+H2),
+`identity_key_extras_accessors_test.go` (M3). **apiref/**: extend ra_full_list (M6).
+**restactions/api/**: refilter concurrency (L13).
+
+**internal/rbac/evaltest/**: extend snapshot_authz_memo (H3+M8), `groups_hash_test.go` (M9),
+extend evaluate (L5+L7). **internal/authn/**: extend authn_test (L6).
+
+**internal/handlers/ & main**: `main_cors_test.go` (H4 — extract cors.Options into a package var),
+`rbac_handler_body_test.go` (H5), extend refreshes (M18), `debug_refreshes_structural_test.go` (L9),
+`debug_servable_test.go` (L10). **middleware/**: extend refreshauth (M17).
+
+**CI/lint**: wire `scripts/lint/*` into `release-pullrequest.yaml` + regression fixtures (H6).
+**Extend existing** `deps_refresh_delivery_falsifier_test.go` (M19).
+
+Every addition is a distinct new file or a named extension in its owning package — keeps the
+`-p 1 -race` serialized run conflict-free.
+
+## Build plan
+
+Author in priority waves, each built + `go test -race` verified before the next:
+- **Wave 1 (security/HIGH + security-MEDIUM):** dispatchers, cache, widgets, rbac/evaltest,
+  handlers+main+middleware. Covers H1–H5, M1–M3, M5, M7, M10–M14, M16–M18, L1–L3, L8, L9, L12.
+- **Wave 2 (remaining + CI):** apiref (M6), restactions/api (L13), authn (L6), CI lint wiring (H6),
+  M6/M15/M19 extensions, L4–L7, L10, L11, L14.

--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -72,11 +72,22 @@ func New(server, tokenPath string) *Client {
 // WithHTTPClient overrides the HTTP client (tests inject a stub transport).
 func (c *Client) WithHTTPClient(h *http.Client) *Client { c.httpClient = h; return c }
 
+// tokenLock / tokenUnlock are the (var-seam) critical-section entry/exit for
+// Token's exchange-and-cache. Production ALWAYS uses c.mu — these are never
+// reassigned outside tests; they exist only so the concurrency falsifier can
+// transiently neuter the mutual exclusion (observe >1 exchange under -race)
+// and restore it, without reflectively mutating a sync.Mutex. Repo idiom:
+// resolveOnceFn / nestedCallResolver / saRESTConfigForInspectFn.
+var (
+	tokenLock   = func(c *Client) { c.mu.Lock() }
+	tokenUnlock = func(c *Client) { c.mu.Unlock() }
+)
+
 // Token returns a valid authn JWT, exchanging the projected SA token when the
 // cache is empty or near expiry.
 func (c *Client) Token(ctx context.Context) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	tokenLock(c)
+	defer tokenUnlock(c)
 
 	if c.cached != "" && c.now().Before(c.expiry.Add(-refreshSkew)) {
 		return c.cached, nil

--- a/internal/authn/authn_concurrency_test.go
+++ b/internal/authn/authn_concurrency_test.go
@@ -1,0 +1,206 @@
+// authn_concurrency_test.go — L6 hermetic falsifiers for the authn.Client
+// exchange-and-cache critical section:
+//
+//	(a) TestToken_ConcurrentExchange_SingleFlight (-race) — 50 goroutines racing
+//	    a cold cache must produce EXACTLY ONE upstream token exchange; the
+//	    remaining 49 observe the just-cached JWT. Guarded by the Token() mutex
+//	    (tokenLock/tokenUnlock var-seam). RED arm: neuter the seam to no-ops →
+//	    every goroutine enters exchange() → >1 exchange under -race.
+//	(b) TestToken_ClockSkewBoundary — with an INJECTED clock, a cached JWT is
+//	    served until exactly refreshSkew (60s) before its exp, and a re-read one
+//	    tick past that boundary (advancing the clock to exp-60s) re-exchanges.
+//
+// Pure in-memory: stub transport + temp token file, injected c.now clock. No
+// network, no wall-clock sleeps.
+
+package authn
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// gatedTransport is a stub RoundTripper that, on each call, records the
+// exchange, announces its arrival on arrived, then blocks until release is
+// closed. This lets the test hold every in-flight exchange OPEN simultaneously
+// so a missing mutex (concurrent exchange()) is observable, with no sleeps.
+type gatedTransport struct {
+	calls   atomic.Int64
+	arrived chan struct{}
+	release chan struct{}
+	issued  string
+}
+
+func (g *gatedTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	g.calls.Add(1)
+	// Announce this exchange began (non-blocking: arrived is buffered wide).
+	select {
+	case g.arrived <- struct{}{}:
+	default:
+	}
+	<-g.release // hold the exchange open until the test releases it
+	body, _ := json.Marshal(map[string]string{"accessToken": g.issued})
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(string(body))), Header: make(http.Header)}, nil
+}
+
+// runConcurrentExchange drives the shared-single-flight scenario and returns
+// the number of upstream exchanges that actually occurred. Reused by the GREEN
+// assertion and the RED arm.
+func runConcurrentExchange(t *testing.T, goroutines int) int64 {
+	t.Helper()
+	tokenPath := writeTokenFile(t, "sa-token-concurrent")
+	g := &gatedTransport{
+		arrived: make(chan struct{}, goroutines),
+		release: make(chan struct{}),
+		issued:  makeJWT(time.Now().Add(time.Hour).Unix()),
+	}
+	c := New("http://authn.test:8082", tokenPath).WithHTTPClient(&http.Client{Transport: g})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	tokens := make([]string, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start // all goroutines block here so they contend on the cold cache
+			tok, err := c.Token(context.Background())
+			if err != nil {
+				t.Errorf("goroutine %d Token: %v", idx, err)
+				return
+			}
+			tokens[idx] = tok
+		}(i)
+	}
+	close(start) // unleash the herd against the empty cache
+
+	// Wait for at least one exchange to be IN FLIGHT, then release everyone.
+	// GREEN: exactly one goroutine reaches the transport (the rest wait on the
+	// mutex, then observe the cached token). RED (mutex neutered): many are in
+	// flight simultaneously and all are counted after release.
+	<-g.arrived
+	close(g.release)
+	wg.Wait()
+
+	// Every goroutine must have gotten the SAME issued JWT (a torn/empty token
+	// would mean the cache handed back a half-written value — a data race).
+	for i, tok := range tokens {
+		if tok != g.issued {
+			t.Errorf("goroutine %d got %q, want the single issued JWT", i, tok)
+		}
+	}
+	return g.calls.Load()
+}
+
+// TestToken_ConcurrentExchange_SingleFlight (falsifier a). Run with -race.
+func TestToken_ConcurrentExchange_SingleFlight(t *testing.T) {
+	const goroutines = 50
+	n := runConcurrentExchange(t, goroutines)
+	if n != 1 {
+		t.Fatalf("concurrent cold-cache Token: %d exchanges, want exactly 1 (the mutex must single-flight the exchange)", n)
+	}
+}
+
+// TestToken_ConcurrentExchange_RedArm_MutexNeutered proves the (a) falsifier
+// DISCRIMINATES: with the tokenLock/tokenUnlock seam transiently neutered to
+// no-ops (removing the mutual exclusion Token() relies on), the same 50
+// goroutines race into exchange() concurrently and produce MORE THAN ONE
+// exchange — the RED the guarded path prevents. Restores the real seam after.
+//
+// It is env-gated (AUTHN_RED_ARM=1) because neutering the mutex ALSO
+// unsynchronises the c.cached/c.expiry writes, so under `go test -race` the
+// detector (correctly) reports the data race and fails the run — the whole
+// point of the falsifier. We do NOT commit an always-run test that reds the
+// -race suite (established repo convention: the committed test is GREEN and the
+// RED is reproducible on demand). Observed RED on 2026-07-30:
+//
+//	$ AUTHN_RED_ARM=1 go test ./internal/authn/ -race -count=1 \
+//	    -run TestToken_ConcurrentExchange_RedArm_MutexNeutered -v
+//	  authn_concurrency_test.go: RED arm: mutex neutered → 9 concurrent exchanges
+//	  WARNING: DATA RACE  ... (*Client).Token authn.go:100  c.cached = jwt
+//	  --- FAIL (race detected)   [count 9 >> 1, race on cache write]
+//
+// Restore (real seam) → single-flights to exactly 1, -race clean (the GREEN
+// TestToken_ConcurrentExchange_SingleFlight above).
+func TestToken_ConcurrentExchange_RedArm_MutexNeutered(t *testing.T) {
+	if os.Getenv("AUTHN_RED_ARM") != "1" {
+		t.Skip("RED arm (mutex-neutered) — set AUTHN_RED_ARM=1 to reproduce; it intentionally reds -race")
+	}
+	origLock, origUnlock := tokenLock, tokenUnlock
+	tokenLock = func(*Client) {}   // neuter: no mutual exclusion
+	tokenUnlock = func(*Client) {} // neuter
+	t.Cleanup(func() { tokenLock, tokenUnlock = origLock, origUnlock })
+
+	const goroutines = 50
+	n := runConcurrentExchange(t, goroutines)
+	if n <= 1 {
+		t.Fatalf("RED arm expected >1 concurrent exchange with the mutex neutered, got %d — the (a) falsifier does not discriminate", n)
+	}
+	t.Logf("RED arm: mutex neutered → %d concurrent exchanges (guarded path single-flights to 1)", n)
+}
+
+// TestToken_ClockSkewBoundary (falsifier b). Drives the refreshSkew boundary
+// with an INJECTED clock: a cached JWT is served for reads strictly before
+// exp-refreshSkew, and a read AT/after exp-refreshSkew re-exchanges. No
+// wall-clock: the test pins and advances c.now itself.
+func TestToken_ClockSkewBoundary(t *testing.T) {
+	tokenPath := writeTokenFile(t, "sa-token")
+
+	// A fixed clock the test advances by hand.
+	var mu sync.Mutex
+	nowT := time.Unix(1_000_000, 0)
+	clock := func() time.Time { mu.Lock(); defer mu.Unlock(); return nowT }
+	advance := func(d time.Duration) { mu.Lock(); nowT = nowT.Add(d); mu.Unlock() }
+
+	// The issued token expires 600s after the initial clock reading.
+	const lifetime = 600 * time.Second
+	exp := nowT.Add(lifetime)
+
+	var calls atomic.Int64
+	c := New("http://authn.test:8082", tokenPath).WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			body, _ := json.Marshal(map[string]string{"accessToken": makeJWT(exp.Unix())})
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(string(body))), Header: make(http.Header)}, nil
+		}),
+	})
+	c.now = clock
+
+	// First read: cold → 1 exchange.
+	if _, err := c.Token(context.Background()); err != nil {
+		t.Fatalf("initial Token: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("cold read: %d exchanges, want 1", calls.Load())
+	}
+
+	// Advance to JUST INSIDE the skew boundary: exp-refreshSkew minus 1s. The
+	// cache-valid predicate is now().Before(exp - refreshSkew); at exp-61s that
+	// is TRUE → served from cache, no re-exchange.
+	advance(lifetime - refreshSkew - 1*time.Second) // now = exp - 61s
+	if _, err := c.Token(context.Background()); err != nil {
+		t.Fatalf("near-boundary Token: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("read at exp-61s must be a cache HIT; got %d exchanges, want 1", calls.Load())
+	}
+
+	// Advance one more tick to reach the boundary exactly (now = exp-60s =
+	// exp-refreshSkew). now().Before(exp-refreshSkew) is FALSE at equality →
+	// re-exchange.
+	advance(1 * time.Second) // now = exp - 60s == exp - refreshSkew
+	if _, err := c.Token(context.Background()); err != nil {
+		t.Fatalf("boundary Token: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("read at exactly exp-refreshSkew (exp-60s) must RE-EXCHANGE; got %d exchanges, want 2", calls.Load())
+	}
+}

--- a/internal/cache/compute_key_identity_invariants_test.go
+++ b/internal/cache/compute_key_identity_invariants_test.go
@@ -1,0 +1,234 @@
+// compute_key_identity_invariants_test.go — coverage-audit M1 + M2.
+//
+// These lock the two SECURITY-critical ComputeKey identity invariants that the
+// H.c-layered / #118 key-shape carries, and which a plausible-wrong refactor
+// could silently break:
+//
+//   M1 [SEC/mem]: RepresentativeUsername + RepresentativeGroups are BOOKKEEPING
+//     carried on ResolvedEntry.Inputs, NOT key material (resolved.go §Ship A.3
+//     "EXCLUDED FROM COMPUTEKEY"). Two members of the same binding equivalence
+//     class writing the same cell must NOT shift the cell's identity by name —
+//     else the per-binding cell fragments per-representative (memory blow-up)
+//     and, worse, an attacker-controlled representative name could partition
+//     cells. The RED arm is an impl that folds Representative* into the hash.
+//
+//   M2 [SEC]: BindingUID is folded for every identity-bound class
+//     (restactions / widgets / apistage / raFullList) but SKIPPED for the
+//     identity-free widgetContent class (resolved.go ComputeKey
+//     `if in.CacheEntryClass != CacheEntryClassWidgetContent`). If widgetContent
+//     folded BindingUID it would fragment the shared envelope per binding
+//     (breaking the shared-content invariant); if an identity-bound class
+//     SKIPPED it, two distinct bindings would COLLIDE on one cell — a
+//     cross-binding RBAC leak. Both directions are asserted; both RED impls are
+//     proven below via a shadow wrong-impl.
+package cache
+
+import "testing"
+
+// baseIdentityInputs is a fully-populated identity-bound key-input bundle. The
+// Representative* fields carry a concrete "first writer" identity; the invariant
+// under test is that mutating ONLY those fields never moves the key.
+func baseIdentityInputs() ResolvedKeyInputs {
+	return ResolvedKeyInputs{
+		CacheEntryClass: CacheEntryClassWidgets,
+		Group:           "widgets.templates.krateo.io",
+		Version:         "v1beta1",
+		Resource:        "compositionsgrids",
+		Namespace:       "demo",
+		Name:            "main",
+		BindingUID:      "C:uid-0123456789abcdef",
+		PerPage:         20,
+		Page:            1,
+		RBACSubGen:      3,
+		Extras:          map[string]any{"foo": "bar"},
+
+		// Representative bookkeeping — must be key-INVISIBLE.
+		RepresentativeUsername: "alice",
+		RepresentativeGroups:   []string{"tenant-a", "viewers"},
+	}
+}
+
+// CacheEntryClassWidgets / CacheEntryClassRestactions are not exported consts in
+// resolved.go (only apistage/widgetContent/raFullList are). The string values
+// are load-bearing and used verbatim across the package; alias them here so the
+// table reads intent-first and a rename would fail to compile.
+const (
+	CacheEntryClassWidgets     = "widgets"
+	CacheEntryClassRestactions = "restactions"
+)
+
+// TestComputeKey_RepresentativeIdentityExcluded is M1: mutating ONLY
+// RepresentativeUsername and RepresentativeGroups leaves the key BYTE-IDENTICAL.
+//
+// RED PROOF: a shadow impl that folds Representative* into the hash
+// (computeKeyFoldingRepresentative below) produces DIVERGENT keys for the two
+// clones — the sub-test at the bottom proves the shadow reds, so this GREEN arm
+// genuinely discriminates against the "folded Representative*" wrong impl.
+func TestComputeKey_RepresentativeIdentityExcluded(t *testing.T) {
+	base := baseIdentityInputs()
+
+	// Clone, then mutate ONLY the representative identity fields.
+	mutated := base
+	mutated.RepresentativeUsername = "mallory" // different (attacker-controlled) name
+	mutated.RepresentativeGroups = []string{"tenant-z", "admins", "extra"}
+
+	if got, want := ComputeKey(mutated), ComputeKey(base); got != want {
+		t.Fatalf("M1: mutating RepresentativeUsername/Groups shifted the key — "+
+			"Representative* MUST be excluded from ComputeKey (per-binding cell would "+
+			"fragment per representative)\n base=%s\n mut =%s", want, got)
+	}
+
+	// Also assert a genuine key field (BindingUID) STILL moves the key — proves
+	// the equality above is not a degenerate "everything hashes the same".
+	moved := base
+	moved.BindingUID = "C:uid-different"
+	if ComputeKey(moved) == ComputeKey(base) {
+		t.Fatalf("M1 control: changing BindingUID must change the key (coalesced inputs)")
+	}
+}
+
+// TestComputeKey_WidgetContentIsIdentityFree is M2 part (1): two widgetContent
+// inputs that differ ONLY in BindingUID hash IDENTICALLY — the shared envelope
+// is identity-free.
+//
+// RED PROOF: a shadow impl that folds BindingUID for widgetContent
+// (computeKeyFoldingBindingUIDForWidgetContent) diverges the two — proven in the
+// dedicated RED sub-test.
+func TestComputeKey_WidgetContentIsIdentityFree(t *testing.T) {
+	in1 := ResolvedKeyInputs{
+		CacheEntryClass: CacheEntryClassWidgetContent,
+		Group:           "g", Version: "v", Resource: "r",
+		Namespace: "ns", Name: "n",
+		BindingUID: "C:uid-alpha",
+		RBACSubGen: 11, // also identity-bound-only; must be excluded for widgetContent
+	}
+	in2 := in1
+	in2.BindingUID = "R:ns/uid-beta"
+	in2.RBACSubGen = 999
+
+	if ComputeKey(in1) != ComputeKey(in2) {
+		t.Fatalf("M2(1): widgetContent keys diverged on BindingUID/RBACSubGen — the "+
+			"identity-free shared envelope must NOT fold identity\n a=%s\n b=%s",
+			ComputeKey(in1), ComputeKey(in2))
+	}
+}
+
+// TestComputeKey_IdentityBoundClassesFoldBindingUID is M2 part (2): for every
+// identity-bound class, two inputs differing ONLY in BindingUID produce DISTINCT
+// keys — else two bindings collide on one cell (cross-binding RBAC leak).
+//
+// RED PROOF: a shadow impl that SKIPS the BindingUID fold for all classes
+// (computeKeyNeverFoldingBindingUID) collapses the two — proven in the RED
+// sub-test.
+func TestComputeKey_IdentityBoundClassesFoldBindingUID(t *testing.T) {
+	for _, class := range []string{
+		CacheEntryClassRestactions,
+		CacheEntryClassWidgets,
+		CacheEntryClassApistage,
+		CacheEntryClassRAFullList,
+	} {
+		t.Run(class, func(t *testing.T) {
+			in1 := ResolvedKeyInputs{
+				CacheEntryClass: class,
+				Group:           "g", Version: "v", Resource: "r",
+				Namespace: "ns", Name: "n",
+				BindingUID: "C:uid-alpha",
+			}
+			in2 := in1
+			in2.BindingUID = "R:ns/uid-beta"
+			if ComputeKey(in1) == ComputeKey(in2) {
+				t.Fatalf("M2(2): class %q did NOT fold BindingUID — two distinct bindings "+
+					"collide on one cell (cross-binding RBAC leak)", class)
+			}
+		})
+	}
+}
+
+// --- RED-arm proofs: shadow wrong-impls + assertions that they RED ----------
+
+// computeKeyFoldingRepresentative is the M1 WRONG impl: it distinguishes inputs
+// by their representative identity (the defect this test guards against).
+func computeKeyFoldingRepresentative(in ResolvedKeyInputs) string {
+	// Cheap, deterministic surrogate: fold the representative identity into the
+	// canonical key by stuffing it into Extras before delegating to the REAL
+	// ComputeKey. If the real ComputeKey ever folded Representative* this is
+	// exactly the divergence we'd see.
+	clone := in
+	clone.Extras = map[string]any{}
+	for k, v := range in.Extras {
+		clone.Extras[k] = v
+	}
+	clone.Extras["__rep_user"] = in.RepresentativeUsername
+	reps := make([]any, 0, len(in.RepresentativeGroups))
+	for _, g := range in.RepresentativeGroups {
+		reps = append(reps, g)
+	}
+	clone.Extras["__rep_groups"] = reps
+	return ComputeKey(clone)
+}
+
+// TestComputeKey_RepresentativeFold_RedArm proves the M1 GREEN arm discriminates:
+// the wrong impl (folds Representative*) DIVERGES on the same clone pair the
+// GREEN arm asserts EQUAL.
+func TestComputeKey_RepresentativeFold_RedArm(t *testing.T) {
+	base := baseIdentityInputs()
+	mutated := base
+	mutated.RepresentativeUsername = "mallory"
+	mutated.RepresentativeGroups = []string{"tenant-z"}
+
+	if computeKeyFoldingRepresentative(base) == computeKeyFoldingRepresentative(mutated) {
+		t.Fatalf("RED-arm sanity: the Representative-folding wrong impl SHOULD diverge on a " +
+			"representative-only mutation — if it does not, the M1 test is not discriminating")
+	}
+}
+
+// computeKeyFoldingBindingUIDForWidgetContent is the M2(1) WRONG impl: it folds
+// BindingUID even for the identity-free widgetContent class.
+func computeKeyFoldingBindingUIDForWidgetContent(in ResolvedKeyInputs) string {
+	clone := in
+	clone.Extras = map[string]any{}
+	for k, v := range in.Extras {
+		clone.Extras[k] = v
+	}
+	clone.Extras["__binding_uid"] = in.BindingUID
+	return ComputeKey(clone)
+}
+
+// TestComputeKey_WidgetContentFold_RedArm proves the M2(1) GREEN arm
+// discriminates: the wrong impl (folds BindingUID for widgetContent) diverges on
+// the BindingUID-only pair the GREEN arm asserts EQUAL.
+func TestComputeKey_WidgetContentFold_RedArm(t *testing.T) {
+	in1 := ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgetContent, BindingUID: "C:a"}
+	in2 := ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgetContent, BindingUID: "C:b"}
+	if computeKeyFoldingBindingUIDForWidgetContent(in1) == computeKeyFoldingBindingUIDForWidgetContent(in2) {
+		t.Fatalf("RED-arm sanity: the widgetContent-BindingUID-folding wrong impl SHOULD diverge; " +
+			"M2(1) is not discriminating otherwise")
+	}
+}
+
+// computeKeyNeverFoldingBindingUID is the M2(2) WRONG impl: it never folds the
+// BindingUID (identity-free for EVERY class). Two distinct bindings collapse.
+func computeKeyNeverFoldingBindingUID(in ResolvedKeyInputs) string {
+	clone := in
+	clone.BindingUID = "" // erase the identity fold
+	return ComputeKey(clone)
+}
+
+// TestComputeKey_NeverFoldBindingUID_RedArm proves the M2(2) GREEN arm
+// discriminates: the wrong impl (never folds BindingUID) COLLIDES the two
+// distinct bindings the GREEN arm asserts DISTINCT.
+func TestComputeKey_NeverFoldBindingUID_RedArm(t *testing.T) {
+	for _, class := range []string{
+		CacheEntryClassRestactions,
+		CacheEntryClassWidgets,
+		CacheEntryClassApistage,
+		CacheEntryClassRAFullList,
+	} {
+		in1 := ResolvedKeyInputs{CacheEntryClass: class, BindingUID: "C:a"}
+		in2 := ResolvedKeyInputs{CacheEntryClass: class, BindingUID: "R:ns/b"}
+		if computeKeyNeverFoldingBindingUID(in1) != computeKeyNeverFoldingBindingUID(in2) {
+			t.Fatalf("RED-arm sanity for class %q: the never-fold-BindingUID wrong impl SHOULD "+
+				"collide two bindings; M2(2) is not discriminating otherwise", class)
+		}
+	}
+}

--- a/internal/cache/gates_widget_content_test.go
+++ b/internal/cache/gates_widget_content_test.go
@@ -1,0 +1,104 @@
+// gates_widget_content_test.go — coverage-audit M10.
+//
+// WidgetContentL1Enabled (resolved.go) is a THREE-gate predicate:
+//   1. CACHE_ENABLED truthy      (Disabled() == false)
+//   2. RESOLVED_CACHE_ENABLED != {"false","0","no"}
+//   3. WIDGET_CONTENT_L1_ENABLED != {"false","0","no"}   (the sub-gate)
+//
+// The sub-gate (3) is default-ON: any value NOT in the explicit-off set
+// ("", "true", "1", "yes", "garbage") enables it. This test drives the sub-gate
+// truth table over the {'', 'true', '1', 'yes', 'garbage'} → true and
+// {'false','0','no'} → false shapes, plus the two master-gate off cases.
+//
+// RED PROOF: an impl that returns ResolvedCacheEnabled() directly (ignoring the
+// WIDGET_CONTENT_L1_ENABLED sub-gate) would report ENABLED even when
+// WIDGET_CONTENT_L1_ENABLED=false — proven by the shadow
+// widgetContentEnabledIgnoringSubgate below.
+package cache
+
+import "testing"
+
+// TestWidgetContentL1Enabled_SubgateTruthTable is M10: with both master gates
+// open, the WIDGET_CONTENT_L1_ENABLED sub-gate follows the default-ON parse.
+func TestWidgetContentL1Enabled_SubgateTruthTable(t *testing.T) {
+	// Master gates open for the whole sub-gate table.
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"", true},        // unset-ish default → ON
+		{"true", true},    // any non-off value → ON
+		{"1", true},       // default-ON parse does NOT special-case "1"
+		{"yes", true},     // ditto
+		{"garbage", true}, // unrecognised → ON (fail-open sub-gate, matches ResolvedCacheEnabled)
+		{"false", false},  // explicit off
+		{"0", false},      // explicit off
+		{"no", false},     // explicit off
+	}
+	for _, tc := range cases {
+		t.Run("WIDGET_CONTENT_L1_ENABLED="+tc.env, func(t *testing.T) {
+			t.Setenv("WIDGET_CONTENT_L1_ENABLED", tc.env)
+			if got := WidgetContentL1Enabled(); got != tc.want {
+				t.Fatalf("WidgetContentL1Enabled() with WIDGET_CONTENT_L1_ENABLED=%q = %v, want %v",
+					tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWidgetContentL1Enabled_MasterGatesGoverning is M10 part 2: either master
+// gate off forces the whole predicate false, REGARDLESS of the sub-gate value.
+func TestWidgetContentL1Enabled_MasterGatesGoverning(t *testing.T) {
+	// The sub-gate is set to its most-permissive value throughout so any
+	// "true" result could ONLY come from the sub-gate being consulted alone.
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "true")
+
+	// CACHE_ENABLED off → false.
+	t.Setenv("CACHE_ENABLED", "false")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	if WidgetContentL1Enabled() {
+		t.Fatalf("CACHE_ENABLED=false must force WidgetContentL1Enabled() false")
+	}
+
+	// CACHE_ENABLED on but RESOLVED_CACHE_ENABLED off → false.
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "false")
+	if WidgetContentL1Enabled() {
+		t.Fatalf("RESOLVED_CACHE_ENABLED=false must force WidgetContentL1Enabled() false")
+	}
+
+	// Both master gates open + sub-gate on → true (control).
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	if !WidgetContentL1Enabled() {
+		t.Fatalf("both master gates + sub-gate open must be true (control)")
+	}
+}
+
+// --- RED-arm proof ----------------------------------------------------------
+
+// widgetContentEnabledIgnoringSubgate is the M10 WRONG impl: it returns the
+// resolved-cache gate directly, ignoring the WIDGET_CONTENT_L1_ENABLED sub-gate.
+func widgetContentEnabledIgnoringSubgate() bool {
+	return ResolvedCacheEnabled()
+}
+
+// TestWidgetContentL1Enabled_IgnoreSubgate_RedArm proves the M10 sub-gate arm
+// discriminates: with both master gates open but WIDGET_CONTENT_L1_ENABLED=false
+// the CORRECT predicate is false while the sub-gate-ignoring shadow is true.
+func TestWidgetContentL1Enabled_IgnoreSubgate_RedArm(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "false")
+
+	if !widgetContentEnabledIgnoringSubgate() {
+		t.Fatalf("RED-arm sanity: the sub-gate-ignoring wrong impl SHOULD report enabled " +
+			"(it only reads the resolved-cache gate)")
+	}
+	if WidgetContentL1Enabled() {
+		t.Fatalf("the CORRECT WidgetContentL1Enabled() must be FALSE when the sub-gate is off; " +
+			"if it matched the wrong impl the M10 sub-gate arm would not discriminate")
+	}
+}

--- a/internal/cache/hash_extras_test.go
+++ b/internal/cache/hash_extras_test.go
@@ -1,0 +1,224 @@
+// hash_extras_test.go — coverage-audit M13 + L2.
+//
+// HashExtras (resolved.go) is the SINGLE canonicalisation site shared by the
+// L1 key (ComputeKey folds canonicaliseExtras) and the F4 SeedResolveMemo key.
+// Its contract:
+//
+//   M13:
+//     - HashExtras(nil) == HashExtras(map[string]any{}) == "e0"  (empty sentinel,
+//       never the empty string, so an empty-extras key segment is unambiguous).
+//     - order-INDEPENDENT: two maps with the same entries hash identically, and
+//       a non-empty map never hashes to the "e0" sentinel.
+//     - PARITY: order-equal Extras drive an EQUAL ComputeKey — HashExtras and the
+//       key both route through canonicaliseExtras, so they cannot drift.
+//
+//   L2 (marshal-failure fallback):
+//     - a value json.Marshal cannot encode (here: a non-JSON func value) still
+//       makes the key VARY with content via the fmt.Sprintf fallback (never
+//       collapses distinct content to one hash).
+//     - nested-map recursion: canonicaliseExtras recurses into nested maps, so
+//       a nested-map difference changes the hash (guards the recursion branch).
+//
+// RED arms:
+//   M13: an order-SENSITIVE HashExtras (no key sort — the shape a fmt.Sprintf(map)
+//     impl would exhibit) produces different hashes for the same content under
+//     different key orderings → the shadow proves order-instability, so the GREEN
+//     order-independence arm discriminates.
+//   L2: a fallback that returns a CONSTANT on marshal error collapses distinct
+//     un-marshalable content to one hash → the shadow proves the collapse.
+package cache
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestHashExtras_EmptySentinel is M13 part 1: nil and empty map both map to the
+// fixed "e0" sentinel, and a non-empty map never does.
+func TestHashExtras_EmptySentinel(t *testing.T) {
+	if got := HashExtras(nil); got != "e0" {
+		t.Fatalf("HashExtras(nil) = %q, want the empty sentinel %q", got, "e0")
+	}
+	if got := HashExtras(map[string]any{}); got != "e0" {
+		t.Fatalf("HashExtras(empty) = %q, want the empty sentinel %q", got, "e0")
+	}
+	if HashExtras(nil) != HashExtras(map[string]any{}) {
+		t.Fatalf("HashExtras(nil) must equal HashExtras(empty-map)")
+	}
+	if got := HashExtras(map[string]any{"k": "v"}); got == "e0" {
+		t.Fatalf("HashExtras of a non-empty map must NOT be the empty sentinel %q", got)
+	}
+}
+
+// TestHashExtras_OrderIndependent is M13 part 2: insertion order is irrelevant.
+// We build the SAME logical map twice with different literal orderings and
+// assert equal hashes.
+//
+// RED PROOF: hashExtrasOrderSensitive (a no-sort shadow) produces different
+// hashes for the same content under different key orderings — proven in
+// TestHashExtras_OrderSensitive_RedArm below.
+func TestHashExtras_OrderIndependent(t *testing.T) {
+	a := map[string]any{"alpha": "1", "beta": "2", "gamma": "3"}
+	b := map[string]any{"gamma": "3", "alpha": "1", "beta": "2"}
+	if HashExtras(a) != HashExtras(b) {
+		t.Fatalf("HashExtras must be order-independent: %q vs %q", HashExtras(a), HashExtras(b))
+	}
+	// Run many times: even if the CORRECT impl were accidentally order-sensitive
+	// it would show up across randomised iterations.
+	for i := 0; i < 50; i++ {
+		if HashExtras(a) != HashExtras(b) {
+			t.Fatalf("HashExtras order-independence flaked on iteration %d", i)
+		}
+	}
+}
+
+// TestHashExtras_KeyParityWithComputeKey is M13 part 3: HashExtras and
+// ComputeKey share canonicaliseExtras, so order-equal Extras drive an EQUAL
+// ComputeKey. This is the "cannot drift" guard between the memo key and L1 key.
+func TestHashExtras_KeyParityWithComputeKey(t *testing.T) {
+	e1 := map[string]any{"x": "1", "y": float64(2), "z": true}
+	e2 := map[string]any{"z": true, "y": float64(2), "x": "1"} // same entries, different order
+
+	// HashExtras parity.
+	if HashExtras(e1) != HashExtras(e2) {
+		t.Fatalf("HashExtras parity: order-equal extras must hash equal")
+	}
+
+	// ComputeKey parity: identical inputs except Extras ordering → equal key.
+	base := ResolvedKeyInputs{
+		CacheEntryClass: CacheEntryClassWidgets,
+		Group:           "g", Version: "v", Resource: "r",
+		Namespace: "ns", Name: "n", BindingUID: "C:uid",
+		PerPage: 5, Page: 1,
+	}
+	k1 := base
+	k1.Extras = e1
+	k2 := base
+	k2.Extras = e2
+	if ComputeKey(k1) != ComputeKey(k2) {
+		t.Fatalf("ComputeKey parity: order-equal extras must produce equal keys")
+	}
+	// And a genuine extras difference MUST move both.
+	e3 := map[string]any{"x": "1", "y": float64(2), "z": false} // z flipped
+	if HashExtras(e1) == HashExtras(e3) {
+		t.Fatalf("HashExtras must vary on an extras VALUE change")
+	}
+	k3 := base
+	k3.Extras = e3
+	if ComputeKey(k1) == ComputeKey(k3) {
+		t.Fatalf("ComputeKey must vary on an extras VALUE change")
+	}
+}
+
+// TestHashExtras_NestedMapRecursion is L2 part 1: canonicaliseExtras recurses
+// into nested maps, so a difference deep in a nested map changes the hash AND is
+// order-independent at the nested level.
+func TestHashExtras_NestedMapRecursion(t *testing.T) {
+	a := map[string]any{
+		"outer": map[string]any{"p": "1", "q": "2"},
+		"top":   "T",
+	}
+	// Same nested content, different nested insertion order → equal.
+	aReordered := map[string]any{
+		"top":   "T",
+		"outer": map[string]any{"q": "2", "p": "1"},
+	}
+	if HashExtras(a) != HashExtras(aReordered) {
+		t.Fatalf("nested-map canonicalisation must be order-independent")
+	}
+	// A change DEEP in the nested map must move the hash — proves recursion
+	// actually visits the nested value rather than hashing an opaque address.
+	b := map[string]any{
+		"outer": map[string]any{"p": "1", "q": "CHANGED"},
+		"top":   "T",
+	}
+	if HashExtras(a) == HashExtras(b) {
+		t.Fatalf("a nested-map value change must change the hash (recursion not applied)")
+	}
+}
+
+// TestHashExtras_MarshalFailureVariesWithContent is L2 part 2: an un-marshalable
+// value (a func) forces canonicaliseExtras to error; the fmt.Sprintf fallback
+// must still make DISTINCT un-marshalable content hash DIFFERENTLY.
+//
+// RED PROOF: hashExtrasConstantOnError (returns a fixed sentinel on marshal
+// error) collapses the two distinct payloads — proven in
+// TestHashExtras_ConstantOnError_RedArm below.
+func TestHashExtras_MarshalFailureVariesWithContent(t *testing.T) {
+	// Two maps that both FAIL json.Marshal (func values) but carry different
+	// discriminating scalar content alongside the un-marshalable value.
+	m1 := map[string]any{"tag": "one", "bad": func() {}}
+	m2 := map[string]any{"tag": "two", "bad": func() {}}
+
+	h1 := HashExtras(m1)
+	h2 := HashExtras(m2)
+	if h1 == "e0" || h2 == "e0" {
+		t.Fatalf("marshal-failure fallback must not collapse to the empty sentinel")
+	}
+	if h1 == h2 {
+		t.Fatalf("marshal-failure fallback must vary with content: %q == %q "+
+			"(a constant-on-error impl would collide distinct un-marshalable extras)", h1, h2)
+	}
+}
+
+// --- RED-arm proofs ---------------------------------------------------------
+
+// hashExtrasOrderSensitive is the M13 WRONG impl: it concatenates entries in the
+// GIVEN key order (no sort), so the same logical content hashed under two
+// different key orderings produces two different hashes. This is the defect a
+// fmt.Sprintf(map)-style impl would exhibit (map iteration order is not sorted);
+// we model it DETERMINISTICALLY via an explicit key-order slice so the RED proof
+// never flakes on Go's randomised — but not guaranteed-divergent — map order.
+func hashExtrasOrderSensitive(keysInOrder []string, m map[string]any) string {
+	if len(m) == 0 {
+		return "e0"
+	}
+	var b []byte
+	for _, k := range keysInOrder {
+		b = append(b, []byte(fmt.Sprintf("%s=%v;", k, m[k]))...)
+	}
+	return string(b)
+}
+
+// TestHashExtras_OrderSensitive_RedArm proves the M13 order-independence arm
+// discriminates: the order-sensitive shadow produces DIFFERENT hashes for the
+// same logical map under two different key orderings — the exact behavior the
+// GREEN order-independence arm forbids. Deterministic (no reliance on runtime
+// map-order divergence).
+func TestHashExtras_OrderSensitive_RedArm(t *testing.T) {
+	m := map[string]any{"alpha": "1", "beta": "2", "gamma": "3"}
+	forward := hashExtrasOrderSensitive([]string{"alpha", "beta", "gamma"}, m)
+	reverse := hashExtrasOrderSensitive([]string{"gamma", "beta", "alpha"}, m)
+	if forward == reverse {
+		t.Fatalf("RED-arm sanity: the order-sensitive wrong impl SHOULD produce different " +
+			"hashes for the same content under different key orderings; the M13 " +
+			"order-independence arm is not discriminating otherwise")
+	}
+	// The correct HashExtras produces the SAME hash regardless of insertion
+	// order (asserted in TestHashExtras_OrderIndependent) — so the GREEN arm
+	// genuinely discriminates against this shadow.
+}
+
+// hashExtrasConstantOnError is the L2 WRONG impl: on marshal error it returns a
+// fixed constant, collapsing all un-marshalable content to one hash.
+func hashExtrasConstantOnError(m map[string]any) string {
+	if len(m) == 0 {
+		return "e0"
+	}
+	if _, err := canonicaliseExtras(m); err != nil {
+		return "MARSHAL_ERROR" // the defect: content-blind constant
+	}
+	return HashExtras(m)
+}
+
+// TestHashExtras_ConstantOnError_RedArm proves the L2 GREEN arm discriminates:
+// the constant-on-error shadow COLLIDES the two distinct un-marshalable payloads
+// the GREEN arm asserts DISTINCT.
+func TestHashExtras_ConstantOnError_RedArm(t *testing.T) {
+	m1 := map[string]any{"tag": "one", "bad": func() {}}
+	m2 := map[string]any{"tag": "two", "bad": func() {}}
+	if hashExtrasConstantOnError(m1) != hashExtrasConstantOnError(m2) {
+		t.Fatalf("RED-arm sanity: the constant-on-error wrong impl SHOULD collide distinct " +
+			"un-marshalable extras; the L2 test is not discriminating otherwise")
+	}
+}

--- a/internal/cache/refresh_broadcaster.go
+++ b/internal/cache/refresh_broadcaster.go
@@ -86,9 +86,17 @@ func RefreshSSEEnabled() bool {
 	}
 }
 
+// refreshCoalesceWindowFn is a (var-seam) indirection over the coalesce-window
+// resolution so the L11 falsifier can transiently install a wrong-shaped
+// resolver (one that coerces an explicit 0 into the 250ms DEFAULT, coalescing
+// away a burst) to observe RED, then restore the real fn. Production NEVER
+// reassigns it. Repo idiom: resolveOnceFn / nestedCallResolver.
+var refreshCoalesceWindowFn = refreshCoalesceWindow
+
 // refreshCoalesceWindow returns the active per-key coalesce window. A value
-// <= 0 disables coalescing (every emit fans out). Read fresh per emit so a
-// deployer can re-tune at pod start (matches the rateFloor env-read idiom).
+// <= 0 disables coalescing (every emit fans out) — an EXPLICIT 0 must be
+// honoured as "off", NOT silently coerced to the default. Read fresh per emit
+// so a deployer can re-tune at pod start (matches the rateFloor env-read idiom).
 func refreshCoalesceWindow() time.Duration {
 	return time.Duration(int64FromEnv(envRefreshCoalesceWindowMS, defaultRefreshCoalesceWindowMS)) * time.Millisecond
 }
@@ -155,7 +163,7 @@ func refreshHub() *refreshBroadcaster {
 // non-suppressed emit it stamps lastEmit[l1Key]=now. A window <= 0 disables
 // coalescing entirely (always returns false). Design §2.3.
 func (h *refreshBroadcaster) coalesced(l1Key string, now time.Time) bool {
-	win := refreshCoalesceWindow()
+	win := refreshCoalesceWindowFn()
 	if win <= 0 {
 		return false
 	}

--- a/internal/cache/refresh_broadcaster_test.go
+++ b/internal/cache/refresh_broadcaster_test.go
@@ -281,6 +281,96 @@ func TestRefreshBroadcaster_CoalescePerKey(t *testing.T) {
 	}
 }
 
+// TestRefreshBroadcaster_ZeroWindowDisablesCoalescing (L11). An EXPLICIT
+// REFRESH_COALESCE_WINDOW_MS=0 must DISABLE coalescing — a 5-event burst for
+// the SAME key delivers all 5, coalesced==0. This guards the coalesced() win<=0
+// early-return against a naive "0 means use the default 250ms" coercion that
+// would silently collapse the burst to 1.
+//
+// The RED arm (TestRefreshBroadcaster_ZeroWindowRedArm below) proves the
+// discrimination by transiently installing exactly that wrong-shaped resolver.
+func TestRefreshBroadcaster_ZeroWindowDisablesCoalescing(t *testing.T) {
+	withRefreshLayer(t) // sets REFRESH_COALESCE_WINDOW_MS=0 (coalescing OFF)
+
+	// Sanity: the active window really is 0 (disable), not the default.
+	if w := refreshCoalesceWindow(); w != 0 {
+		t.Fatalf("refreshCoalesceWindow()=%v under REFRESH_COALESCE_WINDOW_MS=0 — want 0 (disable)", w)
+	}
+
+	ch, unsub := SubscribeRefresh(map[string]struct{}{"k": {}})
+	defer unsub()
+
+	const burst = 5
+	for i := 0; i < burst; i++ {
+		PublishRefresh("k")
+	}
+
+	// All 5 must be delivered (buffer cap 64 >> 5, so none dropped).
+	got := 0
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && got < burst {
+		if _, ok := drainOne(t, ch, 50*time.Millisecond); ok {
+			got++
+		}
+	}
+	if got != burst {
+		t.Fatalf("zero-window burst delivered %d/%d — coalescing was NOT disabled by window=0", got, burst)
+	}
+	published, delivered, dropped, coalesced := RefreshBroadcasterCounters()
+	if coalesced != 0 {
+		t.Fatalf("coalesced=%d want 0 — window=0 must fan out EVERY emit", coalesced)
+	}
+	if published != burst || delivered != burst || dropped != 0 {
+		t.Fatalf("window=0 counters: published=%d delivered=%d dropped=%d, want %d/%d/0",
+			published, delivered, dropped, burst, burst)
+	}
+}
+
+// TestRefreshBroadcaster_ZeroWindowRedArm proves L11 DISCRIMINATES: with the
+// refreshCoalesceWindowFn seam transiently swapped for the buggy resolver that
+// coerces an explicit 0 into the 250ms DEFAULT, the same 5-event burst collapses
+// (coalesced>0, delivered<5) — the exact defect the zero-window path prevents.
+// Restores the real fn after (t.Cleanup) so the committed suite stays GREEN.
+func TestRefreshBroadcaster_ZeroWindowRedArm(t *testing.T) {
+	withRefreshLayer(t) // REFRESH_COALESCE_WINDOW_MS=0
+
+	orig := refreshCoalesceWindowFn
+	// Buggy resolver: treat 0 as "unset" → default window (the naive coercion
+	// L11 guards against).
+	refreshCoalesceWindowFn = func() time.Duration {
+		w := orig()
+		if w <= 0 {
+			return time.Duration(defaultRefreshCoalesceWindowMS) * time.Millisecond
+		}
+		return w
+	}
+	t.Cleanup(func() { refreshCoalesceWindowFn = orig })
+
+	ch, unsub := SubscribeRefresh(map[string]struct{}{"k": {}})
+	defer unsub()
+
+	const burst = 5
+	for i := 0; i < burst; i++ {
+		PublishRefresh("k")
+	}
+
+	got := 0
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, ok := drainOne(t, ch, 40*time.Millisecond); ok {
+			got++
+		}
+	}
+	_, _, _, coalesced := RefreshBroadcasterCounters()
+	if coalesced == 0 {
+		t.Fatalf("RED arm: coalesced=0 with 0-coerced-to-default window — L11 does not discriminate")
+	}
+	if got >= burst {
+		t.Fatalf("RED arm: delivered %d/%d — the default-window coercion failed to collapse the burst", got, burst)
+	}
+	t.Logf("RED arm: 0-coerced-to-250ms → burst collapsed (delivered=%d/%d, coalesced=%d)", got, burst, coalesced)
+}
+
 // --- 9.6 — slow consumer never stalls the producer (-race) ------------------
 
 // TestRefreshBroadcaster_SlowConsumerNeverStalls is falsifier 9.6. Run under

--- a/internal/cache/resolved.go
+++ b/internal/cache/resolved.go
@@ -1324,6 +1324,20 @@ func (s ResolvedCacheStats) WidgetContentEvictPressure() float64 {
 	return float64(s.WidgetContentEvictTotal) / float64(s.WidgetContentStoreTotal)
 }
 
+// RAFullListEvictPressure is the Ship 4a (0.30.198) per-class budget signal —
+// same shape as ApistageEvictPressure/WidgetContentEvictPressure but for the
+// raFullList (RA full-list slice) layer: the ratio of raFullList entry
+// evictions to raFullList entry stores. 0 means no raFullList churn (nothing
+// stored yet, or every stored slice is still resident). A ratio approaching 1
+// means the LRU/resident budget is too small for the full-list cardinality —
+// the pinned-slice contract is being pushed out as fast as it is written.
+func (s ResolvedCacheStats) RAFullListEvictPressure() float64 {
+	if s.RAFullListStoreTotal == 0 {
+		return 0
+	}
+	return float64(s.RAFullListEvictTotal) / float64(s.RAFullListStoreTotal)
+}
+
 // HitRate computes a simple cumulative hit rate. Returns 0 when there
 // has been no traffic. Useful for the 5-min summary line and for the
 // post-deploy falsifier (<50% hit rate = STOP per plan).
@@ -1567,6 +1581,7 @@ func startResolvedCacheSummary(c *ResolvedCacheStore) {
 				// means the resident budget overflowed or pinning is disabled.
 				slog.Uint64("ra_full_list_store_total", s.RAFullListStoreTotal),
 				slog.Uint64("ra_full_list_evict_total", s.RAFullListEvictTotal),
+				slog.Float64("ra_full_list_evict_pressure", s.RAFullListEvictPressure()),
 				slog.Int("resident_entries", s.ResidentEntries),
 				slog.Int64("resident_bytes", s.ResidentBytes),
 				slog.Int64("max_resident_bytes", s.MaxResidentBytes),

--- a/internal/cache/resolved_key_version_golden_test.go
+++ b/internal/cache/resolved_key_version_golden_test.go
@@ -47,7 +47,8 @@ func goldenKeyInputs() ResolvedKeyInputs {
 // goldenKeyInputs() under resolvedKeyVersion "v6". Captured empirically from the
 // real implementation. A drift in the key encoding (or an unannounced version
 // bump) changes this and reds the test.
-const goldenResolvedKeyDigest = "8accc561ccc518aff43998d0f7959d0dacb2dcac728dbe988c4630e73f999031"
+// gitleaks:allow — this is a SHA-256 test golden (ComputeKey output), not a credential.
+const goldenResolvedKeyDigest = "8accc561ccc518aff43998d0f7959d0dacb2dcac728dbe988c4630e73f999031" //gitleaks:allow
 
 // TestResolvedKeyVersion_ConstantAnchor is L3 part 1: the version const is "v6".
 func TestResolvedKeyVersion_ConstantAnchor(t *testing.T) {

--- a/internal/cache/resolved_key_version_golden_test.go
+++ b/internal/cache/resolved_key_version_golden_test.go
@@ -1,0 +1,141 @@
+// resolved_key_version_golden_test.go — coverage-audit L3.
+//
+// resolvedKeyVersion (resolved.go) is the salt folded FIRST into every
+// ComputeKey hash so a key-schema change forces a clean rolling-restart break:
+// no pre-bump entry ever serves as a post-bump hit. This test pins two things:
+//
+//   1. resolvedKeyVersion == "v6" — the current schema generation (#118 (c)-v2).
+//      A silent bump here without a matching golden update fails loud, forcing a
+//      deliberate decision (matches the compile-once golden discipline).
+//
+//   2. A GOLDEN DIGEST anchor for a fixed ResolvedKeyInputs. The golden was
+//      captured from the real ComputeKey; if the key ENCODING (field order,
+//      terminators, version fold) drifts, the digest changes and this reds.
+//
+// RED PROOF: dropping the version prefix from the key encoding leaves the
+// digest UNCHANGED for a same-version corpus — the version salt's whole job is
+// to rotate the space across bumps. The shadow computeKeyWithoutVersionPrefix
+// produces a DIFFERENT digest than the real (version-prefixed) golden, proving
+// the version fold materially contributes to the hash; a real impl that dropped
+// the prefix would match the shadow's digest, not the golden.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"strconv"
+	"testing"
+)
+
+// goldenKeyInputs is the fixed corpus the golden digest anchors. Every field is
+// populated (incl RBACSubGen and Extras) so the golden exercises the full
+// encoding path. DO NOT change this without re-capturing the golden.
+func goldenKeyInputs() ResolvedKeyInputs {
+	return ResolvedKeyInputs{
+		CacheEntryClass: CacheEntryClassRestactions,
+		Group:           "g", Version: "v", Resource: "r",
+		Namespace: "ns", Name: "n",
+		BindingUID: "C:uid-fixed",
+		PerPage:    20, Page: 1,
+		RBACSubGen: 7,
+		Extras:     map[string]any{"a": "1", "z": float64(2)},
+	}
+}
+
+// goldenResolvedKeyDigest is the SHA-256 hex ComputeKey produces for
+// goldenKeyInputs() under resolvedKeyVersion "v6". Captured empirically from the
+// real implementation. A drift in the key encoding (or an unannounced version
+// bump) changes this and reds the test.
+const goldenResolvedKeyDigest = "8accc561ccc518aff43998d0f7959d0dacb2dcac728dbe988c4630e73f999031"
+
+// TestResolvedKeyVersion_ConstantAnchor is L3 part 1: the version const is "v6".
+func TestResolvedKeyVersion_ConstantAnchor(t *testing.T) {
+	if resolvedKeyVersion != "v6" {
+		t.Fatalf("resolvedKeyVersion = %q, want %q — a key-schema bump must be a "+
+			"DELIBERATE change; update this anchor and the golden digest together",
+			resolvedKeyVersion, "v6")
+	}
+}
+
+// TestResolvedKeyVersion_GoldenDigest is L3 part 2: the golden digest anchor.
+func TestResolvedKeyVersion_GoldenDigest(t *testing.T) {
+	got := ComputeKey(goldenKeyInputs())
+	if got != goldenResolvedKeyDigest {
+		t.Fatalf("ComputeKey golden drift: got %q, want %q — the key ENCODING changed "+
+			"(field order / terminators / version fold). If intentional, bump "+
+			"resolvedKeyVersion and re-capture the golden.", got, goldenResolvedKeyDigest)
+	}
+}
+
+// --- RED-arm proof ----------------------------------------------------------
+
+// computeKeyWithoutVersionPrefix is the L3 WRONG impl: it re-encodes the SAME
+// key material as the real ComputeKey (identical field order + terminators) but
+// OMITS the leading version-prefix write. This is COMPUTED at runtime (not a
+// copied constant), so it stays faithful even if the encoding evolves — as long
+// as the only intended difference is the missing version fold.
+func computeKeyWithoutVersionPrefix(in ResolvedKeyInputs) string {
+	h := sha256.New()
+	// NOTE: the version prefix write is DELIBERATELY OMITTED here — that is the
+	// whole defect this shadow models.
+	h.Write([]byte(in.CacheEntryClass))
+	h.Write([]byte{0})
+	h.Write([]byte(in.Group))
+	h.Write([]byte{0})
+	h.Write([]byte(in.Version))
+	h.Write([]byte{0})
+	h.Write([]byte(in.Resource))
+	h.Write([]byte{0})
+	h.Write([]byte(in.Namespace))
+	h.Write([]byte{0})
+	h.Write([]byte(in.Name))
+	h.Write([]byte{0})
+	if in.CacheEntryClass != CacheEntryClassWidgetContent {
+		h.Write([]byte(in.BindingUID))
+		h.Write([]byte{0xff})
+		var subgen [8]byte
+		binary.LittleEndian.PutUint64(subgen[:], in.RBACSubGen)
+		h.Write(subgen[:])
+		h.Write([]byte{0xfe})
+	}
+	h.Write([]byte(strconv.Itoa(in.PerPage)))
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.Itoa(in.Page)))
+	h.Write([]byte{0})
+	if in.Stage != "" {
+		h.Write([]byte{0x01})
+		h.Write([]byte(in.Stage))
+		h.Write([]byte{0})
+	}
+	if len(in.Extras) > 0 {
+		if buf, err := canonicaliseExtras(in.Extras); err == nil {
+			h.Write(buf)
+		}
+	}
+	h.Write([]byte{0})
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestResolvedKeyVersion_DropPrefix_RedArm proves the L3 golden discriminates
+// against a version-prefix-dropping impl: the no-version-prefix re-encoding
+// produces a DIFFERENT digest than the version-prefixed golden. If the version
+// fold were a no-op, the two would be equal and the golden could not detect a
+// dropped-prefix regression.
+func TestResolvedKeyVersion_DropPrefix_RedArm(t *testing.T) {
+	in := goldenKeyInputs()
+	real := ComputeKey(in)
+	shadow := computeKeyWithoutVersionPrefix(in)
+
+	// Sanity: the real key matches the pinned golden (guards against the shadow
+	// accidentally equalling a drifted golden).
+	if real != goldenResolvedKeyDigest {
+		t.Fatalf("live ComputeKey no longer matches the version-prefixed golden anchor: %q", real)
+	}
+	// The RED proof: dropping the version prefix MUST change the digest.
+	if shadow == real {
+		t.Fatalf("RED-arm sanity: the no-version-prefix re-encoding MUST differ from the " +
+			"version-prefixed golden; if equal, dropping the version fold would be " +
+			"undetectable and L3 would not discriminate")
+	}
+}

--- a/internal/cache/seed_assert_prod_mode_test.go
+++ b/internal/cache/seed_assert_prod_mode_test.go
@@ -1,0 +1,108 @@
+// seed_assert_prod_mode_test.go — coverage-audit M14.
+//
+// AssertSeedUnitFootprint (seed_assert.go) has the serve_assert-style
+// TestMode/prod asymmetry. The existing seed_assert_falsifier_test.go covers the
+// TEST_MODE=true PANIC path; M14 covers the PRODUCTION posture
+// (env.TestMode()==false):
+//
+//   - over-budget → NO panic, returns false, seedUnitFootprintViolations bumps by
+//     exactly one (best-effort warmth: the unit already resolved, the violation
+//     is alertable, the seed proceeds).
+//   - within-budget → returns true, counter unchanged.
+//   - budget==0    → disabled, returns true, no panic, counter unchanged.
+//
+// RED PROOFS:
+//   - a prod impl that PANICS instead of counting: the GREEN "no panic" arm
+//     catches it (a panic would fail the test).
+//   - a prod impl that NEVER bumps the counter: the GREEN "counter==1" arm
+//     catches it. The shadow assertSeedUnitFootprintNeverCounts proves the
+//     count arm discriminates.
+package cache
+
+import "testing"
+
+// TestAssertSeedUnitFootprint_ProdModeOverBudgetCountsNoPanic is M14 main arm:
+// in production posture an over-budget unit returns false, does NOT panic, and
+// bumps the violation counter exactly once.
+func TestAssertSeedUnitFootprint_ProdModeOverBudgetCountsNoPanic(t *testing.T) {
+	t.Setenv("TEST_MODE", "false") // production posture — count, never panic
+	ResetSeedUnitFootprintViolationsForTest()
+	t.Cleanup(ResetSeedUnitFootprintViolationsForTest)
+
+	// A panic here would crash the test (no recover) → this arm inherently
+	// falsifies a "panic in prod" wrong impl.
+	if ok := AssertSeedUnitFootprint("unit/oversized", 5000, 1000); ok {
+		t.Fatalf("over-budget unit in prod mode must return false (breach observed), got true")
+	}
+	if v := SeedUnitFootprintViolations(); v != 1 {
+		t.Fatalf("over-budget unit in prod mode must bump the violation counter to exactly 1, got %d", v)
+	}
+}
+
+// TestAssertSeedUnitFootprint_ProdModeWithinBudget is M14 part 2: a within-budget
+// unit returns true and leaves the counter at zero.
+func TestAssertSeedUnitFootprint_ProdModeWithinBudget(t *testing.T) {
+	t.Setenv("TEST_MODE", "false")
+	ResetSeedUnitFootprintViolationsForTest()
+	t.Cleanup(ResetSeedUnitFootprintViolationsForTest)
+
+	if ok := AssertSeedUnitFootprint("unit/small", 500, 1000); !ok {
+		t.Fatalf("within-budget unit must return true")
+	}
+	if v := SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("within-budget unit must NOT bump the violation counter, got %d", v)
+	}
+	// An exactly-at-budget unit is within budget (deltaBytes <= budgetBytes).
+	if ok := AssertSeedUnitFootprint("unit/exact", 1000, 1000); !ok {
+		t.Fatalf("delta == budget is within budget (<=), must return true")
+	}
+	if v := SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("at-budget unit must NOT bump the counter, got %d", v)
+	}
+}
+
+// TestAssertSeedUnitFootprint_ProdModeBudgetZeroDisabled is M14 part 3: a zero
+// budget disables the assertion even in prod mode (transparent-fallback for an
+// unset GOMEMLIMIT), no panic, no count.
+func TestAssertSeedUnitFootprint_ProdModeBudgetZeroDisabled(t *testing.T) {
+	t.Setenv("TEST_MODE", "false")
+	ResetSeedUnitFootprintViolationsForTest()
+	t.Cleanup(ResetSeedUnitFootprintViolationsForTest)
+
+	if ok := AssertSeedUnitFootprint("unit/huge", 1<<40, 0); !ok {
+		t.Fatalf("budget==0 must disable the assert and return true even for a huge delta")
+	}
+	if v := SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("budget==0 (disabled) must NOT bump the counter, got %d", v)
+	}
+}
+
+// --- RED-arm proof ----------------------------------------------------------
+
+// assertSeedUnitFootprintNeverCounts is the M14 WRONG prod impl: it returns
+// false on a breach (correct sign) but forgets to bump the violation counter —
+// the alertable signal is silently lost.
+func assertSeedUnitFootprintNeverCounts(deltaBytes, budgetBytes uint64) bool {
+	if budgetBytes == 0 || deltaBytes <= budgetBytes {
+		return true
+	}
+	// defect: no seedUnitFootprintViolations.Add(1)
+	return false
+}
+
+// TestAssertSeedUnitFootprint_NeverCounts_RedArm proves the M14 counter arm
+// discriminates: the never-counts wrong impl leaves the counter at zero on the
+// same over-budget input the GREEN arm asserts bumps to 1.
+func TestAssertSeedUnitFootprint_NeverCounts_RedArm(t *testing.T) {
+	t.Setenv("TEST_MODE", "false")
+	ResetSeedUnitFootprintViolationsForTest()
+	t.Cleanup(ResetSeedUnitFootprintViolationsForTest)
+
+	if ok := assertSeedUnitFootprintNeverCounts(5000, 1000); ok {
+		t.Fatalf("RED-arm sanity: the wrong impl still returns false on breach")
+	}
+	if v := SeedUnitFootprintViolations(); v != 0 {
+		t.Fatalf("RED-arm sanity: the never-counts wrong impl must leave the counter at 0; "+
+			"the M14 counter arm is not discriminating otherwise (got %d)", v)
+	}
+}

--- a/internal/cache/seed_declined_external_set_test.go
+++ b/internal/cache/seed_declined_external_set_test.go
@@ -1,0 +1,169 @@
+// seed_declined_external_set_test.go — coverage-audit L4.
+//
+// SeedDeclinedExternalSet (seed_declined_external_set.go) is the #132 F4b Lever A
+// boot-scope "resolved-but-declined-external" marker. L4 pins its contract:
+//
+//   - Mark is IDEMPOTENT: a second Mark of the same key is a no-op — Marks()
+//     counts DISTINCT keys, never double-counts (LoadOrStore guard).
+//   - nil-safe: (nil).Mark / (nil).Marked / (nil).Marks never panic; Marked is
+//     always false and Marks is always 0 on a nil receiver (the "no set
+//     installed" posture on the /call path).
+//   - empty-key is ignored (Mark("") is a no-op, Marked("") is false).
+//   - WithSeedDeclinedExternalSet installs the set ONLY when the cache subsystem
+//     is enabled — under Disabled() it returns ctx UNCHANGED (no set carried).
+//     Its inverse (SeedDeclinedExternalSetFromContext) is nil off the install
+//     path — the property that makes the marker provably untouched on /call.
+//
+// RED PROOFS:
+//   - double-count: a Mark that increments unconditionally (no LoadOrStore
+//     guard) over-counts a repeated key — shadow markDoubleCounts proves the
+//     idempotency arm discriminates.
+//   - install-under-Disabled: a With* that installs regardless of Disabled()
+//     leaks a set onto a cache-off context — shadow withIgnoringDisabled proves
+//     the gate arm discriminates.
+package cache
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSeedDeclinedExternalSet_MarkIdempotent is L4 part 1: Marks() counts
+// distinct keys; a repeated Mark does not double-count.
+func TestSeedDeclinedExternalSet_MarkIdempotent(t *testing.T) {
+	s := NewSeedDeclinedExternalSet()
+
+	s.Mark("k1")
+	s.Mark("k1") // repeat — must NOT double-count
+	s.Mark("k2")
+
+	if !s.Marked("k1") || !s.Marked("k2") {
+		t.Fatalf("Mark must make keys Marked: k1=%v k2=%v", s.Marked("k1"), s.Marked("k2"))
+	}
+	if s.Marked("k3") {
+		t.Fatalf("an unmarked key must not be Marked")
+	}
+	if got := s.Marks(); got != 2 {
+		t.Fatalf("Marks() must count DISTINCT keys, got %d want 2 (idempotent Mark)", got)
+	}
+
+	// Third distinct key bumps to 3; another repeat of k1 stays at 3.
+	s.Mark("k3")
+	s.Mark("k1")
+	if got := s.Marks(); got != 3 {
+		t.Fatalf("Marks() after a new distinct key + a repeat = %d, want 3", got)
+	}
+}
+
+// TestSeedDeclinedExternalSet_NilAndEmptyKeySafe is L4 part 2: nil-receiver and
+// empty-key are safe no-ops.
+func TestSeedDeclinedExternalSet_NilAndEmptyKeySafe(t *testing.T) {
+	var nilSet *SeedDeclinedExternalSet
+	// nil receiver: no panic, Marked false, Marks 0.
+	nilSet.Mark("anything") // must not panic
+	if nilSet.Marked("anything") {
+		t.Fatalf("(nil).Marked must be false")
+	}
+	if nilSet.Marks() != 0 {
+		t.Fatalf("(nil).Marks must be 0")
+	}
+
+	// empty key on a real set: ignored.
+	s := NewSeedDeclinedExternalSet()
+	s.Mark("") // no-op
+	if s.Marked("") {
+		t.Fatalf("Marked(\"\") must be false — empty key is ignored")
+	}
+	if s.Marks() != 0 {
+		t.Fatalf("Mark(\"\") must not count, got %d", s.Marks())
+	}
+}
+
+// TestSeedDeclinedExternalSet_InstallOnlyWhenEnabled is L4 part 3: the context
+// installer honours the master gate — a set is carried when the cache subsystem
+// is enabled and NOT carried under Disabled().
+func TestSeedDeclinedExternalSet_InstallOnlyWhenEnabled(t *testing.T) {
+	set := NewSeedDeclinedExternalSet()
+
+	// Cache subsystem ENABLED → the set is installed and retrievable.
+	t.Setenv("CACHE_ENABLED", "true")
+	ctxOn := WithSeedDeclinedExternalSet(context.Background(), set)
+	if got := SeedDeclinedExternalSetFromContext(ctxOn); got != set {
+		t.Fatalf("with CACHE_ENABLED=true the set must be installed and retrievable; got %v", got)
+	}
+
+	// Cache subsystem DISABLED → install is a no-op; ctx unchanged; no set.
+	t.Setenv("CACHE_ENABLED", "false")
+	base := context.Background()
+	ctxOff := WithSeedDeclinedExternalSet(base, set)
+	if got := SeedDeclinedExternalSetFromContext(ctxOff); got != nil {
+		t.Fatalf("under Disabled() no set must be carried; got %v", got)
+	}
+
+	// A background context with nothing installed also yields nil (the /call
+	// posture — the marker is provably untouched off the boot-seed path).
+	if got := SeedDeclinedExternalSetFromContext(context.Background()); got != nil {
+		t.Fatalf("a plain context must carry no set; got %v", got)
+	}
+}
+
+// --- RED-arm proofs ---------------------------------------------------------
+
+// markDoubleCounts is the L4 WRONG Mark: it increments unconditionally (no
+// LoadOrStore idempotency guard), over-counting a repeated key.
+type doubleCountingSet struct {
+	seen  map[string]struct{}
+	marks uint64
+}
+
+func (d *doubleCountingSet) Mark(key string) {
+	if key == "" {
+		return
+	}
+	if d.seen == nil {
+		d.seen = map[string]struct{}{}
+	}
+	d.seen[key] = struct{}{}
+	d.marks++ // defect: bumps even on a repeat
+}
+func (d *doubleCountingSet) Marks() uint64 { return d.marks }
+
+// TestSeedDeclinedExternalSet_DoubleCount_RedArm proves the L4 idempotency arm
+// discriminates: the double-counting wrong impl reports 3 for two distinct keys
+// (one repeated), where the correct impl reports 2.
+func TestSeedDeclinedExternalSet_DoubleCount_RedArm(t *testing.T) {
+	d := &doubleCountingSet{}
+	d.Mark("k1")
+	d.Mark("k1") // repeat
+	d.Mark("k2")
+	if got := d.Marks(); got != 3 {
+		t.Fatalf("RED-arm sanity: the double-counting wrong impl SHOULD over-count to 3, got %d", got)
+	}
+	// The correct impl reports 2 for the same sequence (asserted in the GREEN
+	// idempotency test); 3 != 2 confirms the arm discriminates.
+}
+
+// withIgnoringDisabled is the L4 WRONG installer: it installs the set regardless
+// of Disabled(), leaking a marker onto a cache-off context.
+func withIgnoringDisabled(ctx context.Context, set *SeedDeclinedExternalSet) context.Context {
+	if ctx == nil || set == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeySeedDeclinedExternalSet, set) // defect: no Disabled() guard
+}
+
+// TestSeedDeclinedExternalSet_InstallUnderDisabled_RedArm proves the L4 gate arm
+// discriminates: under Disabled() the wrong installer STILL carries a set, where
+// the correct installer returns ctx unchanged (nil retrieval).
+func TestSeedDeclinedExternalSet_InstallUnderDisabled_RedArm(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false") // Disabled() == true
+	set := NewSeedDeclinedExternalSet()
+
+	ctxWrong := withIgnoringDisabled(context.Background(), set)
+	if got := SeedDeclinedExternalSetFromContext(ctxWrong); got != set {
+		t.Fatalf("RED-arm sanity: the install-ignoring-Disabled wrong impl SHOULD carry a set " +
+			"even under Disabled(); the L4 gate arm is not discriminating otherwise")
+	}
+	// The correct installer returns ctx unchanged under Disabled() (asserted in
+	// the GREEN gate test) → the two behaviours differ, so the arm discriminates.
+}

--- a/internal/cache/seeded_at_boot_test.go
+++ b/internal/cache/seeded_at_boot_test.go
@@ -1,0 +1,101 @@
+// seeded_at_boot_test.go — coverage-audit M11.
+//
+// ResolvedEntry.SeededAtBoot (resolved.go) is the #130 F3 boot-seed provenance
+// marker: true iff the entry was written by the Phase-1 boot seed, false once
+// real traffic (a refresher/dispatch re-Put) overwrites the cell. The store's
+// replace-in-place path (Put, resolved.go) rebinds old.entry = entry, so the
+// NEW entry's SeededAtBoot must win — a traffic re-Put correctly re-classifies a
+// seed-warmed cell to traffic-warmed.
+//
+// RED PROOF: an impl that PRESERVES the old entry's SeededAtBoot across a
+// replace-in-place (mutating fields but keeping the prior provenance) would keep
+// reporting true after the traffic re-Put — proven by the shadow store
+// putPreservingSeededAtBoot below.
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSeededAtBoot_RoundTripsThroughGet is M11: a boot-seeded entry reports
+// SeededAtBoot==true on Get; a same-key traffic re-Put flips it to false.
+func TestSeededAtBoot_RoundTripsThroughGet(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour)
+
+	// Boot seed Put: SeededAtBoot=true.
+	c.Put("k", &ResolvedEntry{
+		RawJSON:      []byte(`{"seed":true}`),
+		SeededAtBoot: true,
+		Inputs:       &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgets},
+	})
+	got, ok := c.Get("k")
+	if !ok {
+		t.Fatalf("Get after boot-seed Put should hit")
+	}
+	if !got.SeededAtBoot {
+		t.Fatalf("a boot-seeded entry must report SeededAtBoot==true")
+	}
+
+	// Traffic re-Put of the SAME key: SeededAtBoot=false (the natural zero).
+	c.Put("k", &ResolvedEntry{
+		RawJSON:      []byte(`{"traffic":true}`),
+		SeededAtBoot: false,
+		Inputs:       &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgets},
+	})
+	got, ok = c.Get("k")
+	if !ok {
+		t.Fatalf("Get after traffic re-Put should hit")
+	}
+	if got.SeededAtBoot {
+		t.Fatalf("a traffic re-Put must re-classify the cell: SeededAtBoot expected false, got true")
+	}
+	// The content must also be the NEW entry's (proves it's a genuine replace,
+	// not the marker read off a stale entry).
+	if string(got.RawJSON) != `{"traffic":true}` {
+		t.Fatalf("replace-in-place must serve the new RawJSON, got %q", got.RawJSON)
+	}
+}
+
+// --- RED-arm proof ----------------------------------------------------------
+
+// putPreservingSeededAtBoot models the WRONG replace-in-place: it copies the new
+// entry's content but PRESERVES the prior entry's SeededAtBoot provenance. It
+// operates on the real store via Get to read the current provenance, then Puts a
+// merged entry — mirroring exactly the defect (a re-Put that forgets to reset
+// the boot marker).
+func putPreservingSeededAtBoot(c *ResolvedCacheStore, key string, entry *ResolvedEntry) {
+	if prior, ok := c.Get(key); ok {
+		merged := *entry
+		merged.SeededAtBoot = prior.SeededAtBoot // the defect: carry over old provenance
+		c.Put(key, &merged)
+		return
+	}
+	c.Put(key, entry)
+}
+
+// TestSeededAtBoot_PreserveOnReplace_RedArm proves the M11 GREEN arm
+// discriminates: the preserve-provenance wrong impl keeps reporting true after a
+// traffic re-Put — the exact behavior the GREEN arm forbids.
+func TestSeededAtBoot_PreserveOnReplace_RedArm(t *testing.T) {
+	c := newResolvedCache(10, 1<<20, time.Hour)
+	c.Put("k", &ResolvedEntry{
+		RawJSON:      []byte(`{"seed":true}`),
+		SeededAtBoot: true,
+		Inputs:       &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgets},
+	})
+	// Traffic re-Put through the WRONG path.
+	putPreservingSeededAtBoot(c, "k", &ResolvedEntry{
+		RawJSON:      []byte(`{"traffic":true}`),
+		SeededAtBoot: false,
+		Inputs:       &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgets},
+	})
+	got, ok := c.Get("k")
+	if !ok {
+		t.Fatalf("entry must still be present")
+	}
+	if !got.SeededAtBoot {
+		t.Fatalf("RED-arm sanity: the preserve-provenance wrong impl SHOULD still report " +
+			"SeededAtBoot==true after a traffic re-Put; the M11 test is not discriminating otherwise")
+	}
+}

--- a/internal/cache/stats_widget_content_pressure_test.go
+++ b/internal/cache/stats_widget_content_pressure_test.go
@@ -1,0 +1,191 @@
+// stats_widget_content_pressure_test.go — L8 hermetic coverage for the
+// per-class evict-pressure ratio accessors on ResolvedCacheStats, mirroring
+// TestApistageEvictPressure (resolved_test.go):
+//
+//	WidgetContentEvictPressure = WidgetContentEvictTotal / WidgetContentStoreTotal
+//	RAFullListEvictPressure    = RAFullListEvictTotal    / RAFullListStoreTotal
+//
+// Both are 0 when their OWN store counter is 0 (never divide-by-zero, and never
+// borrow another class's denominator). The discriminating power ("divide by the
+// wrong field") is guaranteed by giving every class DISTINCT store/evict
+// counters, so any cross-field numerator/denominator swap yields a ratio the
+// assertions reject. A dedicated RED helper (assertNotWrongField) makes that
+// discrimination explicit: it enumerates every wrong-field ratio the method
+// could have computed and proves each differs from the correct one.
+//
+// Also asserts the counters are attributed by the entry's CacheEntryClass via
+// real Put()/eviction (mirrors TestApistageCounters_ClassifiedByCacheEntryClass)
+// so the ratio is fed by the real store, not just hand-set struct fields.
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWidgetContentEvictPressure_RatioArithmetic mirrors TestApistageEvictPressure
+// for the Ship G widget-content class.
+func TestWidgetContentEvictPressure_RatioArithmetic(t *testing.T) {
+	var s ResolvedCacheStats
+	if got := s.WidgetContentEvictPressure(); got != 0 {
+		t.Fatalf("WidgetContentEvictPressure with zero stores = %v, want 0 (no divide-by-zero)", got)
+	}
+
+	// Distinct per-class counters: a wrong-field divide is detectable.
+	s.WidgetContentStoreTotal = 8
+	s.WidgetContentEvictTotal = 2
+	s.RAFullListStoreTotal = 5
+	s.RAFullListEvictTotal = 4
+	s.ApistageStoreTotal = 100 // distractor denominator
+	s.ApistageEvictTotal = 7   // distractor numerator
+
+	if got := s.WidgetContentEvictPressure(); got != 0.25 {
+		t.Fatalf("WidgetContentEvictPressure = %v, want 0.25 (2/8)", got)
+	}
+	// RED-arm discrimination: prove the correct ratio is not accidentally equal
+	// to any wrong-field ratio the method could compute (2/100, 4/8, 7/8, ...).
+	assertNotWrongField(t, "WidgetContentEvictPressure", s.WidgetContentEvictPressure(),
+		[]float64{
+			ratio(s.WidgetContentEvictTotal, s.ApistageStoreTotal),   // wrong denom: apistage
+			ratio(s.WidgetContentEvictTotal, s.RAFullListStoreTotal), // wrong denom: raFullList
+			ratio(s.ApistageEvictTotal, s.WidgetContentStoreTotal),   // wrong num: apistage
+			ratio(s.RAFullListEvictTotal, s.WidgetContentStoreTotal), // wrong num: raFullList
+		})
+}
+
+// TestRAFullListEvictPressure_RatioArithmetic mirrors TestApistageEvictPressure
+// for the Ship 4a raFullList class.
+func TestRAFullListEvictPressure_RatioArithmetic(t *testing.T) {
+	var s ResolvedCacheStats
+	if got := s.RAFullListEvictPressure(); got != 0 {
+		t.Fatalf("RAFullListEvictPressure with zero stores = %v, want 0 (no divide-by-zero)", got)
+	}
+
+	s.RAFullListStoreTotal = 5
+	s.RAFullListEvictTotal = 4
+	s.WidgetContentStoreTotal = 8
+	s.WidgetContentEvictTotal = 2
+	s.ApistageStoreTotal = 100
+	s.ApistageEvictTotal = 7
+
+	if got := s.RAFullListEvictPressure(); got != 0.8 {
+		t.Fatalf("RAFullListEvictPressure = %v, want 0.8 (4/5)", got)
+	}
+	assertNotWrongField(t, "RAFullListEvictPressure", s.RAFullListEvictPressure(),
+		[]float64{
+			ratio(s.RAFullListEvictTotal, s.ApistageStoreTotal),      // wrong denom: apistage
+			ratio(s.RAFullListEvictTotal, s.WidgetContentStoreTotal), // wrong denom: widgetContent
+			ratio(s.ApistageEvictTotal, s.RAFullListStoreTotal),      // wrong num: apistage
+			ratio(s.WidgetContentEvictTotal, s.RAFullListStoreTotal), // wrong num: widgetContent
+		})
+}
+
+// ratio is float64(a)/float64(b) with the same zero-guard the real accessors use.
+func ratio(a, b uint64) float64 {
+	if b == 0 {
+		return 0
+	}
+	return float64(a) / float64(b)
+}
+
+// assertNotWrongField is the RED discriminator: it proves the correct ratio is
+// strictly different from every wrong-field ratio the accessor could have
+// computed. If a wrong-field impl HAPPENED to produce the same value, the test
+// would be blind to that divide-by-the-wrong-field defect — so we fail loudly
+// if any collision exists, and otherwise confirm the discrimination margin.
+func assertNotWrongField(t *testing.T, name string, correct float64, wrong []float64) {
+	t.Helper()
+	for i, w := range wrong {
+		if w == correct {
+			t.Fatalf("%s: wrong-field ratio #%d == correct ratio %v — the distinct-counter "+
+				"discrimination collapsed; the test cannot catch a divide-by-the-wrong-field defect",
+				name, i, correct)
+		}
+	}
+}
+
+// TestWidgetContentCounters_ClassifiedByCacheEntryClass mirrors
+// TestApistageCounters_ClassifiedByCacheEntryClass: the widget-content store +
+// evict counters move ONLY for widget-content entries, driving the pressure
+// ratio off the REAL store (not hand-set fields). A non-widgetContent Put must
+// not touch them; a second widgetContent Put at cap-1 evicts the first →
+// evict/store = 1/2 = 0.5.
+func TestWidgetContentCounters_ClassifiedByCacheEntryClass(t *testing.T) {
+	c := newResolvedCache(1, 1<<20, time.Hour) // entry cap 1 → next Put evicts
+
+	// A non-widgetContent entry: widget-content counters stay 0.
+	c.Put("plain", &ResolvedEntry{
+		RawJSON: []byte(`{}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: "restactions"},
+	})
+	if s := c.Stats(); s.WidgetContentStoreTotal != 0 || s.WidgetContentEvictTotal != 0 {
+		t.Fatalf("non-widgetContent Put moved widget counters: store=%d evict=%d",
+			s.WidgetContentStoreTotal, s.WidgetContentEvictTotal)
+	}
+
+	// First widgetContent entry: store ticks; evicting the plain entry does NOT
+	// bump the widget-content evict counter (class-attributed).
+	c.Put("wcA", &ResolvedEntry{
+		RawJSON: []byte(`{"v":1}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgetContent, Namespace: "ns", Name: "a"},
+	})
+	if s := c.Stats(); s.WidgetContentStoreTotal != 1 || s.WidgetContentEvictTotal != 0 {
+		t.Fatalf("first widgetContent Put: store=%d want 1, evict=%d want 0",
+			s.WidgetContentStoreTotal, s.WidgetContentEvictTotal)
+	}
+
+	// Second widgetContent entry evicts the first widgetContent entry → evict
+	// counter ticks; ratio = 1/2.
+	c.Put("wcB", &ResolvedEntry{
+		RawJSON: []byte(`{"v":2}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassWidgetContent, Namespace: "ns", Name: "b"},
+	})
+	s := c.Stats()
+	if s.WidgetContentStoreTotal != 2 || s.WidgetContentEvictTotal != 1 {
+		t.Fatalf("second widgetContent Put: store=%d want 2, evict=%d want 1",
+			s.WidgetContentStoreTotal, s.WidgetContentEvictTotal)
+	}
+	if got := s.WidgetContentEvictPressure(); got != 0.5 {
+		t.Fatalf("WidgetContentEvictPressure off the real store = %v, want 0.5 (1/2)", got)
+	}
+}
+
+// TestRAFullListCounters_ClassifiedByCacheEntryClass mirrors the above for the
+// raFullList class, driving RAFullListEvictPressure off the real store. A
+// raFullList entry is un-pinned here (Pinned defaults false) so the cap-1 LRU
+// sweep can evict it.
+func TestRAFullListCounters_ClassifiedByCacheEntryClass(t *testing.T) {
+	c := newResolvedCache(1, 1<<20, time.Hour)
+
+	c.Put("plain", &ResolvedEntry{
+		RawJSON: []byte(`{}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: "restactions"},
+	})
+	if s := c.Stats(); s.RAFullListStoreTotal != 0 || s.RAFullListEvictTotal != 0 {
+		t.Fatalf("non-raFullList Put moved raFullList counters: store=%d evict=%d",
+			s.RAFullListStoreTotal, s.RAFullListEvictTotal)
+	}
+
+	c.Put("rfA", &ResolvedEntry{
+		RawJSON: []byte(`{"items":[1]}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassRAFullList, Name: "a"},
+	})
+	if s := c.Stats(); s.RAFullListStoreTotal != 1 || s.RAFullListEvictTotal != 0 {
+		t.Fatalf("first raFullList Put: store=%d want 1, evict=%d want 0",
+			s.RAFullListStoreTotal, s.RAFullListEvictTotal)
+	}
+
+	c.Put("rfB", &ResolvedEntry{
+		RawJSON: []byte(`{"items":[2]}`),
+		Inputs:  &ResolvedKeyInputs{CacheEntryClass: CacheEntryClassRAFullList, Name: "b"},
+	})
+	s := c.Stats()
+	if s.RAFullListStoreTotal != 2 || s.RAFullListEvictTotal != 1 {
+		t.Fatalf("second raFullList Put: store=%d want 2, evict=%d want 1",
+			s.RAFullListStoreTotal, s.RAFullListEvictTotal)
+	}
+	if got := s.RAFullListEvictPressure(); got != 0.5 {
+		t.Fatalf("RAFullListEvictPressure off the real store = %v, want 0.5 (1/2)", got)
+	}
+}

--- a/internal/handlers/debug_refreshes_structural_test.go
+++ b/internal/handlers/debug_refreshes_structural_test.go
@@ -1,0 +1,104 @@
+// debug_refreshes_structural_test.go — L9 [SEC-adj]: the /debug/refreshes body
+// is AGGREGATE-ONLY by construction.
+//
+// debugRefreshesBody (debug_refreshes.go) deliberately exposes only process-wide
+// scalar counters + the live subscriber count. It must NEVER grow a per-key or
+// per-identity ENUMERATION field (e.g. a []string ArmedKeys or a
+// map[string]uint64 PerUserDelivered) — which keys/identities are armed is a
+// cross-user signal (it reveals which widgets/resources a connected user is
+// watching, #61 C-3). A structural guard is the right shape here: any future
+// slice/map field on the body is a leak-surface regression, and it should fail
+// at type level in CI, not in a security review months later.
+//
+// This test reflects over debugRefreshesBody and asserts EVERY exported field is
+// a scalar (no slice, no map, no nested struct/array). The RED arm proves the
+// check is discriminating: the SAME reflective assertion applied to a shadow
+// struct carrying a []string ArmedKeys field FAILS.
+
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+// scalarKinds is the allow-list of reflect.Kinds a leak-safe aggregate body may
+// use. Anything outside it (Slice, Map, Struct, Array, Ptr, Interface) is a
+// potential per-key/per-identity enumeration surface and is rejected.
+var scalarKinds = map[reflect.Kind]bool{
+	reflect.Bool:    true,
+	reflect.Int:     true,
+	reflect.Int8:    true,
+	reflect.Int16:   true,
+	reflect.Int32:   true,
+	reflect.Int64:   true,
+	reflect.Uint:    true,
+	reflect.Uint8:   true,
+	reflect.Uint16:  true,
+	reflect.Uint32:  true,
+	reflect.Uint64:  true,
+	reflect.Float32: true,
+	reflect.Float64: true,
+	reflect.String:  true,
+}
+
+// nonScalarFields returns the names of any exported fields on t whose kind is
+// NOT in scalarKinds — i.e. the enumeration/aggregate-shape violations.
+func nonScalarFields(t reflect.Type) []string {
+	var bad []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported — not part of the serialized surface
+		}
+		if !scalarKinds[f.Type.Kind()] {
+			bad = append(bad, f.Name+" ("+f.Type.Kind().String()+")")
+		}
+	}
+	return bad
+}
+
+// TestDebugRefreshesBody_AggregateOnly — every field of debugRefreshesBody is a
+// scalar; no slice/map/struct field (which would be a per-key/per-identity
+// enumeration surface, #61 C-3).
+func TestDebugRefreshesBody_AggregateOnly(t *testing.T) {
+	rt := reflect.TypeOf(debugRefreshesBody{})
+	if rt.Kind() != reflect.Struct {
+		t.Fatalf("debugRefreshesBody must be a struct; got %s", rt.Kind())
+	}
+	if bad := nonScalarFields(rt); len(bad) > 0 {
+		t.Fatalf("L9: /debug/refreshes body must be AGGREGATE-ONLY (all scalar fields); "+
+			"found non-scalar field(s) %v — a slice/map here leaks which keys/identities are "+
+			"armed (cross-user signal, #61 C-3)", bad)
+	}
+}
+
+// TestDebugRefreshesBody_RED_SliceFieldIsCaught is the RED proof: a shadow body
+// type identical to debugRefreshesBody EXCEPT for an added `[]string ArmedKeys`
+// per-key enumeration field MUST be flagged by the same reflective check. If it
+// weren't, the L9 guard would tolerate exactly the leak it exists to prevent.
+func TestDebugRefreshesBody_RED_SliceFieldIsCaught(t *testing.T) {
+	type wrongBody struct {
+		SSEEnabled  bool     `json:"sseEnabled"`
+		Subscribers int      `json:"subscribers"`
+		Published   uint64   `json:"published"`
+		Delivered   uint64   `json:"delivered"`
+		Dropped     uint64   `json:"dropped"`
+		Coalesced   uint64   `json:"coalesced"`
+		ArmedKeys   []string `json:"armedKeys"` // per-key enumeration — the leak
+	}
+	bad := nonScalarFields(reflect.TypeOf(wrongBody{}))
+	if len(bad) != 1 || bad[0] != "ArmedKeys (slice)" {
+		t.Fatalf("RED: the structural check must flag exactly the []string ArmedKeys field; got %v", bad)
+	}
+
+	// Also prove a map[string]uint64 per-identity field is caught.
+	type wrongBodyMap struct {
+		Published        uint64            `json:"published"`
+		PerUserDelivered map[string]uint64 `json:"perUserDelivered"` // per-identity — the leak
+	}
+	badMap := nonScalarFields(reflect.TypeOf(wrongBodyMap{}))
+	if len(badMap) != 1 || badMap[0] != "PerUserDelivered (map)" {
+		t.Fatalf("RED: the structural check must flag the map per-identity field; got %v", badMap)
+	}
+}

--- a/internal/handlers/debug_servable_test.go
+++ b/internal/handlers/debug_servable_test.go
@@ -8,12 +8,19 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/krateoplatformops/snowplow/internal/cache"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 // TestDebugServable_CacheOff returns 200 with cacheEnabled=false and an
@@ -88,4 +95,155 @@ func decodeServable(t *testing.T) debugServableBody {
 		t.Fatalf("decode body: %v", err)
 	}
 	return body
+}
+
+// --- L10: 200 + sorted rows (cache-on) --------------------------------------
+
+// seedServableWatcher wires cache.Global() with a cache-on ResourceWatcher that
+// has SEVERAL GVRs registered, so ServableSnapshot returns multiple rows the
+// handler must sort. It registers the RBAC list-kinds (the watcher always
+// registers these on construction) plus two additional GVRs whose sorted order
+// differs from any plausible map-iteration order. Returns the sorted set of GVR
+// strings the handler should emit.
+func seedServableWatcher(t *testing.T) []string {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	// Two extra GVRs; "aardvarks" sorts before the rbac.* group, "zebras" after —
+	// so a correct sort is unambiguous regardless of registration/map order.
+	aGVR := schema.GroupVersionResource{Group: "a.example.io", Version: "v1", Resource: "aardvarks"}
+	zGVR := schema.GroupVersionResource{Group: "z.example.io", Version: "v1", Resource: "zebras"}
+
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		aGVR: "AardvarkList",
+		zGVR: "ZebraList",
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer syncCancel()
+	if err := rw.WaitForCacheSync(syncCtx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	_, _ = rw.EnsureResourceType(aGVR)
+	_, _ = rw.EnsureResourceType(zGVR)
+	_ = rw.WaitForCacheSync(syncCtx, 5*time.Second)
+
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+	})
+
+	// Build the expected sorted GVR-string set from the live snapshot (the set
+	// of registered GVRs is what we assert ORDER over, not membership).
+	rows := rw.ServableSnapshot()
+	gvrs := make([]string, 0, len(rows))
+	for _, r := range rows {
+		gvrs = append(gvrs, r.GVR)
+	}
+	sort.Strings(gvrs)
+	return gvrs
+}
+
+// TestDebugServable_CacheOn_SortedRows — L10: with the cache on and several GVRs
+// registered, /debug/servable returns 200, cacheEnabled=true, count==len(gvrs),
+// and the rows are sorted by GVR string (stable output across requests). The
+// expected GVRs include the two extras + the always-registered rbac.* list-kinds.
+func TestDebugServable_CacheOn_SortedRows(t *testing.T) {
+	wantSorted := seedServableWatcher(t)
+	if len(wantSorted) < 2 {
+		t.Fatalf("setup: expected >=2 registered GVRs to test ordering; got %d", len(wantSorted))
+	}
+
+	body := decodeServable(t)
+	if !body.CacheEnabled {
+		t.Fatalf("cache-on: body.cacheEnabled must be true")
+	}
+	if body.Count != len(body.GVRs) {
+		t.Fatalf("count=%d != len(gvrs)=%d", body.Count, len(body.GVRs))
+	}
+	if body.Count != len(wantSorted) {
+		t.Fatalf("count=%d, want %d registered GVRs", body.Count, len(wantSorted))
+	}
+
+	got := make([]string, len(body.GVRs))
+	for i, r := range body.GVRs {
+		got[i] = r.GVR
+	}
+	// (1) The rows must be sorted by GVR string.
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("L10: /debug/servable rows must be sorted by GVR; got %v", got)
+	}
+	// (2) And carry exactly the registered set (membership + order).
+	for i := range wantSorted {
+		if got[i] != wantSorted[i] {
+			t.Fatalf("L10: sorted rows mismatch at [%d]: got %q want %q (full got=%v want=%v)",
+				i, got[i], wantSorted[i], got, wantSorted)
+		}
+	}
+	// Sanity: the two distinctive extras are present and correctly ordered
+	// (aardvarks before zebras). GVR.String() renders as
+	// "group/version, Resource=resource".
+	ai := indexOf(got, "a.example.io/v1, Resource=aardvarks")
+	zi := indexOf(got, "z.example.io/v1, Resource=zebras")
+	if ai < 0 || zi < 0 {
+		t.Fatalf("L10: expected extras missing; got=%v", got)
+	}
+	if ai > zi {
+		t.Fatalf("L10: aardvarks (idx %d) must sort before zebras (idx %d); got=%v", ai, zi, got)
+	}
+}
+
+// TestDebugServable_RED_UnsortedRowsCaught is the RED proof for the sort arm.
+// The handler sorts before emitting; to prove the "sorted" assertion is
+// discriminating we reproduce the plausible wrong impl (emit rows in
+// unsorted/reverse order) and assert the SAME sort.StringsAreSorted check the
+// green test uses FAILS on it.
+func TestDebugServable_RED_UnsortedRowsCaught(t *testing.T) {
+	wantSorted := seedServableWatcher(t)
+	if len(wantSorted) < 2 {
+		t.Skip("need >=2 GVRs to demonstrate an unsorted ordering")
+	}
+	// Wrong impl: reverse-sorted rows (what a handler that forgot sort.Slice, or
+	// sorted descending, would emit).
+	reversed := make([]string, len(wantSorted))
+	for i := range wantSorted {
+		reversed[i] = wantSorted[len(wantSorted)-1-i]
+	}
+	if sort.StringsAreSorted(reversed) {
+		t.Fatalf("RED setup invalid: reversed slice should NOT be ascending-sorted; %v", reversed)
+	}
+	// The green test's sorted-check MUST reject this wrong ordering.
+	if sort.StringsAreSorted(reversed) {
+		t.Fatalf("RED: the sorted assertion failed to catch a reverse-ordered emission %v", reversed)
+	}
+}
+
+func indexOf(ss []string, want string) int {
+	for i, s := range ss {
+		if s == want {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/handlers/dispatchers/check_dispatch_rbac_test.go
+++ b/internal/handlers/dispatchers/check_dispatch_rbac_test.go
@@ -1,0 +1,168 @@
+// check_dispatch_rbac_test.go — M5 (coverage-audit) SECURITY: the cache=on
+// dispatch RBAC gate (checkDispatchRBAC, helpers.go) is FAIL-CLOSED on every
+// failure mode and carries the correct EvaluateRBAC contract.
+//
+// checkDispatchRBAC is the ONLY thing standing between a cache=on /call and the
+// dispatched CR (in cache=on mode fetchObject does NOT enforce RBAC for that
+// GET — the gate must). So its failure modes are security-critical:
+//
+//	no UserInfo on ctx      → false (deny)
+//	EvaluateRBAC returns err → false (deny)
+//	allowed=false            → false (deny)
+//	allowed=true             → true  (permit)
+//
+// AND it MUST call EvaluateRBAC with Verb=="get" + SkipBindingUID==true (the
+// per-item posture — it discards matchedBindingUID, so skipping the stable-sort
+// is both correct and the 50K-scale CPU win, Ship L1).
+//
+// RED arm (fail-OPEN): if checkDispatchRBAC returned true on a missing UserInfo
+// or an evaluator error, an unauthenticated / evaluator-degraded request would
+// be dispatched. The no-UserInfo and eval-error rows below are GREEN only
+// because the gate fails CLOSED; a fail-open impl reds them. Proven by the
+// shadow-wrong-impl in TestM5_FailClosed_RED_ShadowFailOpen.
+
+package dispatchers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/rbac"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// setEvaluateRBACForTest swaps the checkDispatchRBAC evaluation seam and returns
+// a restore. Production never reassigns evaluateRBACFn.
+func setEvaluateRBACForTest(fn func(ctx context.Context, opts rbac.EvaluateOptions) (bool, string, error)) func() {
+	prev := evaluateRBACFn
+	evaluateRBACFn = fn
+	return func() { evaluateRBACFn = prev }
+}
+
+var m5GVR = schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+
+func m5CtxWithUser() context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "alice", Groups: []string{"devs"}}))
+}
+
+// TestM5_CheckDispatchRBAC_Table drives every verdict/error branch through the
+// REAL checkDispatchRBAC with a stubbed evaluator, and asserts the fail-closed
+// contract + the EvaluateOptions the gate must send.
+func TestM5_CheckDispatchRBAC_Table(t *testing.T) {
+	cases := []struct {
+		name       string
+		withUser   bool
+		evalRet    bool
+		evalErr    error
+		wantResult bool
+		evalCalled bool // whether the evaluator should even be reached
+	}{
+		{name: "no UserInfo → deny (evaluator never reached)", withUser: false, wantResult: false, evalCalled: false},
+		{name: "evaluator error → deny", withUser: true, evalErr: fmt.Errorf("snapshot not yet built"), wantResult: false, evalCalled: true},
+		{name: "allowed=false → deny", withUser: true, evalRet: false, wantResult: false, evalCalled: true},
+		{name: "allowed=true → permit", withUser: true, evalRet: true, wantResult: true, evalCalled: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				called  bool
+				gotOpts rbac.EvaluateOptions
+			)
+			restore := setEvaluateRBACForTest(func(ctx context.Context, opts rbac.EvaluateOptions) (bool, string, error) {
+				called = true
+				gotOpts = opts
+				return tc.evalRet, "", tc.evalErr
+			})
+			defer restore()
+
+			ctx := context.Background()
+			if tc.withUser {
+				ctx = m5CtxWithUser()
+			}
+
+			got := checkDispatchRBAC(ctx, m5GVR, "krateo-system")
+			if got != tc.wantResult {
+				t.Fatalf("checkDispatchRBAC = %v, want %v", got, tc.wantResult)
+			}
+			if called != tc.evalCalled {
+				t.Fatalf("evaluator called = %v, want %v (a missing UserInfo must SHORT-CIRCUIT before evaluating)", called, tc.evalCalled)
+			}
+			if tc.evalCalled {
+				// The load-bearing contract: this is a per-item GET check that
+				// discards the BindingUID, so it MUST skip the stable-sort.
+				if gotOpts.Verb != "get" {
+					t.Fatalf("EvaluateOptions.Verb = %q, want \"get\" (the dispatch gate is a GET-permit check)", gotOpts.Verb)
+				}
+				if !gotOpts.SkipBindingUID {
+					t.Fatalf("EvaluateOptions.SkipBindingUID = false, want true (per-item caller discards matchedBindingUID — Ship L1 CPU posture)")
+				}
+				if gotOpts.Group != m5GVR.Group || gotOpts.Resource != m5GVR.Resource {
+					t.Fatalf("EvaluateOptions group/resource = %q/%q, want %q/%q", gotOpts.Group, gotOpts.Resource, m5GVR.Group, m5GVR.Resource)
+				}
+				if gotOpts.Namespace != "krateo-system" {
+					t.Fatalf("EvaluateOptions.Namespace = %q, want krateo-system", gotOpts.Namespace)
+				}
+				if gotOpts.Username != "alice" {
+					t.Fatalf("EvaluateOptions.Username = %q, want alice (the ctx identity)", gotOpts.Username)
+				}
+			}
+		})
+	}
+}
+
+// TestM5_FailClosed_RED_ShadowFailOpen proves the fail-closed arms are
+// DISCRIMINATING: a shadow gate that fails OPEN (returns true when UserInfo is
+// missing or the evaluator errored — the classic RBAC regression) gives the
+// WRONG (permit) answer on exactly the inputs the real gate denies. The real
+// checkDispatchRBAC returns the SAFE (deny) answer for the same inputs.
+func TestM5_FailClosed_RED_ShadowFailOpen(t *testing.T) {
+	// A wrong impl that fails OPEN. This is what the RED mutation of the prod
+	// gate would look like.
+	shadowFailOpen := func(ctx context.Context, gvr schema.GroupVersionResource, namespace string) bool {
+		ui, err := xcontext.UserInfo(ctx)
+		if err != nil {
+			return true // RED: fail OPEN on missing identity
+		}
+		allowed, _, evalErr := evaluateRBACFn(ctx, rbac.EvaluateOptions{
+			Username: ui.Username, Groups: ui.Groups, Verb: "get",
+			Group: gvr.Group, Resource: gvr.Resource, Namespace: namespace, SkipBindingUID: true,
+		})
+		if evalErr != nil {
+			return true // RED: fail OPEN on evaluator error
+		}
+		return allowed
+	}
+
+	// Arm 1: missing UserInfo.
+	restore := setEvaluateRBACForTest(func(ctx context.Context, opts rbac.EvaluateOptions) (bool, string, error) {
+		return false, "", nil
+	})
+	defer restore()
+
+	noUserCtx := context.Background()
+	if real := checkDispatchRBAC(noUserCtx, m5GVR, "krateo-system"); real != false {
+		t.Fatalf("real gate must DENY a no-UserInfo request; got %v", real)
+	}
+	if shadow := shadowFailOpen(noUserCtx, m5GVR, "krateo-system"); shadow != true {
+		t.Fatalf("shadow fail-open must (wrongly) PERMIT the no-UserInfo request — else the RED arm is not discriminating; got %v", shadow)
+	}
+
+	// Arm 2: evaluator error.
+	restore2 := setEvaluateRBACForTest(func(ctx context.Context, opts rbac.EvaluateOptions) (bool, string, error) {
+		return false, "", fmt.Errorf("degraded")
+	})
+	defer restore2()
+
+	userCtx := m5CtxWithUser()
+	if real := checkDispatchRBAC(userCtx, m5GVR, "krateo-system"); real != false {
+		t.Fatalf("real gate must DENY on an evaluator error; got %v", real)
+	}
+	if shadow := shadowFailOpen(userCtx, m5GVR, "krateo-system"); shadow != true {
+		t.Fatalf("shadow fail-open must (wrongly) PERMIT on an evaluator error — the discriminant that proves fail-closed matters; got %v", shadow)
+	}
+}

--- a/internal/handlers/dispatchers/deps_extract.go
+++ b/internal/handlers/dispatchers/deps_extract.go
@@ -59,6 +59,21 @@ var restActionGVR = schema.GroupVersionResource{
 	Resource: "restactions",
 }
 
+// recordListDepFn is the list-scope (name="*" wildcard) dep-record seam
+// used by recordWidgetDeps for a NAME-LESS resourcesRefs target (a ref
+// that displays "all of kind X in namespace Y" — the /call path carries
+// resource+apiVersion but no name). Production wires it to the real
+// DepTracker.RecordList; the ONLY reassigner is the _test.go falsifier,
+// which transiently neuters it to a by-name Record to prove the RED
+// (a by-name edge wildcard-misses a sibling object's reconcile → zero
+// delivery). A package var (not a parameter) so recordWidgetDeps's
+// signature is untouched; production never reassigns it.
+//
+// Idiom-match: resolveOnceFn / paginationFetchPageFn in this package.
+var recordListDepFn = func(deps *cache.DepTracker, l1Key string, gvr schema.GroupVersionResource, namespace string) {
+	deps.RecordList(l1Key, gvr, namespace)
+}
+
 // recordWidgetDeps walks the resolved widget object and records dep
 // edges into the cache.DepTracker. l1Key is the L1 entry's cache key
 // the dependent edges are recorded against.
@@ -118,8 +133,9 @@ func recordWidgetDeps(log *slog.Logger, l1Key string, gvr schema.GroupVersionRes
 		ensureWatcherInformerForGVR(refGVR)
 		if ref.Name == "" {
 			// List-scope dep (e.g., a ref that targets "all of kind X
-			// in namespace Y"). Record with name="*".
-			deps.RecordList(l1Key, refGVR, ref.Namespace)
+			// in namespace Y"). Record with name="*" (via the
+			// recordListDepFn seam — prod default is deps.RecordList).
+			recordListDepFn(deps, l1Key, refGVR, ref.Namespace)
 			continue
 		}
 		deps.Record(l1Key, refGVR, ref.Namespace, ref.Name)

--- a/internal/handlers/dispatchers/deps_refresh_delivery_falsifier_test.go
+++ b/internal/handlers/dispatchers/deps_refresh_delivery_falsifier_test.go
@@ -230,3 +230,217 @@ func TestFalsifier61_EndToEndDelivery(t *testing.T) {
 			deliveredAfter, deliveredBefore+1)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// M19 — name-less LIST delivery target + action-only-ref no-edge.
+//
+// A composition-DETAIL / list widget can resolve a NAME-LESS displayed
+// target into status.resourcesRefs: the /call path carries resource +
+// apiVersion but NO `name` (it displays "all of kind X in namespace Y").
+// ParseCallPathToObjectRef returns a ref with Name=="" → recordWidgetDeps
+// takes the ref.Name=="" branch and MUST RecordList (name="*"), so that ANY
+// object of that GVR in the namespace reconciling dirty-marks the widget key
+// (a newly-created / updated member of the displayed list changes what the
+// widget renders). Recording it as a by-name exact edge instead would
+// wildcard-MISS a sibling member's reconcile → zero delivery.
+// ---------------------------------------------------------------------------
+
+// listWidgetForTest builds a list widget whose displayed target is a NAME-LESS
+// /call path (resource+apiVersion, no name) in status.resourcesRefs. This is
+// the exact shape that must yield a RecordList('*') list-scope dep edge.
+func listWidgetForTest() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Panel",
+		"metadata": map[string]any{
+			"name":      "list-panel-1",
+			"namespace": "demo-ns",
+		},
+		"spec": map[string]any{},
+		"status": map[string]any{
+			"resourcesRefs": map[string]any{
+				"items": []any{
+					map[string]any{
+						"id": "list-displayed-1",
+						// NO &name= param → a list-scope target.
+						"path":    "/call?resource=awsvpcstacks&apiVersion=composition.krateo.io%2Fv1&namespace=demo-system",
+						"verb":    "GET",
+						"allowed": true,
+					},
+				},
+			},
+		},
+	}}
+}
+
+// TestFalsifierM19_NameLessListTarget_RecordsWildcard — the DISCRIMINATING
+// list-scope dep-coverage arm. recordWidgetDeps on a name-less status target
+// must record a LIST edge (name="*"); OnUpdate of ANY object of that GVR in
+// the namespace (an arbitrary member name that was NEVER named in the ref)
+// must dirty-mark the widget key.
+//
+// RED (proven by neutering recordListDepFn): swap the real RecordList for a
+// by-name Record under a synthetic placeholder name → the sibling-member
+// OnUpdate wildcard-MISSES → marked==0 (delivered==0 downstream). Restore →
+// GREEN.
+func TestFalsifierM19_NameLessListTarget_RecordsWildcard(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	// A sibling member of the displayed list — a name that is NOT encoded in
+	// the ref (the ref is name-less). Only a wildcard list edge can match it.
+	const siblingMember = "some-vpc-created-later"
+
+	// --- RED arm: neuter RecordList → by-name Record under a placeholder ---
+	orig := recordListDepFn
+	t.Cleanup(func() { recordListDepFn = orig })
+	cache.ResetDepsForTest()
+	recordListDepFn = func(deps *cache.DepTracker, l1Key string, gvr schema.GroupVersionResource, namespace string) {
+		// The wrong-granularity impl: a by-name exact edge. name!="" (Record
+		// drops name==""), but the name is a fixed placeholder that no real
+		// list member will ever equal.
+		deps.Record(l1Key, gvr, namespace, "__wrong_byname_placeholder__")
+	}
+	recordWidgetDeps(slog.Default(), "L1_list_red", detailWidgetGVR, listWidgetForTest())
+	if marked := cache.Deps().OnUpdate(displayedGVR, displayedNS, siblingMember); marked != 0 {
+		t.Fatalf("RED arm expected to MISS: a by-name edge dirty-marked %d keys for a sibling member "+
+			"OnUpdate — the wrong-granularity Record was supposed to wildcard-miss", marked)
+	}
+
+	// --- GREEN arm: restore real RecordList → wildcard hit ---
+	recordListDepFn = orig
+	cache.ResetDepsForTest()
+	l1Key := "L1_list_green"
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, listWidgetForTest())
+
+	// The list edge must be a wildcard: a member NEVER named in the ref matches.
+	matched := cache.Deps().CollectMatchesForTest(displayedGVR, displayedNS, siblingMember)
+	if _, ok := matched[l1Key]; !ok {
+		t.Fatalf("M19 GREEN: name-less status target did NOT record a LIST('*') edge — a sibling member "+
+			"%s/%s/%s does not dirty-mark the widget key. recordWidgetDeps must RecordList, not Record, "+
+			"for a name-less ref. matched=%v", displayedGVR, displayedNS, siblingMember, matched)
+	}
+	if marked := cache.Deps().OnUpdate(displayedGVR, displayedNS, siblingMember); marked < 1 {
+		t.Fatalf("M19 GREEN: OnUpdate(%s/%s/%s) dirty-marked %d keys — the wildcard list edge never fired",
+			displayedGVR, displayedNS, siblingMember, marked)
+	}
+}
+
+// TestFalsifierM19_NameLessListTarget_EndToEndDelivery — the sufficiency arm
+// for the LIST path: a name-less list target's member reconcile must reach
+// PublishRefresh for the armed widget key. Mirrors C-1's real
+// OnUpdate→dirty-mark→hook→PublishRefresh→subscriber chain, but the trigger is
+// a sibling LIST member (matched only by the wildcard edge).
+func TestFalsifierM19_NameLessListTarget_EndToEndDelivery(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("REFRESH_SSE_ENABLED", "true")
+	cache.ResetDepsForTest()
+	cache.ResetRefreshBroadcasterForTest()
+	t.Cleanup(cache.ResetRefreshBroadcasterForTest)
+
+	l1Key := "L1_list_e2e"
+	cache.Deps().SetRefreshHook(func(key string, _ schema.GroupVersionResource) {
+		cache.PublishRefresh(key)
+	})
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, listWidgetForTest())
+
+	ch, unsub := cache.SubscribeRefresh(map[string]struct{}{l1Key: {}})
+	defer unsub()
+
+	_, deliveredBefore, _, _ := cache.RefreshBroadcasterCounters()
+
+	// A brand-new member of the displayed list reconciles — a name never in the ref.
+	cache.Deps().OnUpdate(displayedGVR, displayedNS, "brand-new-member-vpc")
+
+	select {
+	case got := <-ch:
+		if got != l1Key {
+			t.Fatalf("M19 E2E: subscriber received key %q, want the armed widget key %q", got, l1Key)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("M19 E2E RED: /refreshes subscriber received NOTHING within 2s after a list MEMBER reconciled — "+
+			"the name-less list target recorded no wildcard dep edge (Record-by-name instead of RecordList).")
+	}
+
+	_, deliveredAfter, _, _ := cache.RefreshBroadcasterCounters()
+	if deliveredAfter != deliveredBefore+1 {
+		t.Fatalf("M19 E2E: refreshDeliveredTotal = %d, want %d", deliveredAfter, deliveredBefore+1)
+	}
+}
+
+// TestFalsifierM19_ActionOnlyRef_RecordsNoDepEdge — an action-only ref (its
+// id appears in status.widgetData.actions[*].resourceRefId — e.g. a "View
+// Logs" button target) must NOT record a render dep edge (Revision 14
+// filter). Tracking it would spuriously invalidate the widget every time the
+// action target reconciled. RED (proven by neutering the skip set): with the
+// filter dropped, the action ref DOES record an edge → the action target's
+// reconcile spuriously dirty-marks the widget key.
+func TestFalsifierM19_ActionOnlyRef_RecordsNoDepEdge(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	// A widget whose ONLY status resourcesRef is an action-only target: its id
+	// ("action-target-1") is declared under status.widgetData.actions.
+	actionWidget := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "widgets.templates.krateo.io/v1beta1",
+			"kind":       "Panel",
+			"metadata":   map[string]any{"name": "action-panel", "namespace": "demo-ns"},
+			"spec":       map[string]any{},
+			"status": map[string]any{
+				"resourcesRefs": map[string]any{
+					"items": []any{
+						map[string]any{
+							"id":      "action-target-1",
+							"path":    "/call?resource=awsvpcstacks&apiVersion=composition.krateo.io%2Fv1&namespace=demo-system&name=logs-target",
+							"verb":    "GET",
+							"allowed": true,
+						},
+					},
+				},
+				"widgetData": map[string]any{
+					"actions": map[string]any{
+						"rest": []any{
+							map[string]any{"resourceRefId": "action-target-1"},
+						},
+					},
+				},
+			},
+		}}
+	}
+
+	actionGVR := displayedGVR // awsvpcstacks
+	actionNS := displayedNS
+	actionName := "logs-target"
+
+	// GREEN: the action-only ref records NO edge → its reconcile marks 0.
+	cache.ResetDepsForTest()
+	l1Key := "L1_action_only"
+	recordWidgetDeps(slog.Default(), l1Key, detailWidgetGVR, actionWidget())
+	matched := cache.Deps().CollectMatchesForTest(actionGVR, actionNS, actionName)
+	if _, ok := matched[l1Key]; ok {
+		t.Fatalf("M19: an action-only ref (id in status.widgetData.actions) recorded a render dep edge on "+
+			"%s/%s/%s — tracking it spuriously invalidates the widget on every action-target reconcile. matched=%v",
+			actionGVR, actionNS, actionName, matched)
+	}
+	if marked := cache.Deps().OnUpdate(actionGVR, actionNS, actionName); marked != 0 {
+		t.Fatalf("M19: action-target reconcile dirty-marked %d keys — action-only refs must NOT be tracked", marked)
+	}
+
+	// RED (control that the arm can distinguish a real edge): the SAME widget
+	// WITHOUT the action classification (the ref is treated as a render dep)
+	// DOES record an edge. Proves the arm's GREEN above is the filter working,
+	// not a dead code path that never records anything.
+	renderWidget := actionWidget()
+	// Drop the widgetData.actions so the ref is no longer action-classified.
+	unstructured.RemoveNestedField(renderWidget.Object, "status", "widgetData")
+	cache.ResetDepsForTest()
+	l1Key2 := "L1_render_ref"
+	recordWidgetDeps(slog.Default(), l1Key2, detailWidgetGVR, renderWidget)
+	matched2 := cache.Deps().CollectMatchesForTest(actionGVR, actionNS, actionName)
+	if _, ok := matched2[l1Key2]; !ok {
+		t.Fatalf("M19 control: with the action classification removed, the ref MUST record a render dep edge "+
+			"(else the GREEN arm above is a no-op that never records anything). matched=%v", matched2)
+	}
+}

--- a/internal/handlers/dispatchers/dispatch_seams.go
+++ b/internal/handlers/dispatchers/dispatch_seams.go
@@ -1,0 +1,48 @@
+package dispatchers
+
+// dispatch_seams.go — H1 (coverage-audit) dispatcher ServeHTTP orchestration
+// seams. These are package-level indirection vars for the FOUR collaborators
+// the RESTAction / Widget ServeHTTP handlers depend on, defaulting to the real
+// production functions:
+//
+//   - fetchObjectFn        → fetchObject         (helpers.go)
+//   - checkDispatchRBACFn  → checkDispatchRBAC   (helpers.go)
+//   - restactionsResolveFn → restactions.Resolve (restactions.go)
+//   - widgetsResolveFn     → widgets.Resolve     (widgets.go)
+//
+// PROD-TESTABILITY, BEHAVIOR-PRESERVING: production NEVER reassigns these — the
+// handlers call the var, which points at the real function, so the compiled
+// prod path is byte-identical to a direct call. Only the H1 _test.go shim
+// (dispatch_seams_testshim_test.go) swaps them for the duration of a test to
+// drive ServeHTTP hermetically (fake fetchObject / RBAC verdict / Resolve) so
+// the SERVE ORCHESTRATION itself is exercised — the ordering (RBAC-before-Get
+// vs Get-before-serve), the exactly-one-Put-under-derived-key, the
+// cache≡no-cache byte-parity, and the RBAC-sensitive-widget content-lookup skip
+// — none of which are observable at sub-block granularity.
+//
+// This mirrors the repo's established var-seam idiom: resolveOnceFn
+// (resolve_populate.go:70, swapped by resolve_populate_testshim_test.go) and
+// the api.nestedCallResolver seam (nested_call_testshim_test.go). A package var
+// rather than a handler struct field so the RESTAction()/Widgets() constructor
+// signatures and the http.Handler contract are untouched.
+
+import (
+	"context"
+
+	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+)
+
+// fetchObjectFn is the fetch-the-dispatched-CR seam (fetchObject → objects.Get).
+var fetchObjectFn = fetchObject
+
+// checkDispatchRBACFn is the cache=on EvaluateRBAC dispatch gate seam.
+var checkDispatchRBACFn = checkDispatchRBAC
+
+// restactionsResolveFn is the top-level RESTAction resolve seam.
+var restactionsResolveFn = restactions.Resolve
+
+// widgetsResolveFn is the top-level Widget resolve seam.
+var widgetsResolveFn = func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error) {
+	return widgets.Resolve(ctx, opts)
+}

--- a/internal/handlers/dispatchers/dispatch_seams_testshim_test.go
+++ b/internal/handlers/dispatchers/dispatch_seams_testshim_test.go
@@ -1,0 +1,52 @@
+// dispatch_seams_testshim_test.go — test-only swappers for the H1 ServeHTTP
+// orchestration seams (dispatch_seams.go). The setters live in a _test.go file
+// so production restactions.go / widgets.go / helpers.go never expose a setter;
+// the seams are reassignable ONLY from tests. Mirrors
+// resolve_populate_testshim_test.go (resolveOnceFn) and
+// nested_call_testshim_test.go (api.nestedCallResolver).
+
+package dispatchers
+
+import (
+	"context"
+	"net/http"
+
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// setFetchObjectForTest swaps fetchObjectFn and returns a restore the caller
+// MUST defer/Cleanup. Restores the production fetchObject.
+func setFetchObjectForTest(fn func(req *http.Request) objects.Result) func() {
+	prev := fetchObjectFn
+	fetchObjectFn = fn
+	return func() { fetchObjectFn = prev }
+}
+
+// setCheckDispatchRBACForTest swaps the cache=on dispatch RBAC gate verdict and
+// returns a restore. Records every (gvr, namespace) it is asked so a test can
+// assert the gate ran (or did NOT run) and in what order.
+func setCheckDispatchRBACForTest(fn func(ctx context.Context, gvr schema.GroupVersionResource, namespace string) bool) func() {
+	prev := checkDispatchRBACFn
+	checkDispatchRBACFn = fn
+	return func() { checkDispatchRBACFn = prev }
+}
+
+// setRestactionsResolveForTest swaps the top-level RESTAction resolve seam and
+// returns a restore.
+func setRestactionsResolveForTest(fn func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error)) func() {
+	prev := restactionsResolveFn
+	restactionsResolveFn = fn
+	return func() { restactionsResolveFn = prev }
+}
+
+// setWidgetsResolveForTest swaps the top-level Widget resolve seam and returns a
+// restore.
+func setWidgetsResolveForTest(fn func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error)) func() {
+	prev := widgetsResolveFn
+	widgetsResolveFn = fn
+	return func() { widgetsResolveFn = prev }
+}

--- a/internal/handlers/dispatchers/f6_resolve_input_reach_test.go
+++ b/internal/handlers/dispatchers/f6_resolve_input_reach_test.go
@@ -1,0 +1,129 @@
+// f6_resolve_input_reach_test.go — L12 (coverage-audit): the F6 request-extras
+// allowlist is KEY-ONLY. An UNDECLARED request extra (not in spec.keyExtras) is
+// DROPPED from the cache KEY (filterDeclaredKeyExtras / effectiveKeyExtras) but
+// STILL REACHES the resolve INPUT — widgets.go hands widgets.Resolve the RAW,
+// unfiltered extras, so a widget's widgetDataTemplate jq that reads an undeclared
+// extra still renders correctly (the design's deliberate "resolve sees
+// everything, key sees only declared" split, helpers.go filterDeclaredKeyExtras
+// doc §KEY-ONLY).
+//
+// This is the resolve-side complement of the farch_f6_keyextras_test.go arms
+// (which pin the KEY side — undeclared extras drop from the key). Here we DRIVE
+// the REAL widgets.Resolve over a CR whose jq echoes extras.debugFlag while
+// declaring NO keyExtras, and assert:
+//
+//	(1) RESOLVE INPUT reach: the rendered body echoes debugFlag=on (the raw extra
+//	    reached widgets.Resolve's jq dict), AND
+//	(2) KEY exclusion: effectiveKeyExtras / filterDeclaredKeyExtras DROP debugFlag
+//	    from the key material (it does not partition the cell).
+//
+// RED arm (resolve path filters extras by the keyExtras allowlist): if widgets.go
+// mistakenly passed the FILTERED (declared-only) extras to widgets.Resolve — i.e.
+// applied the key-side allowlist to the resolve input — debugFlag would be absent
+// from the dict and the rendered body would NOT echo it. TestL12_RED_FilteredExtrasDropEcho
+// drives resolve with the key-side-FILTERED extras and asserts the echo VANISHES,
+// proving arm (1) discriminates the "resolve filters by keyExtras" regression.
+
+package dispatchers
+
+import (
+	"testing"
+)
+
+// widgetCRDebugEcho builds a widget CR that declares NO spec.keyExtras and whose
+// widgetDataTemplate echoes the request extra `.debugFlag` into
+// status.widgetData.echoedDebug via jq. No apiRef (hermetic — no apiserver).
+func widgetCRDebugEcho() map[string]any {
+	return map[string]any{"spec": map[string]any{
+		// NO keyExtras → debugFlag is UNDECLARED (must drop from the key).
+		"widgetData": map[string]any{},
+		"widgetDataTemplate": []any{
+			map[string]any{"forPath": ".echoedDebug", "expression": "${ .debugFlag }"},
+		},
+	}}
+}
+
+// TestL12_UndeclaredExtra_ReachesResolveInput_NotKey — the make-or-break L12
+// arm. debugFlag is undeclared: it is DROPPED from the key but REACHES the
+// resolve input (echoed in the rendered body).
+func TestL12_UndeclaredExtra_ReachesResolveInput_NotKey(t *testing.T) {
+	cr := widgetCRDebugEcho()
+	ctx := ctxAsIdentity("alice", "devs") // farch_identity_contract_test.go helper
+	requestExtras := map[string]any{"debugFlag": "on"}
+
+	// (1) RESOLVE INPUT reach — drive the REAL widgets.Resolve with the RAW
+	// request extras (exactly what widgets.go passes to the resolver: unfiltered).
+	wd := resolveRenderedWidgetData(t, ctx, cr, requestExtras)
+	if wd["echoedDebug"] != "on" {
+		t.Fatalf("L12 (resolve-input reach): the undeclared extra debugFlag must REACH the resolve input and echo into the body; status.widgetData=%#v — widgets.go must pass the RAW extras to widgets.Resolve", wd)
+	}
+
+	// (2) KEY exclusion — the SAME undeclared extra must be DROPPED from the key
+	// material. filterDeclaredKeyExtras (no declaration → drop everything) and the
+	// full effectiveKeyExtras must both exclude debugFlag.
+	filtered := filterDeclaredKeyExtras(cr, requestExtras)
+	if _, present := filtered["debugFlag"]; present {
+		t.Fatalf("L12 (key exclusion): filterDeclaredKeyExtras must DROP an undeclared extra from the key; got %#v", filtered)
+	}
+	keyExtras := effectiveKeyExtras(ctx, cr, requestExtras)
+	if _, present := keyExtras["debugFlag"]; present {
+		t.Fatalf("L12 (key exclusion): effectiveKeyExtras must NOT fold an undeclared extra into the key; got %#v", keyExtras)
+	}
+
+	// The two halves together are the KEY-ONLY property: the extra shaped the
+	// BODY (resolve input) but not the KEY. That is exactly why widgets.go pairs
+	// the fold-nothing key with the F6 self-quarantine Put-gate — the body is
+	// correct-but-unshareable, so it must not be Put into the shared cohort cell.
+}
+
+// TestL12_DeclaredExtra_FoldsIntoKey_Control — control: once the widget DECLARES
+// keyExtras:[debugFlag], the SAME extra BOTH reaches the resolve input AND folds
+// into the key (it now legitimately partitions the cell). Proves the drop in the
+// main arm is caused by the MISSING declaration, not by the extra being special.
+func TestL12_DeclaredExtra_FoldsIntoKey_Control(t *testing.T) {
+	cr := widgetCRDebugEcho()
+	// Declare debugFlag now.
+	spec := cr["spec"].(map[string]any)
+	spec["keyExtras"] = []any{"debugFlag"}
+
+	ctx := ctxAsIdentity("alice", "devs")
+	requestExtras := map[string]any{"debugFlag": "on"}
+
+	// Still reaches the resolve input (unchanged — resolve always sees raw extras).
+	wd := resolveRenderedWidgetData(t, ctx, cr, requestExtras)
+	if wd["echoedDebug"] != "on" {
+		t.Fatalf("control: a declared extra must still reach the resolve input; wd=%#v", wd)
+	}
+	// Now it DOES fold into the key.
+	keyExtras := effectiveKeyExtras(ctx, cr, requestExtras)
+	if keyExtras["debugFlag"] != "on" {
+		t.Fatalf("control: a DECLARED extra must fold into the key material; got %#v", keyExtras)
+	}
+}
+
+// TestL12_RED_FilteredExtrasDropEcho proves arm (1) is DISCRIMINATING. If the
+// resolve path had (wrongly) filtered the extras by the key-side allowlist
+// before handing them to widgets.Resolve, debugFlag would be gone from the dict
+// and the body would NOT echo it. Driving resolve with the key-side-FILTERED
+// extras (the regression's input) makes the echo VANISH — the exact RED the
+// main arm's GREEN echo excludes.
+func TestL12_RED_FilteredExtrasDropEcho(t *testing.T) {
+	cr := widgetCRDebugEcho() // no keyExtras
+	ctx := ctxAsIdentity("alice", "devs")
+	requestExtras := map[string]any{"debugFlag": "on"}
+
+	// The key-side allowlist output an undeclared-widget would produce = {}.
+	filtered := filterDeclaredKeyExtras(cr, requestExtras)
+	if len(filtered) != 0 {
+		t.Fatalf("setup: an undeclared widget's key-side filter must be empty; got %#v", filtered)
+	}
+
+	// Drive resolve with the FILTERED extras (the regression: resolve fed the
+	// key-side allowlist). The echo must VANISH — this is the wrong impl.
+	wd := resolveRenderedWidgetData(t, ctx, cr, filtered)
+	if wd["echoedDebug"] == "on" {
+		t.Fatalf("RED arm inconsistent: feeding the FILTERED extras must DROP the echo (that IS the regression); wd=%#v", wd)
+	}
+	// And the GREEN main arm proves the prod path (raw extras) keeps the echo —
+	// so "resolve filters by keyExtras" is a real, detectable defect.
+}

--- a/internal/handlers/dispatchers/helpers.go
+++ b/internal/handlers/dispatchers/helpers.go
@@ -106,6 +106,16 @@ func normalizePagination(perPage, page int) (int, int) {
 	return perPage, page
 }
 
+// evaluateRBACFn is the RBAC-evaluation seam consumed by checkDispatchRBAC
+// (M5 coverage-audit). Defaults to rbac.EvaluateRBAC; production NEVER
+// reassigns it (the compiled path is byte-identical to a direct call). Only
+// the M5 _test.go shim swaps it, to drive checkDispatchRBAC's fail-closed
+// branches (no-UserInfo / eval-error / deny / allow) AND to capture the
+// EvaluateOptions so the test can assert the load-bearing (Verb=="get",
+// SkipBindingUID==true) contract without wiring a full RBAC snapshot. Mirrors
+// the resolveOnceFn / dispatch_seams.go var-seam idiom.
+var evaluateRBACFn = rbac.EvaluateRBAC
+
 // checkDispatchRBAC is the cache=on permission gate (Revision 2
 // binding, Tag 0.30.4). Returns true iff the user identified by ctx is
 // permitted to GET the dispatched CR in namespace.
@@ -133,7 +143,7 @@ func checkDispatchRBAC(ctx context.Context, gvr schema.GroupVersionResource, nam
 	// (allowed, matchedBindingUID, err). This per-item caller ignores
 	// matchedBindingUID; cache-key callers consume it (helpers.go:202 +
 	// :306 via the per-request memo, Phase 2b).
-	allowed, _, evalErr := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+	allowed, _, evalErr := evaluateRBACFn(ctx, rbac.EvaluateOptions{
 		Username:  ui.Username,
 		Groups:    ui.Groups,
 		Verb:      "get",

--- a/internal/handlers/dispatchers/inline_parent_identity_key_test.go
+++ b/internal/handlers/dispatchers/inline_parent_identity_key_test.go
@@ -1,0 +1,124 @@
+// inline_parent_identity_key_test.go — L1 (coverage-audit) SECURITY:
+// inlineParentIdentityForKey (helpers.go, A2 §4.3 F-ARCH-5 marker) — the
+// KEY-side per-user marker that keeps an inline-embedding parent's cell per-USER
+// so an embedded child's identity-varying `rendered` body cannot leak across
+// users sharing one BindingUID.
+//
+// TestFARCH5_InlineParent_PerUserKey pins the WHOLE-effectiveKeyExtras outcome
+// (alice-key != bob-key). This file pins the marker FUNCTION directly across the
+// partial-identity shapes it must handle exactly, because the marker's precise
+// map SHAPE is load-bearing:
+//
+//	identity-less ctx (no UserInfo)     → nil     (fail-safe: the request already
+//	                                              fail-closes to the ""-BindingUID
+//	                                              MISS path; the marker must not
+//	                                              synthesize a {} key material)
+//	username-only (no groups)           → {"username": u}                (no groups key)
+//	groups-only (no username)           → {"groups": []any{...}}         (no username key)
+//	both                                → {"username": u, "groups": []any{...}}
+//	NON-inline widget (any identity)    → nil     (marker scoped to inline parents)
+//
+// AND every "groups" value MUST be JSON-native []any (NOT Go []string) — the
+// shape-uniformity contract (feedback_identity_extras_must_be_json_native_slices):
+// a []string that ever reached a resolve-input DeepCopyJSON would panic; the
+// marker is key-only today but is built []any so it can never regress.
+//
+// RED arms (each expressed as a discriminating assertion):
+//   - returns {} on identity-less  → a fold of {} into the key would make the
+//     inline parent cell shared again (leak). Asserted nil, not empty.
+//   - leaks marker to non-inline    → a non-inline widget getting a per-user
+//     marker over-partitions the ~99% corpus. Asserted nil for non-inline.
+//   - groups as []string            → asserted the concrete type is []any.
+
+package dispatchers
+
+import (
+	"context"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+)
+
+// l1Ctx builds a ctx carrying the given identity. Empty username + nil groups
+// still installs a (zero) UserInfo — for the true "identity-less" case use
+// context.Background() (no WithUserInfo), which makes xcontext.UserInfo error.
+func l1Ctx(username string, groups []string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: groups}))
+}
+
+func TestL1_InlineParentIdentityForKey_Shapes(t *testing.T) {
+	inlineCR := widgetCRInlineParent() // hasInlineGETRef==true (farch_identity_contract_test.go)
+	if !hasInlineGETRef(inlineCR) {
+		t.Fatal("setup: widgetCRInlineParent must classify hasInlineGETRef==true")
+	}
+
+	t.Run("identity-less ctx → nil (RED: returns {})", func(t *testing.T) {
+		got := inlineParentIdentityForKey(context.Background(), inlineCR)
+		if got != nil {
+			t.Fatalf("identity-less inline parent must return nil, got %#v — a {} return would fold empty identity into the key and re-share the inline cell (leak)", got)
+		}
+	})
+
+	t.Run("username-only → {username} (no groups key)", func(t *testing.T) {
+		got := inlineParentIdentityForKey(l1Ctx("alice", nil), inlineCR)
+		if got == nil {
+			t.Fatal("username-only inline parent must return a non-nil marker")
+		}
+		if got["username"] != "alice" {
+			t.Fatalf("username marker = %#v, want username=alice", got)
+		}
+		if _, ok := got["groups"]; ok {
+			t.Fatalf("no groups present → the marker must NOT carry a groups key; got %#v", got)
+		}
+	})
+
+	t.Run("groups-only → {groups:[]any} (no username key)", func(t *testing.T) {
+		got := inlineParentIdentityForKey(l1Ctx("", []string{"devs", "ops"}), inlineCR)
+		if got == nil {
+			t.Fatal("groups-only inline parent must return a non-nil marker")
+		}
+		if _, ok := got["username"]; ok {
+			t.Fatalf("empty username → the marker must NOT carry a username key; got %#v", got)
+		}
+		g, ok := got["groups"]
+		if !ok {
+			t.Fatalf("groups-only marker must carry a groups key; got %#v", got)
+		}
+		// RED: groups as []string. The marker MUST be JSON-native []any.
+		as, isStrings := g.([]string)
+		if isStrings {
+			t.Fatalf("RED (groups as []string): groups must be JSON-native []any, not []string %v — a []string reaching a resolve-input DeepCopyJSON panics", as)
+		}
+		anyG, isAny := g.([]any)
+		if !isAny {
+			t.Fatalf("groups must be []any; got %T (%#v)", g, g)
+		}
+		if len(anyG) != 2 || anyG[0] != "devs" || anyG[1] != "ops" {
+			t.Fatalf("groups []any content = %#v, want [devs ops]", anyG)
+		}
+	})
+
+	t.Run("both → {username, groups:[]any}", func(t *testing.T) {
+		got := inlineParentIdentityForKey(l1Ctx("bob", []string{"team-a"}), inlineCR)
+		if got["username"] != "bob" {
+			t.Fatalf("marker username = %#v, want bob", got["username"])
+		}
+		g, ok := got["groups"].([]any)
+		if !ok || len(g) != 1 || g[0] != "team-a" {
+			t.Fatalf("marker groups = %#v, want []any{team-a}", got["groups"])
+		}
+	})
+
+	t.Run("NON-inline widget → nil (RED: marker leaks to non-inline)", func(t *testing.T) {
+		nonInline := map[string]any{"spec": map[string]any{}}
+		if hasInlineGETRef(nonInline) {
+			t.Fatal("setup: the non-inline CR must NOT classify hasInlineGETRef")
+		}
+		got := inlineParentIdentityForKey(l1Ctx("alice", []string{"devs"}), nonInline)
+		if got != nil {
+			t.Fatalf("RED (marker leaks to non-inline): a non-inline widget must return nil (no per-user marker), got %#v — else the ~99%% identity-free corpus over-partitions", got)
+		}
+	})
+}

--- a/internal/handlers/dispatchers/phase1_pip_seed.go
+++ b/internal/handlers/dispatchers/phase1_pip_seed.go
@@ -633,8 +633,34 @@ func hasTemplatedEndpointRef(cr *templatesv1.RESTAction) bool {
 	return false
 }
 
+// hasTemplatedEndpointRefFn is the #113 seed-skip PREDICATE seam. Production
+// wires it to the real hasTemplatedEndpointRef; the ONLY reassigner is the
+// _test.go falsifier, which transiently NEUTERS it to always-false to prove the
+// RED (an impl that fails to skip a templated-endpointRef RA reaches the Put and
+// poisons the no-extras cell with a truncated body — the #113 §4 defect). A
+// package var (not a parameter) so seedOneRestaction's signature is untouched;
+// production never reassigns it. Idiom-match: resolveOnceFn.
+var hasTemplatedEndpointRefFn = hasTemplatedEndpointRef
+
+// seedObjectsGetFn is the RESTAction-fetch seam for seedOneRestaction.
+// Production wires it to the real objects.Get; the ONLY reassigner is the
+// _test.go falsifier, which injects a fetched RESTAction unstructured (a
+// templated- vs static-endpointRef shape) to drive the #113 seed-skip
+// hermetically — without a cluster. A package var (not a parameter) so
+// seedOneRestaction's signature is untouched; production never reassigns it.
+// Idiom-match: resolveOnceFn / paginationFetchPageFn.
+var seedObjectsGetFn = objects.Get
+
+// seedRestactionResolveAndPutFn is the RESOLVE+encode+GTTL-gate+Put TAIL of
+// seedOneRestaction — everything AFTER the #113 templated-endpointRef skip.
+// Extracting it as a seam lets a test observe whether the seed reached the Put
+// (static RA) or short-circuited before it (templated RA → NO Put) without a
+// live resolver/encoder. Production wires it to the real tail
+// (seedRestactionResolveAndPutProd); only the _test.go falsifier reassigns it.
+var seedRestactionResolveAndPutFn = seedRestactionResolveAndPutProd
+
 func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.ObjectReference, authnNS string, mode seedScopeMode) error {
-	got := objects.Get(ctx, ref)
+	got := seedObjectsGetFn(ctx, ref)
 	if got.Err != nil {
 		// #158 (design §1.3): preserve the typed status error so the call
 		// site's classifySeedErr sees 403 (RBAC deny) vs 5xx (operational)
@@ -741,7 +767,7 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	// (§3.2) → never cached anyway, so the seed was never going to warm a servable
 	// cell for it. Greppable skip line mirrors the Class-5 refHasUnresolvedTemplateToken
 	// idiom. Every api-step EndpointRef is nil-guarded (*Reference, may be nil).
-	if hasTemplatedEndpointRef(&cr) {
+	if hasTemplatedEndpointRefFn(&cr) {
 		slog.Default().Info("phase1.seed.skip.templated_endpointref",
 			slog.String("subsystem", "cache"),
 			slog.String("restaction", ref.Namespace+"/"+ref.Name),
@@ -801,8 +827,30 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	resCtx, stageErrSink := cache.WithStageErrorSink(resCtx)
 	resCtx, extTouchedSink := cache.WithExternalTouchedSink(resCtx)
 
+	// Resolve + encode + GTTL-gate + Put TAIL (via the seedRestactionResolveAndPutFn
+	// seam — prod default is seedRestactionResolveAndPutProd). The #113 templated-
+	// endpointRef skip above short-circuits BEFORE this tail, so a templated RA
+	// never reaches the Put.
+	return seedRestactionResolveAndPutFn(ctx, resCtx, &cr, ref, authnNS, key, handle, inputs, got, stageErrSink, extTouchedSink)
+}
+
+// seedRestactionResolveAndPutProd is the production resolve+encode+GTTL-gate+Put
+// tail of seedOneRestaction, extracted verbatim behind the
+// seedRestactionResolveAndPutFn seam. Behaviour is byte-identical to the inlined
+// tail; the only change is that it is now reachable/observable through a seam.
+func seedRestactionResolveAndPutProd(
+	ctx, resCtx context.Context,
+	cr *templatesv1.RESTAction,
+	ref templatesv1.ObjectReference,
+	authnNS, key string,
+	handle cacheHandle,
+	inputs *cache.ResolvedKeyInputs,
+	got objects.Result,
+	stageErrSink *cache.StageErrorSink,
+	extTouchedSink *cache.ExternalTouchedSink,
+) error {
 	res, err := restactions.Resolve(resCtx, restactions.ResolveOptions{
-		In: &cr,
+		In: cr,
 		// Ship 0.30.230 fix-at-root: SArc is the SA *rest.Config carried
 		// on ctx by withCohortSeedContext upstream. Threading it here
 		// ensures the inner endpointReferenceMapper has a non-nil rc for
@@ -845,7 +893,7 @@ func seedOneRestaction(ctx context.Context, cohortLabel string, ref templatesv1.
 	// override) when the knob is unset or the RA has no UAF stage → byte-identical
 	// to today for a non-UAF seed cell and when disabled.
 	if inputs != nil {
-		inputs.HasUAF = restactionHasUAFStage(&cr)
+		inputs.HasUAF = restactionHasUAFStage(cr)
 	}
 	// Put under the per-user key — exactly the shape restactions.go
 	// :212-216 puts under at serve time.

--- a/internal/handlers/dispatchers/phase1_readyz_backstop_test.go
+++ b/internal/handlers/dispatchers/phase1_readyz_backstop_test.go
@@ -1,0 +1,162 @@
+// phase1_readyz_backstop_test.go — M7 (coverage-audit): the Phase-1 readiness
+// C2 BACKSTOP is unconditional. phase1WarmupWith flips /readyz (MarkPhase1Done)
+// on EVERY exit of the Step-7.6 seed block — normal return, seed error, ctx /
+// pipGlobalTimeout expiry, OR a panic unwinding through the recover — so a
+// stuck/panicking/failing seed yields Ready-DEGRADED, NEVER not-Ready-forever.
+//
+//	(a) panicking seed  → IsPhase1Done()==true after return + backstop counter++
+//	                      AND the panic does NOT escape phase1WarmupWith.
+//	(b) blocking seed past a tiny ctx timeout → the flip STILL happens (the
+//	                      MarkPhase1Done defer fires when the seed ctx cancels).
+//	(c) lister listErr  → NO early flip / early return; the walk falls through to
+//	                      the SINGLE Step-7.6 seed flip (seed invoked exactly once).
+//
+// RED arms:
+//   - "early-return on roots_list_failed": a regression that early-returned (or
+//     early-flipped + returned) on the lister error would NOT invoke the seed —
+//     arm (c) asserts the seed runs exactly once, so that regression reds it.
+//   - "panic escapes past MarkPhase1Done": arm (a) asserts phase1WarmupWith
+//     returns without propagating the panic AND readiness flipped; a missing /
+//     misordered recover reds both.
+//
+// Complements F5-4 (readiness_backstop_metrics_test.go, panic→counter) with the
+// blocking-timeout and lister-error backstop arms it does not cover. Drives the
+// REAL phase1WarmupWith over the phase1TestWatcher — no shadow of the flip logic.
+
+package dispatchers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestM7_PanicSeed_FlipsAndCounts_NoEscape — arm (a). A panicking seed must NOT
+// crash phase1WarmupWith (recover swallows), readiness still flips, and the
+// backstop counter records the worst failure mode.
+func TestM7_PanicSeed_FlipsAndCounts_NoEscape(t *testing.T) {
+	rw := phase1TestWatcher(t)
+	cache.ResetPhase1DoneForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	lister := func(ctx context.Context) ([]navigationRoot, error) { return nil, nil }
+	resolver := func(ctx context.Context, root navigationRoot) error { return nil }
+	panicSeed := pipSeedFn(func(ctx context.Context) error { panic("M7: seed panic") })
+
+	before := readinessBackstopFired.Value()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// The call must return (recover ran) — a panic escaping here fails the test
+	// process, which is itself the "panic escapes past MarkPhase1Done" RED.
+	err := phase1WarmupWith(ctx, rw, lister, resolver, nil, nil, panicSeed, nil)
+	if err != nil {
+		t.Fatalf("arm (a): phase1WarmupWith must survive a panicking seed; got err=%v", err)
+	}
+	if !cache.IsPhase1Done() {
+		t.Fatal("arm (a) RED (panic escapes past MarkPhase1Done): readiness did NOT flip after a seed panic — the MarkPhase1Done defer must run AFTER the recover, unconditionally")
+	}
+	if got := readinessBackstopFired.Value(); got != before+1 {
+		t.Fatalf("arm (a): a panicking seed must count exactly ONE backstop-Ready; got %d want %d", got, before+1)
+	}
+}
+
+// TestM7_BlockingSeedPastCtxTimeout_StillFlips — arm (b). A seed that blocks
+// until its ctx cancels (here bounded by a tiny OUTER ctx timeout that the seed
+// ctx inherits) must NOT wedge readiness: the MarkPhase1Done defer fires when
+// the seed returns after cancellation. Proves the flip is min(seed-complete,
+// timeout), never not-Ready-forever.
+func TestM7_BlockingSeedPastCtxTimeout_StillFlips(t *testing.T) {
+	rw := phase1TestWatcher(t)
+	cache.ResetPhase1DoneForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	lister := func(ctx context.Context) ([]navigationRoot, error) { return nil, nil }
+	resolver := func(ctx context.Context, root navigationRoot) error { return nil }
+
+	seedObservedCancel := make(chan struct{}, 1)
+	blockingSeed := pipSeedFn(func(ctx context.Context) error {
+		// Block until the seed ctx (a child of the warmup ctx) cancels.
+		<-ctx.Done()
+		seedObservedCancel <- struct{}{}
+		return ctx.Err()
+	})
+
+	// Tiny OUTER timeout → the seed ctx (WithTimeout(ctx, pipGlobalTimeout)) is a
+	// child, so it cancels when the outer ctx expires well before 8 minutes.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- phase1WarmupWith(ctx, rw, lister, resolver, nil, nil, blockingSeed, nil) }()
+
+	select {
+	case <-done:
+		// phase1WarmupWith returned — the seed unblocked on cancellation.
+	case <-time.After(10 * time.Second):
+		t.Fatal("arm (b) RED: phase1WarmupWith did not return within 10s — a blocking seed WEDGED readiness (not-Ready-forever). The seed ctx must be bounded so the MarkPhase1Done defer still fires.")
+	}
+
+	select {
+	case <-seedObservedCancel:
+		// good — the seed observed its ctx cancel (bounded), not a leak.
+	default:
+		t.Fatal("arm (b): the seed never observed ctx cancellation — the seed ctx must be a bounded child of the warmup ctx")
+	}
+
+	if !cache.IsPhase1Done() {
+		t.Fatal("arm (b) RED: readiness did NOT flip after the seed ctx cancelled — MarkPhase1Done must fire regardless (C2 backstop)")
+	}
+}
+
+// TestM7_ListerError_NoEarlyReturn_SingleSeedFlip — arm (c). A lister error
+// (config-vars ConfigMap absent at boot) must NOT early-return / early-flip. The
+// walk falls through Steps 4-7 over the empty roots set to the SINGLE Step-7.6
+// seed, so the seed is invoked EXACTLY ONCE and readiness flips there (not on a
+// deleted early-flip path). RED (early-return on roots_list_failed): the old
+// give-up branch would skip the seed entirely — seedCalls==0.
+func TestM7_ListerError_NoEarlyReturn_SingleSeedFlip(t *testing.T) {
+	rw := phase1TestWatcher(t)
+	cache.ResetPhase1DoneForTest()
+	t.Cleanup(cache.ResetPhase1DoneForTest)
+
+	lister := func(ctx context.Context) ([]navigationRoot, error) {
+		return nil, context.DeadlineExceeded // model "config-vars ConfigMap not present yet"
+	}
+	resolver := func(ctx context.Context, root navigationRoot) error {
+		t.Fatal("arm (c): the resolver must not run when the lister errored (empty roots set)")
+		return nil
+	}
+
+	var seedCalls atomic.Int64
+	seed := pipSeedFn(func(ctx context.Context) error {
+		seedCalls.Add(1)
+		// Assert the walk reached the seed WITHOUT having flipped early: the
+		// only flip is the Step-7.6 MarkPhase1Done defer that fires on this
+		// block's exit — so at the moment the seed body runs, readiness is
+		// still pre-flip.
+		if cache.IsPhase1Done() {
+			t.Error("arm (c) RED (early-flip on roots_list_failed): readiness flipped BEFORE the Step-7.6 seed — the roots-error branch must NOT flip early; the single flip is the seed-block defer")
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := phase1WarmupWith(ctx, rw, lister, resolver, nil, nil, seed, nil)
+	// walkErr==nil (the lister error is logged + tolerated, not returned);
+	// syncErr==nil over the meta-query seeds. So the return is nil.
+	if err != nil {
+		t.Fatalf("arm (c): a lister error must be TOLERATED (logged, roots=nil), not returned; got %v", err)
+	}
+	if n := seedCalls.Load(); n != 1 {
+		t.Fatalf("arm (c) RED (early-return on roots_list_failed): the Step-7.6 seed must run EXACTLY ONCE despite the lister error; got %d invocations", n)
+	}
+	if !cache.IsPhase1Done() {
+		t.Fatal("arm (c): readiness must flip via the SINGLE Step-7.6 seed-block defer")
+	}
+}

--- a/internal/handlers/dispatchers/phase1_seed_templated_endpointref_test.go
+++ b/internal/handlers/dispatchers/phase1_seed_templated_endpointref_test.go
@@ -144,7 +144,10 @@ func TestC113_3_SeedSkipWiredBeforeResolve(t *testing.T) {
 	}
 	s := string(src)
 	for _, want := range []string{
-		"if hasTemplatedEndpointRef(&cr) {",
+		// The skip routes through the hasTemplatedEndpointRefFn seam (prod
+		// default = hasTemplatedEndpointRef), so the falsifier can neuter the
+		// predicate. The wiring guard tracks the seam call site.
+		"if hasTemplatedEndpointRefFn(&cr) {",
 		"phase1.seed.skip.templated_endpointref",
 	} {
 		if !strings.Contains(s, want) {
@@ -152,7 +155,7 @@ func TestC113_3_SeedSkipWiredBeforeResolve(t *testing.T) {
 		}
 	}
 	// The skip MUST precede restactions.Resolve (else it can't prevent the Put).
-	skipIdx := strings.Index(s, "if hasTemplatedEndpointRef(&cr) {")
+	skipIdx := strings.Index(s, "if hasTemplatedEndpointRefFn(&cr) {")
 	resolveIdx := strings.Index(s, "res, err := restactions.Resolve(resCtx, restactions.ResolveOptions{")
 	if skipIdx < 0 || resolveIdx < 0 || skipIdx > resolveIdx {
 		t.Fatalf("#113 seed-skip must appear BEFORE restactions.Resolve (skipIdx=%d resolveIdx=%d)", skipIdx, resolveIdx)

--- a/internal/handlers/dispatchers/refresh_class_stamp_ast_test.go
+++ b/internal/handlers/dispatchers/refresh_class_stamp_ast_test.go
@@ -1,0 +1,185 @@
+// refresh_class_stamp_ast_test.go — M16 (coverage-audit): a build-time AST
+// invariant over the dispatcher serve sites. EVERY setRefreshKeyHeader /
+// setRefreshKeyHeaderUnlessExternal call whose `class` argument is a STRING
+// LITERAL must stamp a class in the SubscriptionCoordinates.Class allowlist
+// (DeriveSubscriptionKey's switch). A literal outside the allowlist would make
+// the frontend arm a /refreshes subscription under a class DeriveSubscriptionKey
+// fails-closed on (default: no key) — the header + the subscription decoder
+// would silently disagree and the live-refresh channel would never fire for
+// that response.
+//
+// The class the dispatcher stamps and the class the subscription decoder accepts
+// are two ends of ONE contract that is expressed as two hand-written literal
+// sets (the serve-site literals here, the switch cases in
+// refresh_subscription.go). This scanner pins them: it fails the build if a
+// serve site stamps a class the switch does not accept — the exact drift a
+// case-typo ("widgetcontent" vs "widgetContent") introduces.
+//
+// RED arm: TestM16_RED_TypoClassIsFlagged feeds the SAME classifier a synthetic
+// call-site stamping "widgetcontent" (lowercase typo) and asserts it is flagged
+// — proving the scanner discriminates a wrong literal, not just rubber-stamps.
+
+package dispatchers
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// refreshClassAllowlist is the SubscriptionCoordinates.Class allowlist =
+// DeriveSubscriptionKey's accepted set (refresh_subscription.go switch):
+// cache.CacheEntryClass{WidgetContent,Apistage,RAFullList} + the classWidgets /
+// classRestActions string values. Kept as literals here (this is a literal-vs-
+// literal contract check); a divergence from the switch is what the scanner
+// exists to catch.
+var refreshClassAllowlist = map[string]struct{}{
+	"widgets":       {},
+	"widgetContent": {},
+	"restactions":   {},
+	"apistage":      {},
+	"raFullList":    {},
+}
+
+// setRefreshKeyHeaderClassArgIndex maps the two stamping helpers to the 0-based
+// index of their `class` string argument.
+var setRefreshKeyHeaderClassArgIndex = map[string]int{
+	"setRefreshKeyHeader":               2, // (wri, key, class)
+	"setRefreshKeyHeaderUnlessExternal": 2, // (wri, key, class, externalTTL)
+}
+
+// scanRefreshClassLiterals walks a parsed file and returns every string-literal
+// class argument passed to a stamping helper, tagged with its position.
+type classStamp struct {
+	fn    string
+	class string
+	pos   string
+}
+
+func scanRefreshClassLiterals(t *testing.T, fset *token.FileSet, file *ast.File) []classStamp {
+	t.Helper()
+	var out []classStamp
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		idx, tracked := setRefreshKeyHeaderClassArgIndex[ident.Name]
+		if !tracked || idx >= len(call.Args) {
+			return true
+		}
+		lit, ok := call.Args[idx].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			// A non-literal class arg (e.g. a variable) is out of scope — this
+			// scanner pins LITERAL serve sites; a variable is checked by the
+			// class-derivation tests. The prod dispatcher sites all use literals.
+			return true
+		}
+		unq, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		out = append(out, classStamp{fn: ident.Name, class: unq, pos: fset.Position(lit.Pos()).String()})
+		return true
+	})
+	return out
+}
+
+// TestM16_RefreshClassStampsAreInAllowlist scans EVERY .go file in this package
+// and asserts every literal class stamped at a serve site is in the allowlist.
+func TestM16_RefreshClassStampsAreInAllowlist(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	total := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Scan production files only — a _test.go RED fixture deliberately
+		// stamps a bad literal (TestM16_RED_TypoClassIsFlagged) and must not
+		// fail the production invariant.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(".", name)
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", path, perr)
+		}
+		for _, s := range scanRefreshClassLiterals(t, fset, f) {
+			total++
+			if _, ok := refreshClassAllowlist[s.class]; !ok {
+				t.Errorf("M16: %s stamps refresh-class %q at %s — NOT in the SubscriptionCoordinates.Class allowlist %v; the frontend would arm a subscription DeriveSubscriptionKey fails-closed on",
+					s.fn, s.class, s.pos, keysOf(refreshClassAllowlist))
+			}
+		}
+	}
+
+	// Sanity: the scanner actually found the known prod serve sites (guards
+	// against a silent zero-match pass if the helper names ever change).
+	if total < 3 {
+		t.Fatalf("M16: expected to scan >=3 literal refresh-class serve sites (restactions x2, widgetContent, widgets x2); found %d — the scanner matched nothing, so the invariant is not actually being enforced", total)
+	}
+}
+
+// TestM16_RED_TypoClassIsFlagged proves the scanner is DISCRIMINATING: a
+// synthetic serve site stamping "widgetcontent" (the lowercase typo of the real
+// "widgetContent") is flagged as NOT in the allowlist. The GREEN prod scan above
+// passes only because every real literal is correct; this arm shows a wrong one
+// is caught.
+func TestM16_RED_TypoClassIsFlagged(t *testing.T) {
+	const src = `package dispatchers
+func serveTypo(wri any, key string) {
+	setRefreshKeyHeader(wri, key, "widgetcontent") // TYPO: lowercase c
+}
+func serveGood(wri any, key string) {
+	setRefreshKeyHeader(wri, key, "widgetContent") // correct
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic_typo.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse synthetic: %v", err)
+	}
+	stamps := scanRefreshClassLiterals(t, fset, f)
+	if len(stamps) != 2 {
+		t.Fatalf("expected 2 stamps in the synthetic source; got %d (%v)", len(stamps), stamps)
+	}
+
+	var flagged, accepted []string
+	for _, s := range stamps {
+		if _, ok := refreshClassAllowlist[s.class]; ok {
+			accepted = append(accepted, s.class)
+		} else {
+			flagged = append(flagged, s.class)
+		}
+	}
+	if len(flagged) != 1 || flagged[0] != "widgetcontent" {
+		t.Fatalf("RED arm: the typo \"widgetcontent\" must be flagged (not in allowlist); flagged=%v", flagged)
+	}
+	if len(accepted) != 1 || accepted[0] != "widgetContent" {
+		t.Fatalf("RED arm control: the correct \"widgetContent\" must be accepted; accepted=%v", accepted)
+	}
+}
+
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/handlers/dispatchers/restactions.go
+++ b/internal/handlers/dispatchers/restactions.go
@@ -82,7 +82,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 		return
 	}
 
-	got := fetchObject(req)
+	got := fetchObjectFn(req)
 	if got.Err != nil {
 		response.Encode(wri, got.Err)
 		return
@@ -94,7 +94,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 	// Cache=off skips this gate — fetchObject already runs per-user
 	// against apiserver, which enforces RBAC inline.
 	if !cache.Disabled() {
-		if !checkDispatchRBAC(req.Context(), got.GVR, got.Unstructured.GetNamespace()) {
+		if !checkDispatchRBACFn(req.Context(), got.GVR, got.Unstructured.GetNamespace()) {
 			log.Warn("RESTAction dispatch denied by EvaluateRBAC",
 				slog.String("name", got.Unstructured.GetName()),
 				slog.String("namespace", got.Unstructured.GetNamespace()),
@@ -294,7 +294,7 @@ func (r *restActionHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request
 	// (no informer/dep edge can invalidate it). Additive to the stage-error
 	// sink — both gate the Put independently. nil-receiver-safe.
 	ctx, extTouchedSink := cache.WithExternalTouchedSink(ctx)
-	res, err := restactions.Resolve(ctx, restactions.ResolveOptions{
+	res, err := restactionsResolveFn(ctx, restactions.ResolveOptions{
 		In:      &cr,
 		SArc:    r.saRC,
 		AuthnNS: r.authnNS,

--- a/internal/handlers/dispatchers/seed_templated_endpointref_skip_test.go
+++ b/internal/handlers/dispatchers/seed_templated_endpointref_skip_test.go
@@ -1,0 +1,223 @@
+// seed_templated_endpointref_skip_test.go — M15 BEHAVIORAL arm for the #113
+// seed-skip: the REAL seedOneRestaction, driven end-to-end (fetch → convert →
+// #113 templated-endpointRef skip → resolve+Put tail), must NOT reach the Put
+// for a templated-endpointRef RA, and MUST reach it for a static one.
+//
+// WHY A BEHAVIORAL ARM (vs the pure predicate table in
+// phase1_seed_templated_endpointref_test.go): the predicate table proves
+// hasTemplatedEndpointRef in isolation; the §4 decline-gate arm proves the
+// GTTL-1 gate can't catch this miss class. Neither proves the SKIP is actually
+// wired to short-circuit the Put inside the real function. The
+// seed_resolves_counter_test.go header documents that reaching seedOneRestaction's
+// Put hermetically was "NOT possible" because restactions.Resolve dials the
+// apiserver. Two minimal, behaviour-preserving var-seams close that gap:
+//
+//   - seedObjectsGetFn — the RESTAction-fetch boundary (default objects.Get).
+//     Injects a templated- vs static-endpointRef RESTAction unstructured so the
+//     REAL FromUnstructured conversion + REAL hasTemplatedEndpointRefFn run over
+//     it — no apiserver.
+//   - seedRestactionResolveAndPutFn — the resolve+encode+GTTL-gate+Put TAIL
+//     (default seedRestactionResolveAndPutProd), replaced by a recorder so we
+//     observe whether the seed REACHED the Put without a live resolver/encoder.
+//
+// The #113 skip lives in seedOneRestaction BETWEEN the two seams, so this
+// exercises the real skip. A granted RBAC snapshot (dynamicfake) is published so
+// the granted cohort re-derives a NON-empty BindingUID and clears the earlier
+// FIX-C empty-binding guard, letting execution reach the #113 skip.
+//
+// RED (proven by transiently neutering the REAL predicate seam
+// hasTemplatedEndpointRefFn to always-false): a templated RA then FAILS to skip
+// and reaches the Put tail — the exact #113 §4 poisoning (a truncated no-extras
+// body Put under the serve key). Restore → GREEN. Hermetic, -race, no cluster,
+// never touches ./internal/rbac.
+
+package dispatchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// buildGrantedRestactionWatcher publishes an RBAC snapshot granting `user`
+// get/list on the RESTAction GVR so dispatchCacheLookupKey("restactions", …)
+// re-derives a NON-empty first-match BindingUID (clearing the FIX-C empty-
+// binding guard that precedes the #113 skip). Mirrors buildFixCWatcher but on
+// restActionGVR. The RA CR itself is NOT seeded into the fake client — the fetch
+// is seamed via seedObjectsGetFn, so only the grant matters here.
+func buildGrantedRestactionWatcher(t *testing.T, user string) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	t.Cleanup(cache.ResetResolvedCacheForTest)
+
+	raGVR := restActionGVR // restactions.templates.krateo.io/v1
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		raGVR:  "RESTActionList",
+		crbGVR: "ClusterRoleBindingList",
+		crGVR:  "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+	}
+	raRule := []rbacv1.PolicyRule{{Verbs: []string{"get", "list"}, APIGroups: []string{raGVR.Group}, Resources: []string{raGVR.Resource}}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "ra-reader"}, Rules: raRule},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "granted-ra-bind", UID: types.UID("uid-ra-granted")},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: user}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "ra-reader"},
+		},
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	rw.EnsureResourceType(raGVR)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+// fetchedRestaction builds the objects.Result seedObjectsGetFn returns for a
+// RESTAction whose sole api-step's endpointRef.name is either templated
+// (${...}-shaped → hasTemplatedEndpointRef true) or a static literal. The
+// unstructured is what the REAL FromUnstructured conversion in seedOneRestaction
+// converts into templatesv1.RESTAction before the #113 predicate runs.
+func fetchedRestaction(templated bool) objects.Result {
+	epName := "spoke-a-endpoint" // static literal
+	if templated {
+		epName = `${ .name + "-endpoint" }` // request-extras-driven endpoint selection
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": restActionGVR.Group + "/" + restActionGVR.Version,
+		"kind":       "RESTAction",
+		"metadata":   map[string]any{"name": "hub-spoke-ra", "namespace": "krateo-system"},
+		"spec": map[string]any{
+			"api": []any{
+				map[string]any{
+					"name": "s1",
+					"endpointRef": map[string]any{
+						"name":      epName,
+						"namespace": "krateo-system",
+					},
+				},
+			},
+		},
+	}}
+	return objects.Result{
+		GVR:          restActionGVR,
+		Unstructured: u,
+	}
+}
+
+// seedCohortCtx installs the granted cohort's identity so dispatchCacheLookupKey
+// re-derives the non-empty BindingUID. saEP/saRC inert — the resolve+Put tail is
+// seamed away, so no transport is used.
+func seedCohortCtx(user string) context.Context {
+	return withCohortSeedContext(context.Background(),
+		seedTarget{Username: user}, endpoints.Endpoint{}, nil)
+}
+
+// TestM15_SeedOneRestaction_SkipsTemplated_PutsStatic — the M15 behavioral
+// falsifier. Drives the REAL seedOneRestaction with the fetch + resolve/Put tail
+// seamed; asserts the templated RA NEVER reaches the Put tail and the static RA
+// DOES. RED arm neuters the real hasTemplatedEndpointRefFn predicate → the
+// templated RA then reaches the Put (the #113 §4 truncated-body poisoning).
+func TestM15_SeedOneRestaction_SkipsTemplated_PutsStatic(t *testing.T) {
+	const user = "userGranted"
+	buildGrantedRestactionWatcher(t, user)
+
+	ref := templatesv1.ObjectReference{
+		Reference:  templatesv1.Reference{Name: "hub-spoke-ra", Namespace: "krateo-system"},
+		APIVersion: restActionGVR.Group + "/" + restActionGVR.Version,
+		Resource:   restActionGVR.Resource,
+	}
+
+	// Observe whether the resolve+Put TAIL was reached (a proxy for "the Put
+	// happened"). The recorder returns nil so seedOneRestaction completes.
+	var putReached bool
+	origPut := seedRestactionResolveAndPutFn
+	origGet := seedObjectsGetFn
+	origPred := hasTemplatedEndpointRefFn
+	t.Cleanup(func() {
+		seedRestactionResolveAndPutFn = origPut
+		seedObjectsGetFn = origGet
+		hasTemplatedEndpointRefFn = origPred
+	})
+	seedRestactionResolveAndPutFn = func(
+		_, _ context.Context, _ *templatesv1.RESTAction, _ templatesv1.ObjectReference,
+		_, _ string, _ cacheHandle, _ *cache.ResolvedKeyInputs, _ objects.Result,
+		_ *cache.StageErrorSink, _ *cache.ExternalTouchedSink,
+	) error {
+		putReached = true
+		return nil
+	}
+
+	run := func(t *testing.T, templated bool) bool {
+		t.Helper()
+		putReached = false
+		seedObjectsGetFn = func(_ context.Context, _ templatesv1.ObjectReference) objects.Result {
+			return fetchedRestaction(templated)
+		}
+		if err := seedOneRestaction(seedCohortCtx(user), "cohort-granted", ref, "krateo-system", seedModeBoot); err != nil {
+			t.Fatalf("seedOneRestaction returned %v; want nil (skip and success paths both return nil)", err)
+		}
+		return putReached
+	}
+
+	// --- GREEN: templated → SKIP (Put tail NOT reached). ---
+	hasTemplatedEndpointRefFn = origPred // real predicate
+	if run(t, true) {
+		t.Fatal("M15: seedOneRestaction REACHED the Put tail for a TEMPLATED-endpointRef RA — " +
+			"the #113 skip must short-circuit before resolve+Put (else a truncated no-extras body is Put " +
+			"under the serve key, the §4 poisoning).")
+	}
+
+	// --- GREEN control: static → PROCEED (Put tail reached). ---
+	if !run(t, false) {
+		t.Fatal("M15 control: seedOneRestaction did NOT reach the Put tail for a STATIC-endpointRef RA — " +
+			"a static RA must be seeded (else the skip is over-broad and GREEN above is a no-op that never Puts anything).")
+	}
+
+	// --- RED: neuter the REAL predicate → templated RA fails to skip → Put reached. ---
+	hasTemplatedEndpointRefFn = func(*templatesv1.RESTAction) bool { return false }
+	if !run(t, true) {
+		t.Fatal("M15 RED expected the Put tail to be REACHED once hasTemplatedEndpointRefFn is neutered to " +
+			"always-false — if the templated RA STILL skipped, the skip is driven by something other than the " +
+			"predicate and the GREEN arm is not discriminating.")
+	}
+}

--- a/internal/handlers/dispatchers/servehttp_orchestration_test.go
+++ b/internal/handlers/dispatchers/servehttp_orchestration_test.go
@@ -1,0 +1,701 @@
+// servehttp_orchestration_test.go — H1 (coverage-audit) SECURITY: hermetic
+// httptest drive of the RESTAction AND Widget ServeHTTP ORCHESTRATION.
+//
+// WHY A SEAMED FULL-SERVE DRIVE (and not the sub-block mirror the repo uses for
+// error-encoding): the H1 gaps are ORDERING + WHOLE-PATH properties that are
+// invisible at sub-block granularity —
+//   (a) the RBAC gate runs BEFORE the cache Get (a cache HIT must never
+//       short-circuit the permission check → serve-before-RBAC leak);
+//   (c) a cold miss Puts EXACTLY ONE entry under the DERIVED key + records a dep;
+//   (d) the warm-hit bytes == the cache-off resolve bytes (cache ≡ no-cache);
+//   (e/f) an RBAC-sensitive widget SKIPS the shared identity-free content cell;
+//   (h/i/j) the stage-error / external sinks gate the Put (serve 200, no Put).
+// None of these can be asserted by mirroring one `if` block. So this file swaps
+// the four ServeHTTP collaborators (dispatch_seams.go: fetchObjectFn,
+// checkDispatchRBACFn, restactionsResolveFn, widgetsResolveFn) for hermetic
+// fakes and drives the REAL handler. The cache-key derivation
+// (dispatchCacheLookupKey → real rbac.EvaluateRBAC over a wired dynamicfake
+// watcher), the real *resolvedCache handle, setRefreshKeyHeader, the encode +
+// the Put-gate control flow all stay PRODUCTION — only the object fetch, the
+// coarse gate verdict, and the resolve output are faked.
+//
+// Never touches ./internal/rbac (the RBAC snapshot is built via the cache
+// package's RebuildRBACSnapshotForTest, exactly like serve_empty_binding_miss_test.go).
+
+package dispatchers
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/widgets"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var (
+	h1RAGVR     = schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"}
+	h1WidgetGVR = schema.GroupVersionResource{Group: "widgets.templates.krateo.io", Version: "v1beta1", Resource: "panels"}
+)
+
+const (
+	h1NS     = "krateo-system"
+	h1RAName = "demo-ra"
+	h1WName  = "demo-widget"
+	h1User   = "alice"
+)
+
+// h1BuildWatcher wires a cache=on ResourceWatcher whose RBAC snapshot grants
+// h1User get/list on BOTH the RA and widget GVRs, so dispatchCacheLookupKey
+// re-derives a NON-empty first-match BindingUID (serveFromCacheEligible==true)
+// and the L1 Put/Get paths are actually reachable. Mirrors buildSec95Watcher.
+func h1BuildWatcher(t *testing.T) {
+	t.Helper()
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	t.Cleanup(cache.ResetResolvedCacheForTest)
+	// The DepTracker is a process-wide singleton — reset it so an earlier arm's
+	// cold-Put dep edge (same reqCtx → same derived key) does not leak into a
+	// later arm's dep assertions (arm (c) records; arm (i) asserts none).
+	cache.ResetDepsForTest()
+	t.Cleanup(cache.ResetDepsForTest)
+
+	crbGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		h1RAGVR:     "RESTActionList",
+		h1WidgetGVR: "PanelList",
+		crbGVR:      "ClusterRoleBindingList",
+		crGVR:       "ClusterRoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+	}
+	rule := []rbacv1.PolicyRule{{
+		Verbs:     []string{"get", "list"},
+		APIGroups: []string{h1RAGVR.Group, h1WidgetGVR.Group},
+		Resources: []string{h1RAGVR.Resource, h1WidgetGVR.Resource},
+	}}
+	seed := []runtime.Object{
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "h1-reader"}, Rules: rule},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "h1-bind", UID: types.UID("uid-h1")},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: h1User}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "h1-reader"},
+		},
+	}
+
+	wctx, wcancel := context.WithCancel(context.Background())
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	rw, err := cache.NewResourceWatcher(wctx, dyn)
+	if err != nil {
+		wcancel()
+		t.Fatalf("NewResourceWatcher: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rw.WaitForCacheSync(ctx, 5*time.Second); err != nil {
+		rw.Stop()
+		wcancel()
+		t.Fatalf("WaitForCacheSync: %v", err)
+	}
+	cache.RebuildRBACSnapshotForTest(rw)
+	prev := cache.Global()
+	cache.SetGlobal(rw)
+	t.Cleanup(func() {
+		rw.Stop()
+		wcancel()
+		cache.SetGlobal(prev)
+		cache.PublishRBACSnapshotForTest(nil)
+	})
+}
+
+// h1ReqCtx is a per-request context carrying ONLY the JWT identity (the real
+// /call path). Deliberately carries NO WithInternalEndpoint / WithInternalRESTConfig
+// (out-of-cluster handler → saEP/saRC nil → no attach) — M12 reads this back.
+func h1ReqCtx(user string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: user, Groups: []string{"devs"}}))
+}
+
+func h1RAUnstructured() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": h1RAGVR.Group + "/" + h1RAGVR.Version,
+		"kind":       "RESTAction",
+		"metadata":   map[string]any{"name": h1RAName, "namespace": h1NS},
+		"spec":       map[string]any{"api": []any{}},
+	}}
+}
+
+func h1WidgetUnstructured(spec map[string]any) *unstructured.Unstructured {
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": h1WidgetGVR.Group + "/" + h1WidgetGVR.Version,
+		"kind":       "Panel",
+		"metadata":   map[string]any{"name": h1WName, "namespace": h1NS},
+		"spec":       spec,
+	}}
+}
+
+// installRAFakes swaps the three RESTAction ServeHTTP collaborators for the
+// duration of a test: fetchObject (returns the given CR), the RBAC gate verdict
+// (allow/deny via allowFn), and the resolver. Returns ONE restore closure.
+func installRAFakes(t *testing.T, cr *unstructured.Unstructured, allowFn func() bool,
+	resolve func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error)) func() {
+	t.Helper()
+	r1 := setFetchObjectForTest(func(req *http.Request) objects.Result {
+		return objects.Result{GVR: h1RAGVR, Unstructured: cr}
+	})
+	r2 := setCheckDispatchRBACForTest(func(ctx context.Context, gvr schema.GroupVersionResource, ns string) bool {
+		return allowFn()
+	})
+	r3 := setRestactionsResolveForTest(resolve)
+	return func() { r3(); r2(); r1() }
+}
+
+// installWidgetFakes is the widget twin of installRAFakes.
+func installWidgetFakes(t *testing.T, cr *unstructured.Unstructured, allowFn func() bool,
+	resolve func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error)) func() {
+	t.Helper()
+	r1 := setFetchObjectForTest(func(req *http.Request) objects.Result {
+		return objects.Result{GVR: h1WidgetGVR, Unstructured: cr}
+	})
+	r2 := setCheckDispatchRBACForTest(func(ctx context.Context, gvr schema.GroupVersionResource, ns string) bool {
+		return allowFn()
+	})
+	r3 := setWidgetsResolveForTest(resolve)
+	return func() { r3(); r2(); r1() }
+}
+
+// depRecordedFor reports whether the L1 dep tracker holds a forward edge from
+// the given object tuple to l1Key (a DELETE/UPDATE of the object would touch the
+// key). CollectMatchesForTest is the same reverse-index the dispatcher's Record
+// call writes to (cache.Deps().Record at the cold-Put site).
+func depRecordedFor(l1Key string, gvr schema.GroupVersionResource, ns, name string) bool {
+	_, ok := cache.Deps().CollectMatchesForTest(gvr, ns, name)[l1Key]
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// RESTAction ServeHTTP arms
+// ---------------------------------------------------------------------------
+
+// TestH1_RA_RBACDenyIsBeforeCacheGet — arm (a) SECURITY. A cache=on dispatch
+// denied by the RBAC gate returns 403 AND never consults the cache handle. RED
+// (serve-before-RBAC): if the handler read the cache first, a HIT would 200 a
+// forbidden request. We prove the Get is never called by pre-seeding a HIT cell
+// under the request's real key and asserting the response is 403, not the cell.
+func TestH1_RA_RBACDenyIsBeforeCacheGet(t *testing.T) {
+	h1BuildWatcher(t)
+
+	// Pre-seed a HIT cell under alice's REAL derived key so that a
+	// serve-before-RBAC bug would return it.
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, inputs := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" || inputs == nil || inputs.BindingUID == "" {
+		t.Fatalf("setup: expected a live non-empty-BindingUID key; key=%q handle=%v inputs=%+v", key, handle != nil, inputs)
+	}
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: []byte(`{"leaked":"cache-hit-body"}`), Inputs: inputs})
+
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return false /* DENY */ },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			t.Fatalf("arm (a): resolver must NOT run on an RBAC-denied dispatch")
+			return nil, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 403 {
+		t.Fatalf("arm (a): RBAC-denied dispatch must be 403; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("cache-hit-body")) {
+		t.Fatalf("arm (a) RED (serve-before-RBAC): a denied request was served the pre-seeded cache cell — the RBAC gate must run BEFORE the cache Get. body=%s", rec.Body.String())
+	}
+}
+
+// TestH1_RA_L1Hit_ServesCellAndRefreshHeader_NoResolve — arm (b) + (k). An
+// allowed request with a warm cell serves entry.RawJSON verbatim + stamps the
+// refresh-key/class headers, and NEVER calls the resolver. RED: resolver runs
+// on a hit (wasted resolve + potential body divergence).
+func TestH1_RA_L1Hit_ServesCellAndRefreshHeader_NoResolve(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, inputs := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" || inputs == nil || inputs.BindingUID == "" {
+		t.Fatalf("setup: expected a live non-empty-BindingUID key; got %q %v %+v", key, handle != nil, inputs)
+	}
+	warm := []byte(`{"warm":"ra-cell"}` + "\n")
+	handle.Put(key, &cache.ResolvedEntry{RawJSON: warm, Inputs: inputs})
+
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			t.Fatalf("arm (b) RED: resolver ran on an L1 HIT")
+			return nil, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (b): expected 200 on a hit; got %d", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), warm) {
+		t.Fatalf("arm (b): hit must serve entry.RawJSON verbatim; got %q want %q", rec.Body.Bytes(), warm)
+	}
+	if got := rec.Header().Get(refreshKeyHeader); got != key {
+		t.Fatalf("arm (k): hit with a non-empty key must stamp %s=%q; got %q", refreshKeyHeader, key, got)
+	}
+	if got := rec.Header().Get(refreshClassHeader); got != "restactions" {
+		t.Fatalf("arm (b): hit must stamp refresh-class=restactions; got %q", got)
+	}
+}
+
+// TestH1_RA_Miss_PutsOnceUnderDerivedKey_AndDep — arm (c). A cold miss resolves,
+// serves, and Puts EXACTLY ONE entry under the request's DERIVED key + records a
+// dep edge. RED (Put-under-wrong-key / no-Put): the served warm cell would not
+// be retrievable under the same key a subsequent identical request derives.
+func TestH1_RA_Miss_PutsOnceUnderDerivedKey_AndDep(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, _ := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" {
+		t.Fatalf("setup: expected a live key/handle")
+	}
+	if _, ok := handle.Get(key); ok {
+		t.Fatalf("setup: the derived key must be cold before the miss")
+	}
+
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			return resolved, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (c): miss must serve 200; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	entry, ok := handle.Get(key)
+	if !ok {
+		t.Fatalf("arm (c) RED: after a cold miss NOTHING was Put under the request's DERIVED key %q — a subsequent identical request would never hit", key)
+	}
+	// The Put bytes are exactly the served bytes (encode-once, write-once).
+	if !bytes.Equal(entry.RawJSON, rec.Body.Bytes()) {
+		t.Fatalf("arm (c): the Put'd bytes must equal the served bytes; put=%q served=%q", entry.RawJSON, rec.Body.Bytes())
+	}
+	// Dep edge recorded: the RA GVR/ns/name self-dep exists for the key.
+	if !depRecordedFor(key, h1RAGVR, h1NS, h1RAName) {
+		t.Fatalf("arm (c): a cold Put must record the self-dep (DELETE→evict / UPDATE→re-resolve) for key %q", key)
+	}
+}
+
+// TestH1_RA_WarmEqualsCacheOff — arm (d) cache≡no-cache. The bytes served on a
+// warm HIT are byte-identical to the bytes a cache-off resolve-and-encode
+// produces from the SAME resolver output. RED: an encode-path divergence
+// between the hit-serve and the miss-encode.
+func TestH1_RA_WarmEqualsCacheOff(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+
+	// (1) MISS path: drive ServeHTTP cold → capture the served (and Put) bytes.
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			return resolved, nil
+		})
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec1, req1)
+	restore()
+	if rec1.Code != 200 {
+		t.Fatalf("arm (d): miss serve must be 200; got %d", rec1.Code)
+	}
+	missBytes := append([]byte(nil), rec1.Body.Bytes()...)
+
+	// (2) HIT path: a SECOND identical request now hits the cell the miss Put.
+	restore2 := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			t.Fatalf("arm (d): the second request must be a HIT (no resolve)")
+			return nil, nil
+		})
+	defer restore2()
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec2, req2)
+	if rec2.Code != 200 {
+		t.Fatalf("arm (d): hit serve must be 200; got %d", rec2.Code)
+	}
+	hitBytes := rec2.Body.Bytes()
+
+	// (3) cache-off reference: encode the SAME resolver output directly.
+	ref, err := encodeResolvedJSON(resolved)
+	if err != nil {
+		t.Fatalf("arm (d): reference encode: %v", err)
+	}
+	if !bytes.Equal(missBytes, ref) || !bytes.Equal(hitBytes, ref) {
+		t.Fatalf("arm (d) RED (cache != no-cache): warm/miss bytes diverge from the cache-off resolve-encode.\nmiss=%q\nhit=%q\nref=%q", missBytes, hitBytes, ref)
+	}
+}
+
+// TestH1_RA_StageErrorSink_ServesButDoesNotPut — arm (h). The resolver bumps the
+// ctx StageErrorSink (a per-item hard error); the body is SERVED 200 but the
+// full-TTL Put is DECLINED. RED (Put-regardless-of-sink): the partial cell would
+// be pinned for the TTL.
+func TestH1_RA_StageErrorSink_ServesButDoesNotPut(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, _ := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" {
+		t.Fatalf("setup: live key/handle expected")
+	}
+
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			cache.StageErrorSinkFromContext(ctx).Bump("apistage", "per-item boom")
+			return resolved, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (h): a per-item stage error must still SERVE 200; got %d", rec.Code)
+	}
+	if _, ok := handle.Get(key); ok {
+		t.Fatalf("arm (h) RED (Put-regardless-of-sink): a stage-error result was PERSISTED — the full-TTL Put must be gated on StageErrorSink.Count()==0")
+	}
+}
+
+// TestH1_RA_ExternalSink_ServesNoPutNoDep_BumpsCounter — arm (i). The resolver
+// bumps the ExternalTouchedSink; the body is served 200, the Put + dep-Record
+// are declined, and the process-wide external-skipped-put counter bumps. RED:
+// caching an external-touched result (no dep edge can ever invalidate it).
+func TestH1_RA_ExternalSink_ServesNoPutNoDep_BumpsCounter(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, _ := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" {
+		t.Fatalf("setup: live key/handle expected")
+	}
+
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			cache.ExternalTouchedSinkFromContext(ctx).Bump()
+			return resolved, nil
+		})
+	defer restore()
+
+	before := cache.ExternalSkippedPut()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (i): external-touched must still SERVE 200; got %d", rec.Code)
+	}
+	if _, ok := handle.Get(key); ok {
+		t.Fatalf("arm (i) RED: an external-touched result was cached — external data has no dep edge to invalidate it, the Put must be declined")
+	}
+	if depRecordedFor(key, h1RAGVR, h1NS, h1RAName) {
+		t.Fatalf("arm (i): an external-touched result must NOT record a dep edge")
+	}
+	if got := cache.ExternalSkippedPut(); got != before+1 {
+		t.Fatalf("arm (i): the external-skipped-put counter must bump exactly once; got %d want %d", got, before+1)
+	}
+}
+
+// TestH1_RA_BothSinks_StageErrorBranchFirst — arm (j). When BOTH sinks are
+// bumped, the stage-error branch is taken FIRST (decline-partial), so the
+// external-skipped-put counter does NOT bump (the external else-if is not
+// reached). RED: an ordering flip would bump the external counter.
+func TestH1_RA_BothSinks_StageErrorBranchFirst(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	key, handle, _ := dispatchCacheLookupKey(reqCtx, "restactions",
+		h1RAGVR.Group, h1RAGVR.Version, h1RAGVR.Resource, h1NS, h1RAName, -1, -1, nil)
+	if handle == nil || key == "" {
+		t.Fatalf("setup: live key/handle expected")
+	}
+
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			cache.StageErrorSinkFromContext(ctx).Bump("apistage", "boom")
+			cache.ExternalTouchedSinkFromContext(ctx).Bump()
+			return resolved, nil
+		})
+	defer restore()
+
+	before := cache.ExternalSkippedPut()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (j): both-sinks must still serve 200; got %d", rec.Code)
+	}
+	if _, ok := handle.Get(key); ok {
+		t.Fatalf("arm (j): both-sinks must decline the Put (stage-error branch)")
+	}
+	if got := cache.ExternalSkippedPut(); got != before {
+		t.Fatalf("arm (j) RED: the stage-error branch must be taken FIRST — the external-skipped-put counter must NOT bump when both sinks fire; got %d want %d", got, before)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Widget ServeHTTP arms
+// ---------------------------------------------------------------------------
+
+// TestH1_Widget_ContentHit_GatedBody_ClassWidgetContent — arm (e). A non-RBAC-
+// sensitive widget with a warm identity-free content cell serves the GATED body
+// under class=widgetContent. RED: serving the ungated shell, or the wrong class.
+func TestH1_Widget_ContentHit_GatedBody_ClassWidgetContent(t *testing.T) {
+	h1BuildWatcher(t)
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "true")
+	reqCtx := h1ReqCtx(h1User)
+
+	// A plain (non-RBAC-sensitive) widget: no apiRef, no inline GET ref.
+	cr := h1WidgetUnstructured(map[string]any{})
+	keyExtras := effectiveKeyExtras(reqCtx, cr.Object, nil)
+	contentKey, contentHandle, _ := dispatchWidgetContentKey(reqCtx,
+		h1WidgetGVR.Group, h1WidgetGVR.Version, h1WidgetGVR.Resource, h1NS, h1WName, -1, -1, keyExtras)
+	if contentHandle == nil || contentKey == "" {
+		t.Fatalf("setup: expected a live widgetContent handle+key")
+	}
+	// A minimal well-formed envelope gateWidgetEnvelope can serve (status shell
+	// with an empty resourcesRefs items list — nothing to narrow, served as-is).
+	shell := []byte(`{"status":{"widgetData":{"x":1},"resourcesRefs":{"items":[]}}}`)
+	contentHandle.Put(contentKey, &cache.ResolvedEntry{RawJSON: shell, Inputs: nil})
+
+	restore := installWidgetFakes(t, cr, func() bool { return true },
+		func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error) {
+			t.Fatalf("arm (e) RED: resolver ran despite a widgetContent HIT")
+			return nil, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	Widgets().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (e): content-hit must serve 200; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get(refreshClassHeader); got != "widgetContent" {
+		t.Fatalf("arm (e): a content-hit must stamp refresh-class=widgetContent; got %q", got)
+	}
+	if got := rec.Header().Get(refreshKeyHeader); got != contentKey {
+		t.Fatalf("arm (e): a content-hit must stamp the content key; got %q want %q", got, contentKey)
+	}
+}
+
+// TestH1_Widget_RBACSensitive_SkipsContentLookup — arm (f) SECURITY. An
+// RBAC-sensitive widget (apiRef + widgetDataTemplate) must SKIP the shared
+// identity-free content cell entirely and fall through to the per-user resolve —
+// even when a content cell EXISTS under its content key. RED (read shared
+// content cell for RBAC-sensitive widget): the SA-maximal shell would leak.
+func TestH1_Widget_RBACSensitive_SkipsContentLookup(t *testing.T) {
+	h1BuildWatcher(t)
+	t.Setenv("WIDGET_CONTENT_L1_ENABLED", "true")
+	reqCtx := h1ReqCtx(h1User)
+
+	// RBAC-sensitive: apiRef + widgetDataTemplate → isRBACSensitiveApiRefWidget==true.
+	cr := h1WidgetUnstructured(map[string]any{
+		"apiRef":             map[string]any{"name": "agg-ra", "namespace": h1NS},
+		"widgetDataTemplate": []any{map[string]any{"forPath": ".x", "expression": "${ .a }"}},
+	})
+	if !isRBACSensitiveApiRefWidget(cr.Object) {
+		t.Fatalf("setup: the CR must classify RBAC-sensitive")
+	}
+	// Plant a POISON content cell under its content key — a skip-bug would serve it.
+	keyExtras := effectiveKeyExtras(reqCtx, cr.Object, nil)
+	contentKey, contentHandle, _ := dispatchWidgetContentKey(reqCtx,
+		h1WidgetGVR.Group, h1WidgetGVR.Version, h1WidgetGVR.Resource, h1NS, h1WName, -1, -1, keyExtras)
+	if contentHandle == nil || contentKey == "" {
+		t.Fatalf("setup: expected a live widgetContent handle+key")
+	}
+	contentHandle.Put(contentKey, &cache.ResolvedEntry{
+		RawJSON: []byte(`{"status":{"widgetData":{"SA_MAXIMAL":"leak"},"resourcesRefs":{"items":[]}}}`),
+		Inputs:  nil,
+	})
+
+	resolved := h1WidgetUnstructured(map[string]any{})
+	_ = unstructured.SetNestedField(resolved.Object, "per-user", "status", "widgetData", "own")
+	resolverRan := false
+	restore := installWidgetFakes(t, cr, func() bool { return true },
+		func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error) {
+			resolverRan = true
+			return resolved, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	Widgets().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("arm (f): expected 200; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("SA_MAXIMAL")) {
+		t.Fatalf("arm (f) RED (read shared content cell for RBAC-sensitive widget): the SA-maximal poison shell leaked — an RBAC-sensitive widget must SKIP the identity-free content lookup. body=%s", rec.Body.String())
+	}
+	if !resolverRan {
+		t.Fatalf("arm (f): an RBAC-sensitive widget must fall through to the per-user resolve (content lookup skipped)")
+	}
+	// It served under the per-cohort widgets class, NOT widgetContent.
+	if got := rec.Header().Get(refreshClassHeader); got == "widgetContent" {
+		t.Fatalf("arm (f): an RBAC-sensitive widget must NOT serve under the widgetContent class; got %q", got)
+	}
+}
+
+// TestH1_Widget_StatusError_ItsCodeNot500 — arm (g). widgets.Resolve returning a
+// StatusError-wrapped error emits its Code (403), not a generic 500. RED: the
+// dispatcher swallows the StatusError and 500s.
+func TestH1_Widget_StatusError_ItsCodeNot500(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+	cr := h1WidgetUnstructured(map[string]any{})
+
+	restore := installWidgetFakes(t, cr, func() bool { return true },
+		func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error) {
+			return nil, h1ForbiddenStatusError()
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	Widgets().ServeHTTP(rec, req)
+
+	if rec.Code != 403 {
+		t.Fatalf("arm (g) RED: a StatusError(403) from widgets.Resolve must emit 403, not a generic 500; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// h1ForbiddenStatusError builds the exact *apierrors.StatusError shape
+// widgets.Resolve surfaces on an apiRef 403 — the shape widgets.go's
+// errors.As(err, *apierrors.StatusError) must recover Code=403 from.
+func h1ForbiddenStatusError() error {
+	return &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status:  metav1.StatusFailure,
+		Message: "forbidden: cannot get restactions",
+		Reason:  metav1.StatusReasonForbidden,
+		Code:    403,
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// M12 — SA transport capture: out-of-cluster ⇒ ctx carries NO internal endpoint
+// ---------------------------------------------------------------------------
+
+// TestM12_RA_OutOfCluster_NoInternalTransportOnResolveCtx — construct RESTAction()
+// out-of-cluster (snowplowSACtx→nil,nil → saEP/saRC nil) → ServeHTTP → the ctx
+// handed to the resolver carries NO WithInternalEndpoint / WithInternalRESTConfig.
+// RED: a per-request SA attach (or a nil-attach) would put a value on the ctx.
+func TestM12_RA_OutOfCluster_NoInternalTransportOnResolveCtx(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+
+	// The handler struct fields must be nil out-of-cluster (the construction-time
+	// capture). This is the M12 precondition the ServeHTTP attach nil-guards on.
+	h := RESTAction().(*restActionHandler)
+	if h.saEP != nil || h.saRC != nil {
+		t.Fatalf("M12: out-of-cluster RESTAction() must capture nil saEP/saRC; got saEP=%v saRC=%v", h.saEP, h.saRC)
+	}
+
+	var sawEP, sawRC bool
+	resolved := &templatesv1.RESTAction{}
+	resolved.SetName(h1RAName)
+	resolved.SetNamespace(h1NS)
+	restore := installRAFakes(t, h1RAUnstructured(), func() bool { return true },
+		func(ctx context.Context, opts restactions.ResolveOptions) (*templatesv1.RESTAction, error) {
+			_, sawEP = cache.InternalEndpointFromContext(ctx)
+			_, sawRC = cache.InternalRESTConfigFromContext(ctx)
+			return resolved, nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	RESTAction().ServeHTTP(rec, req)
+
+	if sawEP || sawRC {
+		t.Fatalf("M12 RED: the resolve ctx carried an internal SA endpoint/restconfig on the out-of-cluster path (sawEP=%v sawRC=%v) — the attach must be nil-guarded and SKIP when saEP/saRC are nil", sawEP, sawRC)
+	}
+}
+
+// TestM12_Widget_OutOfCluster_NoInternalTransportOnResolveCtx — the widget twin.
+func TestM12_Widget_OutOfCluster_NoInternalTransportOnResolveCtx(t *testing.T) {
+	h1BuildWatcher(t)
+	reqCtx := h1ReqCtx(h1User)
+
+	h := Widgets().(*widgetsHandler)
+	if h.saEP != nil || h.saRC != nil {
+		t.Fatalf("M12: out-of-cluster Widgets() must capture nil saEP/saRC; got saEP=%v saRC=%v", h.saEP, h.saRC)
+	}
+
+	var sawEP, sawRC bool
+	restore := installWidgetFakes(t, h1WidgetUnstructured(map[string]any{}), func() bool { return true },
+		func(ctx context.Context, opts widgets.ResolveOptions) (*widgets.Widget, error) {
+			_, sawEP = cache.InternalEndpointFromContext(ctx)
+			_, sawRC = cache.InternalRESTConfigFromContext(ctx)
+			return h1WidgetUnstructured(map[string]any{}), nil
+		})
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/call", nil).WithContext(reqCtx)
+	Widgets().ServeHTTP(rec, req)
+
+	if sawEP || sawRC {
+		t.Fatalf("M12 RED (widget): the resolve ctx carried an internal SA endpoint/restconfig out-of-cluster (sawEP=%v sawRC=%v)", sawEP, sawRC)
+	}
+}

--- a/internal/handlers/dispatchers/widgets.go
+++ b/internal/handlers/dispatchers/widgets.go
@@ -67,7 +67,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	got := fetchObject(req)
+	got := fetchObjectFn(req)
 	if got.Err != nil {
 		response.Encode(wri, got.Err)
 		return
@@ -88,7 +88,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	// dispatch by EvaluateRBAC. Cache=off skips the gate — fetchObject
 	// already ran per-user against apiserver.
 	if !cache.Disabled() {
-		if !checkDispatchRBAC(req.Context(), got.GVR, got.Unstructured.GetNamespace()) {
+		if !checkDispatchRBACFn(req.Context(), got.GVR, got.Unstructured.GetNamespace()) {
 			log.Warn("widget dispatch denied by EvaluateRBAC",
 				slog.String("gvr", got.GVR.String()),
 			)
@@ -314,7 +314,7 @@ func (r *widgetsHandler) ServeHTTP(wri http.ResponseWriter, req *http.Request) {
 	// the resolve chain). Additive to the stage-error sink.
 	ctx, extTouchedSink := cache.WithExternalTouchedSink(ctx)
 
-	res, err := widgets.Resolve(ctx, widgets.ResolveOptions{
+	res, err := widgetsResolveFn(ctx, widgets.ResolveOptions{
 		In:      got.Unstructured,
 		RC:      r.saRC,
 		AuthnNS: r.authnNS,

--- a/internal/handlers/middleware/refreshauth_test.go
+++ b/internal/handlers/middleware/refreshauth_test.go
@@ -1,0 +1,235 @@
+// refreshauth_test.go — M17 [SEC]: hermetic falsifiers for middleware.RefreshAuth,
+// the cookie-or-header JWT gate for GET /refreshes.
+//
+// RefreshAuth's SECURITY contract (refreshauth.go header):
+//   (a) it reads the JWT from the `Authorization: Bearer` header OR the
+//       configured session cookie (REFRESH_SESSION_COOKIE, default
+//       "krateo-session") — a custom cookie name is honored and the default
+//       name is rejected once a custom one is configured;
+//   (b) NO TOKEN-IN-URL: a valid JWT presented ONLY in the query string is
+//       NOT accepted (would leak in logs/referrer) → 401;
+//   (c) an expired JWT → 401 (jwtutil.Validate returns ErrTokenExpired).
+//
+// RED arm (TestRefreshAuth_RED_QueryStringMustNotAuthenticate): a plausible
+// wrong middleware that ALSO reads the token from the query string authenticates
+// the token-in-URL request (reaches the terminal handler). The real RefreshAuth
+// on the SAME request 401s — proving arm (b) is discriminating.
+//
+// Hermetic: httptest + a test signing key. NO apiserver.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
+)
+
+const refreshAuthTestKey = "test-signing-key-for-refreshauth-m17-2026-07-30"
+
+// mintRefreshToken issues a JWT signed with the test key. A negative duration
+// yields an already-expired token (jwtutil.Validate → ErrTokenExpired).
+func mintRefreshToken(t *testing.T, username string, dur time.Duration) string {
+	t.Helper()
+	tok, err := jwtutil.CreateToken(jwtutil.CreateTokenOptions{
+		Username:   username,
+		Groups:     []string{"devs"},
+		Duration:   dur,
+		SigningKey: refreshAuthTestKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	return tok
+}
+
+// runRefreshAuth drives one request through middleware.RefreshAuth wrapping a
+// terminal handler that records (a) whether it was reached and (b) the resolved
+// username. Returns the status code and the reached/username observations.
+func runRefreshAuth(t *testing.T, req *http.Request) (status int, reached bool, username string) {
+	t.Helper()
+	terminal := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		if ui, err := xcontext.UserInfo(r.Context()); err == nil {
+			username = ui.Username
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.RefreshAuth(refreshAuthTestKey)(terminal)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code, reached, username
+}
+
+// --- M17(a): cookie-name configuration --------------------------------------
+
+// TestRefreshAuth_CustomCookieHonored_DefaultRejected — when
+// REFRESH_SESSION_COOKIE names a CUSTOM cookie, a JWT in that cookie
+// authenticates (200, identity placed) while the SAME JWT in the DEFAULT
+// "krateo-session" cookie is NOT read → 401. This proves the cookie name is
+// config-driven (feedback_no_special_cases), not hardcoded.
+func TestRefreshAuth_CustomCookieHonored_DefaultRejected(t *testing.T) {
+	t.Setenv("REFRESH_SESSION_COOKIE", "my-portal-session")
+	tok := mintRefreshToken(t, "userA", time.Hour)
+
+	t.Run("custom cookie honored", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/refreshes?sub=x", nil)
+		req.AddCookie(&http.Cookie{Name: "my-portal-session", Value: tok})
+		status, reached, user := runRefreshAuth(t, req)
+		if status != http.StatusOK || !reached {
+			t.Fatalf("M17(a): custom cookie must authenticate; status=%d reached=%v", status, reached)
+		}
+		if user != "userA" {
+			t.Fatalf("M17(a): identity must be placed on ctx; got username=%q", user)
+		}
+	})
+
+	t.Run("default cookie rejected when custom configured", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/refreshes?sub=x", nil)
+		req.AddCookie(&http.Cookie{Name: "krateo-session", Value: tok}) // the DEFAULT name
+		status, reached, _ := runRefreshAuth(t, req)
+		if status != http.StatusUnauthorized || reached {
+			t.Fatalf("M17(a): with a custom cookie configured, the default 'krateo-session' cookie must "+
+				"NOT authenticate; status=%d reached=%v", status, reached)
+		}
+	})
+}
+
+// TestRefreshAuth_DefaultCookieHonoredWhenUnset — with REFRESH_SESSION_COOKIE
+// unset the default "krateo-session" cookie authenticates (the deployed default
+// path). Complements the custom-name arm above.
+func TestRefreshAuth_DefaultCookieHonoredWhenUnset(t *testing.T) {
+	t.Setenv("REFRESH_SESSION_COOKIE", "") // unset → default
+	tok := mintRefreshToken(t, "userA", time.Hour)
+
+	req := httptest.NewRequest(http.MethodGet, "/refreshes?sub=x", nil)
+	req.AddCookie(&http.Cookie{Name: "krateo-session", Value: tok})
+	status, reached, user := runRefreshAuth(t, req)
+	if status != http.StatusOK || !reached || user != "userA" {
+		t.Fatalf("M17(a): default cookie must authenticate when REFRESH_SESSION_COOKIE unset; "+
+			"status=%d reached=%v user=%q", status, reached, user)
+	}
+}
+
+// --- M17(b): no-token-in-URL ------------------------------------------------
+
+// TestRefreshAuth_QueryParamTokenRejected — a VALID JWT presented ONLY in the
+// query string (?token= / ?access_token= / ?jwt=) is NOT accepted → 401, and
+// the terminal handler is NEVER reached. The token must not travel in the URL
+// (log/referrer leak). Table over the common query-key spellings.
+func TestRefreshAuth_QueryParamTokenRejected(t *testing.T) {
+	tok := mintRefreshToken(t, "userA", time.Hour)
+
+	for _, key := range []string{"token", "access_token", "jwt", "authorization"} {
+		t.Run(key, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/refreshes?"+key+"="+tok, nil)
+			status, reached, _ := runRefreshAuth(t, req)
+			if status != http.StatusUnauthorized || reached {
+				t.Fatalf("M17(b): a valid JWT ONLY in query param %q must be rejected 401 (no token-in-URL); "+
+					"status=%d reached=%v", key, status, reached)
+			}
+		})
+	}
+}
+
+// --- M17(c): expired JWT ----------------------------------------------------
+
+// TestRefreshAuth_ExpiredTokenRejected — an expired JWT (in the header) → 401.
+// Also confirmed via the cookie transport, since both channels funnel into the
+// same jwtutil.Validate.
+func TestRefreshAuth_ExpiredTokenRejected(t *testing.T) {
+	t.Setenv("REFRESH_SESSION_COOKIE", "krateo-session")
+	expired := mintRefreshToken(t, "userA", -1*time.Hour) // ExpiresAt in the past
+
+	t.Run("header transport", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/refreshes?sub=x", nil)
+		req.Header.Set("Authorization", "Bearer "+expired)
+		status, reached, _ := runRefreshAuth(t, req)
+		if status != http.StatusUnauthorized || reached {
+			t.Fatalf("M17(c): expired JWT (header) must 401; status=%d reached=%v", status, reached)
+		}
+	})
+
+	t.Run("cookie transport", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/refreshes?sub=x", nil)
+		req.AddCookie(&http.Cookie{Name: "krateo-session", Value: expired})
+		status, reached, _ := runRefreshAuth(t, req)
+		if status != http.StatusUnauthorized || reached {
+			t.Fatalf("M17(c): expired JWT (cookie) must 401; status=%d reached=%v", status, reached)
+		}
+	})
+}
+
+// --- M17 RED: query-string auth must be caught ------------------------------
+
+// queryReadingAuth is a SHADOW wrong middleware that ALSO reads the token from
+// the query string (?token=) in addition to header/cookie — the exact
+// vulnerability M17(b) guards against. It exists only to prove the M17(b)
+// assertion is discriminating.
+func queryReadingAuth(signingKey string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var token string
+			if h := r.Header.Get("Authorization"); len(h) > 7 && h[:7] == "Bearer " {
+				token = h[7:]
+			}
+			if token == "" {
+				if ck, err := r.Cookie("krateo-session"); err == nil {
+					token = ck.Value
+				}
+			}
+			if token == "" {
+				token = r.URL.Query().Get("token") // THE BUG: token-in-URL
+			}
+			if token == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			ui, err := jwtutil.Validate(signingKey, token)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			ctx := xcontext.BuildContext(r.Context(), xcontext.WithUserInfo(ui))
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// TestRefreshAuth_RED_QueryStringMustNotAuthenticate is the RED proof for
+// M17(b). A token-in-URL request:
+//   - against the SHADOW query-reading middleware → 200 + reached (the bug);
+//   - against the REAL middleware.RefreshAuth        → 401 + NOT reached.
+//
+// The divergence proves the token-in-URL assertion catches the vulnerable impl.
+func TestRefreshAuth_RED_QueryStringMustNotAuthenticate(t *testing.T) {
+	tok := mintRefreshToken(t, "userA", time.Hour)
+	newReq := func() *http.Request {
+		return httptest.NewRequest(http.MethodGet, "/refreshes?token="+tok, nil)
+	}
+
+	// (1) The wrong impl authenticates the token-in-URL request — RED confirmed.
+	var wrongReached bool
+	wrongTerminal := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		wrongReached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrongRec := httptest.NewRecorder()
+	queryReadingAuth(refreshAuthTestKey)(wrongTerminal).ServeHTTP(wrongRec, newReq())
+	if wrongRec.Code != http.StatusOK || !wrongReached {
+		t.Fatalf("RED setup invalid: the query-reading shadow impl should have authenticated the "+
+			"token-in-URL request; status=%d reached=%v", wrongRec.Code, wrongReached)
+	}
+
+	// (2) The real middleware rejects the SAME request — the property under test.
+	status, reached, _ := runRefreshAuth(t, newReq())
+	if status != http.StatusUnauthorized || reached {
+		t.Fatalf("RED: middleware.RefreshAuth must NOT authenticate a token-in-URL request "+
+			"(the shadow impl did); status=%d reached=%v", status, reached)
+	}
+}

--- a/internal/handlers/rbac.go
+++ b/internal/handlers/rbac.go
@@ -50,6 +50,20 @@ type restActionRef struct {
 	Namespace string `json:"namespace"`
 }
 
+// rbacGetObjectFn and rbacInspectReadSetFn are package-private test seams over
+// the handler's two external dependencies — the RA loader (objects.Get) and the
+// dispatch-free inspect pass (api.InspectReadSet). Production wires the real
+// functions (assigned below); the hermetic falsifier (rbac_handler_body_test.go,
+// H5) swaps them so the handler's body/status logic — 422 naming an unresolvable
+// stage, empty-readSet-as-[] not null, deduped-sorted 200 — is exercised without
+// an apiserver or informer. Mirrors the saRESTConfigForInspectFn seam pattern in
+// internal/resolvers/restactions/api/inspect.go. Behaviour is identical to a
+// direct call: the defaults ARE the real functions.
+var (
+	rbacGetObjectFn      = objects.Get
+	rbacInspectReadSetFn = api.InspectReadSet
+)
+
 // RBAC returns the GET /rbac handler. It is constructed once at mount and is
 // stateless — every request reads the RA fresh from objects.Get (informer cache
 // or apiserver), so a CR edit is reflected on the next call.
@@ -79,7 +93,7 @@ func RBAC() http.Handler {
 		// Load the referenced RESTAction CR. objects.Get serves from the
 		// informer cache when possible and falls back to a direct apiserver GET
 		// — the SAME loader /call's fetchObject uses.
-		got := objects.Get(req.Context(), templatesv1.ObjectReference{
+		got := rbacGetObjectFn(req.Context(), templatesv1.ObjectReference{
 			Reference:  templatesv1.Reference{Name: name, Namespace: namespace},
 			APIVersion: templatesv1.SchemeGroupVersion.String(),
 			Resource:   "restactions",
@@ -99,7 +113,7 @@ func RBAC() http.Handler {
 			return
 		}
 
-		readSet, unresolved, err := api.InspectReadSet(req.Context(), &cr, extras)
+		readSet, unresolved, err := rbacInspectReadSetFn(req.Context(), &cr, extras)
 		if err != nil {
 			// A structural failure (cyclic api[], SA rest.Config unavailable):
 			// the read-set cannot be trusted — fail loud.

--- a/internal/handlers/rbac_handler_body_test.go
+++ b/internal/handlers/rbac_handler_body_test.go
@@ -1,0 +1,296 @@
+// rbac_handler_body_test.go — H5 hermetic body/status falsifier for GET /rbac.
+//
+// rbac_test.go already proves the AUTH GATE (UserConfig 401s a bad/absent JWT
+// before the handler runs). This file proves the HANDLER BODY LOGIC — the four
+// non-auth response shapes — WITHOUT an apiserver or informer, by swapping the
+// two package-private seams (rbacGetObjectFn / rbacInspectReadSetFn, rbac.go)
+// for in-memory fakes:
+//
+//	(a) an unresolvable stage  -> 422 whose message NAMES the stage
+//	    (formatUnresolved) — a partial read-set is NEVER returned as success;
+//	(b) a missing apiRefName / apiRefNamespace -> 400 (before any load);
+//	(c) an all-external RESTAction (readSet nil) -> 200 with "readSet": []
+//	    (marshalled as an empty array, NOT null);
+//	(d) a valid RESTAction -> 200 with the deduped, sorted read-set verbatim.
+//
+// RED arm (proved in-file, TestRBAC_Body_RED_PartialReadSetMustNot200): a wrong
+// impl that returns the partial read-set as a 200 (ignoring the unresolved
+// stages) is caught — arm (a) demands 422 exactly when unresolved is non-empty.
+//
+// The seams default to the REAL objects.Get / api.InspectReadSet in prod; this
+// test overrides them per-test and restores via t.Cleanup, so it perturbs no
+// production behaviour and no other test.
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/http/response"
+	templatesv1 "github.com/krateoplatformops/snowplow/apis/templates/v1"
+	"github.com/krateoplatformops/snowplow/internal/objects"
+	"github.com/krateoplatformops/snowplow/internal/resolvers/restactions/api"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// fakeRAUnstructured is a minimal RESTAction object that converts cleanly to the
+// typed templatesv1.RESTAction the handler builds via FromUnstructured. Its spec
+// is irrelevant — rbacInspectReadSetFn is stubbed, so the inspect pass never
+// actually walks it.
+func fakeRAUnstructured(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": templatesv1.SchemeGroupVersion.String(),
+		"kind":       "RESTAction",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{},
+	}}
+}
+
+// withRBACSeams installs the two handler seams for the duration of the test and
+// restores them on cleanup.
+func withRBACSeams(t *testing.T,
+	get func(ctx context.Context, ref templatesv1.ObjectReference) objects.Result,
+	inspect func(ctx context.Context, in *templatesv1.RESTAction, extras map[string]any) ([]api.Resource, []api.Unresolved, error),
+) {
+	t.Helper()
+	prevGet, prevInspect := rbacGetObjectFn, rbacInspectReadSetFn
+	rbacGetObjectFn = get
+	rbacInspectReadSetFn = inspect
+	t.Cleanup(func() {
+		rbacGetObjectFn = prevGet
+		rbacInspectReadSetFn = prevInspect
+	})
+}
+
+// callRBAC drives RBAC().ServeHTTP with the given query, returning the recorder.
+// A default logger is on the ctx (xcontext.Logger returns one anyway); no
+// middleware — the seams stand in for objects.Get / api.InspectReadSet.
+func callRBAC(t *testing.T, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/rbac"+query, nil).
+		WithContext(xcontext.BuildContext(context.Background()))
+	RBAC().ServeHTTP(rec, req)
+	return rec
+}
+
+// okGet returns a seam that serves the fake RA for (name, namespace).
+func okGet(name, namespace string) func(context.Context, templatesv1.ObjectReference) objects.Result {
+	return func(_ context.Context, ref templatesv1.ObjectReference) objects.Result {
+		return objects.Result{
+			GVR:          schema.GroupVersionResource{Group: "templates.krateo.io", Version: "v1", Resource: "restactions"},
+			Unstructured: fakeRAUnstructured(ref.Name, ref.Namespace),
+		}
+	}
+}
+
+// TestRBAC_Body_Unresolvable422NamesStage — arm (a): when the inspect pass
+// reports an unresolvable stage, the handler MUST 422 and the body message MUST
+// name that stage (formatUnresolved) — never return a partial read-set as 200.
+func TestRBAC_Body_Unresolvable422NamesStage(t *testing.T) {
+	withRBACSeams(t,
+		okGet("foo", "krateo-system"),
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			// A partial read-set AND an unresolved stage: the handler must
+			// prefer the 422 over shipping the partial set.
+			return []api.Resource{{Group: "", Version: "v1", Resource: "configmaps", Verb: "get"}},
+				[]api.Unresolved{{Stage: "listPods", Reason: "needs upstream output"}},
+				nil
+		},
+	)
+
+	rec := callRBAC(t, "?apiRefName=foo&apiRefNamespace=krateo-system")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("H5(a): unresolvable stage must yield 422, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var st response.Status
+	if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+		t.Fatalf("H5(a): decode 422 body: %v (%s)", err, rec.Body.String())
+	}
+	if !containsStr(st.Message, "listPods") {
+		t.Fatalf("H5(a): 422 message must NAME the unresolvable stage 'listPods'; got %q", st.Message)
+	}
+}
+
+// TestRBAC_Body_MissingParams400 — arm (b): a missing apiRefName or
+// apiRefNamespace yields 400 BEFORE any RA load (the seams must not even be
+// consulted). Table-driven over the two params.
+func TestRBAC_Body_MissingParams400(t *testing.T) {
+	getCalled := false
+	withRBACSeams(t,
+		func(_ context.Context, _ templatesv1.ObjectReference) objects.Result {
+			getCalled = true
+			return objects.Result{}
+		},
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			return nil, nil, nil
+		},
+	)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"missing name", "?apiRefNamespace=krateo-system"},
+		{"missing namespace", "?apiRefName=foo"},
+		{"missing both", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			getCalled = false
+			rec := callRBAC(t, c.query)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("H5(b) %s: want 400, got %d", c.name, rec.Code)
+			}
+			if getCalled {
+				t.Fatalf("H5(b) %s: RA loader must NOT run when required params are absent", c.name)
+			}
+		})
+	}
+}
+
+// TestRBAC_Body_AllExternalReadSetEmptyArray — arm (c): a RESTAction whose every
+// stage is external/discovery legitimately reads no in-cluster resource; the
+// inspect pass returns a nil read-set. The handler MUST marshal it as [] (empty
+// array), NOT null — a null readSet would be a JSON-shape regression for the
+// core-provider consumer.
+func TestRBAC_Body_AllExternalReadSetEmptyArray(t *testing.T) {
+	withRBACSeams(t,
+		okGet("all-external", "krateo-system"),
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			return nil, nil, nil // nil read-set, nothing unresolved
+		},
+	)
+
+	rec := callRBAC(t, "?apiRefName=all-external&apiRefNamespace=krateo-system")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("H5(c): all-external RA must yield 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	// Assert the RAW JSON carries "readSet": [] and NOT null. Decoding into a Go
+	// slice would collapse both null and [] to a nil slice, masking the bug —
+	// so match the raw bytes.
+	raw := rec.Body.String()
+	if !containsStr(raw, `"readSet": []`) {
+		t.Fatalf("H5(c): body must marshal an empty read-set as [] (not null); got:\n%s", raw)
+	}
+	// Belt-and-suspenders: the typed decode succeeds and yields an empty set.
+	var body rbacResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("H5(c): decode 200 body: %v", err)
+	}
+	if len(body.ReadSet) != 0 {
+		t.Fatalf("H5(c): read-set must be empty; got %d rows", len(body.ReadSet))
+	}
+}
+
+// TestRBAC_Body_Valid200SortedDeduped — arm (d): a valid RESTAction yields 200
+// and the read-set the inspect pass produced, verbatim, in the body's readSet.
+// (The dedupe+sort is the inspect pass's contract; the handler passes it through
+// unchanged — this arm proves the pass-through + the identity echo.)
+func TestRBAC_Body_Valid200SortedDeduped(t *testing.T) {
+	want := []api.Resource{
+		{Group: "", Version: "v1", Resource: "configmaps", Namespace: "krateo-system", Verb: "get"},
+		{Group: "apps", Version: "v1", Resource: "deployments", Namespace: "krateo-system", Verb: "list"},
+	}
+	withRBACSeams(t,
+		okGet("valid-ra", "krateo-system"),
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			return want, nil, nil
+		},
+	)
+
+	rec := callRBAC(t, "?apiRefName=valid-ra&apiRefNamespace=krateo-system")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("H5(d): valid RA must yield 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var body rbacResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("H5(d): decode 200 body: %v", err)
+	}
+	if body.RESTAction.Name != "valid-ra" || body.RESTAction.Namespace != "krateo-system" {
+		t.Fatalf("H5(d): body must echo the RA identity; got %+v", body.RESTAction)
+	}
+	if len(body.ReadSet) != len(want) {
+		t.Fatalf("H5(d): read-set len = %d, want %d (%+v)", len(body.ReadSet), len(want), body.ReadSet)
+	}
+	for i := range want {
+		if body.ReadSet[i] != want[i] {
+			t.Fatalf("H5(d): read-set[%d] = %+v, want %+v", i, body.ReadSet[i], want[i])
+		}
+	}
+}
+
+// TestRBAC_Body_GetErrorEncoded — a loader error (e.g. NotFound) is encoded with
+// its own status code, never a 200. Guards the "load failed → fail loud" branch.
+func TestRBAC_Body_GetErrorEncoded(t *testing.T) {
+	withRBACSeams(t,
+		func(_ context.Context, ref templatesv1.ObjectReference) objects.Result {
+			return objects.Result{Err: response.New(http.StatusNotFound, http.ErrNoLocation)}
+		},
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			t.Fatalf("inspect must NOT run when the RA load errored")
+			return nil, nil, nil
+		},
+	)
+
+	rec := callRBAC(t, "?apiRefName=absent&apiRefNamespace=krateo-system")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("H5(load-err): a NotFound load must encode 404, got %d", rec.Code)
+	}
+}
+
+// TestRBAC_Body_RED_PartialReadSetMustNot200 is the RED proof for arm (a): it
+// demonstrates that the discriminating assertion (422 on any unresolved stage)
+// catches the plausible wrong impl "return the partial read-set as 200,
+// ignoring unresolved". We simulate that wrong impl by directly reproducing its
+// output shape (200 + partial body) and asserting the H5(a) invariant would
+// FAIL on it — i.e. the arm is not vacuously green.
+func TestRBAC_Body_RED_PartialReadSetMustNot200(t *testing.T) {
+	// Shadow the wrong-impl response: a handler that ships the partial set as
+	// 200 despite unresolved stages.
+	wrong := httptest.NewRecorder()
+	wrong.Code = http.StatusOK
+	partial := rbacResponse{
+		RESTAction: restActionRef{Name: "foo", Namespace: "krateo-system"},
+		ReadSet:    []api.Resource{{Group: "", Version: "v1", Resource: "configmaps", Verb: "get"}},
+	}
+	_ = json.NewEncoder(wrong.Body).Encode(partial)
+
+	// The H5(a) invariant applied to the wrong impl's output MUST fail (it is
+	// 200, not 422). If this ever passes, arm (a) is not discriminating.
+	if wrong.Code == http.StatusUnprocessableEntity {
+		t.Fatalf("RED setup invalid: wrong impl should be 200, not 422")
+	}
+	// Confirm the real handler, on the SAME unresolved condition, is 422 — the
+	// exact behaviour the wrong impl lacks.
+	withRBACSeams(t,
+		okGet("foo", "krateo-system"),
+		func(_ context.Context, _ *templatesv1.RESTAction, _ map[string]any) ([]api.Resource, []api.Unresolved, error) {
+			return partial.ReadSet, []api.Unresolved{{Stage: "listPods", Reason: "needs upstream output"}}, nil
+		},
+	)
+	rec := callRBAC(t, "?apiRefName=foo&apiRefNamespace=krateo-system")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("RED: real handler must 422 where the wrong impl 200s; got %d", rec.Code)
+	}
+}
+
+// containsStr is a tiny substring helper (avoids importing strings in a test
+// file already dense with imports; behaviour == strings.Contains).
+func containsStr(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handlers/refreshes_test.go
+++ b/internal/handlers/refreshes_test.go
@@ -14,15 +14,18 @@ package handlers
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/jwtutil"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/handlers/middleware"
@@ -389,5 +392,191 @@ func TestRefreshes_CacheOff_IdleStream(t *testing.T) {
 		// the window as benign (the stream did not emit a refresh).
 	case <-time.After(500 * time.Millisecond):
 		// No refresh frame within the window — correct (idle stream).
+	}
+}
+
+// --- M18 [SEC-adj] ----------------------------------------------------------
+
+// subParamRawURL builds the SAME coordinate array as subParam but encodes it
+// with base64.RawURLEncoding (unpadded, URL-safe alphabet) — the encoding a
+// browser EventSource URL naturally carries. It is distinct from the StdEncoding
+// form whenever the payload has padding or +// bytes.
+func subParamRawURL(t *testing.T) string {
+	t.Helper()
+	body := []map[string]any{{
+		"class":     "widgetContent",
+		"group":     "widgets.templates.krateo.io",
+		"version":   "v1beta1",
+		"resource":  "panels",
+		"namespace": "krateo-system",
+		"name":      "dashboard-piechart",
+		"perPage":   5,
+		"page":      1,
+	}}
+	raw, _ := json.Marshal(body)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// TestRefreshes_RawURLEncodedSubReachesHandler is M18(a): a ?sub= encoded with
+// RawURLEncoding (the browser EventSource path) decodes via validateSubscription's
+// URL-safe fallback and reaches the handler → 200 + text/event-stream. Without
+// the RawURLEncoding fallback the browser payload would fail StdEncoding decode
+// and 400 — the exact regression the RED arm below reproduces.
+func TestRefreshes_RawURLEncodedSubReachesHandler(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	t.Setenv("REFRESH_SSE_ENABLED", "")
+	seedAuthTestWidget(t) // #64: the armed widget CR must be fetchable
+	base := refreshServer(t)
+
+	resp, cancel := openStream(t, base, "?sub="+subParamRawURL(t), func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+mintToken(t, "userA"))
+	})
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("M18(a) RawURLEncoding sub: status=%d want 200 (EventSource URL-safe base64 path)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("M18(a): Content-Type=%q want text/event-stream", ct)
+	}
+}
+
+// TestRefreshes_RawURLEncoding_RED_StdOnlyRejectsBrowserPayload is the RED proof
+// for M18(a). It reproduces the plausible wrong impl — decode with StdEncoding
+// ONLY, no RawURLEncoding fallback — and asserts that the browser's RawURL
+// payload FAILS to decode under it. This is exactly the 400-on-browser-path
+// regression the fallback in validateSubscription prevents; the green test above
+// proves the real code does NOT regress.
+func TestRefreshes_RawURLEncoding_RED_StdOnlyRejectsBrowserPayload(t *testing.T) {
+	raw := subParamRawURL(t)
+	// Sanity: the RawURL form must actually differ from the Std form for this
+	// payload (else the arm is vacuous). The JSON has enough bytes that its
+	// base64 is padded → StdEncoding carries '=' that RawURLEncoding omits.
+	body := []map[string]any{{
+		"class": "widgetContent", "group": "widgets.templates.krateo.io", "version": "v1beta1",
+		"resource": "panels", "namespace": "krateo-system", "name": "dashboard-piechart", "perPage": 5, "page": 1,
+	}}
+	j, _ := json.Marshal(body)
+	std := base64.StdEncoding.EncodeToString(j)
+	if raw == std {
+		t.Skipf("RawURL and Std encodings coincide for this payload; RED arm not meaningful")
+	}
+
+	// Wrong impl: StdEncoding-only decode of the browser (RawURL) payload.
+	if _, err := base64.StdEncoding.DecodeString(raw); err == nil {
+		t.Fatalf("RED: StdEncoding-only decode of a RawURL payload should FAIL (proving the fallback is load-bearing); it succeeded")
+	}
+	// And the real code path (with the fallback) accepts it — proven at the HTTP
+	// level by TestRefreshes_RawURLEncodedSubReachesHandler; here we assert the
+	// in-package decode contract directly.
+	if _, err := base64.RawURLEncoding.DecodeString(raw); err != nil {
+		t.Fatalf("RED control: the RawURLEncoding fallback must decode the browser payload; got %v", err)
+	}
+}
+
+// TestRefreshes_SubEntryCountBoundary is M18(b): the refreshSubMaxEntries cap is
+// INCLUSIVE — exactly 512 entries is accepted (validateSubscription returns no
+// error), 513 is rejected. Driven through validateSubscription directly so the
+// boundary is isolated from the downstream armed==0 → 400 (a 512-entry all-skip
+// subscription would otherwise 400 at the handler for a DIFFERENT reason,
+// masking the count guard).
+func TestRefreshes_SubEntryCountBoundary(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+
+	mkSub := func(n int) string {
+		arr := make([]map[string]any, n)
+		for i := range arr {
+			// Empty object → a valid subRequest (all fields optional) that skips
+			// derivation (no class), which is NOT a validateSubscription error.
+			// Kept minimal (2 bytes each) so even cap+1 entries stay well under
+			// refreshSubParamMaxBytes — isolating the entry-COUNT guard from the
+			// byte-size guard (an unknown-class fixture would trip the byte cap
+			// first at 512 entries, masking the boundary under test).
+			arr[i] = map[string]any{}
+		}
+		raw, _ := json.Marshal(arr)
+		return base64.StdEncoding.EncodeToString(raw)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	call := func(n int) error {
+		ctx := xcontext.BuildContext(context.Background(),
+			xcontext.WithLogger(logger),
+			xcontext.WithUserInfo(jwtutil.UserInfo{Username: "userA", Groups: []string{"devs"}}),
+		)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/refreshes?sub="+mkSub(n), nil)
+		_, err := validateSubscription(req)
+		return err
+	}
+
+	if err := call(refreshSubMaxEntries); err != nil {
+		t.Fatalf("M18(b): exactly %d entries (the cap) must be accepted; got error %v", refreshSubMaxEntries, err)
+	}
+	if err := call(refreshSubMaxEntries + 1); err == nil {
+		t.Fatalf("M18(b): %d entries (cap+1) must be rejected; got nil error", refreshSubMaxEntries+1)
+	}
+}
+
+// TestRefreshes_AbsentCoord_SkippedNoApiserverError is M18(c): a coord whose CR
+// is absent from the informer is SKIPPED (informer-miss) and reflected in the
+// subscription summary — with NO ERROR-level log line (the #101 property: the
+// informer-only ctx turns the absent-CR read into a quiet NotFound-shaped skip,
+// NOT the "unable to get user endpoint" apiserver-fallthrough ERROR storm).
+func TestRefreshes_AbsentCoord_SkippedNoApiserverError(t *testing.T) {
+	seedSummaryWidget(t) // one armable "armed-panel" CR + RBAC binding
+
+	buf := &bytes.Buffer{}
+	// Capture at DEBUG so an ERROR line, if any were emitted, is definitely seen.
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	body := []map[string]any{
+		widgetContentCoord("armed-panel"),    // present → arms
+		widgetContentCoord("absent-panel-1"), // absent → informer-miss skip
+		widgetContentCoord("absent-panel-2"), // absent → informer-miss skip
+	}
+	raw, _ := json.Marshal(body)
+	sub := base64.StdEncoding.EncodeToString(raw)
+
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithLogger(logger),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: "userA", Groups: []string{"devs"}}),
+	)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/refreshes?sub="+sub, nil)
+
+	armed, err := validateSubscription(req)
+	if err != nil {
+		t.Fatalf("M18(c): validateSubscription must not error on absent coords; got %v", err)
+	}
+	if len(armed) != 1 {
+		t.Fatalf("M18(c): only the present coord arms; want 1, got %d", len(armed))
+	}
+
+	// (1) The summary line reflects the two informer-miss skips.
+	sum := findSummaryLine(t, buf)
+	if sum.Requested != 3 || sum.Armed != 1 || sum.SkippedInformerMiss != 2 {
+		t.Fatalf("M18(c): summary want {requested:3 armed:1 skipped_informer_miss:2}; got %+v", sum)
+	}
+
+	// (2) NO ERROR-level log line was emitted — the #101 apiserver-fallthrough
+	// error storm is gone. Scan every captured JSON line for level==ERROR.
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec struct {
+			Level string `json:"level"`
+			Msg   string `json:"msg"`
+		}
+		if json.Unmarshal(line, &rec) != nil {
+			continue
+		}
+		if rec.Level == "ERROR" {
+			t.Fatalf("M18(c): an absent-CR coord must NOT emit an ERROR log line (apiserver-fallthrough storm); "+
+				"saw ERROR msg=%q\nfull log:\n%s", rec.Msg, buf.String())
+		}
 	}
 }

--- a/internal/rbac/evaltest/evaluate_test.go
+++ b/internal/rbac/evaltest/evaluate_test.go
@@ -11,15 +11,21 @@ import (
 	"testing"
 	"time"
 
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	"github.com/krateoplatformops/snowplow/internal/rbac"
 
+	authv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 // rbacListKinds mirrors the helper in internal/cache/watcher_test.go.
@@ -765,5 +771,242 @@ func TestEvaluateRBAC_SubjectIndex_NegativesUnaffected(t *testing.T) {
 				t.Errorf("Subject-index path OVER-GRANTED: %+v should be denied", opts)
 			}
 		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// L5 [SEC] — cache=off SAR PERMIT branch, hermetic.
+//
+// The existing TestEvaluateRBAC_CacheOffFallsThroughToSAR proves the
+// DENY side of the cache=off path (no UserConfig → UserCan errors →
+// deny). L5 pins the PERMIT side hermetically: with CACHE_ENABLED=false,
+// a fake authorization clientset that answers Allowed=true makes
+// EvaluateRBAC return permit — AND the fake asserts that EvaluateRBAC
+// mapped opts.{Verb,Group,Resource,Namespace} onto the
+// SelfSubjectAccessReview's ResourceAttributes correctly.
+//
+// The clientset is injected via rbac.SetSARClientsetForTest (the minimal
+// behaviour-preserving seam added to rbac.go). No apiserver, no kind.
+// ──────────────────────────────────────────────────────────────────────
+
+// newSARFakeAllowingOnly builds a fake kubernetes clientset whose
+// SelfSubjectAccessReview create-reactor returns Allowed=true ONLY when
+// the review's ResourceAttributes match the expected mapped tuple, and
+// records the ResourceAttributes it actually observed. A mis-mapped
+// EvaluateRBAC (e.g. Group and Resource swapped) would submit attributes
+// that don't match `want`, so the reactor returns Allowed=false and the
+// permit assertion fails — that is the L5 RED.
+func newSARFakeAllowingOnly(want authv1.ResourceAttributes, gotRA **authv1.ResourceAttributes) *k8sfake.Clientset {
+	cs := k8sfake.NewSimpleClientset()
+	cs.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action ktesting.Action) (bool, runtime.Object, error) {
+			ca, ok := action.(ktesting.CreateAction)
+			if !ok {
+				return false, nil, nil
+			}
+			ssar, ok := ca.GetObject().(*authv1.SelfSubjectAccessReview)
+			if !ok || ssar.Spec.ResourceAttributes == nil {
+				return true, &authv1.SelfSubjectAccessReview{
+					Status: authv1.SubjectAccessReviewStatus{Allowed: false},
+				}, nil
+			}
+			ra := *ssar.Spec.ResourceAttributes
+			*gotRA = ssar.Spec.ResourceAttributes
+			allowed := ra.Verb == want.Verb &&
+				ra.Group == want.Group &&
+				ra.Resource == want.Resource &&
+				ra.Namespace == want.Namespace
+			return true, &authv1.SelfSubjectAccessReview{
+				Status: authv1.SubjectAccessReviewStatus{Allowed: allowed},
+			}, nil
+		})
+	return cs
+}
+
+// TestEvaluateRBAC_CacheOffSARPermit_Hermetic exercises the cache=off SAR
+// PERMIT branch with an injected fake clientset. EvaluateRBAC must return
+// (true,"",nil) and the SAR it issued must carry the correctly mapped
+// ResourceAttributes.
+//
+// RED arm: a ResourceAttributes mis-map (the fake only allows the exact
+// mapped tuple). If EvaluateRBAC/userCanViaSAR mis-populated the SAR
+// (e.g. swapped Group↔Resource or dropped Namespace), the reactor returns
+// Allowed=false and the permit assertion below fails.
+func TestEvaluateRBAC_CacheOffSARPermit_Hermetic(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+	// TEST_MODE=true so xcontext.UserConfig does not rewrite the endpoint's
+	// ServerURL to the in-cluster default (irrelevant to the fake, but keeps
+	// the resolved endpoint faithful to what we set).
+	t.Setenv("TEST_MODE", "true")
+
+	if !cache.Disabled() {
+		t.Fatalf("Disabled() should be true with CACHE_ENABLED=false")
+	}
+
+	want := authv1.ResourceAttributes{
+		Verb:      "list",
+		Group:     "apps",
+		Resource:  "deployments",
+		Namespace: "demo-system",
+	}
+	var gotRA *authv1.ResourceAttributes
+	fakeCS := newSARFakeAllowingOnly(want, &gotRA)
+
+	restore := rbac.SetSARClientsetForTest(
+		func(_ context.Context, _ endpoints.Endpoint) (kubernetes.Interface, error) {
+			return fakeCS, nil
+		})
+	t.Cleanup(restore)
+
+	// userCanViaSAR reads xcontext.UserConfig(ctx); provide an endpoint so
+	// it does not short-circuit to deny before reaching the (fake) clientset.
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserConfig(endpoints.Endpoint{ServerURL: "https://sar.test"}),
+	)
+
+	ok, uid, err := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+		Username:  "alice",
+		Verb:      "list",
+		Group:     "apps",
+		Resource:  "deployments",
+		Namespace: "demo-system",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRBAC (cache=off SAR permit): %v", err)
+	}
+	if !ok {
+		t.Fatalf("L5: cache=off + fake SAR Allowed=true must PERMIT — got deny. "+
+			"If the fake observed mis-mapped ResourceAttributes it denies: observed=%+v want=%+v", raOrNil(gotRA), want)
+	}
+	// cache=off returns no BindingUID (no in-process snapshot).
+	if uid != "" {
+		t.Fatalf("L5: cache=off SAR path must return empty BindingUID; got %q", uid)
+	}
+	// The SAR must have been issued with the correctly mapped attributes.
+	if gotRA == nil {
+		t.Fatalf("L5: no SelfSubjectAccessReview reached the fake clientset — the SAR path was not exercised")
+	}
+	if *gotRA != want {
+		t.Fatalf("L5 MIS-MAP: SAR ResourceAttributes = %+v, want %+v (EvaluateRBAC mapped opts onto the SAR incorrectly)", *gotRA, want)
+	}
+}
+
+// TestEvaluateRBAC_CacheOffSAR_DenyPropagates is the negative twin: the
+// fake answers Allowed=false and EvaluateRBAC must return deny. Guards
+// against a fake/plumbing artifact that would make the permit test pass
+// vacuously (i.e. proves the verdict tracks the SAR answer, not a
+// hard-coded allow).
+func TestEvaluateRBAC_CacheOffSAR_DenyPropagates(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "false")
+	t.Setenv("TEST_MODE", "true")
+
+	cs := k8sfake.NewSimpleClientset()
+	cs.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &authv1.SelfSubjectAccessReview{
+				Status: authv1.SubjectAccessReviewStatus{Allowed: false},
+			}, nil
+		})
+	restore := rbac.SetSARClientsetForTest(
+		func(_ context.Context, _ endpoints.Endpoint) (kubernetes.Interface, error) {
+			return cs, nil
+		})
+	t.Cleanup(restore)
+
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserConfig(endpoints.Endpoint{ServerURL: "https://sar.test"}),
+	)
+	ok, _, err := rbac.EvaluateRBAC(ctx, rbac.EvaluateOptions{
+		Username: "alice", Verb: "get", Group: "", Resource: "secrets", Namespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRBAC (cache=off SAR deny): %v", err)
+	}
+	if ok {
+		t.Fatalf("L5 negative: fake SAR Allowed=false must DENY; got permit")
+	}
+}
+
+func raOrNil(ra *authv1.ResourceAttributes) any {
+	if ra == nil {
+		return "<no SAR issued>"
+	}
+	return *ra
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// L7 — concrete-namespace ServiceAccount form: a cluster-wide grant to
+// the SA's synthetic group MUST authorize a request carrying a CONCRETE
+// (non-empty) request namespace, exactly as it does for the cluster-scoped
+// (empty) namespace form. Converts the previously non-asserting
+// ship11 PROBE-1b (which only t.Logf'd) into a hard assertion.
+//
+// RED arm: an impl that special-cases the empty request namespace (e.g.
+// only lands the SA's synthetic-group index when opts.Namespace == "")
+// would DENY the concrete-ns form. The SA's synthetic groups derive from
+// the SA's OWN namespace, not the request namespace, and a cluster-wide
+// CRB permits regardless of request namespace — so the concrete-ns form
+// MUST permit.
+// ──────────────────────────────────────────────────────────────────────
+
+// TestEvaluateRBAC_SAGroups_ConcreteNamespaceGrant asserts the concrete-ns
+// SA form permits, and that the empty-ns form permits identically (parity).
+func TestEvaluateRBAC_SAGroups_ConcreteNamespaceGrant(t *testing.T) {
+	// Cluster-wide */* grant to the synthetic group
+	// system:serviceaccounts:krateo-system — every SA in krateo-system is a
+	// member, cluster-wide.
+	newTestWatcher(t,
+		clusterRole("ns-sas", rule([]string{"*"}, []string{"*"}, []string{"get", "list", "watch"})),
+		clusterRoleBinding("ns-sas-bind", "ns-sas",
+			groupSubject("system:serviceaccounts:krateo-system"),
+		),
+	)
+
+	sa := "system:serviceaccount:krateo-system:snowplow"
+
+	cases := []struct {
+		name      string
+		namespace string
+	}{
+		{"cluster_scope_empty_ns", ""},           // the PROBE-1 form
+		{"concrete_ns_demo_system", "demo-system"}, // the PROBE-1b form (was non-asserting)
+		{"concrete_ns_other", "other"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			ok, _, err := rbac.EvaluateRBAC(context.Background(), rbac.EvaluateOptions{
+				Username:  sa,
+				Groups:    []string{"system:authenticated"},
+				Verb:      "list",
+				Group:     "",
+				Resource:  "namespaces",
+				Namespace: c.namespace,
+			})
+			if err != nil {
+				t.Fatalf("EvaluateRBAC(ns=%q): %v", c.namespace, err)
+			}
+			if !ok {
+				t.Fatalf("L7 INVARIANT: SA %s with cluster-wide grant to system:serviceaccounts:krateo-system MUST be permitted for request namespace=%q (concrete-ns form must NOT be special-cased against the empty-ns form)", sa, c.namespace)
+			}
+		})
+	}
+
+	// Negative guard: an SA in a DIFFERENT namespace is NOT a member of
+	// system:serviceaccounts:krateo-system and MUST be denied — for the
+	// concrete-ns form too (proves the permit above is not a blanket allow).
+	ok, _, err := rbac.EvaluateRBAC(context.Background(), rbac.EvaluateOptions{
+		Username:  "system:serviceaccount:other-ns:worker",
+		Groups:    []string{"system:authenticated"},
+		Verb:      "list",
+		Group:     "",
+		Resource:  "namespaces",
+		Namespace: "demo-system",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRBAC(other-ns SA): %v", err)
+	}
+	if ok {
+		t.Fatalf("L7 negative: an SA in other-ns must NOT match system:serviceaccounts:krateo-system on the concrete-ns form")
 	}
 }

--- a/internal/rbac/evaltest/groups_hash_test.go
+++ b/internal/rbac/evaltest/groups_hash_test.go
@@ -1,0 +1,123 @@
+// groups_hash_test.go — M9 [SEC-adj] direct-unit falsifier for
+// internal/rbac/groups_hash.go's canonicalGroupsHash, the single source
+// of truth for the snapshot-authz memo key's GroupsHash dimension.
+//
+// TestL2_B3_GroupsHashCollisionAndOrder (snapshot_authz_memo_test.go)
+// already exercises the hasher THROUGH EvaluateRBAC's observable verdict.
+// This file asserts the hasher's contract DIRECTLY at the unit boundary
+// via the rbac.CanonicalGroupsHashForTest hook — so a hasher regression
+// is caught even if a future memo-key change stopped routing groups
+// through it, and so the three properties that the behavioural test
+// cannot cheaply separate (empty-vs-[""] distinctness, input-slice
+// purity) are pinned explicitly.
+//
+// Contract (groups_hash.go):
+//   1. length-prefix framing => h(["a","bc"]) != h(["ab","c"]) (the
+//      0.30.239 naive-concat alias is impossible).
+//   2. order independence     => h(["x","y"]) == h(["y","x"]).
+//   3. empty-set stability     => h(nil) == h([]) != h([""]).
+//   4. input purity            => the caller's slice is NOT mutated
+//      (the impl sorts a COPY, never in place).
+//
+// evaltest package only — never `go test ./internal/rbac/...` against the
+// remote kubeconfig (feedback_no_go_test_against_remote_kubeconfig). This
+// test spins nothing (no watcher, no kind) — it is a pure function probe.
+
+package evaltest
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/rbac"
+)
+
+// TestM9_CanonicalGroupsHash_Collision asserts the length-prefix framing
+// defeats the classic partition alias: ["a","bc"] and ["ab","c"] both
+// naive-concat to "abc" but are DIFFERENT sets and MUST hash differently.
+// RED arm: a hasher that concatenates element bytes without a length
+// prefix (or with a fixed separator that can appear in element data)
+// aliases these two and this assertion fails.
+func TestM9_CanonicalGroupsHash_Collision(t *testing.T) {
+	h1 := rbac.CanonicalGroupsHashForTest([]string{"a", "bc"})
+	h2 := rbac.CanonicalGroupsHashForTest([]string{"ab", "c"})
+	if h1 == h2 {
+		t.Fatalf("M9 COLLISION: h([\"a\",\"bc\"])=%d == h([\"ab\",\"c\"])=%d — the length-prefix framing failed to disambiguate the partition (0.30.239 naive-concat alias)", h1, h2)
+	}
+
+	// A second, adversarial partition pair to make the RED wider: a naive
+	// concat with ANY single-byte separator that also appears in the data
+	// would still alias one of these.
+	h3 := rbac.CanonicalGroupsHashForTest([]string{"x", "yz"})
+	h4 := rbac.CanonicalGroupsHashForTest([]string{"xy", "z"})
+	if h3 == h4 {
+		t.Fatalf("M9 COLLISION: h([\"x\",\"yz\"])=%d == h([\"xy\",\"z\"])=%d — partition alias not defeated", h3, h4)
+	}
+}
+
+// TestM9_CanonicalGroupsHash_OrderIndependent asserts the hash is a SET
+// hash: reordering the same members yields the SAME value (the impl sorts
+// a copy first). RED arm: a hasher that folds groups in caller order
+// (no sort) produces different values for ["x","y"] vs ["y","x"].
+func TestM9_CanonicalGroupsHash_OrderIndependent(t *testing.T) {
+	cases := [][2][]string{
+		{{"x", "y"}, {"y", "x"}},
+		{{"a", "bc", "def"}, {"def", "a", "bc"}},
+		{{"system:authenticated", "admins"}, {"admins", "system:authenticated"}},
+	}
+	for _, c := range cases {
+		h1 := rbac.CanonicalGroupsHashForTest(c[0])
+		h2 := rbac.CanonicalGroupsHashForTest(c[1])
+		if h1 != h2 {
+			t.Fatalf("M9 ORDER: h(%v)=%d != h(%v)=%d — hash is not order-independent (missing sort)", c[0], h1, c[1], h2)
+		}
+	}
+}
+
+// TestM9_CanonicalGroupsHash_EmptyVsSingletonEmptyString asserts the
+// empty-set stability contract: nil and [] hash identically (the empty
+// stream), and BOTH differ from [""] (a one-element set whose single
+// member is the empty string — which writes a length prefix of 0 followed
+// by zero element bytes). RED arm: an impl that early-returns the empty
+// hash for len==0 but forgets the length prefix on non-empty elements
+// would collide h(nil) with h([""]) (both would hash "nothing").
+func TestM9_CanonicalGroupsHash_EmptyVsSingletonEmptyString(t *testing.T) {
+	hNil := rbac.CanonicalGroupsHashForTest(nil)
+	hEmpty := rbac.CanonicalGroupsHashForTest([]string{})
+	hEmptyStr := rbac.CanonicalGroupsHashForTest([]string{""})
+
+	if hNil != hEmpty {
+		t.Fatalf("M9 EMPTY: h(nil)=%d != h([])=%d — nil and empty slice must hash identically", hNil, hEmpty)
+	}
+	if hNil == hEmptyStr {
+		t.Fatalf("M9 EMPTY: h(nil)=%d == h([\"\"])=%d — the empty SET and the one-element set {\"\"} must hash differently (length-prefix distinguishes them)", hNil, hEmptyStr)
+	}
+}
+
+// TestM9_CanonicalGroupsHash_InputNotMutated asserts caller-slice purity:
+// canonicalGroupsHash sorts a COPY, so an UNSORTED caller slice must be
+// unchanged after the call. RED arm: an impl that sorts opts.Groups
+// in place mutates the caller's slice — which in prod would silently
+// reorder the auth layer's group slice (and could corrupt a concurrent
+// reader). We pass a deliberately out-of-order slice and assert both the
+// element order AND that the hash still matched its sorted twin.
+func TestM9_CanonicalGroupsHash_InputNotMutated(t *testing.T) {
+	in := []string{"zebra", "alpha", "mid"}
+	before := make([]string, len(in))
+	copy(before, in)
+
+	_ = rbac.CanonicalGroupsHashForTest(in)
+
+	if !reflect.DeepEqual(in, before) {
+		t.Fatalf("M9 PURITY: canonicalGroupsHash mutated its input slice: got %v, want unchanged %v (impl must sort a copy, never in place)", in, before)
+	}
+
+	// Cross-check the mutation would have been observable via the hash's
+	// order independence: the unsorted input and its explicit sorted form
+	// hash equal, so the ONLY way to detect an in-place sort is the slice
+	// contents above.
+	sorted := []string{"alpha", "mid", "zebra"}
+	if rbac.CanonicalGroupsHashForTest(in) != rbac.CanonicalGroupsHashForTest(sorted) {
+		t.Fatalf("M9 PURITY sanity: unsorted input and its sorted twin must hash equal")
+	}
+}

--- a/internal/rbac/evaltest/snapshot_authz_memo_test.go
+++ b/internal/rbac/evaltest/snapshot_authz_memo_test.go
@@ -453,6 +453,202 @@ func TestL2_B3_GroupsHashCollisionAndOrder(t *testing.T) {
 	}
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// H3 [SEC] — role-RULE republish invalidation (same binding/role NAME,
+// rules changed). The memo MUST NOT serve a stale allow when a
+// ClusterRole's RULES are narrowed to no longer grant the resource, and
+// MUST re-allow when the rules are widened again. This is the role-rule
+// edit dimension of the memory note
+// feedback_hermetic_keyrotation_is_not_endtoend_fix — a memo keyed only
+// on the BINDING set (ignoring that the bound Role's rules changed) would
+// serve a stale allow across a rule Update that failed to bump PublishSeq
+// OR whose bump the memo ignored.
+// ──────────────────────────────────────────────────────────────────────
+
+// TestL2_H3_RoleRuleRepublish_NarrowWiden seeds G1 where alice is allowed
+// `get configmaps` via a ClusterRole "cm-getter" whose rule grants exactly
+// that. The verdict is cached (repeat = hit). G2 republishes (PublishSeq+1)
+// the SAME binding NAME and SAME ClusterRole NAME "cm-getter" but with its
+// rule NARROWED to grant `get secrets` only — no longer configmaps. The
+// next `get configmaps` call MUST DENY (shard swapped on the generation
+// change, re-walk sees the narrowed rule) and the swap counter MUST move.
+// G3 WIDENS the rule back to grant configmaps and MUST re-allow.
+//
+// RED arm: a memo that keys on the binding set alone (or otherwise fails
+// to invalidate when only the bound Role's rules change) serves the cached
+// G1 allow at G2 — a stale allow, the forbidden SEC defect.
+func TestL2_H3_RoleRuleRepublish_NarrowWiden(t *testing.T) {
+	rbac.ResetAuthzMemoForTest()
+
+	// The binding is STABLE across all three generations — only the bound
+	// ClusterRole's RULES change. Same NAME + UID throughout.
+	crb := clusterRoleBindingWithUID("alice-cm-bind", "cm-getter", "cm-crb-uid",
+		userSubject("alice"),
+	)
+
+	// G1 — cm-getter grants `get configmaps`.
+	newTestWatcher(t,
+		clusterRole("cm-getter", rule([]string{""}, []string{"configmaps"}, []string{"get"})),
+		crb,
+	)
+
+	opts := rbac.EvaluateOptions{
+		Username: "alice", Verb: "get", Group: "", Resource: "configmaps", Namespace: "default",
+		SkipBindingUID: true,
+	}
+
+	// G1 allow + cache it (repeat = hit).
+	if a, _, err := rbac.EvaluateRBAC(context.Background(), opts); err != nil || !a {
+		t.Fatalf("H3 G1: expected allowed=true err=nil; got allowed=%v err=%v", a, err)
+	}
+	if a, _, _ := rbac.EvaluateRBAC(context.Background(), opts); !a {
+		t.Fatalf("H3 G1 repeat: expected cached allowed=true")
+	}
+	hits1, _, _, _, _ := rbac.AuthzMemoStatsForTest()
+	if hits1 == 0 {
+		t.Fatalf("H3 G1: expected a memo hit on the repeated allow tuple; got 0")
+	}
+
+	// G2 — republish the SAME binding + SAME ClusterRole NAME but with the
+	// rule NARROWED to `get secrets` (no longer configmaps). PublishSeq+1.
+	swapsBefore := func() uint64 { _, _, s, _, _ := rbac.AuthzMemoStatsForTest(); return s }()
+	narrowSnap := &cache.RBACSnapshot{
+		ClusterRolesByName: map[string]*rbacv1.ClusterRole{
+			"cm-getter": clusterRole("cm-getter", rule([]string{""}, []string{"secrets"}, []string{"get"})),
+		},
+		ClusterRoleBindings: []*rbacv1.ClusterRoleBinding{crb},
+	}
+	cache.RebuildSubjectIndexesForTest(narrowSnap)
+	narrowSnap.PublishSeq = currentPublishSeq(t) + 1
+	cache.PublishRBACSnapshotForTest(narrowSnap)
+
+	a2, _, err := rbac.EvaluateRBAC(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("H3 G2: err=%v", err)
+	}
+	if a2 {
+		t.Fatalf("H3 INVARIANT BROKEN (SEC): stale allow served across a role-RULE narrow — cm-getter no longer grants `get configmaps` at G2 (binding NAME unchanged), MUST deny. A memo keyed only on the binding set would return the cached G1 allow.")
+	}
+	swapsAfter := func() uint64 { _, _, s, _, _ := rbac.AuthzMemoStatsForTest(); return s }()
+	if swapsAfter <= swapsBefore {
+		t.Fatalf("H3 G2: expected the shard to swap on the generation change; swaps %d -> %d", swapsBefore, swapsAfter)
+	}
+
+	// G3 — WIDEN the rule back to grant configmaps. Same binding + role
+	// NAME. PublishSeq+1. MUST re-allow (bidirectional).
+	widenSnap := &cache.RBACSnapshot{
+		ClusterRolesByName: map[string]*rbacv1.ClusterRole{
+			"cm-getter": clusterRole("cm-getter", rule([]string{""}, []string{"configmaps"}, []string{"get"})),
+		},
+		ClusterRoleBindings: []*rbacv1.ClusterRoleBinding{crb},
+	}
+	cache.RebuildSubjectIndexesForTest(widenSnap)
+	widenSnap.PublishSeq = currentPublishSeq(t) + 1
+	cache.PublishRBACSnapshotForTest(widenSnap)
+
+	a3, _, err := rbac.EvaluateRBAC(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("H3 G3: err=%v", err)
+	}
+	if !a3 {
+		t.Fatalf("H3 bidirectional: G3 re-widened cm-getter to grant `get configmaps`; MUST allow again; got allowed=false")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// M8 — capacity: on cap breach the memo REFUSES to insert (never evicts),
+// and a refused tuple still returns the correct walk-fallback verdict.
+// ──────────────────────────────────────────────────────────────────────
+
+// TestL2_M8_CapRefusesNeverEvicts drives >16384 DISTINCT permit tuples in
+// ONE generation against a wildcard-admin CRB (every tuple permits). The
+// tuples vary only in the Name dimension so each produces a distinct memo
+// key. Once the shard fills to the empirical cap (snapshotAuthzMemoCap =
+// 16384) further inserts MUST be REFUSED (authzMemoRefused > 0), the entry
+// count MUST settle at EXACTLY the cap (never above — no unbounded growth;
+// never evicted below — refuse, don't LRU-evict), and a tuple whose insert
+// was refused MUST still return the correct allow (the caller always gets
+// the freshly-walked verdict; only the cache insert is skipped).
+//
+// RED arms this discriminates:
+//   - unbounded growth: entries would exceed the cap.
+//   - LRU-evict instead of refuse: authzMemoRefused would stay 0.
+//   - wrong verdict on a refused key: the refused tuple would deny.
+func TestL2_M8_CapRefusesNeverEvicts(t *testing.T) {
+	rbac.ResetAuthzMemoForTest()
+
+	// Wildcard admin — alice may do anything, so every tuple permits and
+	// therefore every tuple is a cache CANDIDATE (only permits are stored,
+	// see #301). Keeping every tuple a permit is what lets us fill the map.
+	newTestWatcher(t,
+		clusterRole("admin", rule([]string{"*"}, []string{"*"}, []string{"*"})),
+		clusterRoleBindingWithUID("alice-bind", "admin", "uid-alice", userSubject("alice")),
+	)
+
+	const cap = 16384 // snapshotAuthzMemoCap (snapshot_authz_memo.go)
+	const overfill = cap + 500
+
+	base := rbac.EvaluateOptions{
+		Username: "alice", Verb: "get", Group: "", Resource: "secrets", Namespace: "default",
+		SkipBindingUID: true,
+	}
+
+	// Fill past the cap with DISTINCT Name values -> distinct keys.
+	// Every call MUST permit (wildcard admin); the memo silently refuses
+	// once full.
+	for i := 0; i < overfill; i++ {
+		o := base
+		o.Name = fmt.Sprintf("obj-%06d", i)
+		a, _, err := rbac.EvaluateRBAC(context.Background(), o)
+		if err != nil {
+			t.Fatalf("M8 fill i=%d: err=%v", i, err)
+		}
+		if !a {
+			t.Fatalf("M8 fill i=%d: wildcard admin must permit every tuple; got deny for Name=%q", i, o.Name)
+		}
+	}
+
+	_, _, _, refused, entries := rbac.AuthzMemoStatsForTest()
+
+	// Cap breach must have REFUSED inserts (not evicted to make room).
+	if refused == 0 {
+		t.Fatalf("M8 CAP BROKEN: filled %d distinct permit tuples (cap=%d) but authzMemoRefused==0 — the memo EVICTED instead of refusing (or the cap is not enforced)", overfill, cap)
+	}
+	// Entries must settle EXACTLY at the cap: never above (unbounded), and
+	// never below (refuse, don't evict).
+	if entries != cap {
+		t.Fatalf("M8 CAP BROKEN: entries=%d, want exactly cap=%d (>cap = unbounded growth; <cap = eviction). refused=%d", entries, cap, refused)
+	}
+	// The number of refused inserts must equal the overflow beyond the cap
+	// (each distinct tuple is a new key; the first `cap` fill the map, the
+	// rest are refused). This pins "refuse, don't evict" precisely.
+	if want := uint64(overfill - cap); refused != want {
+		t.Fatalf("M8 CAP: refused=%d, want exactly overflow=%d (overfill %d - cap %d) — off means evict-then-reinsert churn", refused, want, overfill, cap)
+	}
+
+	// A tuple whose insert was refused (one of the LAST `overfill-cap`
+	// filled) MUST still return the correct walk-fallback verdict on a
+	// re-ask. Re-ask the very last one — its key is not in the map, so
+	// this re-walks; the verdict MUST be allow.
+	refusedOpts := base
+	refusedOpts.Name = fmt.Sprintf("obj-%06d", overfill-1)
+	a, _, err := rbac.EvaluateRBAC(context.Background(), refusedOpts)
+	if err != nil {
+		t.Fatalf("M8 refused re-ask: err=%v", err)
+	}
+	if !a {
+		t.Fatalf("M8 CAP BROKEN: a refused-insert tuple returned deny on re-ask — the walk-fallback verdict is wrong (the caller must always get the freshly-walked allow; only the cache insert is skipped)")
+	}
+
+	// Entries must STILL be exactly the cap after the refused re-ask (the
+	// re-ask of a refused key must not grow the map beyond cap, and the
+	// idempotent-overwrite exemption applies only to keys ALREADY present).
+	_, _, _, _, entriesAfter := rbac.AuthzMemoStatsForTest()
+	if entriesAfter != cap {
+		t.Fatalf("M8 CAP: entries grew to %d after re-asking a refused key (want steady at cap=%d)", entriesAfter, cap)
+	}
+}
+
 // currentPublishSeq reads the live snapshot's PublishSeq via the cache
 // test seam. Helper for the F3 synthetic-republish phases.
 func currentPublishSeq(t *testing.T) uint64 {

--- a/internal/rbac/export_test_hooks.go
+++ b/internal/rbac/export_test_hooks.go
@@ -1,5 +1,12 @@
 package rbac
 
+import (
+	"context"
+
+	"github.com/krateoplatformops/plumbing/endpoints"
+	"k8s.io/client-go/kubernetes"
+)
+
 // export_for_test.go — Ship 1.1 S1 drift-guard hooks.
 //
 // Exposes the SA-username parser + the synthetic-SA-group expansion to the
@@ -24,4 +31,29 @@ func ParseServiceAccountUsernameForTest(u string) (string, string, bool) {
 // original reads (only Groups is consulted by effectiveGroups).
 func EffectiveGroupsForTest(groups []string, isSA bool, saNS string) []string {
 	return effectiveGroups(EvaluateOptions{Groups: groups}, isSA, saNS)
+}
+
+// CanonicalGroupsHashForTest exposes canonicalGroupsHash (groups_hash.go)
+// to the cross-package M9 collision/order/purity falsifier in evaltest.
+// The hasher is the single source of truth for the memo key's GroupsHash
+// dimension; the falsifier asserts its contract directly (length-prefix
+// framing defeats the ["a","bc"]/["ab","c"] alias; order independence;
+// nil==empty!=[""]; caller slice unmutated) WITHOUT routing through
+// EvaluateRBAC's observable behaviour, so a regression in the hasher is
+// caught at the unit boundary. Thin pass-through; zero production surface.
+func CanonicalGroupsHashForTest(groups []string) uint64 {
+	return canonicalGroupsHash(groups)
+}
+
+// SetSARClientsetForTest overrides the SAR-baseline clientset factory
+// (rbac.go's sarClientsetForEndpoint) so the hermetic cache=off L5 test
+// can inject a fake authorization clientset instead of building a real
+// one from the user endpoint. Returns a restore func; production code
+// MUST NOT call it. The factory receives the endpoint the SAR path
+// resolved from ctx and returns the kubernetes.Interface whose
+// AuthorizationV1().SelfSubjectAccessReviews() the SAR path calls.
+func SetSARClientsetForTest(f func(ctx context.Context, ep endpoints.Endpoint) (kubernetes.Interface, error)) (restore func()) {
+	prev := sarClientsetForEndpoint
+	sarClientsetForEndpoint = f
+	return func() { sarClientsetForEndpoint = prev }
 }

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
 	"github.com/krateoplatformops/plumbing/kubeconfig"
 	"github.com/krateoplatformops/snowplow/internal/cache"
 	authv1 "k8s.io/api/authorization/v1"
@@ -59,6 +60,21 @@ func UserCan(ctx context.Context, opts UserCanOptions) (ok bool) {
 	return userCanViaSAR(ctx, opts)
 }
 
+// sarClientsetForEndpoint builds the per-user kubernetes clientset the
+// SAR baseline issues its SelfSubjectAccessReview against. It is a
+// package var (not an inline call) SOLELY so the hermetic evaltest can
+// inject a fake authorization clientset — production NEVER reassigns it,
+// so the default body is byte-for-byte the pre-seam path (build a
+// rest.Config from the user endpoint, then a real clientset). Adds zero
+// production surface: the indirection is a single func-var deref.
+var sarClientsetForEndpoint = func(ctx context.Context, ep endpoints.Endpoint) (kubernetes.Interface, error) {
+	rc, err := kubeconfig.NewClientConfig(ctx, ep)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(rc)
+}
+
 // userCanViaSAR is the upstream cache=off correctness baseline. It
 // MUST be reachable only when cache.Disabled() == true — any cache=on
 // call here is a Revision 1 binding violation (rollback trigger).
@@ -71,15 +87,9 @@ func userCanViaSAR(ctx context.Context, opts UserCanOptions) (ok bool) {
 		return false
 	}
 
-	rc, err := kubeconfig.NewClientConfig(ctx, ep)
+	clientset, err := sarClientsetForEndpoint(ctx, ep)
 	if err != nil {
-		log.Error("unable to create user client config", slog.Any("err", err))
-		return false
-	}
-
-	clientset, err := kubernetes.NewForConfig(rc)
-	if err != nil {
-		log.Error("unable to create kubernetes clientset", slog.Any("err", err))
+		log.Error("unable to create kubernetes clientset for SAR", slog.Any("err", err))
 		return false
 	}
 

--- a/internal/resolvers/restactions/api/refilter_concurrency_test.go
+++ b/internal/resolvers/restactions/api/refilter_concurrency_test.go
@@ -1,0 +1,408 @@
+// refilter_concurrency_test.go — L13 hermetic falsifiers for the
+// restactions/api UAF refilter dispatch path.
+//
+//	(a) -race over concurrent iterator workers running the REAL per-worker
+//	    refilter (applyUserAccessFilterOnPig / refilterSlice). Each iterator
+//	    stage worker (resolve.go g.Go) shares ONE read-only *UserAccessFilterSpec
+//	    (mapping) + the process-global RBAC snapshot; the hoisted nsCode/nameCode
+//	    are per-CALL compiled *gojq.Code (immutable, safe to run concurrently).
+//	    The K>1 × M>1 harness runs the real path under -race → GREEN (no race).
+//	    RED: a SHARED-MUTABLE nsCode (a package-var mutated per item across
+//	    workers) races — demonstrated by racingRefilterSlice, which the SAME
+//	    harness flags under -race (proving the harness discriminates a racing
+//	    shared-nsCode impl from the real per-call-compile one). See
+//	    feedback_falsifier_shape_must_discriminate (K>1×M>1 + a RED arm).
+//
+//	(b) SA-endpoint ACQUIRE FAILURE → empty items, fail-closed-but-respond:
+//	    resolveStageEndpoint's UAF branch, when dynamic.ServiceAccountEndpoint
+//	    (via the serviceAccountEndpointFn seam) errors, MUST write
+//	    dict[id]={items:[]} + return stageContinue (the C-2 posture) and NEVER
+//	    fall through to the per-user (user-bearer) dispatch. RED: neuter the
+//	    saErr branch so it returns stageProceed with a zero endpoint → the stage
+//	    proceeds with no SA endpoint (the user-bearer leak class).
+//
+//	(c) evalJQString / NamespaceFrom MULTI-YIELD → fails closed: a NamespaceFrom
+//	    that yields >1 value surfaces ErrMultiYield → evalSingle denies the item
+//	    (never a silent concatenated-garbage namespace flowing into EvaluateRBAC).
+//	    RED: map ErrMultiYield to a permit (or to ns="") → the item is kept.
+
+package api
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/itchyny/gojq"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	templates "github.com/krateoplatformops/snowplow/apis/templates/v1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// L13(a) — -race over concurrent iterator workers running the refilter stage.
+// ─────────────────────────────────────────────────────────────────────────
+
+// seedCompReaderRBAC grants the "devs" group `list compositions` in each of
+// the given namespaces (a Role+RoleBinding per ns), the realistic narrow-RBAC
+// shape a per-namespace iterator fan-out refilters against.
+func seedCompReaderRBAC(namespaces ...string) []runtime.Object {
+	var out []runtime.Object
+	for _, ns := range namespaces {
+		out = append(out,
+			&rbacv1.Role{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+				ObjectMeta: metav1.ObjectMeta{Name: "comp-reader", Namespace: ns},
+				Rules: []rbacv1.PolicyRule{
+					{Verbs: []string{"list"}, APIGroups: []string{"composition.krateo.io"}, Resources: []string{"compositions"}},
+				},
+			},
+			&rbacv1.RoleBinding{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+				ObjectMeta: metav1.ObjectMeta{Name: "comp-reader-binding", Namespace: ns},
+				Subjects:   []rbacv1.Subject{{Kind: "Group", APIGroup: "rbac.authorization.k8s.io", Name: "devs"}},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "comp-reader"},
+			},
+		)
+	}
+	return out
+}
+
+// nsItems builds M composition objects, half in a GRANTED namespace and half
+// in a DENIED one, so a worker's expected (kept, dropped) split is non-trivial
+// (proves the concurrent workers each compute the RIGHT answer, not just "no
+// crash"). granted are the namespaces the user can list; denied are refused.
+func nsItems(m int, granted, denied string) []any {
+	items := make([]any, 0, m)
+	for i := 0; i < m; i++ {
+		ns := granted
+		if i%2 == 1 {
+			ns = denied
+		}
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": padName3(i), "namespace": ns},
+		})
+	}
+	return items
+}
+func padName3(i int) string {
+	return "c-" + string(rune('0'+(i/100)%10)) + string(rune('0'+(i/10)%10)) + string(rune('0'+i%10))
+}
+
+// TestRefilter_ConcurrentIteratorWorkers_Race is L13(a) GREEN. K>1 concurrent
+// goroutines model the iterator errgroup workers; each runs the REAL
+// applyUserAccessFilterOnPig over its OWN pig (a distinct per-worker map, index
+// -aligned like resolve.go's dispatchOneCall bundle) with M>1 items, all sharing
+// ONE read-only *UserAccessFilterSpec + the process-global RBAC snapshot. Under
+// -race this must be clean; each worker must independently narrow to the granted
+// half. (Run with -race to arm the concurrency tooth; the correctness assertions
+// run in both modes.)
+func TestRefilter_ConcurrentIteratorWorkers_Race(t *testing.T) {
+	const (
+		K       = 8  // workers > 1 (feedback_falsifier_shape_must_discriminate)
+		M       = 24 // items per worker > 1
+		granted = "bench-ns-01"
+		denied  = "bench-ns-02"
+	)
+	newRefilterTestWatcher(t, seedCompReaderRBAC(granted)...)
+
+	// ONE shared, read-only mapping (mirrors the single *templates.API the stage
+	// loop hands every iterator worker).
+	sharedUAF := &templates.UserAccessFilterSpec{
+		Verb:          "list",
+		Group:         "composition.krateo.io",
+		Resource:      "compositions",
+		NamespaceFrom: ".metadata.namespace",
+	}
+	ctx := ctxWithUser("cyberjoker", "devs")
+
+	var wg sync.WaitGroup
+	errs := make([]error, K)
+	kept := make([]int, K) // disjoint slot per worker (no lock needed)
+	for k := 0; k < K; k++ {
+		k := k
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each worker owns its pig — the shared state is sharedUAF (read-only)
+			// + the RBAC global. This is exactly the resolve.go per-worker shape.
+			pig := map[string]any{
+				"compositions": map[string]any{"items": nsItems(M, granted, denied)},
+			}
+			res := applyUserAccessFilterOnPig(ctx, pig, nil, "compositions", sharedUAF)
+			kept[k] = res.Kept
+			if res.Kept != M/2 || res.Dropped != M/2 {
+				errs[k] = &countMismatch{worker: k, kept: res.Kept, dropped: res.Dropped, want: M / 2}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for k := 0; k < K; k++ {
+		if errs[k] != nil {
+			t.Fatalf("worker %d: %v", k, errs[k])
+		}
+		if kept[k] != M/2 {
+			t.Fatalf("worker %d: kept=%d want %d (granted half only)", k, kept[k], M/2)
+		}
+	}
+}
+
+type countMismatch struct {
+	worker, kept, dropped, want int
+}
+
+func (e *countMismatch) Error() string {
+	return "refilter miscount: kept=" + itoaSmall(e.kept) + " dropped=" + itoaSmall(e.dropped) + " want kept/dropped=" + itoaSmall(e.want)
+}
+func itoaSmall(i int) string {
+	if i < 10 {
+		return string(rune('0' + i))
+	}
+	return string(rune('0'+i/10)) + string(rune('0'+i%10))
+}
+
+// racingSharedNsCode is the DELIBERATELY-BROKEN shared-mutable *gojq.Code slot
+// the RED arm uses. The real refilterSlice hoists a per-CALL nsCode local; a
+// (hypothetical) "optimisation" that cached one *gojq.Code in a package var and
+// REASSIGNED it per item across workers would create a data race on THIS write.
+var racingSharedNsCode *gojq.Code
+
+// racingRefilterSlice mimics refilterSlice but WRITES the shared package var
+// racingSharedNsCode on every item — the exact wrong-shape L13(a) guards
+// against. It exists ONLY so TestRefilter_SharedNsCode_RED_Races proves the
+// K×M harness (and -race) actually catch a shared-mutable-nsCode impl; the REAL
+// path (TestRefilter_ConcurrentIteratorWorkers_Race) never touches it.
+func racingRefilterSlice(ctx context.Context, uaf *templates.UserAccessFilterSpec, items []any) int {
+	kept := 0
+	for range items {
+		// The racing write: a shared *gojq.Code reassigned per item, concurrently
+		// across workers → the -race arm flags it. (Value intentionally recomputed
+		// so the compiler cannot elide the store.)
+		code, _ := gojq.Parse(uaf.NamespaceFrom)
+		racingSharedNsCode, _ = gojq.Compile(code)
+		_ = ctx
+		kept++
+	}
+	return kept
+}
+
+// TestRefilter_SharedNsCode_RED_Races is the L13(a) RED-arm PROOF: under -race
+// the SHARED-MUTABLE nsCode impl (racingRefilterSlice) races, so the same K×M
+// harness that passes clean for the real path FAILS the race detector here.
+// This is a MANUAL RED (skipped in normal runs) — running it under -race shows
+// the harness + -race discriminate the wrong shared-nsCode shape. Un-skip +
+// `go test -race -run TestRefilter_SharedNsCode_RED_Races` to observe the RED.
+func TestRefilter_SharedNsCode_RED_Races(t *testing.T) {
+	t.Skip("RED-arm proof (manual): un-skip and run under -race to observe the shared-mutable nsCode data race the L13(a) harness+detector catch")
+
+	const (
+		K = 8
+		M = 24
+	)
+	uaf := &templates.UserAccessFilterSpec{NamespaceFrom: ".metadata.namespace"}
+	items := nsItems(M, "a", "b")
+	var wg sync.WaitGroup
+	for k := 0; k < K; k++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			racingRefilterSlice(context.Background(), uaf, items)
+		}()
+	}
+	wg.Wait()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// L13(b) — SA-endpoint acquire failure → empty items, fail-closed-but-respond.
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestResolveStageEndpoint_UAF_SAAcquireFailure_FailClosedButResponds is L13(b).
+// When the SA-endpoint acquire (serviceAccountEndpointFn) errors, the UAF branch
+// of resolveStageEndpoint MUST: (1) write dict[id]={items:[]} (respond, empty),
+// (2) return stageContinue (the loop continues — downstream stages still run),
+// (3) return a ZERO endpoint (never a user-bearer endpoint). The fail-closed-
+// but-respond posture (Revision 5): there is NO fallback to the per-user path,
+// because that would leak the user's bearer token to a SA-marked stage.
+//
+// RED: neuter the saErr branch to return (zeroEP, stageProceed) instead of
+// writing the empty result + stageContinue → the stage proceeds WITHOUT a SA
+// endpoint (the user-bearer / no-endpoint leak class this branch prevents).
+func TestResolveStageEndpoint_UAF_SAAcquireFailure_FailClosedButResponds(t *testing.T) {
+	// Seam-inject a FAILING SA-endpoint acquire (hermetic — does not depend on
+	// the ambient /var/run/secrets files). Restore on cleanup.
+	orig := serviceAccountEndpointFn
+	t.Cleanup(func() { serviceAccountEndpointFn = orig })
+	var acquireCalls atomic.Int64
+	serviceAccountEndpointFn = func() (*endpoints.Endpoint, error) {
+		acquireCalls.Add(1)
+		return nil, context.DeadlineExceeded // any non-nil error
+	}
+
+	r := &resolveRun{
+		log:  scalarFalsifierLogger(),
+		dict: map[string]any{},
+	}
+	apiCall := &templates.API{
+		Name: "compositions",
+		UserAccessFilter: &templates.UserAccessFilterSpec{
+			Verb: "list", Group: "composition.krateo.io", Resource: "compositions",
+		},
+	}
+
+	ep, action := r.resolveStageEndpoint("compositions", apiCall, true /*uafActive*/)
+
+	if acquireCalls.Load() != 1 {
+		t.Fatalf("SA-endpoint acquire must be attempted exactly once via the seam, got %d", acquireCalls.Load())
+	}
+	// (2) stageContinue — the stage produces its empty result and the loop
+	// continues; it must NOT be stageProceed (proceed would dispatch with a
+	// zero/absent endpoint) nor stageReturn (that would truncate the resolve).
+	if action != stageContinue {
+		t.Fatalf("L13(b) RED: SA-acquire failure must return stageContinue (fail-closed-but-respond); got %v", action)
+	}
+	// (3) ZERO endpoint — NEVER a user-bearer endpoint. No token, no server URL.
+	if ep != (endpoints.Endpoint{}) {
+		t.Fatalf("L13(b) RED: SA-acquire failure must return a ZERO endpoint (never a user-bearer fallback); got %+v", ep)
+	}
+	// (1) dict[id] is the canonical empty result — respond, but empty (no leak).
+	raw, ok := r.dict["compositions"]
+	if !ok {
+		t.Fatalf("L13(b) RED: SA-acquire failure must WRITE an empty result at dict[id] (fail-closed-but-RESPOND); dict[id] absent")
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("L13(b): dict[id] must be a map with an empty items slice; got %T", raw)
+	}
+	itemsRaw, hasItems := m["items"]
+	if !hasItems {
+		t.Fatalf("L13(b): dict[id] must carry an empty items slice; got %v", m)
+	}
+	items, ok := itemsRaw.([]any)
+	if !ok || len(items) != 0 {
+		t.Fatalf("L13(b) RED: dict[id].items must be EMPTY on SA-acquire failure (no SA-dispatched or user-dispatched rows leak); got %v", itemsRaw)
+	}
+}
+
+// TestResolveStageEndpoint_UAF_SAAcquireSuccess_Proceeds is the discriminating
+// control: with a SUCCESSFUL SA-endpoint acquire the same branch returns the SA
+// endpoint + stageProceed (proving the fail-closed path keys on the ACQUIRE
+// ERROR, not on uafActive per se).
+func TestResolveStageEndpoint_UAF_SAAcquireSuccess_Proceeds(t *testing.T) {
+	orig := serviceAccountEndpointFn
+	t.Cleanup(func() { serviceAccountEndpointFn = orig })
+	saEP := &endpoints.Endpoint{ServerURL: "https://kubernetes.default.svc", Token: "sa-token"}
+	serviceAccountEndpointFn = func() (*endpoints.Endpoint, error) { return saEP, nil }
+
+	r := &resolveRun{log: scalarFalsifierLogger(), dict: map[string]any{}}
+	apiCall := &templates.API{
+		Name:             "compositions",
+		UserAccessFilter: &templates.UserAccessFilterSpec{Verb: "list", Group: "composition.krateo.io", Resource: "compositions"},
+	}
+
+	ep, action := r.resolveStageEndpoint("compositions", apiCall, true)
+	if action != stageProceed {
+		t.Fatalf("control: a successful SA acquire must return stageProceed; got %v", action)
+	}
+	if ep.ServerURL != saEP.ServerURL || ep.Token != saEP.Token {
+		t.Fatalf("control: a successful SA acquire must return the SA endpoint; got %+v", ep)
+	}
+	if _, wrote := r.dict["compositions"]; wrote {
+		t.Fatalf("control: the SUCCESS path must NOT write the empty-result placeholder")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// L13(c) — evalJQString / NamespaceFrom multi-yield → fails closed.
+// ─────────────────────────────────────────────────────────────────────────
+
+// TestEvalJQString_MultiYield_FailsClosed proves the evalJQString path itself
+// surfaces ErrMultiYield (the DELIBERATE §3.4.5 change) — a NamespaceFrom that
+// yields >1 value returns ("", ErrMultiYield), never a silent concatenated
+// invalid-JSON namespace string. This is the low-level tooth L13(c) rests on.
+func TestEvalJQString_MultiYield_FailsClosed(t *testing.T) {
+	// `.[]` over a 2-element array yields TWO values → multi-yield.
+	s, err := evalJQString(context.Background(), ".[]", []any{"ns-a", "ns-b"})
+	if err == nil {
+		t.Fatalf("L13(c) RED: a multi-yield NamespaceFrom must return an error (ErrMultiYield), got string=%q err=nil (silent garbage would flow into EvaluateRBAC)", s)
+	}
+	if s != "" {
+		t.Fatalf("L13(c): a multi-yield must return the empty string alongside the error; got %q", s)
+	}
+	// Discriminating control: a SINGLE-yield expression returns the value + nil err.
+	one, err := evalJQString(context.Background(), ".metadata.namespace",
+		map[string]any{"metadata": map[string]any{"namespace": "ns-a"}})
+	if err != nil || one != "ns-a" {
+		t.Fatalf("control: a single-yield NamespaceFrom must succeed; got %q err=%v", one, err)
+	}
+}
+
+// TestEvalSingle_MultiYieldNamespaceFrom_DeniesItem is L13(c): a NamespaceFrom
+// that MULTI-YIELDS on the item makes evalSingle fail closed (deny), so a
+// permitted-looking object is DROPPED rather than admitted under a garbage
+// namespace. Driven through the REAL compileNamespaceFrom + evalSingle so the
+// ErrMultiYield → deny contract is exercised end-to-end.
+//
+// RED: change jqValueToString to map ErrMultiYield to ("", nil) (or evalSingle
+// to permit on a NamespaceFrom error) → the item is KEPT under an empty/garbage
+// namespace — the leak this test forbids.
+func TestEvalSingle_MultiYieldNamespaceFrom_DeniesItem(t *testing.T) {
+	// admin has cluster-admin: EvaluateRBAC would PERMIT for any resolvable
+	// namespace, so a KEPT result can ONLY come from the multi-yield NOT failing
+	// closed. This isolates the fail-closed tooth from the RBAC decision.
+	newRefilterTestWatcher(t, adminClusterAdmin()...)
+
+	// A NamespaceFrom that yields TWO values for the item → ErrMultiYield.
+	multiYieldUAF := &templates.UserAccessFilterSpec{
+		Verb:          "get",
+		Group:         "composition.krateo.io",
+		Resource:      "compositions",
+		NamespaceFrom: ".metadata | .name, .namespace", // 2 yields → multi-yield
+	}
+	item := map[string]any{"metadata": map[string]any{"name": "c1", "namespace": "ns-a"}}
+
+	nsExpr, nsCode := compileNamespaceFrom(multiYieldUAF)
+	nameExpr, nameCode := compileNameFrom(multiYieldUAF)
+	permitted := evalSingle(ctxWithUser("admin"), scalarFalsifierLogger(),
+		"admin", nil, multiYieldUAF, []string{"compositions"},
+		item, nsExpr, nsCode, nameExpr, nameCode)
+	if permitted {
+		t.Fatalf("L13(c) RED: a multi-yield NamespaceFrom must DENY the item (fail-closed); evalSingle PERMITTED it — a garbage/empty namespace reached EvaluateRBAC and matched admin's cluster-wide grant (leak)")
+	}
+
+	// Discriminating control: the SAME admin + item with a SINGLE-yield
+	// NamespaceFrom IS permitted (proves the deny came from the multi-yield, not
+	// from a missing grant).
+	okUAF := &templates.UserAccessFilterSpec{
+		Verb: "get", Group: "composition.krateo.io", Resource: "compositions",
+		NamespaceFrom: ".metadata.namespace",
+	}
+	okNsExpr, okNsCode := compileNamespaceFrom(okUAF)
+	okNameExpr, okNameCode := compileNameFrom(okUAF)
+	if !evalSingle(ctxWithUser("admin"), scalarFalsifierLogger(), "admin", nil, okUAF,
+		[]string{"compositions"}, item, okNsExpr, okNsCode, okNameExpr, okNameCode) {
+		t.Fatalf("control: a single-yield NamespaceFrom on the same admin/item must be PERMITTED (proves the multi-yield deny is the discriminator)")
+	}
+}
+
+// adminClusterAdmin builds a cluster-admin ClusterRole + a CRB binding it to
+// user "admin" — so EvaluateRBAC permits admin on any (verb,group,resource,ns).
+func adminClusterAdmin() []runtime.Object {
+	return []runtime.Object{
+		&rbacv1.ClusterRole{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+			Rules:      []rbacv1.PolicyRule{{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}}},
+		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"},
+			ObjectMeta: metav1.ObjectMeta{Name: "admin-binding"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: "admin"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "cluster-admin"},
+		},
+	}
+}

--- a/internal/resolvers/restactions/api/resolve.go
+++ b/internal/resolvers/restactions/api/resolve.go
@@ -373,7 +373,7 @@ const (
 //   - success → return (ep, stageProceed).
 func (r *resolveRun) resolveStageEndpoint(id string, apiCall *templates.API, uafActive bool) (endpoints.Endpoint, stageAction) {
 	if uafActive {
-		saEP, saErr := dynamic.ServiceAccountEndpoint()
+		saEP, saErr := serviceAccountEndpointFn()
 		if saErr != nil {
 			r.log.Error("userAccessFilter: cannot acquire ServiceAccount endpoint; falling through to per-user dispatch (degraded mode)",
 				slog.String("name", id), slog.Any("err", saErr))
@@ -1673,6 +1673,18 @@ func Resolve(ctx context.Context, opts ResolveOptions) map[string]any {
 // without standing up a real discovery client. Production path is
 // unchanged. Mirrors cache.discoveryClientBuilder (discovery_lookup.go:151).
 var discoverGroupResourcesFn = cache.DiscoverGroupResources
+
+// serviceAccountEndpointFn is the package-private indirection over
+// dynamic.ServiceAccountEndpoint so the L13(b) fail-closed falsifier
+// (refilter_concurrency_test.go) can drive the UAF SA-endpoint ACQUIRE-FAILURE
+// branch of resolveStageEndpoint deterministically — without depending on the
+// ambient /var/run/secrets SA files being absent (a fragile, non-hermetic
+// trigger). Production path is UNCHANGED: the default is the real
+// dynamic.ServiceAccountEndpoint and production never reassigns it. Mirrors
+// discoverGroupResourcesFn (above) and cache.discoveryClientBuilder
+// (discovery_lookup.go:151) — the established resolveOnceFn/nestedCallResolver
+// var-seam idiom.
+var serviceAccountEndpointFn = dynamic.ServiceAccountEndpoint
 
 // lazyRegisterInnerCallPaths walks the per-stage RequestOptions slice
 // (one entry per iterator dispatch — the iterator + non-iterator paths

--- a/internal/resolvers/widgets/apiref/ra_full_list_external_miss_test.go
+++ b/internal/resolvers/widgets/apiref/ra_full_list_external_miss_test.go
@@ -1,0 +1,152 @@
+// ra_full_list_external_miss_test.go — M6 [SEC stale-forever] falsifier for
+// the RAFullList known-sliceable CELL-MISS re-resolve path (ra_full_list.go
+// lines ~316-342), the external-no-cache surface #4 on the repopulate branch.
+//
+// THE GAP the existing ra_full_list_test.go leaves open: the first-sight
+// external-touched surface (lines ~359-370) IS covered by
+// TestRAServe_NonSliceableFallsBack's sibling assertions, but the SECOND
+// external surface — the one on the KNOWN-SLICEABLE cell-MISS repopulate path
+// — is not. That path resolves the full list UNPAGINATED to repopulate an
+// evicted cell; if that unpaginated re-resolve touches a genuine external
+// endpoint, the code MUST serve the (correct, fresh) Go-slice but DECLINE the
+// re-Put + the dep Record + record RAFullListServeFallback + BumpExternalSkippedPut
+// (external data has no informer edge → caching it serves it stale forever).
+//
+// RED arm (howVerified): neuter the `extSink.Count() > 0` check on the
+// repopulate branch → the external aggregate is Put into L1 (a dep edge is
+// recorded, no BumpExternalSkippedPut) and a subsequent page HIT serves the
+// stale cached slice. Proven by transiently editing ra_full_list.go to make
+// the repopulate-branch external check always-false, observing this test RED
+// (cell Put + dep edge present + ExternalSkippedPut delta 0), then restoring.
+
+package apiref
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/krateoplatformops/snowplow/internal/cache"
+)
+
+// TestRAServe_KnownSliceableCellMiss_ExternalTouched_DeclinesPut is the M6
+// falsifier. It drives the KNOWN-SLICEABLE + cell-MISS repopulate branch with
+// an unpaginated re-resolve that bumps the ExternalTouchedSink, and asserts
+// the five load-bearing surface-#4 properties on that branch:
+//
+//	(1) served=true with the CORRECT page slice (fresh, page-keyed-equivalent),
+//	(2) PutRAFullList NOT called (the cell stays absent after the serve),
+//	(3) NO dep edge recorded for the raKey (external RA never enters DepTracker),
+//	(4) RAFullListServeFallback serve-outcome fired (not RepopulateSlice),
+//	(5) BumpExternalSkippedPut fired (ExternalSkippedPut delta == 1).
+func TestRAServe_KnownSliceableCellMiss_ExternalTouched_DeclinesPut(t *testing.T) {
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("RESOLVED_CACHE_ENABLED", "true")
+	cache.ResetResolvedCacheForTest()
+	// #95 arch C-1: publish the f6 grant so admin re-derives a REAL non-empty
+	// BindingUID (C:crb-a-f6-uid) on the restactions GVR — the servable state
+	// this branch requires (a "" binding declines before ever reaching here).
+	newF6Watcher(t, f6BuildFixture()...)
+
+	// Unique RA name so this test is self-isolating from the PROCESS-GLOBAL
+	// sliceability memo (NOT reset by ResetResolvedCacheForTest) — a verdict
+	// recorded by another test must never leak here, and ours must not leak out.
+	const raName = "compositions-panels-extmiss"
+
+	// The raKey the serve path derives (seedFullListRAKey → RAFullListKeyInputs
+	// → ComputeKey), keyed on admin's f6 first-match BindingUID on restactions.
+	keyInputs := cache.RAFullListKeyInputs(gvr().Group, gvr().Version, gvr().Resource,
+		"krateo-system", raName, "C:crb-a-f6-uid", nil)
+	raKey := cache.ComputeKey(keyInputs)
+	shape := cache.SliceShapeHash(raFullListCallerClass, gvr().Group, gvr().Version,
+		gvr().Resource, "krateo-system", raName, raSliceJQ)
+
+	// Pre-seed a KNOWN-SLICEABLE verdict but NO cell — so raFullListServe enters
+	// the `known && sliceable` branch and takes the cell-MISS repopulate path.
+	// (This is the steady-state-after-eviction posture: the verdict outlives the
+	// cell because the sliceability memo is process-global while the L1 cell is
+	// LRU/TTL-bounded.)
+	cache.RecordSliceability(raKey, shape, true)
+	if _, ok := cache.ResolvedCache().Get(raKey); ok {
+		t.Fatalf("setup: no cell must be present (cell-miss repopulate path requires a MISS)")
+	}
+	if sliceable, known := cache.SliceabilityLookup(raKey, shape); !known || !sliceable {
+		t.Fatalf("setup: verdict must be known-sliceable; known=%v sliceable=%v", known, sliceable)
+	}
+
+	// Snapshot the process-global external-skipped-Put + serve-outcome counters
+	// so we assert DELTAS (both are process-wide atomics).
+	skippedBefore := cache.ExternalSkippedPut()
+	serveBefore := cache.RAFullListServeSnapshot()
+
+	// The resolve stub bumps the ExternalTouchedSink attached to the ctx it is
+	// called with (raFullListServe threads it down as fullCtx via WithL1KeyContext).
+	// It bumps ONLY on the unpaginated (perPage==0 && page==0) re-resolve — the
+	// exact call the repopulate branch makes — so we prove the external touch is
+	// the trigger, not an unconditional bump.
+	var calls atomic.Int64
+	var unpaginatedResolves atomic.Int64
+	base := stubResolveRA(t, panelDict(40), &calls)
+	resolve := func(ctx context.Context, perPage, page int) (map[string]any, error) {
+		if perPage == 0 && page == 0 {
+			unpaginatedResolves.Add(1)
+			cache.ExternalTouchedSinkFromContext(ctx).Bump() // nil-safe; fires on the fullCtx sink
+		}
+		return base(ctx, perPage, page)
+	}
+
+	// Install the external-touched sink on the request ctx (the request path is
+	// the first ExternalTouchedSink consumer; raFullListServe inherits it via
+	// fullCtx = WithL1KeyContext(ctx, raKey)).
+	ctx, sink := cache.WithExternalTouchedSink(ctxWithUser(t))
+
+	got, ok, err := raFullListServe(ctx, gvr(), "krateo-system", raName,
+		ra(raSliceJQ), 10, 2, nil, resolve)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// (1) served=true with the correct slice.
+	if !ok {
+		t.Fatalf("external-touched repopulate MUST still SERVE the fresh slice (ok=true), not decline")
+	}
+	// The unpaginated re-resolve ran exactly once and touched the external sink.
+	if n := unpaginatedResolves.Load(); n != 1 {
+		t.Fatalf("repopulate path must resolve UNPAGINATED exactly once, got %d", n)
+	}
+	if sink.Count() == 0 {
+		t.Fatalf("setup sanity: the unpaginated re-resolve must have bumped the external sink")
+	}
+	// The served bytes equal a fresh page-2 page-keyed resolve (the correct slice).
+	ref, _ := base(ctx, 10, 2)
+	assertCanonEqual(t, got, ref, "extmiss-page2")
+
+	// (2) PutRAFullList NOT called — the cell must STILL be absent.
+	if _, ok := cache.ResolvedCache().Get(raKey); ok {
+		t.Fatalf("M6 RED: external-touched repopulate PUT the cell — an external aggregate with no informer edge is now cached and will serve STALE across pages")
+	}
+
+	// (3) NO dep edge for the raKey (external RA never enters the DepTracker).
+	// The serve path records its self-dep on (gvr, ns, name); an external decline
+	// must skip that Record so no informer event dirty-marks a non-existent cell.
+	deps := cache.Deps().CollectMatchesForTest(gvr(), "krateo-system", raName)
+	if _, present := deps[raKey]; present {
+		t.Fatalf("M6 RED: a dep edge was recorded for the external-touched raKey — the external RA entered the DepTracker (no informer edge can invalidate it; the Record must be declined alongside the Put)")
+	}
+
+	// (4) RAFullListServeFallback fired (NOT RepopulateSlice — the external gate
+	// is checked BEFORE the normal repopulate Put/serve).
+	serveAfter := cache.RAFullListServeSnapshot()
+	if serveAfter.Fallback-serveBefore.Fallback != 1 {
+		t.Fatalf("expected exactly one RAFullListServeFallback outcome, got delta %d (before=%+v after=%+v)",
+			serveAfter.Fallback-serveBefore.Fallback, serveBefore, serveAfter)
+	}
+	if serveAfter.Repopulate-serveBefore.Repopulate != 0 {
+		t.Fatalf("M6 RED: RAFullListServeRepopulateSlice fired (delta %d) — the external gate did NOT fire, the code took the normal repopulate-Put path",
+			serveAfter.Repopulate-serveBefore.Repopulate)
+	}
+
+	// (5) BumpExternalSkippedPut fired exactly once.
+	if d := cache.ExternalSkippedPut() - skippedBefore; d != 1 {
+		t.Fatalf("M6 RED: ExternalSkippedPut delta = %d, want 1 — the external-touched Put-decline metric did NOT fire on the repopulate branch", d)
+	}
+}

--- a/internal/resolvers/widgets/identity_key_extras_accessors_test.go
+++ b/internal/resolvers/widgets/identity_key_extras_accessors_test.go
@@ -1,0 +1,225 @@
+package widgets
+
+import (
+	"context"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/jwtutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// identity_key_extras_accessors_test.go — M3 [SEC] for the three author-declared
+// identity/key-extras accessors (widgets.go): GetIdentityContext,
+// DeclaredIdentity, GetKeyExtras. All are pure / context-only ⇒ fully hermetic,
+// no cluster.
+//
+// The load-bearing security property is the D1 enum foreclosure on
+// GetIdentityContext: ONLY {username, groups} survive; anything else (a typo, a
+// stale/forbidden displayName declaration) is DROPPED in code, so the server can
+// never inject a key the JWT principal does not carry into the cache key OR the
+// resolve input. GetKeyExtras is the request-extras twin with NO enum (any name
+// is honored) — but with the SAME order-preserving + dedup + absence-tolerant
+// contract.
+
+// specWith wraps a spec.<field> value into the unstructured shape the accessors
+// read (maps.NestedSlice(obj, "spec", <field>)).
+func specWith(field string, val any) map[string]any {
+	return map[string]any{"spec": map[string]any{field: val}}
+}
+
+// ---------------------------------------------------------------------------
+// GetIdentityContext — enum-filtered, order-preserving, dedup, absence-tolerant.
+// ---------------------------------------------------------------------------
+
+func TestGetIdentityContext(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want []string
+	}{
+		{
+			name: "SEC enum filter + order + dedup + non-string drop",
+			// [username, displayName, groups, username(dup), 42] → [username, groups]
+			obj:  specWith("identityContext", []any{"username", "displayName", "groups", "username", 42}),
+			want: []string{"username", "groups"},
+		},
+		{
+			name: "order preserved (groups before username)",
+			obj:  specWith("identityContext", []any{"groups", "username"}),
+			want: []string{"groups", "username"},
+		},
+		{
+			name: "displayName ALONE is dropped ⇒ empty (D1 foreclosure)",
+			obj:  specWith("identityContext", []any{"displayName"}),
+			want: nil,
+		},
+		{
+			name: "arbitrary out-of-enum typo dropped",
+			obj:  specWith("identityContext", []any{"userName", "Groups", "user"}), // wrong case / typo
+			want: nil,
+		},
+		{
+			name: "absent spec.identityContext ⇒ nil",
+			obj:  map[string]any{"spec": map[string]any{}},
+			want: nil,
+		},
+		{
+			name: "empty slice ⇒ nil",
+			obj:  specWith("identityContext", []any{}),
+			want: nil,
+		},
+		{
+			name: "wrong type (string not slice) ⇒ nil (absence-tolerant)",
+			obj:  specWith("identityContext", "username"),
+			want: nil,
+		},
+		{
+			name: "no spec at all ⇒ nil",
+			obj:  map[string]any{},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetIdentityContext(tc.obj)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeclaredIdentity — materialises the DECLARED enum keys from the ctx principal.
+// ---------------------------------------------------------------------------
+
+// ctxWithUser builds a context carrying the given authenticated principal, the
+// way the authn middleware does in production (xcontext.WithUserInfo).
+func ctxWithUser(username string, groups []string) context.Context {
+	return xcontext.BuildContext(context.Background(),
+		xcontext.WithUserInfo(jwtutil.UserInfo{Username: username, Groups: groups}))
+}
+
+func TestDeclaredIdentity(t *testing.T) {
+	t.Run("declared username+groups materialises both as JSON-native", func(t *testing.T) {
+		obj := specWith("identityContext", []any{"username", "groups"})
+		ctx := ctxWithUser("cyberjoker", []string{"devs", "ops"})
+
+		got := DeclaredIdentity(ctx, obj)
+		require.NotNil(t, got)
+		assert.Equal(t, "cyberjoker", got["username"])
+		// groups MUST be JSON-native []any (NOT []string) — else the downstream
+		// DeepCopyJSON in the resolve/key fold panics.
+		gg, ok := got["groups"].([]any)
+		require.True(t, ok, "groups must be []any (JSON-native), got %T", got["groups"])
+		assert.Equal(t, []any{"devs", "ops"}, gg)
+	})
+
+	t.Run("SEC: displayName declaration is foreclosed ⇒ nil (never injected)", func(t *testing.T) {
+		obj := specWith("identityContext", []any{"displayName"})
+		ctx := ctxWithUser("cyberjoker", []string{"devs"})
+		assert.Nil(t, DeclaredIdentity(ctx, obj),
+			"an out-of-enum declaration must yield no injection — the server never injects a key the principal lacks")
+	})
+
+	t.Run("no declaration ⇒ nil (prod-inert default)", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{}}
+		ctx := ctxWithUser("cyberjoker", []string{"devs"})
+		assert.Nil(t, DeclaredIdentity(ctx, obj))
+	})
+
+	t.Run("declared but NO principal on ctx ⇒ nil (fail-safe)", func(t *testing.T) {
+		obj := specWith("identityContext", []any{"username", "groups"})
+		assert.Nil(t, DeclaredIdentity(context.Background(), obj),
+			"absent UserInfo must inject nothing (fail-safe), never a spurious key")
+	})
+
+	t.Run("empty username is not a key", func(t *testing.T) {
+		obj := specWith("identityContext", []any{"username", "groups"})
+		ctx := ctxWithUser("", []string{"devs"})
+		got := DeclaredIdentity(ctx, obj)
+		require.NotNil(t, got, "groups still present ⇒ non-nil map")
+		_, hasUser := got["username"]
+		assert.False(t, hasUser, "an empty username must NOT be injected as a key")
+		assert.Equal(t, []any{"devs"}, got["groups"])
+	})
+
+	t.Run("declared groups but principal has none ⇒ nil", func(t *testing.T) {
+		obj := specWith("identityContext", []any{"groups"})
+		ctx := ctxWithUser("cyberjoker", nil)
+		assert.Nil(t, DeclaredIdentity(ctx, obj),
+			"declared groups with an empty principal group set injects nothing (len(out)==0 ⇒ nil)")
+	})
+
+	t.Run("groups slice does NOT alias the ctx principal slice", func(t *testing.T) {
+		src := []string{"devs", "ops"}
+		obj := specWith("identityContext", []any{"groups"})
+		ctx := ctxWithUser("cyberjoker", src)
+		got := DeclaredIdentity(ctx, obj)
+		gg := got["groups"].([]any)
+		// Mutating the injected copy must not corrupt the source (fresh []any).
+		gg[0] = "MUTATED"
+		assert.Equal(t, "devs", src[0], "DeclaredIdentity must copy the groups, never alias the ctx slice")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// GetKeyExtras — arbitrary names honored (NO enum), order-preserving, dedup,
+// absence-tolerant.
+// ---------------------------------------------------------------------------
+
+func TestGetKeyExtras(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want []string
+	}{
+		{
+			name: "arbitrary names honored, order preserved, dedup, non-string dropped",
+			obj:  specWith("keyExtras", []any{"namespace", "name", "namespace", "custom-param", 7}),
+			want: []string{"namespace", "name", "custom-param"},
+		},
+		{
+			name: "NO enum filter — displayName-shaped name is honored (unlike identityContext)",
+			obj:  specWith("keyExtras", []any{"displayName", "anything"}),
+			want: []string{"displayName", "anything"},
+		},
+		{
+			name: "absent ⇒ nil (fold-nothing default)",
+			obj:  map[string]any{"spec": map[string]any{}},
+			want: nil,
+		},
+		{
+			name: "empty slice ⇒ nil",
+			obj:  specWith("keyExtras", []any{}),
+			want: nil,
+		},
+		{
+			name: "wrong type ⇒ nil",
+			obj:  specWith("keyExtras", map[string]any{"namespace": true}),
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetKeyExtras(tc.obj)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGetKeyExtras_VsIdentityContext_EnumDivergence is the SEC discriminator
+// between the two accessors on the SAME input: identityContext DROPS a
+// displayName / typo (enum foreclosure), keyExtras KEEPS it (open-ended request
+// key names). Encodes why they are two functions, not one.
+func TestGetKeyExtras_VsIdentityContext_EnumDivergence(t *testing.T) {
+	input := []any{"username", "displayName", "namespace"}
+
+	idc := GetIdentityContext(specWith("identityContext", input))
+	assert.Equal(t, []string{"username"}, idc,
+		"identityContext MUST drop displayName + the request-only 'namespace' (enum = {username, groups})")
+
+	ke := GetKeyExtras(specWith("keyExtras", input))
+	assert.Equal(t, []string{"username", "displayName", "namespace"}, ke,
+		"keyExtras MUST honor every declared name (no enum) — the divergence that requires two accessors")
+}

--- a/internal/resolvers/widgets/resolve.go
+++ b/internal/resolvers/widgets/resolve.go
@@ -42,6 +42,27 @@ type ResolveOptions struct {
 	Extras  map[string]any
 }
 
+// resolveApiRefFn and validateObjectStatusFn are the two cross-boundary
+// hops Resolve makes that require a live apiserver — the apiRef RESTAction
+// fetch (apiref.Resolve, reached via resolveApiRef) and the CRD-status schema
+// validation (crdschema.ValidateObjectStatus → cache.GVRFor discovery). They
+// are exposed as package-level function VARIABLES bound to the real
+// implementations so a HERMETIC unit test can drive the orchestration of
+// Resolve (error propagation to status.error, the 400 StatusError wrap, and
+// the resourcesRefsTemplateExtras scope-isolation ordering) WITHOUT a cluster,
+// by transiently swapping the var and restoring it.
+//
+// Production behaviour is BYTE-IDENTICAL: the defaults are the exact functions
+// Resolve called before (resolveApiRef and crdschema.ValidateObjectStatus),
+// invoked with the same arguments in the same order — this is an indirection
+// seam only, not a behaviour change (test-hook per the coverage-audit plan;
+// no env flag, no special-case). Tests MUST restore the original value in a
+// defer so package-level state never leaks across tests.
+var (
+	resolveApiRefFn        = resolveApiRef
+	validateObjectStatusFn = crdschema.ValidateObjectStatus
+)
+
 func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	log := xcontext.Logger(ctx).With(loggerAttr(opts.In.Object))
 
@@ -101,7 +122,7 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	}()
 
 	apirefStart := time.Now()
-	ds, err := resolveApiRef(ctx, opts)
+	ds, err := resolveApiRefFn(ctx, opts)
 	phaseApirefMs = time.Since(apirefStart).Milliseconds()
 	if err != nil {
 		log.Error("unable to resolve api reference", slog.Any("err", err))
@@ -208,7 +229,7 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*Widget, error) {
 	// deployments (the seed path runs with a context-injected
 	// internal-dispatch rc, NOT in-cluster). The call site KNOWS
 	// the rc; the helper shouldn't recover it.
-	err = crdschema.ValidateObjectStatus(ctx, opts.RC, opts.In.Object)
+	err = validateObjectStatusFn(ctx, opts.RC, opts.In.Object)
 	phaseValidateMs = time.Since(validateStart).Milliseconds()
 	if err != nil {
 		maps.SetNestedField(opts.In.Object, err.Error(), "status", "error")

--- a/internal/resolvers/widgets/resolve_orchestration_test.go
+++ b/internal/resolvers/widgets/resolve_orchestration_test.go
@@ -1,0 +1,397 @@
+package widgets
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	xcontext "github.com/krateoplatformops/plumbing/context"
+	"github.com/krateoplatformops/plumbing/endpoints"
+	xenv "github.com/krateoplatformops/plumbing/env"
+	"github.com/krateoplatformops/snowplow/internal/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+// hermeticCtx builds a context the resolver's resourcesRefs stage can run
+// against WITHOUT a cluster: it carries a UserConfig endpoint (so
+// resourcesrefs.Resolve's xcontext.UserConfig succeeds) and an internal
+// *rest.Config (so cache.ClientConfigFor returns it directly and never dials
+// kubeconfig). TestMode keeps UserConfig from rewriting the endpoint's
+// ServerURL to the in-cluster address. The GET-verb resourceRefs the tests use
+// (v1/namespaces) resolve their Kind from the builtin scheme (no discovery hop)
+// and build a /call path string only — no network I/O.
+func hermeticCtx(t *testing.T) context.Context {
+	t.Helper()
+	prev := xenv.TestMode()
+	xenv.SetTestMode(true)
+	t.Cleanup(func() { xenv.SetTestMode(prev) })
+
+	ctx := xcontext.BuildContext(context.Background(),
+		xcontext.WithUserConfig(endpoints.Endpoint{ServerURL: "https://test.invalid"}))
+	ctx = cache.WithInternalRESTConfig(ctx, &rest.Config{Host: "https://test.invalid"})
+	return ctx
+}
+
+// resolve_orchestration_test.go — M20 (widgets.Resolve orchestration) + H2
+// (resolveWidgetData #69 fail-soft). These are HERMETIC unit tests: neither the
+// apiRef RESTAction fetch (apiref.Resolve → apiserver) nor the CRD-status
+// validation (crdschema.ValidateObjectStatus → cache.GVRFor discovery) can run
+// without a cluster, so the two boundary hops are swapped through the
+// package-level function-variable seams (resolveApiRefFn / validateObjectStatusFn,
+// resolve.go) whose defaults are the real implementations. Every stub is
+// restored in a defer so package state never leaks across tests. All other
+// stages (mergeExtras, injectSlice, resolveWidgetData, resolveResourceRefs) run
+// their REAL code against the stubbed ds — so these tests exercise the genuine
+// orchestration and ordering of Resolve, not a re-implementation.
+
+// stubApiRef swaps resolveApiRefFn to return (ds, err) and restores the real
+// implementation when the test ends. The returned ds is what the rest of
+// Resolve (injectSlice → mergeExtras → resolveWidgetData → resolveResourceRefs)
+// evaluates against.
+func stubApiRef(t *testing.T, ds map[string]any, err error) {
+	t.Helper()
+	orig := resolveApiRefFn
+	resolveApiRefFn = func(_ context.Context, _ ResolveOptions) (map[string]any, error) {
+		if ds == nil && err == nil {
+			return map[string]any{}, nil
+		}
+		return ds, err
+	}
+	t.Cleanup(func() { resolveApiRefFn = orig })
+}
+
+// stubValidate swaps validateObjectStatusFn to return err and restores the real
+// implementation when the test ends.
+func stubValidate(t *testing.T, err error) {
+	t.Helper()
+	orig := validateObjectStatusFn
+	validateObjectStatusFn = func(_ context.Context, _ *rest.Config, _ map[string]any) error {
+		return err
+	}
+	t.Cleanup(func() { validateObjectStatusFn = orig })
+}
+
+// baseWidget builds a minimal apiRef-less Button widget with a static
+// widgetData block. widgetDataTemplate / resourcesRefsTemplate are added by the
+// individual tests.
+func baseWidget() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "w", "namespace": "demo-system"},
+		"spec": map[string]any{
+			"widgetData": map[string]any{
+				"label": "static-base",
+			},
+		},
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// M20(a): an apiRef error sets status.error and Resolve returns that same error.
+// ---------------------------------------------------------------------------
+
+func TestResolve_ApiRefError_SetsStatusErrorAndReturns(t *testing.T) {
+	sentinel := errors.New("apiref boom: forbidden")
+	// apiRef fails BEFORE ds is produced.
+	stubApiRef(t, nil, sentinel)
+	// validate must NOT be reached; if it is, make that observable by failing.
+	validateReached := false
+	orig := validateObjectStatusFn
+	validateObjectStatusFn = func(_ context.Context, _ *rest.Config, _ map[string]any) error {
+		validateReached = true
+		return nil
+	}
+	t.Cleanup(func() { validateObjectStatusFn = orig })
+
+	w := baseWidget()
+	got, err := Resolve(hermeticCtx(t), ResolveOptions{In: w})
+
+	require.Error(t, err, "Resolve must propagate the apiRef error")
+	assert.ErrorIs(t, err, sentinel, "the returned error must be the apiRef error unchanged")
+	assert.Same(t, w, got, "Resolve returns opts.In on the apiRef-error path")
+
+	// status.error must carry the apiRef error message.
+	statusErr, ok, e := unstructured.NestedString(w.Object, "status", "error")
+	require.NoError(t, e)
+	require.True(t, ok, "status.error must be set on the apiRef-error path")
+	assert.Equal(t, sentinel.Error(), statusErr,
+		"status.error must equal the apiRef error message")
+
+	// Short-circuit: validate + widgetData must NOT have run.
+	assert.False(t, validateReached, "validate must not be reached after an apiRef error")
+	_, wdSet, _ := unstructured.NestedMap(w.Object, "status", "widgetData")
+	assert.False(t, wdSet, "status.widgetData must NOT be written after an apiRef error")
+}
+
+// ---------------------------------------------------------------------------
+// M20(b): a validate error is wrapped as an *apierrors.StatusError with HTTP 400
+// (BadRequest), and status.error carries the raw validate message.
+// ---------------------------------------------------------------------------
+
+func TestResolve_ValidateError_WrapsAs400StatusError(t *testing.T) {
+	// apiRef succeeds with an empty ds; widgetDataTemplate absent ⇒ static
+	// widgetData is kept; resourcesRefsTemplate absent ⇒ no refs.
+	stubApiRef(t, map[string]any{}, nil)
+	validateMsg := "status.widgetData.label: Invalid value: must be a string"
+	stubValidate(t, errors.New(validateMsg))
+
+	w := baseWidget()
+	got, err := Resolve(hermeticCtx(t), ResolveOptions{In: w})
+
+	require.Error(t, err, "a validate error must fail Resolve")
+	assert.Same(t, w, got, "Resolve returns opts.In on the validate-error path")
+
+	// The error must be recoverable as an *apierrors.StatusError with 400.
+	var se *apierrors.StatusError
+	require.True(t, errors.As(err, &se),
+		"validate error must be wrapped as *apierrors.StatusError (the dispatcher's errors.As contract)")
+	assert.Equal(t, int32(http.StatusBadRequest), se.ErrStatus.Code,
+		"the wrapped StatusError code must be 400 BadRequest")
+	assert.Equal(t, metav1.StatusReasonBadRequest, se.ErrStatus.Reason,
+		"the wrapped StatusError reason must be BadRequest")
+	assert.Equal(t, validateMsg, se.ErrStatus.Message,
+		"the wrapped StatusError message must carry the raw validate message")
+
+	// status.error carries the raw validate message (set before the wrap).
+	statusErr, ok, e := unstructured.NestedString(w.Object, "status", "error")
+	require.NoError(t, e)
+	require.True(t, ok, "status.error must be set on the validate-error path")
+	assert.Equal(t, validateMsg, statusErr)
+
+	// status.widgetData was still written before validation ran (the static block).
+	wd, ok, e := unstructured.NestedMap(w.Object, "status", "widgetData")
+	require.NoError(t, e)
+	require.True(t, ok, "status.widgetData must be written before validation runs")
+	assert.Equal(t, "static-base", wd["label"])
+}
+
+// TestResolve_ValidateOK_ReturnsNilNoStatusError — the happy path: validate
+// passes ⇒ no error, no status.error, status.widgetData present. Guards that
+// the 400 wrap is truly gated on the validate error (not always emitted).
+func TestResolve_ValidateOK_ReturnsNilNoStatusError(t *testing.T) {
+	stubApiRef(t, map[string]any{}, nil)
+	stubValidate(t, nil)
+
+	w := baseWidget()
+	got, err := Resolve(hermeticCtx(t), ResolveOptions{In: w})
+
+	require.NoError(t, err, "validate-OK path must not error")
+	assert.Same(t, w, got)
+	_, hasErr, _ := unstructured.NestedString(w.Object, "status", "error")
+	assert.False(t, hasErr, "status.error must NOT be set on the success path")
+	wd, ok, _ := unstructured.NestedMap(w.Object, "status", "widgetData")
+	require.True(t, ok)
+	assert.Equal(t, "static-base", wd["label"])
+}
+
+// ---------------------------------------------------------------------------
+// M20(c): resourcesRefsTemplateExtras is referenceable in the resourcesRefsTemplate
+// jq but NOT in the widgetDataTemplate jq — the scope isolation that the
+// mergeExtras(GetResourcesRefsExtras) fold ORDER guarantees (it runs AFTER
+// resolveWidgetData, BEFORE resolveResourceRefs).
+//
+// RED arm: if that fold were moved BEFORE resolveWidgetData, the rrt-only key
+// would leak into the widgetData. TestResolve_RrtExtras_LeaksWhenFoldedEarly
+// proves the arm discriminates by simulating that wrong ordering.
+// ---------------------------------------------------------------------------
+
+// scopeIsolationWidget mirrors extras_integration_test.go's inlineStaticWidget:
+// widgetDataTemplate reads `.rrtNs` (must be ABSENT), resourcesRefsTemplate
+// reads it (must be PRESENT), and the sibling resourcesRefsTemplateExtras block
+// is the sole source of rrtNs.
+func scopeIsolationWidget() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "w", "namespace": "demo-system"},
+		"spec": map[string]any{
+			"widgetData": map[string]any{"label": "base"},
+			"widgetDataTemplate": []any{
+				map[string]any{"forPath": "label", "expression": `${ "ns=" + (.rrtNs // "ABSENT") }`},
+			},
+			"resourcesRefsTemplate": []any{
+				map[string]any{
+					"template": map[string]any{
+						"id": `${ "from-rrtNs-" + .rrtNs }`, "apiVersion": "v1",
+						"resource": "namespaces", "namespace": `${ .rrtNs }`, "verb": "GET",
+					},
+				},
+			},
+			"resourcesRefsTemplateExtras": map[string]any{
+				"rrtNs": "inline-team",
+			},
+		},
+	}}
+}
+
+func TestResolve_RrtExtras_ScopedToResourcesRefsOnly(t *testing.T) {
+	// apiRef-less: ds starts empty. No request extras.
+	stubApiRef(t, map[string]any{}, nil)
+	stubValidate(t, nil) // don't gate the assertion on cluster schema.
+
+	w := scopeIsolationWidget()
+	_, err := Resolve(hermeticCtx(t), ResolveOptions{In: w})
+	require.NoError(t, err)
+
+	// Scope isolation: the widgetDataTemplate ran BEFORE the rrt-extras fold, so
+	// .rrtNs was absent → label == "ns=ABSENT".
+	wd, ok, e := unstructured.NestedMap(w.Object, "status", "widgetData")
+	require.NoError(t, e)
+	require.True(t, ok)
+	assert.Equal(t, "ns=ABSENT", wd["label"],
+		"widgetDataTemplate MUST NOT see the resourcesRefsTemplateExtras-only key rrtNs (scope isolation)")
+
+	// The resourcesRefsTemplate jq DID see rrtNs → one ref with the derived id.
+	items, ok, e := unstructured.NestedSlice(w.Object, "status", "resourcesRefs", "items")
+	require.NoError(t, e)
+	require.True(t, ok, "status.resourcesRefs.items must be present")
+	require.Len(t, items, 1)
+	m, _ := items[0].(map[string]any)
+	require.NotNil(t, m)
+	assert.Equal(t, "from-rrtNs-inline-team", m["id"],
+		"resourcesRefsTemplate jq MUST see the inline rrtNs (derived id proves it reached the rrt jq)")
+}
+
+// TestResolve_RrtExtras_LeaksWhenFoldedEarly is the RED-arm falsifier for the
+// scope-isolation ordering. It reproduces the WRONG ordering the plan warns
+// against — "move mergeExtras(GetResourcesRefsExtras) before resolveWidgetData"
+// — by folding the rrt-extras into ds BEFORE running the widgetDataTemplate.
+// With that wrong ordering the rrt-only key rrtNs LEAKS into the widgetData
+// (label == "ns=inline-team", not "ns=ABSENT"). This proves the assertion in
+// TestResolve_RrtExtras_ScopedToResourcesRefsOnly is discriminating: the real
+// Resolve's fold ORDER is what keeps rrtNs out of widgetData.
+func TestResolve_RrtExtras_LeaksWhenFoldedEarly(t *testing.T) {
+	w := scopeIsolationWidget()
+
+	// WRONG ordering (the RED impl): fold the rrt-extras into ds FIRST …
+	ds := map[string]any{}
+	mergeExtras(ds, GetResourcesRefsExtras(w.Object))
+	// … THEN run the widgetDataTemplate against that ds.
+	widgetData, err := resolveWidgetData(context.Background(), w, ds)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ns=inline-team", widgetData["label"],
+		"RED PROOF: with the rrt-extras folded BEFORE resolveWidgetData, the rrt-only key rrtNs LEAKS "+
+			"into widgetData — this is exactly the leak the real Resolve's fold ORDER prevents")
+}
+
+// ---------------------------------------------------------------------------
+// H2 [SEC]: resolveWidgetData #69 fail-soft. A malformed spec.widgetDataTemplate
+// (a read error from GetWidgetDataTemplate) MUST fail-soft to the STATIC
+// GetWidgetData src — it must NEVER invoke widgetdatatemplate.Resolve nor build
+// an aggregate from ds (the SA-maximal cross-namespace data source). If it did,
+// the SA-maximal aggregate would land in the shared identity-free widgetContent
+// cell → cross-user leak (task #69).
+// ---------------------------------------------------------------------------
+
+// malformedWDTWidget makes spec.widgetDataTemplate a STRING (not a []any), so
+// GetWidgetDataTemplate → maps.NestedSliceNoCopy returns an accessor error, and
+// resolveWidgetData must fail-soft. The static widgetData carries `label` (a
+// STATIC key that MUST survive).
+func malformedWDTWidget() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "w", "namespace": "demo-system"},
+		"spec": map[string]any{
+			"widgetData": map[string]any{
+				"label": "static-only",
+			},
+			// MALFORMED — a string where a []any is required.
+			"widgetDataTemplate": "this-is-not-a-slice",
+		},
+	}}
+}
+
+func TestResolveWidgetData_MalformedTemplate_FailsSoftToStatic(t *testing.T) {
+	w := malformedWDTWidget()
+	// ds carries an "aggregate" key that models the SA-maximal cross-ns data
+	// source. It MUST NOT appear in the returned widgetData.
+	ds := map[string]any{
+		"aggregate": []any{
+			map[string]any{"ns": "team-a", "secret": "cross-ns-1"},
+			map[string]any{"ns": "team-b", "secret": "cross-ns-2"},
+		},
+	}
+
+	got, err := resolveWidgetData(context.Background(), w, ds)
+
+	require.NoError(t, err, "a malformed widgetDataTemplate must fail-soft (nil error), not hard-fail")
+	// Fail-soft returns the STATIC src verbatim.
+	assert.Equal(t, "static-only", got["label"], "the static widgetData src must be returned unchanged")
+	// The SA-maximal aggregate key must NOT have leaked into the returned map.
+	_, leaked := got["aggregate"]
+	assert.False(t, leaked,
+		"SEC/#69: the cross-ns aggregate from ds MUST NOT appear in the fail-soft widgetData "+
+			"(else the SA-maximal aggregate lands in the shared identity-free cell — the cross-user leak)")
+}
+
+// TestResolveWidgetData_WellFormedTemplate_BuildsFromDs — negative control:
+// with a WELL-FORMED widgetDataTemplate, resolveWidgetData DOES run the jq
+// against ds and folds the derived value into the static src. Guards that the
+// fail-soft above is truly gated on the read error, not always short-circuiting.
+func TestResolveWidgetData_WellFormedTemplate_BuildsFromDs(t *testing.T) {
+	w := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "widgets.templates.krateo.io/v1beta1",
+		"kind":       "Button",
+		"metadata":   map[string]any{"name": "w", "namespace": "demo-system"},
+		"spec": map[string]any{
+			"widgetData": map[string]any{"label": "static-only"},
+			"widgetDataTemplate": []any{
+				map[string]any{"forPath": "label", "expression": `${ .tenant }`},
+			},
+		},
+	}}
+	ds := map[string]any{"tenant": "acme"}
+
+	got, err := resolveWidgetData(context.Background(), w, ds)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", got["label"],
+		"a well-formed widgetDataTemplate must run against ds and overwrite the static value")
+}
+
+// TestResolveWidgetData_MalformedTemplate_RED_WrongImplLeaks is the RED-arm
+// proof for H2. It runs a SHADOW wrong-impl that, on the SAME read error,
+// proceeds to build the widgetData from ds (the aggregate) instead of failing
+// soft — and asserts the aggregate DOES leak. This demonstrates the assertion
+// in TestResolveWidgetData_MalformedTemplate_FailsSoftToStatic is discriminating:
+// a plausible wrong impl (build-from-ds on read error) is caught by it.
+func TestResolveWidgetData_MalformedTemplate_RED_WrongImplLeaks(t *testing.T) {
+	w := malformedWDTWidget()
+	ds := map[string]any{
+		"aggregate": []any{map[string]any{"ns": "team-a", "secret": "cross-ns-1"}},
+	}
+
+	got := resolveWidgetDataWrongAggregate(w, ds)
+
+	_, leaked := got["aggregate"]
+	assert.True(t, leaked,
+		"RED PROOF: the wrong impl (build aggregate from ds on a widgetDataTemplate read error) "+
+			"leaks the SA-maximal aggregate — exactly what the real fail-soft prevents")
+}
+
+// resolveWidgetDataWrongAggregate is the PLAUSIBLE-WRONG shadow impl referenced
+// by the RED-arm test: on a GetWidgetDataTemplate read error it builds the
+// widgetData by folding ds into the static src (an aggregate build) instead of
+// failing soft. It never touches prod behaviour — it exists only to prove the
+// H2 fail-soft assertion discriminates.
+func resolveWidgetDataWrongAggregate(obj *Widget, ds map[string]any) map[string]any {
+	src := GetWidgetData(obj.Object)
+	if _, err := GetWidgetDataTemplate(obj.Object); err != nil {
+		// WRONG: aggregate ds into the widgetData instead of returning static src.
+		for k, v := range ds {
+			if _, present := src[k]; !present {
+				src[k] = v
+			}
+		}
+		return src
+	}
+	return src
+}

--- a/main.go
+++ b/main.go
@@ -75,6 +75,41 @@ var (
 	build string
 )
 
+// snowplowCORSOptions returns the cors.Options the server's use.CORS wrapper is
+// built from (main's http.Server construction). It is extracted from the inline
+// literal into a named constructor so the CORS contract — in particular the
+// ExposedHeaders that let the browser frontend READ the live-refresh signalling
+// headers (X-Snowplow-Refresh-Key / X-Snowplow-Refresh-Class) plus Link — is
+// unit-testable without standing up the full server (H4). Returning a freshly
+// built value per call (no shared package-level struct) keeps the seam free of
+// mutable shared state. The returned options are byte-identical to the previous
+// inline literal.
+func snowplowCORSOptions() cors.Options {
+	return cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowedHeaders: []string{
+			"Accept",
+			"Authorization",
+			"Content-Type",
+			"X-Auth-Code",
+			"X-Krateo-TraceId",
+			// W3C trace-context + baggage headers — REQUIRED so the
+			// browser frontend can propagate traceparent/tracestate/
+			// baggage into snowplow (cross-repo CORS dependency). D19a:
+			// the audit session correlation id now rides `baggage`
+			// (session.id), REPLACING the old X-Krateo-Correlation-Id
+			// header, which is removed here.
+			"traceparent",
+			"tracestate",
+			"baggage",
+		},
+		ExposedHeaders:   []string{"Link", "X-Snowplow-Refresh-Key", "X-Snowplow-Refresh-Class"},
+		AllowCredentials: true,
+		MaxAge:           300, // Maximum value not ignored by any of major browsers
+	}
+}
+
 // @title SnowPlow API
 // @version 0.1.0
 // @description This the total new Krateo backend.
@@ -1138,30 +1173,8 @@ func main() {
 	)
 
 	server := &http.Server{
-		Addr: fmt.Sprintf(":%d", *port),
-		Handler: use.CORS(cors.Options{
-			AllowedOrigins: []string{"*"},
-			AllowedMethods: []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-			AllowedHeaders: []string{
-				"Accept",
-				"Authorization",
-				"Content-Type",
-				"X-Auth-Code",
-				"X-Krateo-TraceId",
-				// W3C trace-context + baggage headers — REQUIRED so the
-				// browser frontend can propagate traceparent/tracestate/
-				// baggage into snowplow (cross-repo CORS dependency). D19a:
-				// the audit session correlation id now rides `baggage`
-				// (session.id), REPLACING the old X-Krateo-Correlation-Id
-				// header, which is removed here.
-				"traceparent",
-				"tracestate",
-				"baggage",
-			},
-			ExposedHeaders: []string{"Link", "X-Snowplow-Refresh-Key", "X-Snowplow-Refresh-Class"},
-			AllowCredentials: true,
-			MaxAge:           300, // Maximum value not ignored by any of major browsers
-		})(rootHandler),
+		Addr:         fmt.Sprintf(":%d", *port),
+		Handler:      use.CORS(snowplowCORSOptions())(rootHandler),
 		ReadTimeout:  10 * time.Second, // read is fast; unchanged (#351/C2)
 		WriteTimeout: writeTimeout,     // 300s — clears cache-OFF heavy path (#351/C2)
 		IdleTimeout:  30 * time.Second, // keep-alive; unchanged (#351/C2)

--- a/main_cors_test.go
+++ b/main_cors_test.go
@@ -1,0 +1,153 @@
+// main_cors_test.go — H4 [SEC]: the CORS contract that lets the browser
+// frontend READ the live-refresh signalling headers off a cross-origin /call
+// response.
+//
+// EventSource/fetch in a cross-origin browser context can only read a response
+// header if the server lists it in Access-Control-Expose-Headers. The
+// live-refresh feature (refreshes.go) rides X-Snowplow-Refresh-Key /
+// X-Snowplow-Refresh-Class on the /call response; the frontend also reads Link
+// (pagination). If any of those drops out of the CORS ExposedHeaders the
+// browser silently cannot see them and live-refresh / pagination break with no
+// server-side error — a SEC-class silent regression.
+//
+// snowplowCORSOptions() (main.go) is the extracted, named constructor for the
+// exact cors.Options main's http.Server is built from (prod-testability H4). We
+// wrap a trivial handler with the REAL use.CORS(snowplowCORSOptions()) — the
+// identical construction main uses — and drive a cross-origin GET, so the
+// assertion binds to production wiring, not a hand-copied literal.
+//
+// RED arm (TestSnowplowCORS_RED_DroppingExposedHeaderIsCaught): dropping either
+// X-Snowplow-Refresh-Key or X-Snowplow-Refresh-Class from the options makes the
+// exposed-headers assertion FAIL — proving the check is discriminating.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/krateoplatformops/plumbing/server/use"
+	"github.com/krateoplatformops/plumbing/server/use/cors"
+)
+
+// exposeList parses an Access-Control-Expose-Headers value ("A, B, C") into a
+// case-insensitive membership set.
+func exposeList(v string) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range strings.Split(v, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out[strings.ToLower(p)] = true
+		}
+	}
+	return out
+}
+
+// serveCORS wraps a 204 handler with use.CORS(opts), drives a cross-origin GET
+// carrying an Origin header, and returns the response headers.
+func serveCORS(t *testing.T, opts cors.Options) http.Header {
+	t.Helper()
+	h := use.CORS(opts)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://snowplow.example/call", nil)
+	req.Header.Set("Origin", "https://frontend.example") // cross-origin actual request
+	h.ServeHTTP(rec, req)
+	return rec.Result().Header
+}
+
+// requiredExposed is the header set the frontend MUST be able to read.
+var requiredExposed = []string{
+	"X-Snowplow-Refresh-Key",
+	"X-Snowplow-Refresh-Class",
+	"Link",
+}
+
+// TestSnowplowCORS_ExposesRefreshHeaders — a cross-origin GET with an Origin
+// header gets an Access-Control-Expose-Headers that CONTAINS all three
+// frontend-required headers, Access-Control-Allow-Credentials: true, and an
+// Access-Control-Allow-Origin. This is the production contract exercised through
+// the real use.CORS(snowplowCORSOptions()) construction.
+func TestSnowplowCORS_ExposesRefreshHeaders(t *testing.T) {
+	hdr := serveCORS(t, snowplowCORSOptions())
+
+	exposed := exposeList(hdr.Get("Access-Control-Expose-Headers"))
+	for _, want := range requiredExposed {
+		if !exposed[strings.ToLower(want)] {
+			t.Fatalf("H4: Access-Control-Expose-Headers must CONTAIN %q so the browser can read it; "+
+				"got %q", want, hdr.Get("Access-Control-Expose-Headers"))
+		}
+	}
+
+	if got := hdr.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("H4: Access-Control-Allow-Credentials must be \"true\"; got %q", got)
+	}
+	if got := hdr.Get("Access-Control-Allow-Origin"); got == "" {
+		t.Fatalf("H4: a cross-origin GET must receive an Access-Control-Allow-Origin; got empty")
+	}
+}
+
+// TestSnowplowCORS_OptionsShapeInvariants pins the options-level invariants the
+// http.Server relies on, independent of the header round-trip: AllowCredentials
+// on, the three exposed headers present. This is the cheap, wiring-level half
+// (the round-trip test above is the behavioural half).
+func TestSnowplowCORS_OptionsShapeInvariants(t *testing.T) {
+	opts := snowplowCORSOptions()
+	if !opts.AllowCredentials {
+		t.Fatalf("H4: snowplowCORSOptions().AllowCredentials must be true")
+	}
+	have := map[string]bool{}
+	for _, h := range opts.ExposedHeaders {
+		have[strings.ToLower(h)] = true
+	}
+	for _, want := range requiredExposed {
+		if !have[strings.ToLower(want)] {
+			t.Fatalf("H4: ExposedHeaders must include %q; got %v", want, opts.ExposedHeaders)
+		}
+	}
+}
+
+// TestSnowplowCORS_RED_DroppingExposedHeaderIsCaught is the RED proof. We build
+// a plausible wrong impl — the same options with a live-refresh header dropped
+// from ExposedHeaders — and assert the H4 exposed-headers check FAILS on it.
+// This proves TestSnowplowCORS_ExposesRefreshHeaders is discriminating: a
+// silent drop of X-Snowplow-Refresh-Key (or -Class) is caught, not tolerated.
+func TestSnowplowCORS_RED_DroppingExposedHeaderIsCaught(t *testing.T) {
+	for _, drop := range []string{"X-Snowplow-Refresh-Key", "X-Snowplow-Refresh-Class"} {
+		t.Run("drop "+drop, func(t *testing.T) {
+			wrong := snowplowCORSOptions()
+			var kept []string
+			for _, h := range wrong.ExposedHeaders {
+				if !strings.EqualFold(h, drop) {
+					kept = append(kept, h)
+				}
+			}
+			wrong.ExposedHeaders = kept
+
+			hdr := serveCORS(t, wrong)
+			exposed := exposeList(hdr.Get("Access-Control-Expose-Headers"))
+
+			// The SAME assertion the green test uses MUST now fail for the
+			// dropped header — i.e. the dropped header is absent from the
+			// exposed set.
+			if exposed[strings.ToLower(drop)] {
+				t.Fatalf("RED: dropping %q from ExposedHeaders should make it un-exposed, "+
+					"but it is still present (%q) — the H4 check is not discriminating",
+					drop, hdr.Get("Access-Control-Expose-Headers"))
+			}
+			// And the other two remain — the drop is surgical, so the green
+			// assertion fails ONLY on the dropped header (not a blanket break).
+			for _, other := range requiredExposed {
+				if strings.EqualFold(other, drop) {
+					continue
+				}
+				if !exposed[strings.ToLower(other)] {
+					t.Fatalf("RED: dropping %q must not disturb %q, but it is gone", drop, other)
+				}
+			}
+		})
+	}
+}

--- a/scripts/check_no_parallel_binding_derivation.sh
+++ b/scripts/check_no_parallel_binding_derivation.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# check_no_parallel_binding_derivation.sh — H6 CI guard that WIRES the
+# previously-orphaned AST lint scripts/lint/no_parallel_binding_derivation.go
+# into a runnable, exit-code-bearing step.
+#
+# THE GAP (H6): the lint program is a //go:build ignore standalone (so
+# `go build ./...` / `go vet ./...` skip it) and was invoked by NO workflow.
+# A BindingUID derivation reintroduced OUTSIDE the match_subject.go single
+# source of truth — the exact v3-baseline defect class the lint was written
+# to catch — would therefore NOT fail CI. This wrapper closes that gap by
+# running the lint over the production tree and propagating its exit code,
+# mirroring the wiring style of scripts/check_resolveoptions_rc.sh.
+#
+# The lint enforces internal/cache/match_subject.go as the SINGLE SOURCE OF
+# TRUTH for BindingUID derivation: any non-allowlisted production file that
+# iterates snap.CRBsBy* / snap.RBsBy* / snap.CRBsCatchAll / snap.RBsCatchAllByNS
+# (an identity->binding projection outside the SOT) is a hard failure.
+#
+# Run it locally before pushing:
+#
+#   bash scripts/check_no_parallel_binding_derivation.sh
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The lint defaults --root to the go.mod-bearing project root and walks
+# <root>/internal. Invoke via `go run` on the //go:build ignore program —
+# no build step, no extra deps, resolves against the repo's own go.mod.
+go run scripts/lint/no_parallel_binding_derivation.go

--- a/scripts/check_no_unchecked_unstructured_assert.sh
+++ b/scripts/check_no_unchecked_unstructured_assert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# check_no_unchecked_unstructured_assert.sh — H6 CI guard that WIRES the
+# previously-orphaned AST lint scripts/lint/no_unchecked_unstructured_assert.go
+# into a runnable, exit-code-bearing step.
+#
+# THE GAP (H6): the lint program is a //go:build ignore standalone (so
+# `go build ./...` / `go vet ./...` skip it) and was invoked by NO workflow.
+# A raw obj.(*unstructured.Unstructured) content-assert reintroduced inside a
+# literal informer event-handler body — the Ship 0.30.233 defect class that
+# silently drops every CRD event post-H5 (delivery shape is *bytesObject) —
+# would therefore NOT fail CI. This wrapper closes that gap by running the
+# lint over internal/cache and propagating its exit code, mirroring the
+# wiring style of scripts/check_resolveoptions_rc.sh.
+#
+# Run it locally before pushing:
+#
+#   bash scripts/check_no_unchecked_unstructured_assert.sh
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The lint defaults --root to <project-root>/internal/cache (the only tree
+# that installs dynamic-informer event handlers). Invoke via `go run` on the
+# //go:build ignore program — no build step, no extra deps.
+go run scripts/lint/no_unchecked_unstructured_assert.go --root="$(pwd)/internal/cache"

--- a/scripts/lint/gate_test.go
+++ b/scripts/lint/gate_test.go
@@ -1,0 +1,115 @@
+// scripts/lint/gate_test.go — H6 discrimination proof for the two
+// orphaned-then-wired AST lint gates.
+//
+// WHY THIS FILE EXISTS (H6): the lint programs in this directory are
+// //go:build ignore standalone `package main` programs, so `go build
+// ./...` / `go vet ./...` skip them AND `go list ./scripts/lint/...`
+// matches no package — the normal `go test ./...` coverage run never
+// exercised the gate at all. This test is a NORMAL (non-ignore) test
+// file, so `go test ./scripts/lint/...` now builds a test binary here
+// and drives each lint program via `go run` over the good/bad fixtures.
+// That makes the gate's discrimination itself a tested property, per
+// the falsifier-must-actually-run discipline.
+//
+// EACH lint gets both arms:
+//   - GOOD fixture  -> the lint MUST exit 0 (no false positives).
+//   - BAD  fixture  -> the lint MUST exit non-zero AND name the
+//     offending site (the RED arm: if the lint stops discriminating,
+//     this goes RED).
+//
+// The BAD arm is the transient-neuter equivalent: the fixture IS the
+// neutered/regressed state the lint must reject. Verified by hand
+// (see the ship report) and re-verified on every coverage run.
+//
+// package main matches the sibling //go:build ignore lint programs'
+// package declaration; because those are excluded by the build tag, the
+// test binary is built from this file alone — no `func main` required.
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lintProgram is one //go:build ignore lint under scripts/lint/,
+// resolved relative to this test's working directory (which `go test`
+// sets to the package dir, i.e. scripts/lint/).
+type lintCase struct {
+	name string // subtest name
+	// prog is the lint source file, relative to scripts/lint/.
+	prog string
+	// goodRoot / badRoot are --root values relative to scripts/lint/.
+	goodRoot string
+	badRoot  string
+	// mustNameInBad is a substring the BAD-arm output MUST contain (the
+	// offending site) — proves the lint pinpointed the violation, not
+	// merely exited non-zero for an unrelated reason.
+	mustNameInBad string
+}
+
+func lintCases() []lintCase {
+	return []lintCase{
+		{
+			name:          "no_parallel_binding_derivation",
+			prog:          "no_parallel_binding_derivation.go",
+			goodRoot:      filepath.Join("testdata", "parallel_binding", "good"),
+			badRoot:       filepath.Join("testdata", "parallel_binding", "bad"),
+			mustNameInBad: "parallel_derivation.go",
+		},
+		{
+			name:          "no_unchecked_unstructured_assert",
+			prog:          "no_unchecked_unstructured_assert.go",
+			goodRoot:      filepath.Join("testdata", "unchecked_assert", "good"),
+			badRoot:       filepath.Join("testdata", "unchecked_assert", "bad"),
+			mustNameInBad: "regression_unchecked_assert.go",
+		},
+	}
+}
+
+// runLint invokes `go run <prog> --root=<root>` from the scripts/lint/
+// working dir and returns combined output + whether it exited zero.
+func runLint(t *testing.T, prog, root string) (string, bool) {
+	t.Helper()
+	cmd := exec.Command("go", "run", prog, "--root="+root)
+	out, err := cmd.CombinedOutput()
+	return string(out), err == nil
+}
+
+// TestLintGate_GoodFixturePasses is the PASS arm: each lint MUST exit 0
+// on its GOOD fixture (no false positives). A regression that made the
+// lint over-broad would red this.
+func TestLintGate_GoodFixturePasses(t *testing.T) {
+	for _, lc := range lintCases() {
+		lc := lc
+		t.Run(lc.name, func(t *testing.T) {
+			out, ok := runLint(t, lc.prog, lc.goodRoot)
+			if !ok {
+				t.Fatalf("GATE FALSE-POSITIVE: %s exited non-zero on the GOOD fixture %s; it must PASS.\nOutput:\n%s",
+					lc.prog, lc.goodRoot, out)
+			}
+		})
+	}
+}
+
+// TestLintGate_BadFixtureFails is the RED arm: each lint MUST exit
+// non-zero on its BAD fixture AND name the offending site. If the lint's
+// discrimination logic (or its wiring) regresses so the BAD fixture
+// passes, this test goes RED — exactly the H6 property being enforced.
+func TestLintGate_BadFixtureFails(t *testing.T) {
+	for _, lc := range lintCases() {
+		lc := lc
+		t.Run(lc.name, func(t *testing.T) {
+			out, ok := runLint(t, lc.prog, lc.badRoot)
+			if ok {
+				t.Fatalf("GATE DID NOT DISCRIMINATE: %s exited 0 on the BAD fixture %s; it MUST FAIL.\nOutput:\n%s",
+					lc.prog, lc.badRoot, out)
+			}
+			if !strings.Contains(out, lc.mustNameInBad) {
+				t.Fatalf("%s failed the BAD fixture but did not name the offending site %q (wrong-reason failure?).\nOutput:\n%s",
+					lc.prog, lc.mustNameInBad, out)
+			}
+		})
+	}
+}

--- a/scripts/lint/testdata/parallel_binding/bad/internal/cache/parallel_derivation.go
+++ b/scripts/lint/testdata/parallel_binding/bad/internal/cache/parallel_derivation.go
@@ -1,0 +1,43 @@
+// scripts/lint/testdata/parallel_binding/bad/internal/cache/parallel_derivation.go
+// — Ship H6 lint-gate BAD fixture (FAIL side of the dual-state proof for
+// scripts/lint/no_parallel_binding_derivation.go).
+//
+// PURPOSE: this file reproduces the v3-baseline defect class the lint
+// must catch — a BindingUID-equivalent derivation that iterates a
+// snapshot subject index (snap.CRBsByUser) in a NON-allowlisted
+// production file, projecting an identity->binding mapping OUTSIDE the
+// single source of truth (internal/cache/match_subject.go). This is the
+// exact shape of the deleted cohort_* files (binding_set_enumeration.go,
+// cohort_ns_acl.go, rbac_cohorts.go) called out in the lint's dual-state
+// comment.
+//
+// Its relative path from the fixture root is
+// "internal/cache/parallel_derivation.go" — NOT in the fileAllowlist —
+// so the lint MUST flag it (exit 1).
+//
+// The lint's BAD arm invokes:
+//
+//   go run scripts/lint/no_parallel_binding_derivation.go \
+//     --root=$(pwd)/scripts/lint/testdata/parallel_binding/bad
+//   # exit 1; violation reported for the snap.CRBsByUser touch below.
+//
+// `//go:build ignore` keeps `go build ./...` + `go vet ./...` away.
+
+//go:build ignore
+
+package cache
+
+type snapshot struct {
+	CRBsByUser      map[string][]int
+	RBsByUserByNS   map[string]map[string][]int
+	CRBsCatchAll    []int
+	RBsCatchAllByNS map[string][]int
+}
+
+// deriveParallelBindingUID is the VIOLATION: it iterates snap.CRBsByUser
+// to project a per-user binding identity outside the SOT. The lint flags
+// the snap.CRBsByUser selector.
+func deriveParallelBindingUID(snap *snapshot, user string) []int {
+	// THE LINT MUST FLAG THIS snap.CRBsByUser touch.
+	return snap.CRBsByUser[user]
+}

--- a/scripts/lint/testdata/parallel_binding/good/internal/cache/clean.go
+++ b/scripts/lint/testdata/parallel_binding/good/internal/cache/clean.go
@@ -1,0 +1,28 @@
+// scripts/lint/testdata/parallel_binding/good/internal/cache/clean.go —
+// Ship H6 lint-gate GOOD fixture (PASS side, no-target-pattern path).
+//
+// PURPOSE: a NON-allowlisted production-shaped file that simply does not
+// touch any snap.CRBsBy* / snap.RBsBy* / snap.CRBsCatchAll /
+// snap.RBsCatchAllByNS index. It exercises the lint's other PASS path:
+// a file with no target pattern is never a violation, allowlist or not.
+// Confirms the GOOD root stays clean even with a non-allowlisted file
+// present.
+//
+// `//go:build ignore` keeps `go build ./...` + `go vet ./...` away.
+
+//go:build ignore
+
+package cache
+
+// routeThroughSOT is the sanctioned derivation path: it calls the single
+// source of truth (BindingUIDFromCRB) rather than iterating a snapshot
+// subject index. No snap.CRBsBy* access at all — nothing for the lint to
+// flag.
+func routeThroughSOT(crb any) string {
+	return bindingUIDFromCRB(crb)
+}
+
+func bindingUIDFromCRB(crb any) string {
+	_ = crb
+	return "uid"
+}

--- a/scripts/lint/testdata/parallel_binding/good/internal/cache/rbac_snapshot.go
+++ b/scripts/lint/testdata/parallel_binding/good/internal/cache/rbac_snapshot.go
@@ -1,0 +1,44 @@
+// scripts/lint/testdata/parallel_binding/good/internal/cache/rbac_snapshot.go
+// — Ship H6 lint-gate GOOD fixture (PASS side of the dual-state proof for
+// scripts/lint/no_parallel_binding_derivation.go).
+//
+// PURPOSE: this file lives at the allowlisted relative path
+// "internal/cache/rbac_snapshot.go" (see the lint's fileAllowlist at
+// no_parallel_binding_derivation.go:81-84). It touches snap.CRBsByUser
+// exactly the way the real snapshot WRITER does — identity-independent
+// len()-style iteration — which is legitimate BECAUSE it is allowlisted.
+// The lint MUST NOT flag it, so this GOOD root exits 0.
+//
+// Directory layout note: the lint's --root is the PROJECT ROOT and it
+// walks <root>/internal. The fixture therefore nests the file under
+// internal/cache/ so that filepath.Rel(root, path) == the allowlisted
+// key. A sibling clean.go (no snap.CRBsBy* at all) exercises the other
+// PASS path (no target pattern present).
+//
+// The lint's GOOD arm invokes:
+//
+//   go run scripts/lint/no_parallel_binding_derivation.go \
+//     --root=$(pwd)/scripts/lint/testdata/parallel_binding/good
+//   # exit 0; no violations
+//
+// `//go:build ignore` keeps `go build ./...` + `go vet ./...` away.
+
+//go:build ignore
+
+package cache
+
+// snapshot mimics the fields the lint's targetIdentifierPattern matches.
+type snapshot struct {
+	CRBsByUser map[string][]int
+}
+
+// countBindings is the identity-independent iteration the WRITER file is
+// allowed to do. It projects NO BindingUID — it only counts. Because
+// this file is allowlisted, the lint tolerates the snap.CRBsByUser touch.
+func countBindings(snap *snapshot) int {
+	n := 0
+	for range snap.CRBsByUser {
+		n++
+	}
+	return n
+}

--- a/scripts/lint/testdata/unchecked_assert/bad/regression_unchecked_assert.go
+++ b/scripts/lint/testdata/unchecked_assert/bad/regression_unchecked_assert.go
@@ -1,0 +1,69 @@
+// scripts/lint/testdata/unchecked_assert/bad/regression_unchecked_assert.go
+// — Ship H6 lint-gate BAD fixture (FAIL side of the dual-state proof for
+// scripts/lint/no_unchecked_unstructured_assert.go).
+//
+// PURPOSE: this file deliberately reproduces the Ship 0.30.233 defect
+// class the lint must catch: a raw `obj.(*unstructured.Unstructured)`
+// content-assert inside a LITERAL informer event-handler body, with NO
+// decodeBytesObject / fallbackUnstructuredFromIndexer routing. Post
+// Ship-H5 the streaming-listwatch delivers *bytesObject here, NOT
+// *unstructured.Unstructured — the assertion silently fails on every
+// event.
+//
+// It is the isolated-root twin of the historical flat fixture at
+// ../../regression_unchecked_assert.go (kept in place for the lint's own
+// documented `--root=$(pwd)/scripts/lint/testdata` usage). This copy
+// lives under bad/ so the H6 gate test can point --root at a directory
+// that contains ONLY the BAD fixture, keeping the GOOD/BAD arms cleanly
+// separated.
+//
+// The lint's BAD arm invokes:
+//
+//   go run scripts/lint/no_unchecked_unstructured_assert.go \
+//     --root=$(pwd)/scripts/lint/testdata/unchecked_assert/bad
+//   # exit 1; violations reported for each raw assert below.
+//
+// `//go:build ignore` keeps `go build ./...` + `go vet ./...` away.
+
+//go:build ignore
+
+package bad
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clientcache "k8s.io/client-go/tools/cache"
+)
+
+// installBadHandler reproduces the Ship 0.30.233 defect class: a raw
+// *unstructured.Unstructured content-assert inside a literal informer
+// AddFunc / UpdateFunc / DeleteFunc body with no decode-helper routing.
+//
+// THE LINT MUST FLAG THIS FUNCTION.
+func installBadHandler() clientcache.ResourceEventHandlerFuncs {
+	return clientcache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			// REGRESSION: raw content-assert inside a literal AddFunc body.
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok || u == nil {
+				return
+			}
+			_ = u.GetName()
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			// REGRESSION: same defect class, UpdateFunc variant.
+			u, ok := newObj.(*unstructured.Unstructured)
+			if !ok || u == nil {
+				return
+			}
+			_ = u.GetName()
+		},
+		DeleteFunc: func(obj interface{}) {
+			// REGRESSION: same defect class, DeleteFunc variant.
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok || u == nil {
+				return
+			}
+			_ = u.GetName()
+		},
+	}
+}

--- a/scripts/lint/testdata/unchecked_assert/good/clean_handler.go
+++ b/scripts/lint/testdata/unchecked_assert/good/clean_handler.go
@@ -1,0 +1,67 @@
+// scripts/lint/testdata/unchecked_assert/good/clean_handler.go — Ship H6
+// lint-gate GOOD fixture (PASS side of the dual-state proof for
+// scripts/lint/no_unchecked_unstructured_assert.go).
+//
+// PURPOSE: this file is the H5-SAFE counterpart to the BAD fixture at
+// ../bad/regression_unchecked_assert.go. It constructs the SAME
+// clientcache.ResourceEventHandlerFuncs{} shape the lint inspects, but
+// every content-reading handler body routes through decodeBytesObject
+// (the H5-aware decode helper) — so the lint MUST NOT flag it. The
+// all-`_` handler (OQ2) is content-free by construction and equally
+// clean.
+//
+// The lint's GOOD arm invokes:
+//
+//   go run scripts/lint/no_unchecked_unstructured_assert.go \
+//     --root=$(pwd)/scripts/lint/testdata/unchecked_assert/good
+//   # exit 0; no violations
+//
+// `//go:build ignore` keeps `go build ./...` + `go vet ./...` away from
+// this fixture (mirrors the sibling fixture + the lint programs
+// themselves). parser.ParseFile reads it regardless of the build tag —
+// that's how the lint sees it.
+
+//go:build ignore
+
+package good
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clientcache "k8s.io/client-go/tools/cache"
+)
+
+// decodeBytesObject stands in for the real internal/cache helper of the
+// same name. The lint matches decode helpers by IDENTIFIER NAME (see
+// no_unchecked_unstructured_assert.go:112-116), so a local declaration
+// with the canonical name is sufficient for the fixture — no dependency
+// on the internal package.
+func decodeBytesObject(obj interface{}) (*unstructured.Unstructured, bool) {
+	u, ok := obj.(*unstructured.Unstructured)
+	return u, ok
+}
+
+// installGoodHandler is the H5-safe pattern: content access goes through
+// decodeBytesObject, so even though a raw *unstructured.Unstructured
+// assert exists inside decodeBytesObject, the handler bodies themselves
+// route through the helper. The lint MUST NOT flag any of these.
+func installGoodHandler() clientcache.ResourceEventHandlerFuncs {
+	return clientcache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			// H5-safe: route through the decode helper.
+			u, ok := decodeBytesObject(obj)
+			if !ok || u == nil {
+				return
+			}
+			_ = u.GetName()
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			u, ok := decodeBytesObject(newObj)
+			if !ok || u == nil {
+				return
+			}
+			_ = u.GetName()
+		},
+		// OQ2: all-blank params — content-free by construction, never flagged.
+		DeleteFunc: func(_ interface{}) {},
+	}
+}


### PR DESCRIPTION
**Wave 1 of the extensive feature-coverage suite you asked for.** Coverage audit in `docs/test-coverage-audit-2026-07-30.md` (131 features; 89 discriminating / 26 shallow / 16 uncovered; 8 of top-10 gaps were security).

+22 hermetic `_test.go` (~96 funcs, 44 RED-proven arms) filling the HIGH + security-MEDIUM gaps + 5 behavior-preserving prod-testability var-seams. All `-race -p1` GREEN across cache/dispatchers/widgets/rbac-evaltest/handlers/middleware/main.

Draft/PARKED — Diego-reserved merge. Wave 2 (apiref/restactions/authn + wiring the orphaned `scripts/lint` AST gates into CI) to follow as a second commit/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)