### PR TITLE
fix(chart): explicit lenient probe tolerances so CPU contention doesn't flap snowplow

### DIFF
--- a/helm/snowplow/values.yaml
+++ b/helm/snowplow/values.yaml
@@ -122,10 +122,13 @@ resources:
 # port (PORT, 8081) -- there is no dedicated probe listener on the 1.0.x
 # ship line, so all three probes target `http`. The timeouts/thresholds
 # below are EXPLICIT (not k8s defaults): the k8s defaults
-# (timeoutSeconds 1, failureThreshold 3, periodSeconds 10) leave only a
-# 30-second window before kubelet kills the pod; we widen that as
-# defence-in-depth so a transient scheduler hiccup does not restart a
-# healthy pod.
+# (timeoutSeconds 1, failureThreshold 3) kill HEALTHY pods under CPU
+# contention -- on a loaded node a healthy /health can take >1s to answer,
+# three misses restart the pod, and the resulting restart storm worsens
+# the very contention that caused it. Liveness is therefore lenient
+# (~60s of consecutive failure before restart, so only truly dead
+# processes die); readiness keeps prompt endpoint removal but load alone
+# must not flap it.
 
 # Startup probe: gives the binary up to 6 minutes (36 x 10s) to start
 # serving /health. The http server (incl. /health) binds early, before
@@ -140,16 +143,18 @@ startupProbe:
   timeoutSeconds: 3
 
 # Liveness probe: checks only that the binary is alive (/health is a
-# cheap write with zero kube-API touches). failureThreshold 5 +
-# periodSeconds 10 + timeoutSeconds 3 = a 50-second window before
-# kubelet restarts, vs the 30-second window of k8s defaults.
+# cheap write with zero kube-API touches). failureThreshold 6 +
+# periodSeconds 10 + timeoutSeconds 5 = a ~60-second window of
+# consecutive failure before kubelet restarts, vs the 30-second window
+# of k8s defaults -- only a truly dead process dies, and slow probe
+# answers under CPU contention never trigger a restart storm.
 livenessProbe:
   httpGet:
     path: /health
     port: http
   periodSeconds: 10
-  timeoutSeconds: 3
-  failureThreshold: 5
+  timeoutSeconds: 5
+  failureThreshold: 6
 
 # Readiness probe: /readyz flips to 200 once Phase1Done is set. As of
 # 1.5.29 (shape A prewarm-gated readiness) Phase1Done is set AFTER the
@@ -159,13 +164,15 @@ livenessProbe:
 # under the aggregate OOM gate). Post-Ready L1 misses still fall through to a
 # foreground resolve (the #41 on-miss floor is intact). failureThreshold here
 # does NOT kill the pod (readiness only withholds from Endpoints); the rollout
-# bound is progressDeadlineSeconds above.
+# bound is progressDeadlineSeconds above. timeoutSeconds 5 so CPU
+# contention alone does not flap endpoint membership; failureThreshold 3
+# keeps removal of a genuinely unready pod prompt.
 readinessProbe:
   httpGet:
     path: /readyz
     port: http
   periodSeconds: 5
-  timeoutSeconds: 3
+  timeoutSeconds: 5
   failureThreshold: 3
 
 autoscaling:


### PR DESCRIPTION
## Problem

Kubernetes probe defaults (`timeoutSeconds: 1`, `failureThreshold: 3`) kill **healthy** pods under CPU contention — observed live as restart storms on a loaded kind cluster. On a loaded node a healthy `/health` can take >1s to answer, three consecutive misses restart the pod, and the resulting restart storm worsens the very contention that caused it.

The snowplow chart was already partially widened (liveness t=3/fail=5, readiness t=3/fail=3) but still short of the org standard.

## Change (org probe-tolerance standard)

`helm/snowplow/values.yaml` only:

| Probe | Field | Before | After |
|---|---|---|---|
| liveness | timeoutSeconds | 3 | **5** |
| liveness | failureThreshold | 5 | **6** |
| liveness | periodSeconds | 10 | 10 (kept) |
| readiness | timeoutSeconds | 3 | **5** |
| readiness | failureThreshold | 3 | 3 (kept) |
| readiness | periodSeconds | 5 | 5 (kept) |

- **Liveness is lenient**: ~60s of consecutive failure before restart — only truly dead processes die; restart storms would worsen contention.
- **Readiness stays prompt**: endpoint removal of a genuinely unready pod is unchanged (fail=3, per=5), but load alone must not flap it (t=5).
- Rationale comments in values.yaml updated to match.
- No resource, template, or schema changes (`values.schema.json` already types `timeoutSeconds`/`failureThreshold`/`periodSeconds` on both probes). `startupProbe` untouched.

Validated: `helm template` (with version placeholders substituted) exits 0 and renders the new tolerances; schema validation passes.

## Precedent

- chart-inspector probe block in the core-provider chart
- krateo-platformops/authn PR #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)