### PR TITLE
fix(chart): type resources cpu as a Kubernetes Quantity (integer|string)

### DIFF
--- a/helm/snowplow/values.schema.json
+++ b/helm/snowplow/values.schema.json
@@ -227,8 +227,8 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": "integer",
-              "description": "CPU limit.",
+              "type": ["integer", "string"],
+              "description": "CPU limit — a Kubernetes Quantity: integer cores or a string like \"500m\"/\"1\".",
               "title": "CPU"
             },
             "memory": {
@@ -245,8 +245,8 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": "integer",
-              "description": "CPU request.",
+              "type": ["integer", "string"],
+              "description": "CPU request — a Kubernetes Quantity: integer cores or a string like \"500m\"/\"1\".",
               "title": "CPU"
             },
             "memory": {


### PR DESCRIPTION
## Problem (krateo-core-provider#66, observed live)
`values.schema.json` types `resources.{limits,requests}.cpu` as bare `"integer"`. crdgen faithfully propagates that into the generated Snowplow composition CRD — so the CRD types cpu numeric-only. The apiserver's typed conversion inside the `krateo-composition-version` MutatingAdmissionPolicy (ApplyConfiguration) then rejects **any update** of a Snowplow CR carrying idiomatic Quantity strings:

```
policy 'krateo-composition-version' denied request: error applying patch:
failed to convert original object to typed object:
.spec.resources.limits.cpu: expected numeric (int or float), got string
```

which wedges the umbrella reconcile (`Synced=False`) as soon as componentValues set snowplow resources with `"200m"`/`"1"` — reproduced live on kind today.

## Fix
Type cpu as `["integer","string"]` — the same convention the installer chart schema already uses, which crdgen demonstrably maps to `x-kubernetes-int-or-string` in the CRD (the installer CRD accepts both forms today). Both integer cores and Quantity strings then pass helm validation, CRD validation, and the MAP's typed conversion. `memory` was already `"string"` and is unaffected.

4-line diff, surgical. Verified: `helm template` passes with `cpu=200m`+`cpu=1` (strings), `cpu=2` (integer), and defaults.

Note: an org-wide scan of the other first-party chart schemas (frontend, authn, core-provider, helm-render-service, autopilot, installer) found **no other** integer-typed Quantity fields — snowplow was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)