### PR TITLE
docs: adopt the Krateo Documentation Standard (pilot)

### DIFF
--- a/.github/workflows/release-pullrequest.yaml
+++ b/.github/workflows/release-pullrequest.yaml
@@ -23,6 +23,11 @@ jobs:
     with:
       modules: '[{"mod":"snowplow","context":"go/snowplow"}]'
       push: false
+  # Krateo Documentation Standard conformance (shared org workflow): the invariant
+  # docs/ file set, frontmatter, link integrity, banned dead-org strings, examples
+  # pairing. Resolves once krateo-platformops/.github#2 (the standard seed) merges.
+  lint-docs:
+    uses: krateo-platformops/.github/.github/workflows/lint-docs.yaml@main
   checks:
     uses: krateo-platformops/.github/.github/workflows/component-go-checks.yaml@main
     with:

--- a/README.md
+++ b/README.md
@@ -1,26 +1,66 @@
-# `snowplow`
+# snowplow
 
-Snowplow is a web service that plays a key role within the suite of components that make up Krateo PlatformOps. 
+The content API of Krateo PlatformOps: it resolves `RESTAction` and frontend `Widget`
+custom resources into the JSON the Krateo portal renders, served over `GET /call`.
 
-It serves multiple purposes, primarily acting as a bridge between Krateo's custom resources and the UI. By enabling a dynamic and declarative approach to defining UI components and layouts, Snowplow ensures that the interface is interpreted and rendered seamlessly by Krateo Frontend.
+## What is this
 
-It handles on-demand resolution of the `RESTAction` custom resource and all Krateo Frontend `Widgets` custom resources.
+A content bridge, not a BFF: snowplow holds no product state — it composes portal
+content on demand from Kubernetes CRs (declarative REST-call chains, widget
+definitions), enforces the caller's own RBAC, and serves any client that presents a
+Krateo JWT. One monorepo, one version line: the app (`go/snowplow/`) and its Helm
+charts (`helm/`) ship together from a single tag.
+Full picture: [docs/index.md](docs/index.md).
 
-## Learn More
+## Install
 
-### Developer Guide
+Normally installed by the **Krateo installer**, which pins the chart. Standalone:
 
-- [Building `snowplow`](howto/developer-guide.md)
-- [ADR: Decoupling `authn` from `snowplow` for Testing and Operations](howto/decoupling-authn-from-snowplow-for-testing.md)
+```sh
+# CRDs first (RESTAction + the authn ServiceAccount CRD the app chart hard-requires):
+helm install snowplow-crds oci://ghcr.io/krateo-platformops/charts/snowplow-crds --version 1.9.0
+helm install authn-crds oci://ghcr.io/krateo-platformops/charts/authn-crds
 
-### User Guide
+helm install snowplow oci://ghcr.io/krateo-platformops/charts/snowplow \
+  --version 1.9.0 --namespace krateo-system
+```
 
-- [`Endpoint` reference](howto/endpoints.md)
-- [`RESTAction` reference](howto/restactions.md)
-- [Understanding the `Widget` Custom Resource](howto/widgets.md)
-- [Installing `snowplow` on Kind](howto/install.md)
+Details, dependencies and the Kind quickstart: [docs/usage.md](docs/usage.md).
 
-### Examples
+## Configure
 
-- [RESTAction: list _cluster namespaces_](howto/restactions/example-cluster-namespaces.md)
-- [RESTAction: invoke _external API_](howto/restactions/example-external-api.md)
+See [docs/configuration.md](docs/configuration.md). Most used:
+
+| Setting | Default | Effect |
+|---|---|---|
+| `env.CACHE_ENABLED` | `"true"` | The single cache master gate; `false` = transparent direct-apiserver fallback (same data, slower). |
+| `env.GOMEMLIMIT` | `7GiB` | Go GC back-pressure ceiling — must stay strictly below `resources.limits.memory` (8Gi) or Linux OOM-kills instead. |
+| `service.type` / `service.port` | `LoadBalancer` / `8081` | One port serves content, probes and debug surfaces. |
+
+## Examples
+
+- [examples/cluster-namespaces](examples/cluster-namespaces) — a `RESTAction` listing
+  cluster namespaces via the Kubernetes API, JQ-filtered to names.
+- [examples/external-api](examples/external-api) — chained GET→POST against an external
+  service through an `Endpoint` Secret.
+
+## Docs
+
+- [docs/index.md](docs/index.md) — the map (bundle + the code-adjacent deep corpus)
+- [docs/overview.md](docs/overview.md) — what it does and how it works
+- [docs/usage.md](docs/usage.md) — how to install / consume it
+- [docs/configuration.md](docs/configuration.md) — the whole config surface
+- [docs/api.md](docs/api.md) — the `RESTAction` CRD + the HTTP surface
+- [docs/examples.md](docs/examples.md) — examples index
+- [docs/release.md](docs/release.md) — how a release ships
+- [docs/log.md](docs/log.md) — curated history
+
+Internals (code-traced): [go/snowplow/ARCHITECTURE.md](go/snowplow/ARCHITECTURE.md)
+and the deep dives it links.
+
+## Develop & release
+
+`cd go/snowplow && go test ./...` (keep `KUBECONFIG` unset — see
+[CONTRIBUTING](go/snowplow/CONTRIBUTING.md)); local cluster workflow via
+`go/snowplow/scripts/`. Tag `X.Y.Z` (no `v`) ships image + charts — release runbook:
+[docs/release.md](docs/release.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,78 @@
+---
+type: API
+title: snowplow — API
+description: The RESTAction CRD (templates.krateo.io) and the HTTP surface snowplow serves on its single port.
+resource: restactions.templates.krateo.io
+tags: [crd, restaction, http, openapi]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# API
+
+snowplow exposes two contracts: the **`RESTAction` CRD** it owns, and the **HTTP
+surface** it serves (which also resolves the frontend-owned `Widget` CRDs).
+
+## The `RESTAction` CRD
+
+`restactions.templates.krateo.io` — group `templates.krateo.io`, version `v1`, kind
+`RESTAction`, namespaced, short name `ra`. Shipped by the
+[`snowplow-crds` chart](../helm/snowplow-crds/templates/templates.krateo.io_restactions.yaml);
+Go types under [`go/snowplow/apis/templates/`](../go/snowplow/apis/templates/) are the
+source of truth (the CRD is generated, drift-gated in CI).
+
+A `RESTAction` declaratively defines one or more HTTP calls (`spec.api[]`) that may
+depend on each other. Each call's JSON (or YAML — converted transparently,
+[ADR 0006](../go/snowplow/docs/adr/0006-snowplow-owned-external-fetch.md)) response
+joins a shared context that later calls and JQ expressions can reference.
+
+| `spec.api[]` field | Meaning |
+|---|---|
+| `name` | Stage identifier — and the key its filtered result lands under in the returned `status`. |
+| `verb`, `path`, `headers`, `payload` | The HTTP request (verb defaults to `GET`). |
+| `endpointRef` | Reference to an [`Endpoint`](../go/snowplow/howto/endpoints.md) Secret (server URL, auth, TLS, proxy). Absent = the Kubernetes API server. |
+| `dependsOn` | Chains this stage after another; its output is referenceable via JQ. |
+| `filter` | JQ expression applied to the response ([custom modules](./configuration.md) available). |
+| `continueOnError`, `errorKey` | Keep going on failure; where the error lands in `status`. |
+| `exportJwt` | Export a JWT obtained by this stage for later stages. |
+| `resolve` | When `path` points at a `RESTAction`/`Widget` CR, resolve it in-process (default `true`). |
+| `userAccessFilter` | Dispatch the read via snowplow's ServiceAccount, then RBAC-refilter the result per item against the requesting user. CEL rules on the CRD enforce read-verb-only, no `exportJwt`, and the `resource`/`resourcesFrom` XOR. |
+
+A top-level `spec.filter` shapes the overall output.
+
+**Lifecycle — resolved on read, no controller.** Nothing reconciles a `RESTAction`.
+Applying one stores inert spec; the calls execute when the CR is read **through
+`GET /call`**, and the resolved output is returned in the response's `status`. Reading
+the CR via `kubectl` shows it as-is; snowplow does not persist resolved results back to
+the cluster (the CRD's status subresource is free-form for compatibility). Caching and
+prewarm may resolve ahead of time, but that is transparent
+([overview](./overview.md)).
+
+Authoring references: [restactions.md](../go/snowplow/howto/restactions.md) (full field
+reference), [endpoints.md](../go/snowplow/howto/endpoints.md),
+[widgets.md](../go/snowplow/howto/widgets.md), and the worked
+[examples](./examples.md).
+
+## The HTTP surface
+
+Everything is served on the single `http` port (default `8081`). Authenticated routes
+take a Krateo JWT (`Authorization: Bearer …`), validated against `JWT_SIGN_KEY`. The
+authoritative machine-readable spec is
+[`go/snowplow/docs/swagger.json`](../go/snowplow/docs/swagger.json) (served live at
+`GET /swagger/`).
+
+| Route | What it does |
+|---|---|
+| `GET /call` | **The content endpoint.** Resolves the referenced `RESTAction` or `Widget` (`apiVersion`, `resource`, `name`, `namespace` query params; optional [`extras`](../go/snowplow/howto/extras.md)) — dispatched, RBAC-gated, cached. |
+| `POST/PUT/PATCH/DELETE /call` | Write passthrough to the apiserver under the caller's identity — never resolved, never cached. |
+| `GET /export` | Any `/call`-resolvable list as a CSV/JSON attachment; re-dispatches in-process with identical auth/RBAC ([export.md](../go/snowplow/howto/export.md)). |
+| `GET /list` | List resources by category in a namespace. |
+| `GET /api-info/names` | API names/plurals discovery helper. |
+| `GET /rbac` | Enumerates the (group, version, resource, verb) read-set a RESTAction *would* perform, without dispatching — for RBAC pre-generation. |
+| `GET /refreshes` | Per-subject live-refresh SSE stream (cookie-or-header JWT). |
+| `POST /jq` | Evaluate a JQ expression against a JSON input. |
+| `GET /health`, `GET /readyz` | Liveness (always 200 once serving) / readiness (200 on prewarm-complete). |
+| `GET /swagger/` | The OpenAPI UI + spec. |
+| `GET /debug/vars`, `/debug/pprof/*`, `/debug/servable`, `/debug/apistage`, `/debug/refreshes` | Operator diagnostics ([observability](../go/snowplow/docs/architecture/observability.md)); `/debug/refreshes` is JWT-gated. |
+
+Note: the spec also describes `POST /convert` (YAML↔JSON), but that route is currently
+not wired in `main.go` — the spec is a superset on this one endpoint.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,80 @@
+---
+type: Configuration
+title: snowplow — configuration
+description: The whole config surface — Helm values, the env-var ConfigMap contract, probes and runtime tuning — with defaults.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [helm, values, env, tuning]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Configuration
+
+Everything is driven by the `snowplow` Helm chart
+([`helm/snowplow/values.yaml`](../helm/snowplow/values.yaml)). The authoritative
+machine-readable surface is
+[`helm/snowplow/values.schema.json`](../helm/snowplow/values.schema.json) — every value
+below is typed and validated there; this page explains, it does not re-enumerate.
+
+## The env contract
+
+The container takes **no direct `env:` array**. Every value that reaches the process
+goes through `envFrom` ([`deployment.yaml`](../helm/snowplow/templates/deployment.yaml)):
+
+1. the chart-managed `snowplow` ConfigMap — rendered from `.Values.env`;
+2. the JWT signing-key Secret — `jwtSignKeySecretName` (default `jwt-sign-key`,
+   key `JWT_SIGN_KEY`); the pod does not start without it;
+3. `extraEnvFrom` — by default the optional `snowplow-api-override` ConfigMap, so the
+   portal blueprint can layer config without re-templating this chart.
+
+A `checksum/configmap` pod annotation rolls the Deployment when the ConfigMap changes.
+
+## Helm values (top level)
+
+| Value | Default | Effect |
+|---|---|---|
+| `image.registry` / `image.repository` | `ghcr.io` / `krateo-platformops/snowplow` | The app image. `global.imageRegistry` relocates the registry host for mirror/air-gapped installs (repository path preserved). |
+| `image.tag` | `""` (= chart `appVersion`) | Pin only to diverge from the released pairing. |
+| `service.type` / `service.port` | `LoadBalancer` / `8081` | One port serves everything: content, probes, debug. |
+| `replicaCount` | `1` | With `autoscaling.enabled: false` (default). |
+| `strategy` | `RollingUpdate`, `maxSurge: 1`, `maxUnavailable: 0` | Zero-gap deploys: the new pod prewarms behind `/readyz` while the old warm pod keeps serving. |
+| `progressDeadlineSeconds` | `1200` | Rollout deadline; must exceed informer sync + prewarm seed at scale. |
+| `resources` | limits `4 cpu / 8Gi`, requests `2 cpu / 4Gi` | Pre-sized for 50K compositions × 1000 users (informer + in-process L1 cache). |
+| `startupProbe` / `livenessProbe` | `/health`, widened thresholds | `/health` binds early and never gates prewarm; liveness must not kill a warming pod. |
+| `readinessProbe` | `/readyz` | Flips 503→200 on **prewarm-complete**, not mere informer sync. |
+| `ingress` | `enabled: false` | Standard chart ingress if you need it. |
+| `jwtSignKeySecretName` | `jwt-sign-key` | Secret holding `JWT_SIGN_KEY` (shared with authn). |
+| `seedAuthn.*` | group `krateo:snowplow-seed`, namespace `krateo-system`, audience `authn` | The prewarm-seed loopback-auth artifacts (allowlist CR + ClusterRole/Binding + projected token) — **always rendered**; see [usage](./usage.md) for the hard dependency. |
+| `extraEnvFrom` | `snowplow-api-override` ConfigMap (optional) | Extra env sources appended after the defaults. |
+| `env.*` | see below | Rendered into the `snowplow` ConfigMap. |
+
+## `env.*` — the runtime knobs (chart defaults)
+
+| Env var | Default | Effect |
+|---|---|---|
+| `CACHE_ENABLED` | `"true"` | The single master cache gate. `false` = transparent fallback to the direct apiserver — same data, same RBAC, slower ([ADR 0004](../go/snowplow/docs/adr/0004-cache-is-provisional-and-removable.md)). |
+| `GOMEMLIMIT` | `7GiB` | **Must stay strictly below the container memory limit** (default 8Gi) so Go GC back-pressures before Linux OOM-kills. Move it with `resources.limits.memory`. |
+| `GOGC` | `"50"` | Tighter heap for ~1% CPU. |
+| `DEBUG` | `"false"` | Verbose logging. |
+| `PRETTY_LOG` | `"false"` | `false` = single-line JSON logs (the pretty handler is a measured CPU/I/O drag in prod). |
+| `PHASE1_TIMEOUT_SECONDS` | `"900"` | Outer backstop for the whole boot warmup (informer sync + prewarm walk + cohort seed). |
+| `PHASE1_SYNC_PASS_GRACE_SECONDS` | `"45"` | Per-pass grace for one `WaitForCacheSync` pass. |
+| `PHASE1_SYNC_QUIESCENCE_SECONDS` | `"10"` | Registered-set stability window before the sync barrier returns. |
+| `CATALOG_UNSERVABLE_TTL_SECONDS` | `"300"` | Short TTL for entries cached while their informer wasn't servable (self-correcting safety net); `0` disables. |
+| `URL_AUTHN` / `URL_SELF` | authn / snowplow in-cluster service URLs | The prewarm-seed loopback-auth pair: exchange the projected SA token at authn, append the JWT only on exact-`URL_SELF` loopback calls. |
+| `SERVICEACCOUNT_TOKEN_PATH` | `/var/run/secrets/krateo.io/serviceaccount/token` | Where the projected (audience=`authn`) token is mounted. |
+| `JQ_MODULES_PATH` | `/jq-modules` | Custom jq modules, mounted from the chart's `jq-custom-modules` ConfigMap. |
+| `BLIZZARD` | `"false"` | Extra-verbose output dump (`main.go` `-blizzard` flag). |
+
+The binary reads more env vars than the chart sets by default (`PORT` — default `8081`;
+`AUTHN_NAMESPACE`; the fine-grained cache back-out knobs; the prewarm-engine gates).
+Anything the process should see goes in `env.*`; for the full operator view of what
+each knob does at scale (sizing, probe philosophy, incident table) read
+[operating.md](../go/snowplow/howto/operating.md), and for the per-subsystem semantics
+the deep dives under
+[`go/snowplow/docs/architecture/`](../go/snowplow/docs/architecture/).
+
+## The CRDs chart
+
+`snowplow-crds` ([`helm/snowplow-crds/`](../helm/snowplow-crds/)) has no configuration:
+it installs the `RESTAction` CRD ([api](./api.md)). It is deliberately **not** a
+dependency of the app chart, so CRD ownership stays with its own release.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,26 @@
+---
+type: ExampleIndex
+title: snowplow — examples
+description: Runnable RESTAction examples under examples/, each paired with a README stating preconditions and the one apply command.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [examples, restaction]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Examples
+
+Each example is a runnable manifest + a README with preconditions and the one
+`kubectl apply` command. Both work against a stock Krateo installer deploy (they use
+the portal's `demo-system` namespace) and are executed through snowplow's `GET /call`
+([api](./api.md)).
+
+- [cluster-namespaces](../examples/cluster-namespaces/README.md) — the smallest useful
+  `RESTAction`: list the cluster's namespaces via the Kubernetes API, JQ-filtered to
+  names.
+- [external-api](../examples/external-api/README.md) — call an external service
+  (httpbin.org) through an `Endpoint` Secret, chaining a GET into a dependent POST
+  whose payload is JQ-built from the first response.
+
+The line-by-line walkthroughs these were distilled from live with the code:
+[example-cluster-namespaces.md](../go/snowplow/howto/restactions/example-cluster-namespaces.md),
+[example-external-api.md](../go/snowplow/howto/restactions/example-external-api.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,85 @@
+---
+type: Component
+title: snowplow — index
+description: The map of the snowplow doc bundle — the Krateo content API that resolves RESTAction and Widget CRs into portal JSON.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, content-api, restaction]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# snowplow
+
+snowplow is the **content API of the Krateo portal**: it resolves `RESTAction` and
+frontend `Widget` custom resources into the JSON the frontend renders, served over
+`GET /call` — a content bridge, not a BFF. This monorepo carries the app
+(`go/snowplow/`), its Helm charts (`helm/snowplow/`, `helm/snowplow-crds/`) and one
+version line: image and charts ship together from a single plain-semver tag.
+
+## The bundle (start here)
+
+- [overview](./overview.md) — what it does and how it works: `/call`, the resolver
+  layering, the removable cache, its place between authn / frontend / sse-proxy.
+- [usage](./usage.md) — install via the Krateo installer pin or direct
+  `helm install oci://…`; the hard authn-CRD dependency; Kind quickstart.
+- [configuration](./configuration.md) — the whole config surface: values, the env
+  ConfigMap contract, probes, tuning.
+- [api](./api.md) — the `RESTAction` CRD and the HTTP surface; OpenAPI spec pointer.
+- [examples](./examples.md) — the runnable examples under `examples/`.
+- [release](./release.md) — how a release ships (tag → image + charts on GHCR).
+- [log](./log.md) — curated history.
+- [llms.txt](./llms.txt) — the version-pinned agent index of this bundle.
+
+## The deep corpus (code-adjacent, authoritative for internals)
+
+The internals documentation lives next to the code under `go/snowplow/` and stays
+there — it is versioned, code-traced (`file:line`) and consumed at the deployed tag via
+[`go/snowplow/docs/llms.txt`](../go/snowplow/docs/llms.txt).
+
+**Map & contracts**
+
+- [ARCHITECTURE.md](../go/snowplow/ARCHITECTURE.md) — the one-page code-traced map;
+  read before touching internals.
+- [CONTRIBUTING.md](../go/snowplow/CONTRIBUTING.md) — build/run on kind, the rbac
+  TestMain trap, review gate, invariants.
+
+**Architecture deep dives** ([go/snowplow/docs/architecture/](../go/snowplow/docs/architecture/))
+
+- [request-lifecycle](../go/snowplow/docs/architecture/request-lifecycle.md) — `/call` →
+  dispatch → resolve → RBAC filter → serialize; the layering contract.
+- [caching](../go/snowplow/docs/architecture/caching.md) — the three tiers, the two L1
+  keys, invalidation, the transparent-fallback invariant.
+- [prewarm](../go/snowplow/docs/architecture/prewarm.md) — boot seed, the
+  frontend-nav walker, the opt-in prewarm engine.
+- [rbac-uaf](../go/snowplow/docs/architecture/rbac-uaf.md) — per-binding-UID keying,
+  the subject index, serve-time user filtering.
+- [north-star](../go/snowplow/docs/architecture/north-star.md) — the performance
+  contract and the harness that enforces it.
+- [observability](../go/snowplow/docs/architecture/observability.md) — expvars, slog
+  events, pprof.
+
+**Decisions** ([go/snowplow/docs/adr/](../go/snowplow/docs/adr/)) — 0001 decouple
+authn for testing; 0002 per-binding-UID L1 keying; 0003 identity-free content key;
+0004 cache is provisional and removable; 0005 walker-driven informer; 0006
+snowplow-owned external fetch (YAML acceptance).
+
+**How-tos** ([go/snowplow/howto/](../go/snowplow/howto/)) — authoring:
+[restactions](../go/snowplow/howto/restactions.md),
+[widgets](../go/snowplow/howto/widgets.md),
+[endpoints](../go/snowplow/howto/endpoints.md),
+[extras](../go/snowplow/howto/extras.md),
+[migrate-call-stage-to-direct-path](../go/snowplow/howto/migrate-call-stage-to-direct-path.md);
+operating: [install on Kind](../go/snowplow/howto/install.md),
+[operating runbook](../go/snowplow/howto/operating.md),
+[export](../go/snowplow/howto/export.md),
+[health-aggregation](../go/snowplow/howto/health-aggregation.md),
+[audit-correlation](../go/snowplow/howto/audit-correlation.md),
+[developer-guide](../go/snowplow/howto/developer-guide.md) (superseded by
+CONTRIBUTING for the build flow).
+
+**Design docs & engineering notes** — ~40 dated design/RCA/troubleshooting documents
+under [go/snowplow/docs/](../go/snowplow/docs/) and the append-only ship-log under
+[go/snowplow/docs/notes/](../go/snowplow/docs/notes/README.md): point-in-time leads,
+**not** authoritative — the code and the deep dives above win.
+
+**API spec** — [swagger.json](../go/snowplow/docs/swagger.json) /
+[swagger.yaml](../go/snowplow/docs/swagger.yaml), served live at `GET /swagger/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,10 +76,13 @@ operating: [install on Kind](../go/snowplow/howto/install.md),
 [developer-guide](../go/snowplow/howto/developer-guide.md) (superseded by
 CONTRIBUTING for the build flow).
 
-**Design docs & engineering notes** — ~40 dated design/RCA/troubleshooting documents
-under [go/snowplow/docs/](../go/snowplow/docs/) and the append-only ship-log under
-[go/snowplow/docs/notes/](../go/snowplow/docs/notes/README.md): point-in-time leads,
-**not** authoritative — the code and the deep dives above win.
+**Archive** (`tags: [archive]`) — 38 point-in-time design/RCA/troubleshoot/regression
+documents under [go/snowplow/docs/](../go/snowplow/docs/) and the 41-file append-only
+engineering ship-log under
+[go/snowplow/docs/notes/](../go/snowplow/docs/notes/README.md). Each carries archive
+frontmatter with its original date and is preserved verbatim as historical record:
+what was true **on that date**, at the SHA/version pinned in its header — **not**
+current truth. The code and the deep dives above always win.
 
 **API spec** — [swagger.json](../go/snowplow/docs/swagger.json) /
 [swagger.yaml](../go/snowplow/docs/swagger.yaml), served live at `GET /swagger/`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,3 +30,6 @@ go/snowplow/howto/install.md: Kind quickstart install
 go/snowplow/howto/operating.md: operator runbook — probes, tuning, incident table
 go/snowplow/docs/swagger.json: the authoritative OpenAPI spec (served at GET /swagger/)
 go/snowplow/CONTRIBUTING.md: build / test traps / release / invariants
+# Archive (frontmatter tags: [archive]; point-in-time historical record pinned to old SHAs/versions — NOT current truth; never ground answers in these without re-verifying against the code):
+go/snowplow/docs/*.md (dated design/RCA/troubleshoot/regression docs): 38 archived engineering documents, each frontmattered with its original date
+go/snowplow/docs/notes/README.md: charter + entry point of the 41-file append-only engineering ship-log (ship-*, path3-*, task-*, bench-*)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,32 @@
+# snowplow — LLM doc index (pinned: 1.9.0)
+# One line per file; regenerate the pin on release. Read files at the tag that matches
+# the running build (chart version == image tag == the repo tag; no v prefix).
+docs/index.md: the map — what snowplow is + links to the whole bundle and the deep corpus
+docs/overview.md: what it does and how it works — /call, resolver layering, removable cache, platform peers
+docs/usage.md: install via the Krateo installer pin or direct helm install oci://…; hard authn-CRD dependency
+docs/configuration.md: the whole config surface — values, env ConfigMap contract, probes, tuning
+docs/api.md: the RESTAction CRD + the HTTP surface; swagger pointer
+docs/examples.md: index of the runnable examples
+docs/release.md: how a release ships — one plain-semver tag drives image + charts
+docs/log.md: curated history
+examples/cluster-namespaces/README.md: RESTAction listing cluster namespaces via the k8s API (JQ-filtered)
+examples/cluster-namespaces/manifest.yaml: the manifest — kubectl apply -f
+examples/external-api/README.md: RESTAction calling httpbin.org via an Endpoint Secret, chained GET→POST
+examples/external-api/manifest.yaml: the manifest — kubectl apply -f
+# Deep corpus (code-adjacent, authoritative for internals; indexed in detail by go/snowplow/docs/llms.txt):
+go/snowplow/ARCHITECTURE.md: the one-page code-traced internals map — read first for internals
+go/snowplow/docs/llms.txt: the agent index of the internals corpus (version-pinned retrieval procedure)
+go/snowplow/docs/architecture/request-lifecycle.md: /call → dispatch → resolve → RBAC filter → serialize
+go/snowplow/docs/architecture/caching.md: the three cache tiers, L1 keying, invalidation, transparent fallback
+go/snowplow/docs/architecture/prewarm.md: boot seed, frontend-nav walker, opt-in prewarm engine
+go/snowplow/docs/architecture/rbac-uaf.md: per-binding-UID keying, subject index, serve-time user filtering
+go/snowplow/docs/architecture/north-star.md: the performance contract and its measuring harness
+go/snowplow/docs/architecture/observability.md: expvars, slog events, pprof
+go/snowplow/docs/adr/: the durable decisions (0001–0006)
+go/snowplow/howto/restactions.md: authoring RESTAction CRs (full field reference)
+go/snowplow/howto/widgets.md: authoring Widget CRs
+go/snowplow/howto/endpoints.md: Endpoint Secret wiring for external APIs
+go/snowplow/howto/install.md: Kind quickstart install
+go/snowplow/howto/operating.md: operator runbook — probes, tuning, incident table
+go/snowplow/docs/swagger.json: the authoritative OpenAPI spec (served at GET /swagger/)
+go/snowplow/CONTRIBUTING.md: build / test traps / release / invariants

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,59 @@
+---
+type: Log
+title: snowplow — log
+description: Curated chronological history — notable changes, decisions and incidents; release notes stay in GitHub Releases.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [history]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Log
+
+Curated history, newest first. Durable decisions live in
+[`go/snowplow/docs/adr/`](../go/snowplow/docs/adr/); the append-only engineering
+ship-log is [`go/snowplow/docs/notes/`](../go/snowplow/docs/notes/) (point-in-time,
+not authoritative).
+
+## 2026-08-06 — adopted the Krateo Documentation Standard (pilot repo)
+
+This bundle: root `docs/` + `examples/` + thin README. The README's eight doc links had
+been broken since the monorepo fold (targets moved under `go/snowplow/howto/`); the
+install/operating docs still prescribed pre-migration chart and image locations — all
+re-grounded in the current release reality. The deep corpus under `go/snowplow/`
+(architecture, ADRs, how-tos) deliberately stays code-adjacent; this bundle maps into it.
+
+## 2026-08-03 — 1.9.0: the monorepo fold
+
+The separate chart repo was collapsed into `helm/` (one version line: image + both
+charts ship from one tag) and the app moved into `go/snowplow/`; Go module identity
+migrated to `github.com/krateo-platformops/snowplow`; CI moved to the org's shared
+reusable workflows (multi-arch image build, Go checks + CRD-drift guard, security).
+Lesson paid for en route: the first fold release was tagged `v1.8.0` — the `v` prefix
+matches no release workflow trigger, so it shipped nothing; `1.9.0` (plain semver) is
+the release that followed. Tag without `v`, always ([release](./release.md)).
+
+## 2026-07-22/30 — 1.7.14 → 1.7.20: RBAC-correctness and boot-budget hardening
+
+The #118 arc folded a per-user RBAC sub-generation into the resolved cache key (stale
+RBAC reads could no longer serve a pre-rebinding entry), with role-rule coverage and
+key-version bumps; the prewarm seed's boot budget was re-traced and raised
+(`PHASE1_TIMEOUT_SECONDS=900`) so the cohort seed stops starving on large boots; boot
+resume learned to reuse the discovery snapshot; an extensive feature-coverage test
+suite (Waves 1+2) landed alongside.
+
+## 2026-07-02 — 1.5.29: prewarm-gated readiness (zero-gap deploys)
+
+`/readyz` now flips on **prewarm-complete**, not mere informer sync, and the chart
+pairs it with `maxUnavailable: 0` / `maxSurge: 1` — on a rolling deploy the old warm
+pod serves all traffic until the new pod is warm. Companion: the prewarm seed's
+loopback auth (#57) — a projected `audience=authn` ServiceAccount token exchanged at
+authn — which is why the chart hard-requires the authn CRD at install time
+([usage](./usage.md)).
+
+## 2026-06 — the cache invariants settle
+
+The per-binding-UID L1 keying invariant ("never cohort-only" — a six-revert
+retrospective), the identity-free content key with serve-time user filtering, and the
+provisionality contract (`CACHE_ENABLED=false` = transparent fallback) were fixed as
+ADRs 0002–0004 after the May/June cache campaign. They are the load-bearing rules every
+change is reviewed against ([overview](./overview.md)).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,80 @@
+---
+type: Architecture
+title: snowplow — overview
+description: What snowplow is (the Krateo content API), how a /call request flows, and where it sits between authn, frontend and sse-proxy.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, content-api, restaction, cache]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Overview
+
+snowplow is the **content API of the Krateo portal**: it resolves `RESTAction` and
+frontend `Widget` custom resources into the JSON the Krateo frontend renders, served
+over `GET /call`. It is a content bridge, **not a BFF** — it holds no product state and
+composes content on demand from Kubernetes CRs, serving any client that can present a
+Krateo JWT (the SPA, or `curl`).
+
+The canonical, code-traced map of the internals is
+[`go/snowplow/ARCHITECTURE.md`](../go/snowplow/ARCHITECTURE.md); the subsystem deep
+dives under [`go/snowplow/docs/architecture/`](../go/snowplow/docs/architecture/) trace
+every claim to `file:line`. This page is the distilled platform view — it links, it
+does not duplicate.
+
+## What it does
+
+- **Resolves `RESTAction` CRs** ([api](./api.md)): declarative chains of HTTP calls
+  (Kubernetes API or external endpoints) with JQ filtering — resolved on demand when
+  `/call` is invoked, results returned in the resource's `status`.
+- **Resolves frontend `Widget` CRs**: the widget resolver shapes RESTAction output into
+  render-ready widget props (the widget CRDs themselves are owned by
+  [frontend](https://github.com/krateo-platformops/frontend)).
+- **Write passthrough**: `POST/PUT/PATCH/DELETE /call` are a raw apiserver passthrough
+  under the caller's identity — never resolved, never cached.
+
+## The request path
+
+```
+GET /call ─▶ Dispatcher middleware ─▶ dispatcher (restactions | widgets) ─▶ resolve
+                                              │
+                                 RBAC gate + serve-time filter ─▶ serialize ─▶ write
+```
+
+The load-bearing layering contract: a `RESTAction` emits *unordered* data; the *widget*
+canonicalizes and shapes it. Full trace:
+[request-lifecycle](../go/snowplow/docs/architecture/request-lifecycle.md).
+
+## The cache (provisional by design)
+
+A three-tier cache (L3 informer → L1 resolved-entry → dispatcher) with per-binding-UID
+identity keying and a prewarm engine that replays frontend navigation at boot. Two
+invariants matter platform-wide:
+
+- **Per-binding-UID L1 keying, never cohort-only** — cohort-only keying leaks one
+  user's resources to another
+  ([rbac-uaf](../go/snowplow/docs/architecture/rbac-uaf.md),
+  [ADR 0002](../go/snowplow/docs/adr/0002-per-user-l1-keying.md)).
+- **All caching is provisional and cleanly removable** — `CACHE_ENABLED=false` is a
+  transparent fallback to the direct apiserver: same data, same UI, same RBAC, just
+  slower ([ADR 0004](../go/snowplow/docs/adr/0004-cache-is-provisional-and-removable.md),
+  [caching](../go/snowplow/docs/architecture/caching.md)).
+
+Prewarm, the boot walker and readiness gating:
+[prewarm](../go/snowplow/docs/architecture/prewarm.md). The performance contract and how
+it is measured: [north-star](../go/snowplow/docs/architecture/north-star.md).
+
+## Where it sits in the platform
+
+| Peer | Relationship |
+|---|---|
+| **authn** | Issues the Krateo JWTs snowplow validates (shared `JWT_SIGN_KEY`). The prewarm seed exchanges a projected ServiceAccount token at authn for its loopback JWT — a hard install-time dependency on the `serviceaccount.authn.krateo.io` CRD (see [usage](./usage.md)). |
+| **frontend** | The SPA renders what `/call` returns; snowplow reads the frontend nav ConfigMaps (`INIT` / `ROUTES_LOADER`) as prewarm roots. Widget CRDs are frontend-owned. |
+| **sse-proxy** | Serves the portal's *event* streams; snowplow serves the portal's *content* (it also has its own `/refreshes` SSE lane for live-refresh nudges). |
+| **core-provider / cdc** | Compositions and their CRs are the bulk of what RESTActions read; `GET /rbac` enumerates a RESTAction's read-set so core-provider can pre-generate RBAC. |
+
+## Deployment shape
+
+One Deployment, one container, one port (`8081`) serving content, probes and debug
+surfaces alike. All configuration arrives as env vars via a chart-managed ConfigMap
+([configuration](./configuration.md)); the operator runbook is
+[operating.md](../go/snowplow/howto/operating.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,66 @@
+---
+type: Runbook
+title: snowplow — release
+description: How a release ships — one plain-semver tag drives the image build and the OCI chart publish; what lands where and what to verify.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [release, ci, oci]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Release
+
+One tag ships everything. This monorepo has a single version line: the app image, the
+`snowplow` chart and the `snowplow-crds` chart all release at the tag's version.
+
+## The runbook
+
+1. **Merge to `main`** with PR CI green
+   ([`release-pullrequest.yaml`](../.github/workflows/release-pullrequest.yaml):
+   validate-only multi-arch image build, Go tests + CRD-drift guard, the snowplow AST
+   lint gates; plus chart lint, security scanning, and docs lint).
+2. **Tag with plain semver — `X.Y.Z`, no `v` prefix.** Both release workflows trigger
+   on `[0-9]+.[0-9]+.[0-9]+` only; a `v`-prefixed tag ships **nothing**, silently
+   (it has happened: `v1.8.0` produced no artifacts; `1.9.0` is the release that
+   followed).
+
+   ```sh
+   git tag 1.9.1 && git push origin 1.9.1
+   ```
+
+3. **CI builds and publishes**, no manual steps:
+   - [`release-tag.yaml`](../.github/workflows/release-tag.yaml) → the shared
+     `component-image-build` workflow (`krateo-platformops/.github`) builds the
+     multi-arch (amd64+arm64) image from `go/snowplow/` →
+     `ghcr.io/krateo-platformops/snowplow:X.Y.Z`.
+   - [`release-oci.yaml`](../.github/workflows/release-oci.yaml) (the canonical,
+     byte-identical org workflow) discovers every first-class chart under `helm/`,
+     substitutes the `Chart.yaml` placeholders (`CHART_VERSION` → the tag;
+     `APP_VERSION` → the latest app semver tag, which in this monorepo is the same
+     tag), packages, and pushes →
+     `oci://ghcr.io/krateo-platformops/charts/snowplow:X.Y.Z` and
+     `oci://ghcr.io/krateo-platformops/charts/snowplow-crds:X.Y.Z`.
+
+4. **Verify** the artifacts exist and pair up:
+
+   ```sh
+   helm show chart oci://ghcr.io/krateo-platformops/charts/snowplow --version X.Y.Z
+   # appVersion in the output must equal X.Y.Z
+   ```
+
+5. **Roll it out** by bumping the Krateo installer's snowplow chart pin (both charts
+   move together — the installer pins them at one version), or `helm upgrade` on a
+   standalone install ([usage](./usage.md)). Never mutate the running Deployment out
+   of band.
+
+## CRD changes
+
+CRDs are generated from the Go types (`make generate` in `go/snowplow/`), drift-gated
+in PR CI, and shipped via the committed copy under
+[`helm/snowplow-crds/templates/`](../helm/snowplow-crds/templates/) — the old
+cross-repo CRD publish job is gone with the monorepo fold. If you change
+`apis/templates/`, regenerate and update the crds chart template in the same PR.
+
+## Docs
+
+`docs/llms.txt` pins this bundle to the release tag — update the pin (and
+[log](./log.md), when the release is notable) as part of the release PR.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,101 @@
+---
+type: Usage
+title: snowplow — usage
+description: How snowplow is installed — via the Krateo installer component pin, or directly from the OCI chart — and its hard install-time dependencies.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [install, helm, installer]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Usage
+
+snowplow ships as two Helm charts from this monorepo, published by CI to GHCR at the
+**same version = the repo tag** (see [release](./release.md)):
+
+| Artifact | Where |
+|---|---|
+| App chart | `oci://ghcr.io/krateo-platformops/charts/snowplow` |
+| CRDs chart (`RESTAction`) | `oci://ghcr.io/krateo-platformops/charts/snowplow-crds` |
+| Image (multi-arch) | `ghcr.io/krateo-platformops/snowplow` |
+
+## Path 1 — via the Krateo installer (the normal way)
+
+snowplow is a core component of the Krateo installer: the installer umbrella pins the
+chart URL + version and reconciles snowplow (and `snowplow-crds`) as Compositions. A
+platform install gets snowplow with no extra steps; a version bump is a change to the
+installer's pin.
+
+Standalone of the installer, the same mechanism is a raw `CompositionDefinition`
+(requires core-provider), as in [`compositiondefinition.yaml`](../compositiondefinition.yaml):
+
+```yaml
+apiVersion: core.krateo.io/v1alpha1
+kind: CompositionDefinition
+metadata:
+  name: krateo-snowplow
+  namespace: krateo-system
+spec:
+  chart:
+    url: oci://ghcr.io/krateo-platformops/charts/snowplow
+    version: "1.9.0"
+```
+
+## Path 2 — direct `helm install`
+
+```sh
+# CRDs first (RESTAction + the authn ServiceAccount CRD the app chart hard-requires):
+helm install snowplow-crds oci://ghcr.io/krateo-platformops/charts/snowplow-crds --version 1.9.0
+helm install authn-crds oci://ghcr.io/krateo-platformops/charts/authn-crds
+
+# The app chart:
+helm install snowplow oci://ghcr.io/krateo-platformops/charts/snowplow \
+  --version 1.9.0 --namespace krateo-system
+```
+
+### Hard install-time dependencies (fail-loud by design)
+
+The chart renders a `serviceaccount.authn.krateo.io` allowlist CR for the prewarm-seed
+loopback token exchange, **unconditionally**. So the install fails fast unless the
+cluster has:
+
+- the `serviceaccount.authn.krateo.io` CRD (chart `authn-crds`), and — for the exchange
+  to work at runtime — the Krateo **authn** operator (>= 0.24.0);
+- a JWT signing-key Secret named by `jwtSignKeySecretName` (default `jwt-sign-key`,
+  key `JWT_SIGN_KEY`) in the release namespace — the pod does not start without it.
+
+The installer sequences authn before snowplow for exactly this reason. Without a
+running authn the install still succeeds (CRD present is enough) and `/call` serves
+normally — only the seed's best-effort boot warmth is lost. Details in the `seedAuthn`
+block of [`helm/snowplow/values.yaml`](../helm/snowplow/values.yaml).
+
+## Quickstart on Kind
+
+A full single-node walkthrough (namespace, JWT secret, minting a user token, RBAC,
+NodePort install, executing your first RESTAction):
+[Installing snowplow on Kind](../go/snowplow/howto/install.md). Then run the
+[examples](./examples.md).
+
+## Rendering the chart locally
+
+The in-repo `Chart.yaml` carries `CHART_VERSION` / `APP_VERSION` placeholders that CI
+substitutes at release time, so substitute them before a local render (exactly what the
+lint workflow does):
+
+```sh
+sed -i.bak 's/CHART_VERSION/0.0.0/g; s/APP_VERSION/0.0.0/g' helm/snowplow/Chart.yaml
+helm template snowplow helm/snowplow
+git checkout helm/snowplow/Chart.yaml && rm -f helm/snowplow/Chart.yaml.bak
+```
+
+## Upgrading
+
+Reconcile via `helm upgrade` (or bump the installer pin). **Never** `kubectl set image`
+or otherwise mutate the running Deployment out of band — the chart is the source of
+truth. Rolling deploys are zero-gap by design: `maxUnavailable: 0` + prewarm-gated
+`/readyz` keep the old warm pod serving until the new pod is warm
+([configuration](./configuration.md)).
+
+## Calling it
+
+Every content read is `GET /call` with a Krateo JWT — see [api](./api.md) and the
+[examples](./examples.md).

--- a/examples/cluster-namespaces/README.md
+++ b/examples/cluster-namespaces/README.md
@@ -1,0 +1,47 @@
+---
+type: Example
+title: RESTAction — list cluster namespaces
+description: A RESTAction that calls the Kubernetes API server and JQ-filters the namespace list down to names, resolved via GET /call.
+resource: restactions.templates.krateo.io
+tags: [restaction, kubernetes-api, jq]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# RESTAction: list cluster namespaces
+
+The smallest useful `RESTAction`: one API stage against the cluster's own
+`/api/v1/namespaces`, filtered to just the names. Full walkthrough (every field
+explained): [example-cluster-namespaces.md](../../go/snowplow/howto/restactions/example-cluster-namespaces.md).
+
+## Preconditions
+
+- snowplow deployed with the `RESTAction` CRD present — a stock Krateo installer
+  deploy, or the [Kind quickstart](../../go/snowplow/howto/install.md).
+- A `demo-system` namespace (the installer's portal creates it; else
+  `kubectl create namespace demo-system`).
+- To *execute* it: a Krateo JWT for a user whose RBAC allows `get` on this
+  `restactions.templates.krateo.io` resource **and** `list` on `namespaces` (snowplow
+  enforces the caller's own RBAC on every stage; grants shown in the walkthrough).
+
+## Apply
+
+```sh
+kubectl apply -f ./manifest.yaml
+```
+
+## Execute
+
+Applying stores inert spec — the calls run when the CR is read through snowplow:
+
+```sh
+curl -s -G \
+  -H "Authorization: Bearer ${KRATEO_ACCESS_TOKEN}" \
+  -d 'apiVersion=templates.krateo.io/v1' \
+  -d 'resource=restactions' \
+  -d 'name=cluster-namespaces' \
+  -d 'namespace=demo-system' \
+  "http://${SNOWPLOW_HOST}:8081/call"
+```
+
+The response carries the filtered result under `status.namespaces`, e.g.
+`["default", "demo-system", "kube-system", …]`.

--- a/examples/cluster-namespaces/manifest.yaml
+++ b/examples/cluster-namespaces/manifest.yaml
@@ -1,0 +1,18 @@
+# A RESTAction that lists cluster namespaces via the Kubernetes API server and
+# JQ-filters the response down to the namespace names. Resolved on demand by
+# snowplow's GET /call — applying it stores inert spec, nothing reconciles it.
+# Walkthrough: go/snowplow/howto/restactions/example-cluster-namespaces.md
+apiVersion: templates.krateo.io/v1
+kind: RESTAction
+metadata:
+  name: cluster-namespaces
+  namespace: demo-system
+  annotations:
+    krateo.io/verbose: "true"
+spec:
+  api:
+    - name: namespaces
+      path: /api/v1/namespaces?limit=15
+      filter: "[.namespaces.items[] | .metadata.name]"
+      continueOnError: true
+      errorKey: namespacesError

--- a/examples/external-api/README.md
+++ b/examples/external-api/README.md
@@ -1,0 +1,49 @@
+---
+type: Example
+title: RESTAction — invoke an external API
+description: Two chained HTTP calls against httpbin.org through an Endpoint Secret — a GET whose response feeds a dependent POST's JQ-built payload.
+resource: restactions.templates.krateo.io
+tags: [restaction, endpoint, external-api, jq]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# RESTAction: invoke an external API
+
+Calls a service **other than** the Kubernetes API server, so each stage carries an
+`endpointRef` to an [`Endpoint`](../../go/snowplow/howto/endpoints.md) Secret
+(`server-url: https://httpbin.org`). Stage `two` depends on stage `one` and builds its
+POST payload from `one`'s response with a JQ expression — the chained-call pattern.
+Full walkthrough:
+[example-external-api.md](../../go/snowplow/howto/restactions/example-external-api.md).
+
+## Preconditions
+
+- snowplow deployed with the `RESTAction` CRD present — a stock Krateo installer
+  deploy, or the [Kind quickstart](../../go/snowplow/howto/install.md).
+- A `demo-system` namespace (the installer's portal creates it; else
+  `kubectl create namespace demo-system`).
+- Outbound internet access from the snowplow pod (it is snowplow, not your shell, that
+  calls `https://httpbin.org`).
+- To *execute* it: a Krateo JWT for a user whose RBAC allows `get` on this
+  `restactions.templates.krateo.io` resource.
+
+## Apply
+
+```sh
+kubectl apply -f ./manifest.yaml
+```
+
+## Execute
+
+```sh
+curl -s -G \
+  -H "Authorization: Bearer ${KRATEO_ACCESS_TOKEN}" \
+  -d 'apiVersion=templates.krateo.io/v1' \
+  -d 'resource=restactions' \
+  -d 'name=httpbin' \
+  -d 'namespace=demo-system' \
+  "http://${SNOWPLOW_HOST}:8081/call"
+```
+
+The response's `status.one` holds the GET echo; `status.two.json.compositionID` is
+`"AA-BB-CC"` — the value JQ lifted out of stage `one`'s response.

--- a/examples/external-api/manifest.yaml
+++ b/examples/external-api/manifest.yaml
@@ -1,0 +1,38 @@
+# A RESTAction that calls an EXTERNAL service (httpbin.org) through an Endpoint
+# Secret, chaining two calls: a GET whose response feeds a dependent POST whose
+# JSON payload is built with a JQ expression. Resolved on demand by snowplow's
+# GET /call. Walkthrough: go/snowplow/howto/restactions/example-external-api.md
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: httpbin-endpoint
+  namespace: demo-system
+stringData:
+  server-url: https://httpbin.org
+---
+apiVersion: templates.krateo.io/v1
+kind: RESTAction
+metadata:
+  name: httpbin
+  namespace: demo-system
+spec:
+  api:
+    # First call: GET with query parameters.
+    - name: one
+      path: /get?name=Alice&email=alice@example.com&age=30&uid=AA-BB-CC
+      endpointRef:
+        name: httpbin-endpoint
+        namespace: demo-system
+    # Second call: POST that depends on the first and reuses its "uid" value.
+    - name: two
+      dependsOn:
+        name: one
+      verb: POST
+      path: /post
+      headers:
+        - "Content-Type: application/json"
+      payload: '${ {compositionID: .one.args.uid} }'
+      endpointRef:
+        name: httpbin-endpoint
+        namespace: demo-system

--- a/go/snowplow/ARCHITECTURE.md
+++ b/go/snowplow/ARCHITECTURE.md
@@ -100,7 +100,8 @@ RESTAction/widget contract, and must be removable wholesale when Kubernetes ship
 
 ## For agents
 
-The Krateo `krateo-snowplow-agent` grounds in these docs at the **deployed version's tag** — see
+The Krateo `snowplow-agent` grounds in these docs at the **deployed version's tag** — see
 [`docs/llms.txt`](docs/llms.txt) for the index and the version-pinned retrieval procedure. The
-deployment/CRD/wiring view lives in the chart repo (`braghettos/krateo-snowplow-chart` `docs/`);
-this repo's docs are the internals/runtime view.
+deployment/CRD/wiring view lives in this same repo: the Helm charts under
+[`helm/`](../../helm/snowplow/) and the standard doc bundle at the repo root
+([`docs/`](../../docs/index.md)); this directory's docs are the internals/runtime view.

--- a/go/snowplow/ARCHITECTURE.md
+++ b/go/snowplow/ARCHITECTURE.md
@@ -1,7 +1,16 @@
+---
+type: Architecture
+title: snowplow — architecture map
+description: The one-page map of snowplow — what it is, the request path, the three-tier cache, prewarm, RBAC/UAF, and the provisionality invariant, with links to the code-traced deep dives.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [architecture, cache, rbac, prewarm, restaction, widget]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # snowplow — architecture
 
 The single canonical map of snowplow. Everything else hangs off this file; the deep dives under
-[`docs/architecture/`](docs/architecture/) trace each subsystem through the code at `file:line`.
+[`docs/architecture/`](docs/architecture/) trace each subsystem through the code.
 
 > **Read this as a map, not the territory.** Every claim here is traced to the deep dives, which are
 > traced to the current tree. If a deep dive and this page disagree, the deep dive (and the code it
@@ -12,8 +21,11 @@ The single canonical map of snowplow. Everything else hangs off this file; the d
 A **content bridge**: it resolves `RESTAction` and frontend `Widget` custom resources into the JSON
 the Krateo frontend renders, served over **`/call`**. It is not a BFF and holds no product state —
 it composes content on demand from Kubernetes CRs and serves it to whatever client (the SPA, or
-`curl`) reads it. Server wiring and routes live in `main.go` (`/call`, `/health`, `/readyz`,
-`/debug/vars`, `/debug/pprof`).
+`curl`) reads it. Server wiring and routes live in `main.go`: the content routes (`GET/POST/PUT/
+PATCH/DELETE /call`, `GET /list`, `GET /export`, `GET /api-info/names`, `POST /jq`, `GET /rbac`),
+the per-subject live-refresh SSE stream (`GET /refreshes`), the probes (`/health`, `/readyz`), and
+the debug surface (`/debug/vars`, `/debug/pprof/*`, `/debug/servable`, `/debug/apistage`,
+`/debug/refreshes`, `/swagger/`).
 
 ## The request path (→ [request-lifecycle.md](docs/architecture/request-lifecycle.md))
 
@@ -40,30 +52,48 @@ L3 informer cache  ─▶  L1 resolved-entry cache  ─▶  dispatcher cache
 
 - A widget has **two** L1 keys: an **identity-free content key** (`dispatchWidgetContentKey`,
   username/groups zeroed) and an **identity-bound key** that folds the **first-match RBAC
-  `BindingUID`** (`dispatchCacheLookupKey` → `rbac.EvaluateRBAC`). Keys are a versioned SHA-256
-  (`resolved.go ComputeKey`, `resolvedKeyVersion="v4"`).
+  `BindingUID`** *plus* the identity's **per-subject RBAC sub-generation** (`RBACSubGen`)
+  (`dispatchCacheLookupKey` → `rbac.EvaluateRBAC` + `cache.RBACSubGenForSubject`). Keys are a
+  versioned SHA-256 (`resolved.go ComputeKey`, `resolvedKeyVersion="v6"`).
   > **Correction over older docs/notes:** the identity-bound key is **per-binding-UID**, *not*
-  > "per-cohort". The pre-`v4` per-cohort `BindingSetHash` was replaced by per-binding `BindingUID`.
-  > Per-binding sharing is the equivalence class that still satisfies "never cohort-only" (below).
+  > "per-cohort". The pre-`v4` per-cohort `BindingSetHash` was replaced by per-binding `BindingUID`;
+  > `v5`/`v6` added the RBAC sub-generation fold so a grant/revoke touching a user's own bindings
+  > cold-misses that user's cells. Per-binding sharing is the equivalence class that still
+  > satisfies "never cohort-only" (below).
+- Request `extras` partition the key only on two author-declared axes: the widget's
+  `spec.keyExtras` allowlist and the `spec.identityContext` identity keys (username/groups);
+  undeclared request extras never fork a cell (an undeclared-extras resolve is served but not
+  cached).
 - **Invalidation:** `DELETE` evicts only the deleted object's own self-representation; LIST-deps and
   dependent GET-deps are dirty-marked; `ADD`/`UPDATE` dirty-mark (never evict). Values are
-  deduplicated by equivalence class.
+  deduplicated by equivalence class. A resolve that touched a genuine **external** endpoint is
+  never cached (no dep edge can invalidate it) unless the widget opts into a bounded-staleness TTL
+  via the `krateo.io/external-cache-ttl-seconds` annotation.
 
 ## Prewarm (→ [prewarm.md](docs/architecture/prewarm.md))
 
 - Boot seed (`RegisterMetaQuerySeeds`) + a **phase-1 walker that replays frontend navigation**:
   roots are read from the frontend ConfigMap (`navmenus` INIT + `routesloaders` ROUTES_LOADER, not
   hardcoded), recursing `status.resourcesRefs` **only where `verb==GET`**.
-- Cohort model is **dynamic** — no static cohort list, no lazy cold-fill.
-- **The full prewarm *engine* is opt-in** (`PREWARM_ENGINE_ENABLED=false` by default); with it off,
-  the legacy global-cohort seed path runs. CRUD re-prewarm is two mechanisms (object CRUD →
-  refresher re-resolve; new-GVR → engine re-walk); widget-CR-triggered subtree re-walk is currently
-  a **placeholder**.
+- Cohort model is **dynamic** — no static cohort list, no lazy cold-fill. The seed is rank-major
+  (widget-capable identities first) and class-interleaved (each rank's widgets then its
+  RESTActions).
+- **The prewarm engine is the only seed path and is implicit-on-cache**: the whole prewarm family
+  (`PREWARM_ENABLED`, `PREWARM_CONTENT_ENABLED`, `PREWARM_PIP_ENABLED`, `PREWARM_ENGINE_ENABLED`,
+  `PROACTIVE_RA_SEED_ENABLED`) is **retired** into `CACHE_ENABLED` (`retired_flags.go` audits stale
+  values); the legacy global-cohort `runPIPSeed` path is **deleted**. Back-out is
+  `CACHE_ENABLED=false`.
+- **`/readyz` gates on prewarm-complete**: the seed runs *before* `MarkPhase1Done`; readiness flips
+  when every cohort's nav widgets are warm (the first-nav latch), with fire-regardless backstops
+  (Ready-degraded, never not-Ready-forever). Steady-state re-prewarm is object CRUD → refresher
+  re-resolve, new-GVR → engine re-walk, and a TTL-cadenced keepwarm sweep; widget-CR-triggered
+  subtree re-walk is still a **placeholder**.
 
 ## RBAC & user-aware filtering (→ [rbac-uaf.md](docs/architecture/rbac-uaf.md))
 
-- L1 is **keyed per binding-UID, never cohort-only** — this is the load-bearing invariant (a
-  6-revert retrospective); cohort-only keying leaks one user's resources to another.
+- L1 is **keyed per binding-UID (plus the subject's RBAC sub-generation), never cohort-only** —
+  this is the load-bearing invariant (a 6-revert retrospective); cohort-only keying leaks one
+  user's resources to another.
 - An **RBAC subject index** (`internal/cache/rbac_snapshot.go`) selects candidate bindings;
   `EvaluateRBAC` walks ClusterRoleBindings then RoleBindings with **predicate symmetry** across
   User / Group / ServiceAccount subjects.
@@ -96,6 +126,7 @@ RESTAction/widget contract, and must be removable wholesale when Kubernetes ship
 | `internal/cache/` | L3 informer + L1 resolved cache, keying, invalidation, dedup, prewarm engine | [caching](docs/architecture/caching.md), [prewarm](docs/architecture/prewarm.md) |
 | `internal/rbac/` | RBAC evaluation, subject index, authz memo | [rbac-uaf](docs/architecture/rbac-uaf.md) |
 | `internal/objects/`, `internal/dynamic/` | object fetch, cached dynamic client | [request-lifecycle](docs/architecture/request-lifecycle.md) |
+| `internal/metrics/`, `internal/tracing/`, `internal/logging/`, `internal/support/audit/` | default-off OTel export (metrics mirror, traces, log/audit bridge) | [observability](docs/architecture/observability.md) |
 | `apis/templates/` | the `RESTAction` / `Widget` CRD types | [restactions.md](howto/restactions.md), [widgets.md](howto/widgets.md) |
 
 ## For agents

--- a/go/snowplow/CONTRIBUTING.md
+++ b/go/snowplow/CONTRIBUTING.md
@@ -1,6 +1,15 @@
+---
+type: Runbook
+title: Contributing to snowplow
+description: The contributor contract — local kind/ko workflow, CRD codegen, the destructive RBAC-test trap, the review gate, the release process, and the invariants a change must not break.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [contributing, testing, release, kind]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Contributing to snowplow
 
-Thanks for working on snowplow. This is the fork's contributor contract: how to build and run it
+Thanks for working on snowplow. This is the contributor contract: how to build and run it
 locally, the one test you must never run carelessly, the review gate, how releases ship, and the
 invariants a change must keep. Start from [`ARCHITECTURE.md`](ARCHITECTURE.md) — it is the canonical
 map and every rule below points back into it.
@@ -19,7 +28,7 @@ canonical workflow — prefer them over the longhand in [`howto/developer-guide.
 ```sh
 scripts/kind-up.sh      # create the kind cluster (maps host ports 30081 + 30082)
 scripts/reboot.sh       # full cycle: kind-down → kind-up → build → jq ConfigMap → kubectl apply -f manifests/
-scripts/reload.sh       # fast inner loop: rebuild image + re-apply manifests/deploy.snowplow.yaml
+scripts/reload.sh       # fast inner loop: delete the deploy, rebuild the image, re-apply manifests/deploy.snowplow.yaml
 scripts/build.sh        # ko build into kind.local only, then list loaded node images
 scripts/kind-down.sh    # delete the cluster
 ```
@@ -31,8 +40,9 @@ What each does, grounded in the tree:
 - `scripts/build.sh` runs `KO_DOCKER_REPO=kind.local ko build --base-import-paths .` (build config in
   [`.ko.yaml`](.ko.yaml)) — no external registry, no push.
 - `scripts/reboot.sh` is the clean-slate path; `scripts/reload.sh` is the iterate path. Both deploy
-  from [`manifests/`](manifests/) (`manifests/deploy.snowplow.yaml`), not from inline heredocs.
-- `scripts/jqmodule-to-configmap.sh` loads the custom `jq` modules snowplow expects at runtime.
+  from [`manifests/`](manifests/) (`manifests/deploy.snowplow.yaml`), not from inline heredocs, and
+  both re-run `scripts/jqmodule-to-configmap.sh`, which loads the custom `jq` modules snowplow
+  expects at runtime.
 
 ### Codegen (CRDs)
 
@@ -44,7 +54,7 @@ make generate           # go mod tidy + go generate ./...  → regenerates crds/
 ```
 
 `go generate` drives the build-tagged `controller-gen` directive in
-[`apis/generate.go:21`](apis/generate.go), pinned to the `sigs.k8s.io/controller-tools` version in
+[`apis/generate.go`](apis/generate.go), pinned to the `sigs.k8s.io/controller-tools` version in
 [`go.mod`](go.mod). For CI you can use the drift gate directly:
 
 ```sh
@@ -99,9 +109,10 @@ snowplow is a **monorepo**: the app (`go/snowplow/`) and its Helm charts (`helm/
 
 1. **Tag the repo** with plain semver, `X.Y.Z` — **no `v` prefix** (the release workflows
    trigger on `[0-9]+.[0-9]+.[0-9]+` only; a `v`-prefixed tag silently ships nothing).
-2. CI does the rest: the multi-arch image `ghcr.io/krateo-platformops/snowplow:X.Y.Z` plus the
-   `snowplow` and `snowplow-crds` charts at `oci://ghcr.io/krateo-platformops/charts/`, all at
-   the same version. The full runbook is [`docs/release.md`](../../docs/release.md).
+2. CI does the rest: the multi-arch image `ghcr.io/krateo-platformops/snowplow:X.Y.Z` (via the
+   shared org-wide component-image-build workflow) plus the `snowplow` and `snowplow-crds` charts
+   at `oci://ghcr.io/krateo-platformops/charts/`, all at the same version. The full runbook is
+   [`docs/release.md`](../../docs/release.md).
 3. **Reconcile via `helm upgrade`** (or bump the installer's chart pin) against the new chart
    version. **Never** `kubectl set image` or otherwise mutate the running Deployment out of
    band — the chart is the source of truth and an in-place image bump drifts the cluster from
@@ -123,7 +134,7 @@ These are load-bearing. Read the linked deep dives before touching the subsystem
   [`docs/architecture/caching.md`](docs/architecture/caching.md).
 
 - **Cache toggle-ability** — all caching is **provisional and cleanly removable**.
-  `CACHE_ENABLED=false` ([`internal/cache/cache.go:37`](internal/cache/cache.go) `Disabled()`) is a
+  `CACHE_ENABLED=false` ([`internal/cache/cache.go`](internal/cache/cache.go) `Disabled()`) is a
   **transparent fallback** to the direct apiserver: same data, same UI, same RBAC, just slower — not
   a degraded mode. Caching must never constrain the RESTAction/widget contract. See
   [`docs/architecture/caching.md`](docs/architecture/caching.md).
@@ -144,5 +155,6 @@ tree, the tree wins:
 
 - It documents a manual inline-heredoc deploy; the canonical deploy is
   `kubectl apply -f manifests/` via `scripts/reboot.sh` / `scripts/reload.sh`.
-- Its kind config maps only `30081`; `scripts/kind-up.sh` maps **both** `30081` and `30082`.
+- Its kind-config heredoc maps only `30081` (its prose claims both ports);
+  `scripts/kind-up.sh` actually maps **both** `30081` and `30082`.
 - It predates `make generate` / `scripts/gen.sh`; use those for codegen.

--- a/go/snowplow/CONTRIBUTING.md
+++ b/go/snowplow/CONTRIBUTING.md
@@ -94,21 +94,18 @@ A change without an architect sign-off on design and a PM falsifier does not mer
 
 ## Release process
 
-snowplow and its Helm chart are **separate repos that ship in lockstep**.
+snowplow is a **monorepo**: the app (`go/snowplow/`) and its Helm charts (`helm/snowplow/`,
+`helm/snowplow-crds/`) live in `krateo-platformops/snowplow` and ship from **one tag**.
 
-1. **Tag the code repo** — `braghettos/krateo-snowplow` (this repo; confirm with `git remote -v` →
-   `origin https://github.com/braghettos/krateo-snowplow.git`). The image is built and published from
-   the tag.
-2. **Lockstep-tag the chart repo** — `braghettos/krateo-snowplow-chart`, matching the code tag.
-3. **Reconcile via `helm upgrade`** against the new chart version. **Never** `kubectl set image` or
-   otherwise mutate the running Deployment out of band — the chart is the source of truth and an
-   in-place image bump drifts the cluster from the chart.
-
-Repo-name accuracy is critical:
-
-- The chart repo's `origin` remote points at **upstream** (`krateoplatformops/*`). Push the
-  braghettos fork remote **explicitly** — do not push tags to `origin` blindly.
-- **Never push to `krateoplatformops/*`.** This is the braghettos fork only, for both repos.
+1. **Tag the repo** with plain semver, `X.Y.Z` — **no `v` prefix** (the release workflows
+   trigger on `[0-9]+.[0-9]+.[0-9]+` only; a `v`-prefixed tag silently ships nothing).
+2. CI does the rest: the multi-arch image `ghcr.io/krateo-platformops/snowplow:X.Y.Z` plus the
+   `snowplow` and `snowplow-crds` charts at `oci://ghcr.io/krateo-platformops/charts/`, all at
+   the same version. The full runbook is [`docs/release.md`](../../docs/release.md).
+3. **Reconcile via `helm upgrade`** (or bump the installer's chart pin) against the new chart
+   version. **Never** `kubectl set image` or otherwise mutate the running Deployment out of
+   band — the chart is the source of truth and an in-place image bump drifts the cluster from
+   the chart.
 
 ## Invariants a change must not break
 

--- a/go/snowplow/docs/105-marketplace-rewalk-boot-budget-trace-2026-07-24.md
+++ b/go/snowplow/docs/105-marketplace-rewalk-boot-budget-trace-2026-07-24.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "#105 — marketplace-detail null-jq re-enqueues the whole boot re-walk, unboundedly"
+description: "Trace + fix design for #105: marketplace-detail null-jq re-enqueueing the whole boot re-walk unboundedly."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-24T00:00:00Z
+---
+
 # #105 — marketplace-detail null-jq re-enqueues the whole boot re-walk, unboundedly
 
 TRACE + FIX-DESIGN. Read-only. Frozen ref: origin/main `8fc4d87` (= 1.7.17 + #119 PARKED).

--- a/go/snowplow/docs/113-templated-endpointref-design-2026-07-15.md
+++ b/go/snowplow/docs/113-templated-endpointref-design-2026-07-15.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "#113 — template a RESTAction api-step `endpointRef` from request extras"
+description: "Design for #113: templating a RESTAction api-step endpointRef.name from request extras (hub-spoke), with the two credential-selection guardrails."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-15T00:00:00Z
+---
+
 # #113 — template a RESTAction api-step `endpointRef` from request extras
 
 Date: 2026-07-15

--- a/go/snowplow/docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md
+++ b/go/snowplow/docs/118-cv2-rbac-ordering-rolerule-design-2026-07-23.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "#118 (c)-v2 — RBAC ordering + role-rule bump: durable UAF authz-staleness fix"
+description: "Design (#118 c-v2): RBAC ordering + role-rule bump as the durable UAF authz-staleness fix."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-23T00:00:00Z
+---
+
 # #118 (c)-v2 — RBAC ordering + role-rule bump: durable UAF authz-staleness fix
 
 Date: 2026-07-23

--- a/go/snowplow/docs/118-uaf-rbac-stale-read-design-2026-07-22.md
+++ b/go/snowplow/docs/118-uaf-rbac-stale-read-design-2026-07-22.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "#118 — userAccessFilter RBAC stale-read: resolved-cache key blind to the refilter's RBAC dependency"
+description: "Design (#118): userAccessFilter RBAC stale-read — the resolved-cache key was blind to the refilter's RBAC dependency."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-22T00:00:00Z
+---
+
 # #118 — userAccessFilter RBAC stale-read: resolved-cache key blind to the refilter's RBAC dependency
 
 Design doc. Author: cache-architect. Date: 2026-07-22.

--- a/go/snowplow/docs/adr/0001-decouple-authn.md
+++ b/go/snowplow/docs/adr/0001-decouple-authn.md
@@ -1,6 +1,26 @@
+---
+type: Decision
+title: "ADR 0001 — Decouple authn from snowplow for testing and operations"
+description: >-
+  Snowplow can be tested and operated without the authn service: its auth
+  contract is a stateless HS256 JWT plus a per-user clientconfig Secret, both
+  mintable/creatable by hand. The original krateoctl vehicle is gone, and one
+  best-effort runtime coupling (the prewarm-seed loopback token exchange)
+  has since been added.
+resource: snowplow
+tags:
+  - adr
+  - authn
+  - jwt
+  - testing
+status: diverged
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # ADR 0001 — Decouple `authn` from snowplow for testing and operations
 
-- **Status:** Accepted (2025-10-22)
+- **Status:** Accepted (2025-10-22); the tooling vehicle has diverged — see
+  *What holds today* below.
 - **Supersedes:** `howto/decoupling-authn-from-snowplow-for-testing.md` — that how-to is
   preserved here in ADR form; this record is now authoritative.
 
@@ -14,36 +34,57 @@ every snowplow request (it carries the `UserInfo` — Username + Groups — that
 per-user caching), but it should not be a hard dependency for *testing or local operation* of
 snowplow.
 
-## Decision
+## Original decision (2025-10-22)
 
-Use the existing [`krateoctl`][krateoctl] tool (already distributed across environments) via its
-`krateoctl add-user` command. The command performs a one-time user registration and token
-generation using the **shared authentication library** — the same library `authn` uses — without
-requiring the `authn` service to be deployed.
+Use the `krateoctl add-user` command to perform a one-time user registration and token
+generation using the **shared authentication library** — the same library `authn` uses —
+without requiring the `authn` service to be deployed. Because the token is minted from the
+shared library, it is compatible with the real authentication flow.
 
-Developers and admins obtain a valid user and a Bearer token directly from the CLI, then call
-snowplow with that token. Because the token is minted from the shared library, it is compatible
-with the real authentication flow.
+## What holds today
+
+The *architectural* decision — `authn`'s **deployment** is decoupled, its **contract** is not —
+survives, but the vehicle and the exact boundary have both moved:
+
+- **`krateoctl` is gone.** It is not published under the `krateo-platformops` org. The token it
+  minted is a plain **HS256 JWT** from the shared auth library
+  (`github.com/krateo-platformops/plumbing` `jwtutil` — `CreateToken` / `Validate`), so any
+  tool can mint it against the `JWT_SIGN_KEY` secret; [`howto/install.md`](../../howto/install.md)
+  shows a stdlib-Python inline mint that replaces the CLI.
+- **Token validation is stateless.** Snowplow's auth middleware
+  (`internal/handlers/middleware/userconfig.go`, a snowplow-local transcription of plumbing's
+  `use.UserConfig`) calls `jwtutil.Validate(signingKey, token)` — a pure HS256 check against the
+  `jwt-sign-key` secret. No call to the `authn` service is ever made to validate a request.
+- **The full `/call` credential is JWT + clientconfig Secret.** After validating the JWT, the
+  middleware fetches the per-user `<dns1123(username)>-clientconfig` Secret from the authn
+  namespace (cache-first via the in-process Secrets snapshot, apiserver fallback; missing Secret
+  → 401). In production `authn` creates that Secret at login; for authn-free operation it must
+  be provided by hand alongside the minted JWT. Decoupling the *service* does not remove this
+  *data* dependency.
+- **One new, best-effort runtime coupling.** The prewarm seed authenticates its nested loopback
+  `/call`s by exchanging snowplow's projected (audience-bound) ServiceAccount token at `authn`'s
+  `/serviceaccount/login` endpoint (`internal/authn/authn.go`, ported verbatim from the cdc's
+  authn client; wired in `main.go` via `URL_AUTHN`). Without a running `authn` this exchange
+  fails at runtime and the seed is skipped — the seed is best-effort warmth, not a correctness
+  gate, and `/call` serves normally. Additionally, the snowplow chart's prewarm-seed allowlist
+  CR requires the `authn-crds` chart (the `serviceaccount.authn.krateo.io` CRD) at install time
+  — a CRD dependency, not a service dependency.
 
 ## Consequences
 
-- **Simplified testing.** Services that depend on authentication can be tested without `authn`.
-- **Reduced operational overhead.** No `authn` deployment needed in local or CI environments.
-- **Consistency.** The CLI reuses the shared auth library, so tokens behave identically to those
-  issued by the real `authn` service.
-- **Admin utility.** The same command lets administrators bootstrap or manage users quickly.
+- **Simplified testing.** Services that depend on authentication can be tested without the
+  `authn` service: mint the HS256 JWT from the shared library and create the user's
+  clientconfig Secret.
+- **Reduced operational overhead.** No `authn` deployment needed in local or CI environments;
+  the prewarm seed degrades gracefully in its absence.
+- **Consistency.** Tokens are minted from the same shared library `authn` uses, so they behave
+  identically to real `authn`-issued tokens (`jwtutil.Validate` is the single verifier).
 - **Boundary preserved.** This decouples *deployment* of `authn`, not the *contract*: snowplow
   still consumes the same `UserInfo` shape, so the RBAC and per-user-cache invariants
   (ADR 0002 / ADR 0003) are exercised exactly as in production.
 
 This follows microservice testing best practice — reduce inter-service coupling and lean on
-existing operational tools — while staying aligned with the production authentication mechanism.
-
-> **Note (post org migration):** `krateoctl` is not published under the
-> `krateo-platformops` org. The token it mints is a plain HS256 JWT from the shared
-> auth library (`github.com/krateo-platformops/plumbing` `jwtutil`);
-> [`howto/install.md`](../../howto/install.md) shows a tool-free way to mint the
-> same token.
+the shared library boundary — while staying aligned with the production authentication
+mechanism.
 
 [authn]: https://github.com/krateo-platformops/authn
-[krateoctl]: ../../howto/install.md

--- a/go/snowplow/docs/adr/0001-decouple-authn.md
+++ b/go/snowplow/docs/adr/0001-decouple-authn.md
@@ -39,5 +39,11 @@ with the real authentication flow.
 This follows microservice testing best practice — reduce inter-service coupling and lean on
 existing operational tools — while staying aligned with the production authentication mechanism.
 
-[authn]: https://github.com/krateoplatformops/authn
-[krateoctl]: https://github.com/krateoplatformops/krateoctl/releases
+> **Note (post org migration):** `krateoctl` is not published under the
+> `krateo-platformops` org. The token it mints is a plain HS256 JWT from the shared
+> auth library (`github.com/krateo-platformops/plumbing` `jwtutil`);
+> [`howto/install.md`](../../howto/install.md) shows a tool-free way to mint the
+> same token.
+
+[authn]: https://github.com/krateo-platformops/authn
+[krateoctl]: ../../howto/install.md

--- a/go/snowplow/docs/adr/0002-per-user-l1-keying.md
+++ b/go/snowplow/docs/adr/0002-per-user-l1-keying.md
@@ -3,9 +3,10 @@ type: Decision
 title: "ADR 0002 — L1 resolved-cache cells are keyed per-binding, never cohort-only"
 description: >-
   Identity-bound L1 cache cells fold the authorising RBAC binding's UID (plus,
-  since #118, the requesting subject's RBAC sub-generation) into the cache key,
-  so a narrowly-authorised user can never read a broadly-authorised user's
-  cached bytes. Empty-identity cells are neither populated nor served.
+  for the dispatch-keyed classes since #118, the requesting subject's RBAC
+  sub-generation) into the cache key, so a narrowly-authorised user can never
+  read a broadly-authorised user's cached bytes. Empty-identity cells are
+  neither populated nor served.
 resource: snowplow
 tags:
   - adr
@@ -50,9 +51,9 @@ authorised the specific layer's GET.
 
 ## Decision
 
-For the identity-bound entry classes — `restactions`, `widgets`, `raFullList` — the dispatch key
-folds **two** identity terms (`ComputeKey`, `internal/cache/resolved.go`; the current key-schema
-salt is `resolvedKeyVersion = "v6"`):
+For the dispatch-keyed identity-bound entry classes — `restactions`, `widgets` — the dispatch
+key folds **two** identity terms (`ComputeKey`, `internal/cache/resolved.go`; the current
+key-schema salt is `resolvedKeyVersion = "v6"`):
 
 1. **`BindingUID`** — the UID of the first-match RBAC binding that authorised *this layer's GET*
    for *this request's identity*.
@@ -75,6 +76,16 @@ salt is `resolvedKeyVersion = "v6"`):
    UAF refilter depends on), with blast radius proportional to the affected subjects — not the
    whole cache. The seed writes `RBACSubGen==0` (a warm-miss perf gap for moved-sub-gen
    subjects, ticketed; never an authz-staleness bug — the dispatch key stays correct).
+
+`raFullList` is identity-bound via **`BindingUID` only**. Its single key source is
+`seedFullListRAKey` (`internal/resolvers/widgets/apiref/ra_full_list.go`), which derives the
+first-match `BindingUID` on the RA's own coordinates and passes it to `RAFullListKeyInputs`
+(`internal/cache/ra_full_list_slice.go`), which never sets `RBACSubGen` — so every `raFullList`
+cell hashes `RBACSubGen == 0` on Put *and* Get. The sub-gen term is mechanically folded but
+semantically inert for this class: there is no grant/revoke sub-gen rotation for `raFullList`
+cells; they rotate only when the authorising `BindingUID` itself changes. (The only
+`RBACSubGen` stamping site in the tree is `dispatchCacheLookupKey` — the `restactions`/`widgets`
+dispatch key above.)
 
 This is **finer-grained** than the v3 cohort hash it replaced: two users granted by the *same*
 binding share one cell; the *same* user authorised by *different* bindings on different layers
@@ -107,7 +118,9 @@ inputs never populate the identity fields (`contentKeyInputs`,
 `internal/resolvers/restactions/api/apistage.go`), so the cell is identity-invariant, populated
 SA-maximal, and **must** be RBAC-narrowed at serve time. Apistage is therefore governed by
 ADR 0003's identity-free-with-serve-time-gate rule, not by this ADR's per-binding rule. The
-identity-bound classes today are exactly `restactions`, `widgets`, and `raFullList`.
+identity-bound classes today are exactly `restactions`, `widgets`, and `raFullList` — the last
+via `BindingUID` only (its key source never stamps `RBACSubGen`, which hashes as a constant `0`
+for that class; see Decision).
 
 ## Consequences
 
@@ -116,8 +129,10 @@ identity-bound classes today are exactly `restactions`, `widgets`, and `raFullLi
 - **The cache is per-binding, not per-user.** Memory scales with the number of distinct
   authorising bindings, not with the user count — which is what makes the cache viable at
   50K compositions × 1000 users while staying leak-free.
-- **Out-of-band RBAC changes rotate keys.** The `RBACSubGen` fold means a live grant/revoke is
-  reflected on the affected subjects' next `/call` without a global flush. As an interim bound
+- **Out-of-band RBAC changes rotate keys — for the dispatch-keyed classes.** The `RBACSubGen`
+  fold means a live grant/revoke is reflected on the affected subjects' next
+  `restactions`/`widgets` `/call` without a global flush; `raFullList` cells rotate only on a
+  `BindingUID` change. As an interim bound
   for the residual refilter dependency, cells whose RESTAction declares a `userAccessFilter`
   stage also carry a short TTL override (`UAF_RESOLVED_TTL_SECONDS`, #118 (d); `HasUAF` is
   entry bookkeeping, not key material).
@@ -126,7 +141,8 @@ identity-bound classes today are exactly `restactions`, `widgets`, and `raFullLi
   rule stands: *an entry may be identity-free in the key only if it is re-narrowed per-user at
   serve time.*
 - **A regression here is high-severity.** Symptom: a user sees rows they lack a grant for. First
-  check: `ComputeKey` still folds `BindingUID` + `RBACSubGen` for the affected class; the F7
+  check: `ComputeKey` still folds `BindingUID` (+ `RBACSubGen` for the dispatch-keyed classes)
+  for the affected class; the F7
   tests; `compute_key_identity_invariants_test.go`; the `feedback_l1_per_user_keyed_never_cohort`
   history. Re-introducing a cohort/content-only key for an identity-bound class is the exact
   mistake this ADR exists to prevent.

--- a/go/snowplow/docs/adr/0002-per-user-l1-keying.md
+++ b/go/snowplow/docs/adr/0002-per-user-l1-keying.md
@@ -1,7 +1,26 @@
-# ADR 0002 — L1 resolved-cache cells are keyed per-binding-UID, never cohort-only
+---
+type: Decision
+title: "ADR 0002 — L1 resolved-cache cells are keyed per-binding, never cohort-only"
+description: >-
+  Identity-bound L1 cache cells fold the authorising RBAC binding's UID (plus,
+  since #118, the requesting subject's RBAC sub-generation) into the cache key,
+  so a narrowly-authorised user can never read a broadly-authorised user's
+  cached bytes. Empty-identity cells are neither populated nor served.
+resource: snowplow
+tags:
+  - adr
+  - cache
+  - rbac
+  - security
+status: diverged
+timestamp: 2026-08-06T00:00:00Z
+---
 
-- **Status:** Accepted
-- **Related:** ADR 0003 (the one identity-free exception, re-narrowed at serve time),
+# ADR 0002 — L1 resolved-cache cells are keyed per-binding, never cohort-only
+
+- **Status:** Accepted; two material amendments since (the `RBACSubGen` key fold and the
+  empty-identity fail-closed hardening), plus one walk-back (apistage — see ADR 0003).
+- **Related:** ADR 0003 (the identity-free exceptions, re-narrowed at serve time),
   ADR 0004 (the cache is provisional). Deep dives:
   [`docs/architecture/caching.md`](../architecture/caching.md),
   [`docs/architecture/rbac-uaf.md`](../architecture/rbac-uaf.md).
@@ -10,9 +29,9 @@
 
 Snowplow serves Krateo frontend content out of an in-process L1 cache of pre-encoded `/call`
 JSON (`internal/cache/resolved.go`). A cache hit skips the whole resolver and writes the stored
-bytes back to the client. The L1 cell key (`ComputeKey`, `resolved.go:608`) therefore decides
-**which request reads which stored body** — and every byte that leaves the pod must be exactly
-what the *requesting user* is permitted to see.
+bytes back to the client. The L1 cell key (`cache.ComputeKey`) therefore decides **which request
+reads which stored body** — and every byte that leaves the pod must be exactly what the
+*requesting user* is permitted to see.
 
 The tempting design is to key an identity-bound cell by content alone:
 `(group, version, resource, namespace, name, page, extras)`. That is wrong, and the failure is a
@@ -31,30 +50,64 @@ authorised the specific layer's GET.
 
 ## Decision
 
-For every identity-bound entry class — `restactions`, `widgets`, `apistage`, `raFullList` —
-`ComputeKey` folds the **`BindingUID`** into the key (`resolved.go:652-655`): the UID of the
-first-match RBAC binding that authorised *this layer's GET* for *this request's identity*.
+For the identity-bound entry classes — `restactions`, `widgets`, `raFullList` — the dispatch key
+folds **two** identity terms (`ComputeKey`, `internal/cache/resolved.go`; the current key-schema
+salt is `resolvedKeyVersion = "v6"`):
 
-- The UID is derived by `dispatchCacheLookupKey` (`helpers.go:200`) via a direct
-  `EvaluateRBAC(verb=get, …)` call with `SkipBindingUID` left at its safe zero value, so the
-  returned UID is the deterministic, stable-sorted first match (`helpers.go:211-228`).
-- The UID itself is produced by `BindingUIDFromCRB` / `BindingUIDFromRB`
-  (`match_subject.go:83` / `:107`), prefixed `"C:<uid>"` for ClusterRoleBindings and
-  `"R:<ns>/<uid>"` for RoleBindings so the two namespaces of UID never alias and RB scope is
-  carried in the identifier.
-- A deny or evaluation error **fails closed** to `bindingUID == ""` (`helpers.go:197-199`) — the
-  same empty-identity row that `CACHE_ENABLED=false` produces. The biconditional
-  `BindingUID == "" ⟺ (cache off) ∨ (deny / no snapshot)` is asserted both directions by the F7
-  invariant tests (`evaltest/empty_binding_uid_invariant_test.go`).
+1. **`BindingUID`** — the UID of the first-match RBAC binding that authorised *this layer's GET*
+   for *this request's identity*.
+   - Derived by `dispatchCacheLookupKey` (`internal/handlers/dispatchers/helpers.go`) via a
+     direct `rbac.EvaluateRBAC(verb=get, …)` call with `SkipBindingUID` left at its safe zero
+     value, so the returned UID is the deterministic, stable-sorted first match.
+   - Produced by `BindingUIDFromCRB` / `BindingUIDFromRB` (`internal/cache/match_subject.go`),
+     prefixed `"C:<uid>"` for ClusterRoleBindings and `"R:<ns>/<uid>"` for RoleBindings so the
+     two namespaces of UID never alias and RB scope is carried in the identifier. (Bindings with
+     an empty apiserver UID — synthetic/test fixtures — fall back to a content-tuple hash under
+     the same prefixes.)
+   - A deny or evaluation error **fails closed** to `bindingUID == ""`. The biconditional
+     `BindingUID == "" ⟺ (cache off) ∨ (deny / no snapshot)` is asserted both directions by the
+     F7 invariant tests (`internal/rbac/evaltest/empty_binding_uid_invariant_test.go`).
+2. **`RBACSubGen`** (#118 (c)/(c)-v2) — the requesting subject's *effective per-subject RBAC
+   sub-generation* (`cache.RBACSubGenForSubject` over the user + every presented group + SA
+   counters, bumped at snapshot-publish). A grant/revoke that touches this user's *own* bindings
+   rotates the key → cold miss → fresh resolve → fresh userAccessFilter refilter. This closes the
+   staleness window the single dispatch-GET `BindingUID` is blind to (a per-namespace grant the
+   UAF refilter depends on), with blast radius proportional to the affected subjects — not the
+   whole cache. The seed writes `RBACSubGen==0` (a warm-miss perf gap for moved-sub-gen
+   subjects, ticketed; never an authz-staleness bug — the dispatch key stays correct).
 
 This is **finer-grained** than the v3 cohort hash it replaced: two users granted by the *same*
 binding share one cell; the *same* user authorised by *different* bindings on different layers
-gets different cells (`resolved.go:256-267`, `:284-303`).
+gets different cells.
 
 **Value-dedup is a free consequence**, not a separate mechanism: because every member of a
-`BindingUID` equivalence class resolves to byte-identical output, they all land on one cell
-(`resolved.go:312-320`). Page-dedup layers on top via the `raFullList` class, which caches the
-full unpaginated result once and slices per page at serve time (`ra_full_list_slice.go`).
+`BindingUID` equivalence class resolves to byte-identical output, they all land on one cell. The
+first writer's identity is carried on the entry as `RepresentativeUsername`/`Groups` — refresher
+bookkeeping only, explicitly *excluded* from `ComputeKey`. Page-dedup layers on top via the
+`raFullList` class, which caches the full unpaginated result once and slices per page at serve
+time (`internal/cache/ra_full_list_slice.go`).
+
+### The empty-identity cell is dead, not shared
+
+Originally the `BindingUID == ""` row was treated as a shared "safe floor". The #95 security fix
+hardened this in both directions: the seed and the customer/refresher Put paths **skip populating**
+any cell whose re-derived `BindingUID` is `""` (the Put-gates in
+`internal/handlers/dispatchers/restactions.go` / `widgets.go` / the seed's FIX-C skip), and the
+serve path treats a `""`-derivation as a **cache miss** (`serveFromCacheEligible`,
+`internal/handlers/dispatchers/helpers.go`) — falling through to a direct resolve under the
+request's own identity. A `""`-deriving request therefore never reads *or* writes a shared cell;
+deny/error collapses to the same behaviour as `CACHE_ENABLED=false` (transparent direct resolve,
+ADR 0004).
+
+### The apistage walk-back
+
+The 0.30.242 design declared `apistage` identity-bound ("RBAC-narrowed at populate time").
+That claim was **wrong as shipped** and was corrected by #58: the apistage *content* cell's key
+inputs never populate the identity fields (`contentKeyInputs`,
+`internal/resolvers/restactions/api/apistage.go`), so the cell is identity-invariant, populated
+SA-maximal, and **must** be RBAC-narrowed at serve time. Apistage is therefore governed by
+ADR 0003's identity-free-with-serve-time-gate rule, not by this ADR's per-binding rule. The
+identity-bound classes today are exactly `restactions`, `widgets`, and `raFullList`.
 
 ## Consequences
 
@@ -63,13 +116,19 @@ full unpaginated result once and slices per page at serve time (`ra_full_list_sl
 - **The cache is per-binding, not per-user.** Memory scales with the number of distinct
   authorising bindings, not with the user count — which is what makes the cache viable at
   50K compositions × 1000 users while staying leak-free.
-- **One deliberate exception.** `widgetContent` is the only identity-free class, and only because
-  its served body is re-narrowed per request at serve time — see ADR 0003. The general rule:
-  *an entry may be identity-free in the key only if it is re-narrowed per-user at serve time.*
+- **Out-of-band RBAC changes rotate keys.** The `RBACSubGen` fold means a live grant/revoke is
+  reflected on the affected subjects' next `/call` without a global flush. As an interim bound
+  for the residual refilter dependency, cells whose RESTAction declares a `userAccessFilter`
+  stage also carry a short TTL override (`UAF_RESOLVED_TTL_SECONDS`, #118 (d); `HasUAF` is
+  entry bookkeeping, not key material).
+- **The deliberate exceptions are serve-time-gated.** `widgetContent` and `apistage` are
+  identity-free in the key and re-narrowed per request at serve time — see ADR 0003. The general
+  rule stands: *an entry may be identity-free in the key only if it is re-narrowed per-user at
+  serve time.*
 - **A regression here is high-severity.** Symptom: a user sees rows they lack a grant for. First
-  check: `ComputeKey` still folds `BindingUID` for the affected class (`resolved.go:652-655`); the
-  F7 tests; the `feedback_l1_per_user_keyed_never_cohort` history. Re-introducing a cohort/content-
-  only key for an identity-bound class is the exact mistake this ADR exists to prevent.
-- **The empty-UID row is the safe floor.** Deny/error and cache-off all collapse to the same
-  empty-identity cell shape, so the fail-closed path is identical to the transparent fallback
-  (ADR 0004).
+  check: `ComputeKey` still folds `BindingUID` + `RBACSubGen` for the affected class; the F7
+  tests; `compute_key_identity_invariants_test.go`; the `feedback_l1_per_user_keyed_never_cohort`
+  history. Re-introducing a cohort/content-only key for an identity-bound class is the exact
+  mistake this ADR exists to prevent.
+- **Fail-closed floor.** Deny/error and cache-off all collapse to a direct, un-cached resolve
+  under the request's own identity — never a shared cell.

--- a/go/snowplow/docs/adr/0003-identity-free-content-key.md
+++ b/go/snowplow/docs/adr/0003-identity-free-content-key.md
@@ -1,8 +1,29 @@
-# ADR 0003 — Identity-free widget content key + serve-time UAF
+---
+type: Decision
+title: "ADR 0003 — Identity-free content keys + serve-time RBAC gating"
+description: >-
+  Two L1 entry classes — widgetContent and apistage — are identity-free in the
+  cache key and re-narrowed per requesting user at serve time; the cache holds
+  content, identity is applied when the bytes leave the pod. RBAC-sensitive
+  widgets bypass the shared cell, and UAF stages are deliberately exempt from
+  the raw-RBAC serve gate.
+resource: snowplow
+tags:
+  - adr
+  - cache
+  - rbac
+  - widgets
+status: diverged
+timestamp: 2026-08-06T00:00:00Z
+---
 
-- **Status:** Accepted
-- **Related:** ADR 0002 (the general per-binding keying rule this is the sanctioned exception to).
-  Deep dives: [`docs/architecture/caching.md`](../architecture/caching.md),
+# ADR 0003 — Identity-free content keys + serve-time RBAC gating
+
+- **Status:** Accepted; amended — `widgetContent` is no longer the *only* identity-free class
+  (`apistage` joined it when the 0.30.242 "narrowed-at-populate" design was corrected by #58),
+  and the serve-time gate has a deliberate UAF exemption.
+- **Related:** ADR 0002 (the general per-binding keying rule these are the sanctioned exceptions
+  to). Deep dives: [`docs/architecture/caching.md`](../architecture/caching.md),
   [`docs/architecture/rbac-uaf.md`](../architecture/rbac-uaf.md).
 
 ## Context
@@ -18,60 +39,89 @@ The observation that unlocks the exception: a widget's body is largely **identit
 The list of `status.resourcesRefs.items[]` and their content is the same for everyone who can see
 the widget; only the per-item `allowed` flag (does *this* user get the action button?) is
 identity-specific. So the body can be shared if — and only if — the identity-specific part is
-recomputed for each request before the bytes are written.
+recomputed for each request before the bytes are written. The same logic applies one tier down to
+the raw apiserver envelope a RESTAction api-stage caches: the envelope is what the SA saw; which
+*items* a given user may see is per-user and must be decided at serve time.
 
 ## Decision
 
-Snowplow uses two complementary mechanisms.
+Snowplow uses two complementary mechanisms, applied to **two** identity-free entry classes.
 
-### 1. The identity-free content key (`widgetContent`)
+### 1. The identity-free content keys (`widgetContent`, `apistage`)
 
-`widgetContent` (`resolved.go:147`) is the **only** entry class for which `ComputeKey` skips the
-identity fold (`resolved.go:652`). Its key is built by `dispatchWidgetContentKey`
-(`helpers.go:147`) with Username/Groups left zero, so it is keyed only on
-`(gvr, ns, name, perPage, page, extras)`. An admin and a narrow-RBAC user hit the **same cell**.
+- **`widgetContent`** — its key is built by `dispatchWidgetContentKey`
+  (`internal/handlers/dispatchers/helpers.go`) with the identity fields left zero, so it is keyed
+  only on `(gvr, ns, name, perPage, page, extras)`; `ComputeKey` skips the identity fold for this
+  class entirely. An admin and a narrow-RBAC user hit the **same cell**. The stored body is a
+  **shell**: `status.resourcesRefs.items[].allowed` flags are present as the SA walker evaluated
+  them, but the shell is **never served verbatim**.
+- **`apistage`** — its key is built by `contentKeyInputs`
+  (`internal/resolvers/restactions/api/apistage.go`) with the identity fields never populated
+  (`ComputeKey` would fold them for this class, but they are zero by construction), so the
+  per-K8s-call content cell is keyed on `(gvr, ns, name-or-empty, stage)` and shared by every
+  user. It is populated **SA-maximal and un-gated** (the miss dispatch skips the inline RBAC
+  filter under `WithApistageContentResolve`). The 0.30.242 claim that this cell was
+  "RBAC-narrowed at populate time" was wrong as shipped; #58 re-established the serve-time gate.
 
-The stored body is a **shell**: `status.resourcesRefs.items[].allowed` flags are present as the SA
-walker evaluated them, but the shell is **never served verbatim**.
-
-### 2. Serve-time UAF (the cache is not trusted for RBAC)
+### 2. Serve-time gating (the cache is not trusted for RBAC)
 
 Results are re-filtered against the requesting user *at serve time*, never trusted from the cache:
 
-- On a `widgetContent` hit, `gateWidgetEnvelope` (`widgets.go:139-153`) **overwrites every
-  `allowed` flag** under the request's own identity (via `rbac.UserCan`) before serialisation. The
-  body is shared; the bytes that leave the pod are per-user.
-- This path is **bypassed entirely** for RBAC-sensitive apiRef widgets — those whose
-  `status.widgetData` is RBAC-narrowed and would leak the SA-maximal aggregate if shared
-  (`isRBACSensitiveApiRefWidget`, `widgets.go:134`). Such widgets fall through to the per-binding
-  key of ADR 0002.
-- More broadly, serve-time UAF is a per-item gate applied across *all* served bodies, not just
-  widgets. Every site calls `EvaluateRBAC(…, SkipBindingUID=true)` and keeps an item only if
-  `allowed`: `refilter.go` (`applyUserAccessFilter`/`refilterSlice`/`evalSingle`),
-  `informer_dispatch_rbac.go` (`filterListByRBAC`/`filterGetByRBAC`),
-  `cluster_list.go`, and `objects/informer_serve.go`. Every one fails **closed** — a JQ error, an
-  `EvaluateRBAC` error, or a deny **drops** the item.
+- On a `widgetContent` hit, `gateWidgetEnvelope`
+  (`internal/handlers/dispatchers/widget_content.go`) **overwrites every `allowed` flag** under
+  the request's own identity (via `rbac.UserCan`) before serialisation. The body is shared; the
+  bytes that leave the pod are per-user.
+- The shared-cell path is **bypassed entirely** for RBAC-sensitive widgets
+  (`isRBACSensitiveApiRefWidget`, same file — applied symmetrically at the populate-write and
+  serve-read sites): a widget whose `status.widgetData` is built from an apiRef through
+  `widgetDataTemplate`/`resourcesRefsTemplate` (its *data*, not just its action flags, is
+  RBAC-narrowed and would leak the SA-maximal aggregate if shared), and — the #72 extension —
+  any widget carrying an **inline + GET `resourcesRefs` item** (its server-resolved child
+  `rendered` body is narrowed per user). Such widgets fall through to the per-binding key of
+  ADR 0002. A transient accessor error de-classifies safely only because the resolver fails soft
+  to static-only widgetData on the same error — the two sites must stay symmetric.
+  Additionally, `shouldSkipEmptyWidgetShell` keeps transient-empty apiRef+template shells out of
+  the shared cell at boot (a poison-shell guard, not an RBAC guard).
+- On an `apistage` hit, the gate depends on the stage (#58):
+  - **Non-UAF LIST** → `gateListItems` → `filterListByRBAC`
+    (`internal/resolvers/restactions/api/informer_dispatch_rbac.go`): the requester's raw RBAC,
+    per item. **GET-by-name** → `gateContentEnvelope` / `filterGetByRBAC`.
+  - **UAF LIST** → served **un-narrowed** (`serveParsedListEnvelope`). This is deliberate, not a
+    gap: a `userAccessFilter` stage runs with elevated privilege precisely because the requester
+    *lacks* the raw RBAC; the per-user narrowing is the UAF refilter downstream
+    (`refilter.go` — `applyUserAccessFilter`/`refilterSlice`/`evalSingle`), whose verb/resource/
+    namespace derivation diverges from raw list-RBAC. Applying the raw gate here would strip the
+    UAF-intended scope to near-empty and break UAF.
+- More broadly, serve-time per-item RBAC gates run across the served bodies:
+  `filterListByRBAC`/`filterGetByRBAC` on the informer dispatch path
+  (`informer_dispatch.go`), `filterGetByRBAC` in `internal/objects/informer_serve.go` (consumed
+  by `objects/get.go`), and the cluster-list resolver's `EvaluateRBAC(verb=list)` check
+  (`cluster_list.go`). Every gate fails **closed** — a JQ error, an `EvaluateRBAC` error, or a
+  deny **drops** the item (the UAF exemption above being the one privilege-inverting exception,
+  which fails closed inside the refilter instead).
 
 The architectural statement: **the cache holds content; identity is applied at serve time.** A
 hit can never short-circuit a permission check — the dispatcher's `EvaluateRBAC` gate also runs
-*before* the L1 lookup (`restactions.go:96-116`), so the cell is consulted only after the request
-itself is authorised.
+*before* the L1 lookup (`internal/handlers/dispatchers/restactions.go`), so the cell is consulted
+only after the request itself is authorised.
 
 ## Consequences
 
-- **One shared widget shell across all cohorts**, re-personalised per request — the expensive
-  widget body is resolved once, not once-per-binding, without reopening the ADR 0002 leak.
+- **One shared shell across all cohorts**, re-personalised per request — the expensive widget
+  body (and the raw apistage envelope) is resolved once, not once-per-binding, without reopening
+  the ADR 0002 leak.
 - **The cache is RBAC-untrusted by design.** Even a correctly-keyed cell is re-checked per item
   at serve time, so a stale or over-broad cached body cannot leak: the gate drops anything the
   user lacks a grant for.
 - **The exception is narrow and self-policing.** The rule is *identity-free in the key only if
-  re-narrowed per-user at serve time*. The RBAC-sensitive-widget bypass (`widgets.go:134`) is the
-  guard that keeps a widget whose *data* (not just action flags) is identity-specific off the
-  shared path.
-- **Performance lever.** Serve-time per-item gates pass `SkipBindingUID=true` to skip the
-  CRB/RB stable-sort — a ~43% pod-CPU lever at 50K scale (`evaluate.go:107-111`, `:153-166`);
-  correctness is unaffected because the sort only chooses *which* UID is returned, not the verdict.
-- **Failure mode to watch.** If `gateWidgetEnvelope` stops re-stamping, or a non-`widgetContent`
-  class is made identity-free, the shared shell leaks. The invariant is: the only identity-free
-  key class is `widgetContent`, and it is always re-stamped (`widgets.go:139-153`,
-  rationale at `resolved.go:127-147`).
+  re-narrowed per-user at serve time*. The RBAC-sensitive-widget bypass is the guard that keeps
+  a widget whose *data* (not just action flags) is identity-specific off the shared path.
+- **Performance lever.** Serve-time per-item gates pass `SkipBindingUID=true`
+  (`internal/rbac/evaluate.go`) to skip the CRB/RB stable-sort — a ~43% pod-CPU lever at 50K
+  scale; correctness is unaffected because the sort only chooses *which* UID is returned, not
+  the verdict.
+- **Failure modes to watch.** If `gateWidgetEnvelope` stops re-stamping, if an apistage non-UAF
+  LIST is served without `gateListItems` (the #58 over-serve regression: a narrow tenant received
+  the full SA list), or if a third class is made identity-free without a serve-time gate, the
+  shared cell leaks. The invariant: the identity-free key classes are exactly `widgetContent` and
+  `apistage`, and both are always re-narrowed at serve time.

--- a/go/snowplow/docs/adr/0004-cache-is-provisional-and-removable.md
+++ b/go/snowplow/docs/adr/0004-cache-is-provisional-and-removable.md
@@ -1,6 +1,26 @@
+---
+type: Decision
+title: "ADR 0004 — All caching is provisional and removable; CACHE_ENABLED=false is a transparent fallback"
+description: >-
+  CACHE_ENABLED is the single master gate over snowplow's whole cache
+  subsystem; turning it off routes every read straight to the apiserver with
+  identical data, UI, and RBAC — the correctness baseline and the documented
+  incident lever. Sub-tier back-out knobs and bounded-TTL tunables layer under
+  it without changing the invariant.
+resource: snowplow
+tags:
+  - adr
+  - cache
+  - operations
+  - flags
+status: implemented
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # ADR 0004 — All caching is provisional and removable; `CACHE_ENABLED=false` is a transparent fallback
 
-- **Status:** Accepted
+- **Status:** Accepted and implemented as decided; the knob inventory has grown (bounded-TTL
+  tunables) without changing the invariant.
 - **Related:** ADR 0002, ADR 0003 (the cache layers this invariant governs).
   Deep dive: [`docs/architecture/caching.md`](../architecture/caching.md).
 
@@ -23,36 +43,49 @@ Two risks follow from a cache that becomes load-bearing for *correctness*:
 **The cache is provisional and must stay cleanly removable.** This is enforced by a single master
 toggle and the invariant that turning it off is a *transparent fallback*, not a degraded mode.
 
-- `CACHE_ENABLED` is the master gate (`cache.go:37` `Disabled()`). With it off, all three tiers
-  vanish and **every read goes straight to the apiserver — same data, same UI, same RBAC, just
-  slower.** This is not a reduced-functionality path; it is the correctness baseline.
+- `CACHE_ENABLED` is the master gate (`cache.Disabled()`, `internal/cache/cache.go`). The code
+  default is **off** — only an explicit truthy value enables the subsystem (the chart sets
+  `CACHE_ENABLED: "true"` for production). With it off, all tiers vanish and **every read goes
+  straight to the apiserver — same data, same UI, same RBAC, just slower.** This is not a
+  reduced-functionality path; it is the correctness baseline.
 - The fallback is enforced at every tier, by construction, not by special-casing:
-  - **L3** switches to `modePassthrough`: `GetObject` issues a live `Get` (`watcher.go:1616`) and
-    `ListObjects` issues a fresh paged LIST (`watcher.go:1670`) instead of reading the indexer.
-    Same `GetObject`/`ListObjects` surface, two backing implementations chosen once at
-    construction (`NewResourceWatcher`).
-  - **L1** `ResolvedCache()` returns `nil` and every consumer nil-checks and resolves directly
-    (`resolved.go:547-550`, `:484-494`).
-  - **RBAC** routes through `UserCan` → `SelfSubjectAccessReview` against the user's own kubeconfig
-    (`rbac.go:62-103`), and the dispatcher's in-process `EvaluateRBAC` gate is skipped because the
-    per-user apiserver fetch enforces RBAC inline (`restactions.go:92-108`). There is **zero
+  - **L3** switches to `modePassthrough`: `GetObject` issues a live `Get` and `ListObjects` a
+    fresh paged LIST (`internal/cache/watcher.go`) instead of reading the indexer. Same
+    `GetObject`/`ListObjects` surface, two backing implementations chosen once at construction
+    (`NewResourceWatcher`).
+  - **L1** `cache.ResolvedCache()` returns `nil` and every consumer nil-checks and resolves
+    directly (`internal/cache/resolved.go`).
+  - **RBAC** routes through `UserCan` → `SelfSubjectAccessReview` against the user's own
+    kubeconfig (`internal/rbac/rbac.go`), and the dispatcher's in-process `EvaluateRBAC` gate is
+    skipped because the per-user apiserver fetch enforces RBAC inline
+    (`internal/handlers/dispatchers/restactions.go`). There is **zero
     `SubjectAccessReview` to the apiserver in cache-on mode**, and `userCanViaSAR` MUST be
-    reachable only when `cache.Disabled() == true` (`rbac.go:62-64`).
-  - **Prewarm** makes its harvesters nil and the seed a no-op under the master gate
-    (`phase1_walk.go:351-395`).
-- `CACHE_ENABLED` is the single master gate; prewarm and the informer-serve pivot are implicit
-  under it. The api-stage L1 (Ship E) is likewise folded — implicit-on under
-  `RESOLVED_CACHE_ENABLED`, no per-feature flag (#57; `RESOLVED_CACHE_APISTAGE_ENABLED` retired).
-  Only fine-grained back-out knobs remain (`RESOLVED_CACHE_ENABLED`,
-  `WIDGET_CONTENT_L1_ENABLED`, `cache.go:15-24`) for narrowing
-  a regression to one tier without losing the others.
-- The subsystem is kept structurally removable (`cache.go:10-13`).
+    reachable only when `cache.Disabled() == true` (asserted by the F7 invariant tests).
+  - **Prewarm** is implicit under the master gate (`cache.PrewarmEnabled()`,
+    `internal/cache/phase1.go`): with it off, the walk never runs, its harvesters are nil, and
+    the seed is a no-op (`internal/handlers/dispatchers/phase1_walk.go`).
+- `CACHE_ENABLED` is the single master gate; formerly-standalone flags are folded into it (#57,
+  `project_single_cache_flag_direction`): `PREWARM_ENABLED`, `RESOLVER_USE_INFORMER`,
+  `PREWARM_CONTENT_ENABLED`, `PREWARM_PIP_ENABLED`, and `RESOLVED_CACHE_APISTAGE_ENABLED` are
+  retired names, implicit-on under the subsystem (main.go's retired-flag audit warns once on
+  stale values). What remains under it:
+  - **Back-out knobs** for narrowing a regression to one tier without losing the others:
+    `RESOLVED_CACHE_ENABLED` (the L1 store + refresher; the api-stage L1 is implicit under it)
+    and `WIDGET_CONTENT_L1_ENABLED` (the identity-free widget layer only).
+  - **Capacity/TTL tunables**, not feature flags: `RESOLVED_CACHE_MAX_ENTRIES` /
+    `RESOLVED_CACHE_MAX_BYTES` / `RESOLVED_CACHE_TTL_SECONDS` /
+    `RESOLVED_CACHE_MAX_RESIDENT_BYTES` (the pinned-resident region; `0` disables pinning —
+    the Ship 4a kill-switch), and the bounded-staleness backstops
+    `CATALOG_UNSERVABLE_TTL_SECONDS` (#36), `UAF_RESOLVED_TTL_SECONDS` (#118 (d)) and
+    `PARTIAL_RESULT_TTL_SECONDS` (#313 D) — each default `0` = off, purely additive.
+- The subsystem is kept structurally removable (`internal/cache/cache.go` package contract,
+  `project_caching_is_provisional`).
 
 ## Consequences
 
 - **Instant, safe rollback.** A cache-introduced regression is mitigated by one helm `--set
-  CACHE_ENABLED=false`; the pod keeps serving correct content from the apiserver, just slower.
-  This is the documented incident lever.
+  env.CACHE_ENABLED=false`; the pod keeps serving correct content from the apiserver, just
+  slower. This is the documented incident lever.
 - **The cache can never be the correctness story.** Because cache-off is the baseline, any
   cache-on/cache-off behavioural divergence is by definition a bug — which makes the cache testable
   against a known-correct reference (the same `/call` with the toggle flipped).

--- a/go/snowplow/docs/adr/0005-walker-driven-informer.md
+++ b/go/snowplow/docs/adr/0005-walker-driven-informer.md
@@ -1,10 +1,31 @@
-# ADR 0005 — Walker-driven informer set; no process-wide RESTMapper on the hot path
+---
+type: Decision
+title: "ADR 0005 — Walker-driven informer set; no per-call RESTMapper on the hot path"
+description: >-
+  Exactly 7 hardcoded meta-query informer anchors; every business GVR is
+  discovered by resolution. Composition GVRs come from a cached, per-group
+  singleflighted discovery hop driven by the walker plus a CRD-event
+  side-effect bridge (with event-driven delete teardown). The per-call cold
+  RESTMapper rebuild is gone; a cached mapper and a permanent plural store
+  replace it.
+resource: snowplow
+tags:
+  - adr
+  - cache
+  - informers
+  - discovery
+status: diverged
+timestamp: 2026-08-06T00:00:00Z
+---
 
-- **Status:** Accepted
-- **Lead (verify against code):**
+# ADR 0005 — Walker-driven informer set; no per-call RESTMapper on the hot path
+
+- **Status:** Accepted; the realized tree walked back two of the original v6 design's absolutes
+  (recorded below) and has since evolved the discovery hop itself (cached client, freshness
+  short-circuit, forced-fresh event path).
+- **Design history:**
   [`docs/walker-driven-informer-design-2026-06-01.md`](../walker-driven-informer-design-2026-06-01.md)
-  (the v6 design). Where that note and the current tree disagree, the code wins — see
-  *Divergences from the design note* below.
+  (the v6 plan). Where that note and the current tree disagree, the code wins.
 - **Deep dive:** [`docs/architecture/prewarm.md`](../architecture/prewarm.md).
 
 ## Context
@@ -32,66 +53,76 @@ hardcoding navigation paths. Two prior designs created hot-path cost and complex
 every business GVR are read from config / the live RBAC index / the walk — never Go literals.
 
 - **No static GVR catalog.** The only hardcoded GVRs at boot are the meta-query anchors:
-  `MetaQuerySeeds()` (`phase1.go:250`) registers **exactly 7** informer anchors — `routesloaders`,
-  `navmenus`, `restactions`, and the 4 RBAC types — and *no* business GVR. A test asserts the slice
-  is exactly those 7. `customresourcedefinitions` is **not** a seed.
-- **Composition GVRs are discovered by one-shot apiserver discovery**, invoked synchronously from
-  the walker the first time it reaches a templated apiserver path for a group:
-  `DiscoverGroupResources(ctx, rc, group)` (`discovery_lookup.go:217`), reached from the resolver
-  at `resolvers/restactions/api/resolve.go:1335` (`AddNavigationDiscoveredGroup` +
-  `DiscoverGroupResources`). It lists `ServerResourcesForGroupVersion` per version of the group,
-  and for each non-built-in `Kind` (filtered against `scheme.Scheme.AllKnownTypes()`) forms the
-  composition GVR and registers its informer via `EnsureResourceType`.
-- **The dedicated CRD-watch backplane is deleted.** `crdwatch.go` (459 LOC) and its three test
-  files are gone; the `customResourceDefinitionGVR` constant and accessor are removed
-  (`grep customResourceDefinitionGVR internal/` → zero). `DiscoverGroupResources` is a single
-  synchronous transaction — list, register, dirty-mark, return — so there is no initial-LIST replay
-  window and no replay-vs-discover race to reconcile.
+  `MetaQuerySeeds()` (`internal/cache/phase1.go`) registers **exactly 7** informer anchors —
+  `routesloaders`, `navmenus`, `restactions`, and the 4 RBAC types — and *no* business GVR. A
+  test asserts the slice is exactly those 7. `customresourcedefinitions` is **not** a seed (the
+  CRD-meta informer that does exist is registered lazily by the walker — below).
+- **Composition GVRs are discovered by an apiserver discovery hop**
+  (`cache.DiscoverGroupResources`, `internal/cache/discovery_lookup.go`), invoked synchronously
+  from the walker/resolver the first time a templated apiserver path is reached for a group
+  (`AddNavigationDiscoveredGroup` + `DiscoverGroupResources` at the discovery branch of
+  `internal/resolvers/restactions/api/resolve.go`). It lists `ServerResourcesForGroupVersion`
+  per version of the group and, for each non-built-in `Kind` (filtered against
+  `scheme.Scheme.AllKnownTypes()`), forms the composition GVR and registers its informer via
+  `EnsureResourceType`. The hop has since grown three refinements over the original "one-shot"
+  transaction: it runs against a **cached** discovery client (a warm walk pays zero apiserver
+  round-trips), it is **singleflighted per group**, and it **short-circuits** when the cached
+  surface is fresh and every served version's GVR is already registered. The CRD-*event* path
+  uses `DiscoverGroupResourcesFresh` (forceFresh), which invalidates the cached surface first so
+  a CRD CREATE/UPDATE can never register against a stale read.
+- **The dedicated CRD-watch backplane stays deleted.** `crdwatch.go` (459 LOC) and its tests are
+  gone. What replaced the *event* concern is not a backplane but a side-effect bridge — see the
+  walk-backs below. The single sanctioned CRD-GVR literal lives in `internal/cache/crd_gvr.go`
+  (`IsCRDGVR`, the predicate the event bridge consults); every other reference consumes the
+  predicate rather than reconstructing the literal.
 - **The navigation-discovered group set is load-bearing as the removable discriminator.**
-  `IsNavigationDiscoveredGroup(group)` (`discovery_lookup.go:113`, renamed from
-  `matchesAutoDiscoverGroup`) is the predicate at `watcher.go:749` / `:1064` that decides whether a
-  GVR gets a *standalone* informer (tearable down via `RemoveResourceType`) versus a shared-factory
-  one. Composition GVRs must be removable, so their group must be in this set.
-- **No process-wide RESTMapper on the hot path.** The per-`/call` cold restmapper is gone from
+  `IsNavigationDiscoveredGroup(group)` (`internal/cache/discovery_lookup.go`) is the predicate in
+  `watcher.go` that decides whether a GVR gets a *standalone* informer (tearable down via
+  `RemoveResourceType`) versus a shared-factory one. Composition GVRs must be removable, so their
+  group must be in this set.
+- **No per-call RESTMapper on the hot path.** The per-`/call` cold restmapper is gone from
   `internal/dynamic/dynamic.go`; that file is now pure shape accessors with zero apiserver
   round-trips. Plural⇄kind resolution on the resolver path goes through a never-expiring
-  process-wide store (`plurals_resolver.go`): built-in scheme first, permanent `sync.Map` next,
-  one discovery hop on miss — bounded by the GVR set, not by traffic.
+  process-wide store (`internal/cache/plurals_resolver.go`): built-in scheme first, permanent
+  `sync.Map` next, one discovery hop on miss — bounded by the GVR set, not by traffic.
 
 ## Consequences
 
 - **The warm-path allocation/CPU defect is removed.** No fresh restmapper per call; the refresher
   no longer hot-loops discovery. Plural resolution is an in-process map hit after first touch.
-- **No CRD informer LIST/WATCH for the common case.** Composition discovery is a synchronous hop
-  the first time a group is navigated; subsequent CR events flow through the normal informer →
-  `DepTracker` → refresher path.
-- **Walker is the trigger; lag is bounded and accepted.** A CRD CREATE for an already-navigated
-  group is picked up on the next walker pass under that group (Phase 1 + CRUD re-walks). This was
-  ratified as acceptable given near-zero production CRD-DELETE cadence.
+- **No CRD informer LIST/WATCH cost at boot.** The CRD-meta informer is registered lazily by the
+  walker (`lazyRegisterInnerCallPaths`) only when a walked path actually touches CRDs; composition
+  discovery is a synchronous hop the first time a group is navigated; subsequent CR events flow
+  through the normal informer → `DepTracker` → refresher path.
+- **CRD lifecycle is event-driven, walker-backstopped.** A CRD CREATE for a new group is picked up
+  by the AddFunc side-effect bridge (below) without waiting for a walk; the walker's periodic
+  passes remain the backstop.
 - **Strictly read-only discovery.** The walk recurses only on `verb == "GET"` children
-  (`walkShouldRecurse`, `phase1_walk.go:1480`), so the SA's privileged credentials never reach a
-  mutation endpoint while discovering informers.
-- **Toggle-able and removable** per ADR 0004: under `CACHE_ENABLED=false` the walk's harvesters are
-  nil and discovery still runs identically (the permanent stores are process-wide, independent of
-  the cache toggle).
+  (`walkShouldRecurse`, `internal/handlers/dispatchers/phase1_walk.go`), so the SA's privileged
+  credentials never reach a mutation endpoint while discovering informers.
+- **Toggle-able and removable** per ADR 0004: under `CACHE_ENABLED=false` there are no informers
+  to register — `discoverGroupResources` no-ops in passthrough mode — while the permanent
+  plural/kind stores remain live (they are correctness-neutral in-process resolution, independent
+  of the cache toggle).
 
-## Divergences from the design note (code wins, per the documentation rules)
+## Walk-backs from the v6 design (code wins)
 
-The v6 design note (`docs/walker-driven-informer-design-2026-06-01.md`) is a *plan*; two of its
-strongest claims were walked back in the realized tree:
+The v6 design note is a *plan*; two of its strongest claims were walked back in the realized tree:
 
 1. **"No CRD informer at all, ever; discovery only from the walker."** Not true as shipped. The
    walker-only chain had a *stuck-zero-state race*: when a CRD is created at runtime, stage 1 of a
    compositions-list serves the cached `crds` LIST (which doesn't yet include the new CRD), the
    stage-2 iterator is empty, the discovery hop is never reached, and the composition informer is
-   never registered (traced in `ship-0.30.233-s4-cache-invalidation-trace-2026-06-02.md`).
+   never registered (traced in
+   `docs/notes/ship-0.30.233-s4-cache-invalidation-trace-2026-06-02.md`).
    **Ship 0.30.233** restored an event path — but in a simpler form than the deleted backplane:
-   **one side-effect hook on the existing `customresourcedefinitions` informer's AddFunc**
-   (`crd_discovery_side_effect.go`), handing each CRD ADD/UPDATE to a bounded worker
-   (depth 256, drop-on-full + WARN) that calls `AddNavigationDiscoveredGroup` +
-   `DiscoverGroupResources` *off* the informer processor goroutine. **Ship L (0.30.246)** added the
-   DeleteFunc branch for event-driven CRD-DELETE teardown. So a CRD-meta informer *does* exist; the
-   thing that was deleted is the dedicated 459-LOC discovery *backplane*, not the CRD informer
+   **one side-effect hook on the walker-registered `customresourcedefinitions` informer's
+   AddFunc** (`internal/cache/crd_discovery_side_effect.go`, routed via `deps_watch.go` +
+   `IsCRDGVR`), handing each CRD ADD/UPDATE to a bounded worker (depth 256, drop-on-full + WARN)
+   that calls `AddNavigationDiscoveredGroup` + `DiscoverGroupResourcesFresh` *off* the informer
+   processor goroutine. **Ship L (0.30.246)** added the DeleteFunc branch for event-driven
+   CRD-DELETE teardown. So a CRD-meta informer *does* exist (lazily, when the walk touches CRDs);
+   the thing that was deleted is the dedicated 459-LOC discovery *backplane*, not the CRD informer
    concept. The design's `#117` periodic-sweep followup was closed as superseded by event-driven
    delete (2026-06-12).
 

--- a/go/snowplow/docs/adr/0006-snowplow-owned-external-fetch.md
+++ b/go/snowplow/docs/adr/0006-snowplow-owned-external-fetch.md
@@ -1,6 +1,27 @@
+---
+type: Decision
+title: "ADR 0006 — Snowplow owns the external api-step HTTP fetch (accept YAML as well as JSON)"
+description: >-
+  The external api-step branch bypasses plumbing's JSON-only request.Do with a
+  snowplow-owned transcription that reuses plumbing's security helpers verbatim
+  and accepts YAML or JSON. The external cache posture has since been made
+  explicit: an external-touched resolve declines the L1 Put by default, with a
+  per-widget bounded-TTL opt-in annotation.
+resource: snowplow
+tags:
+  - adr
+  - restaction
+  - external-endpoints
+  - plumbing
+status: diverged
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # ADR 0006 — Snowplow owns the external api-step HTTP fetch (accept YAML as well as JSON)
 
-- **Status:** Accepted (snowplow 1.2.0)
+- **Status:** Accepted (shipped in snowplow 1.2.0); the transport decision is implemented as
+  recorded, the *cache posture* consequence has since been superseded by an explicit
+  external-no-cache mechanism with a bounded-TTL opt-in (below).
 - **Lead (verify against code):** `internal/resolvers/restactions/api/external_fetch.go`
   (`httpFetchAllowingNonJSON`), wired at the external branch of
   `internal/resolvers/restactions/api/resolve.go`.
@@ -11,10 +32,9 @@
 A `RESTAction` `spec.api[]` stage that targets an external `endpointRef` is dispatched
 through `github.com/krateo-platformops/plumbing` `http/request.Do`. That function **rejects any
 non-JSON `Content-Type` with HTTP 406 *before* the `ResponseHandler` is invoked**
-(`plumbing@v0.9.x http/request/request.go:118-119`, identical through the latest `v1.9.0`), and
-its handler type is `func(io.ReadCloser) error` (request.go:25) — the `*http.Response`/headers
-are **not** passed to snowplow. snowplow does not patch plumbing for this (kept a shared,
-unforked library).
+(the gate in `http/request/request.go`, present through the currently-pinned `v1.13.0`), and
+its handler type is `func(io.ReadCloser) error` — the `*http.Response`/headers are **not**
+passed to snowplow. snowplow does not patch plumbing for this (kept a shared, unforked library).
 
 The portal Marketplace blueprint-discovery RA must GET a Helm repo `index.yaml` — which repos
 commonly serve as `text/plain` / `text/yaml` / `application/x-yaml`. Under the plumbing path that
@@ -25,8 +45,8 @@ step could consume *any* YAML endpoint.
 
 **For the external api-step branch, snowplow owns the HTTP round-trip** rather than calling
 plumbing's gating `Do`. `httpFetchAllowingNonJSON` (`external_fetch.go`) is a faithful
-transcription of `plumbing` `request.Do` (`request.go:38-116`) **minus only the 406 JSON gate**,
-and it **reuses every security-critical path verbatim** via plumbing's *exported* helpers:
+transcription of `plumbing` `request.Do` **minus only the 406 JSON gate**, and it **reuses every
+security-critical path verbatim** via plumbing's *exported* helpers:
 
 - `HTTPClientForEndpoint` — TLS, custom CA, client certs, proxy, timeouts, **and** the
   bearer / basic / AWS-SigV4 auth roundtrippers.
@@ -34,11 +54,18 @@ and it **reuses every security-critical path verbatim** via plumbing's *exported
 - `ComputeAwsHeaders` — SigV4 header pre-compute.
 
 Only ~40–50 LOC of pure *request assembly* + the non-2xx → `response.Status` error-envelope
-shaping (transcribed byte-identical to `request.go:102-116`) is snowplow-local. With the response
-in hand, snowplow now sees the `Content-Type` and **accepts JSON or YAML transparently**: a
-JSON-shaped body passes through unchanged; otherwise (YAML content-type, or a body that fails
-`json.Unmarshal`) it is converted with `sigs.k8s.io/yaml` `YAMLToJSON` before the existing decode.
-`YAMLToJSON` round-trips valid JSON losslessly, so the JSON fast-path is byte-identical.
+shaping (transcribed byte-identical) is snowplow-local. With the response in hand, snowplow now
+sees the `Content-Type` and **accepts JSON or YAML transparently** — a three-step sniff: explicit
+YAML content-type → `sigs.k8s.io/yaml` `YAMLToJSON`; a JSON-parsing body → passthrough unchanged;
+a body that fails `json.Unmarshal` → last-resort `YAMLToJSON` (covers YAML served as
+`text/plain`). `YAMLToJSON` round-trips valid JSON losslessly, so the JSON fast-path is
+byte-identical.
+
+Since the original decision, the same external branch also gained **templated `endpointRef`
+support** (#113, `evalEndpointRef` in `resolve.go`): the `endpointRef.name` may be a jq template,
+with two hard guardrails — the *namespace* stays the author-literal (never templated), and a
+templated name resolving to the reserved `-clientconfig` suffix is refused before any Secret
+lookup fires.
 
 ## Consequences
 
@@ -47,15 +74,25 @@ JSON-shaped body passes through unchanged; otherwise (YAML content-type, or a bo
   worked previously changes (the application/json control is byte-identical).
 - **The security surface stays minimal.** TLS / CA / client-certs / bearer-basic-AWS creds / proxy
   / retry all remain delegated to plumbing's exported helpers; only stable request *assembly* is
-  transcribed. A future plumbing change to assembly must be mirrored; the volatile parts evolve
-  under us for free.
+  transcribed. A future plumbing change to assembly must be mirrored on a plumbing bump (the
+  transcription was taken from plumbing v0.9.3 and re-verified unchanged at the pinned v1.13.0);
+  the volatile parts evolve under us for free.
 - **One new, bounded error edge.** A 2xx body that is neither JSON nor YAML now reaches the decode
   and errors there (instead of an upstream 406) — caught by the per-item error path
   (`recordItemError`), no panic, no credential leak (the request still carried creds via the reused
   roundtrippers).
-- **Cache posture unchanged.** External-endpoint results were never L1-pivot-cacheable and still
-  aren't — they ride the live fetch each request. This change touches only the transport, downstream
-  of every cache branch.
+- **Cache posture — now an explicit mechanism, no longer a side-effect.** External results have no
+  informer/dep edge to invalidate them, so by default they are **not** L1-cached — but this is now
+  *enforced*, not incidental: the resolve threads an external-touched sink
+  (`cache.WithExternalTouchedSink`; bumped whenever a stage reaches `httpFetchAllowingNonJSON`),
+  and the dispatcher Put-gates (`restactions.go` / `widgets.go` / the seed's external-bound skip)
+  **decline the Put** for any external-touched result — the body is served, every `/call`
+  re-fetches the external API live. One sanctioned exception exists: a widget CR may opt in via
+  the `krateo.io/external-cache-ttl-seconds` annotation
+  (`internal/handlers/dispatchers/external_ttl.go`), which converts the decline into a
+  bounded-staleness Put under the unchanged per-binding `widgets` key (hard-capped at 120s,
+  `ExternalTTL`-marked so the entry never arms a `/refreshes` subscription). Correctness basis for
+  that path is time-bounded staleness, not dep-edge invalidation.
 - **Toggle-able / removable** per ADR 0004: the conversion is on the live external path; under
   `CACHE_ENABLED=false` the same fetch runs (the cache toggle is orthogonal).
 
@@ -64,4 +101,7 @@ JSON-shaped body passes through unchanged; otherwise (YAML content-type, or a bo
 - ADR 0004 — caching is provisional and removable.
 - The companion correctness fix shipped alongside (snowplow 1.2.0): a per-item **feed/decode error
   on any served dispatch branch records into `errorKey` and does *not* truncate the resolve** (the
-  #313 Option C-A contract) — see [`request-lifecycle.md`](../architecture/request-lifecycle.md) §3.
+  #313 Option C-A contract). Its cache-side halves are live in the dispatcher: a stage-error
+  resolve serves 200 but declines the full-TTL Put (with the optional `PARTIAL_RESULT_TTL_SECONDS`
+  bounded-stale backstop, default off) — see
+  [`request-lifecycle.md`](../architecture/request-lifecycle.md) §3.

--- a/go/snowplow/docs/adr/0006-snowplow-owned-external-fetch.md
+++ b/go/snowplow/docs/adr/0006-snowplow-owned-external-fetch.md
@@ -9,11 +9,12 @@
 ## Context
 
 A `RESTAction` `spec.api[]` stage that targets an external `endpointRef` is dispatched
-through `github.com/krateoplatformops/plumbing` `http/request.Do`. That function **rejects any
+through `github.com/krateo-platformops/plumbing` `http/request.Do`. That function **rejects any
 non-JSON `Content-Type` with HTTP 406 *before* the `ResponseHandler` is invoked**
 (`plumbing@v0.9.x http/request/request.go:118-119`, identical through the latest `v1.9.0`), and
 its handler type is `func(io.ReadCloser) error` (request.go:25) — the `*http.Response`/headers
-are **not** passed to snowplow. snowplow cannot patch plumbing (never-upstream, ADR convention).
+are **not** passed to snowplow. snowplow does not patch plumbing for this (kept a shared,
+unforked library).
 
 The portal Marketplace blueprint-discovery RA must GET a Helm repo `index.yaml` — which repos
 commonly serve as `text/plain` / `text/yaml` / `application/x-yaml`. Under the plumbing path that

--- a/go/snowplow/docs/architecture/caching.md
+++ b/go/snowplow/docs/architecture/caching.md
@@ -152,9 +152,12 @@ versioned, NUL-delimited byte stream. The fields folded in, in order:
    `"apistage"`, `"widgetContent"`, `"raFullList"`. The string *values* are load-bearing
    (hashed into the key + used as refresher registry keys).
 3. The dispatched object's `Group / Version / Resource / Namespace / Name`.
-4. **Identity** — folded for *every class except* `widgetContent`, as **two** terms:
-   - `BindingUID` — the first-match binding that authorised this layer's GET (§3.2);
-   - `RBACSubGen` — the requesting identity's per-subject RBAC **sub-generation**
+4. **Identity** — the `BindingUID` and `RBACSubGen` fields are mechanically hashed for *every
+   class except* `widgetContent`, but what they carry is per-class:
+   - `restactions` / `widgets` — **two live terms**, stamped at dispatch by
+     `dispatchCacheLookupKey` (`helpers.go` — the only `RBACSubGen` stamping site in the tree):
+     `BindingUID`, the first-match binding that authorised this layer's GET (§3.2), and
+     `RBACSubGen`, the requesting identity's per-subject RBAC **sub-generation**
      (`cache.RBACSubGenForSubject` over the user + groups + SA counters). A grant/revoke that
      touches this user's own bindings bumps a subject counter at snapshot publish
      (`rbac_subgen_pending.go`) → the term changes → cold miss → fresh resolve + fresh UAF
@@ -162,6 +165,16 @@ versioned, NUL-delimited byte stream. The fields folded in, in order:
      which is why this replaced a global RBAC generation. The seed writes `RBACSubGen==0`
      (a warm-miss perf gap for a moved-sub-gen subject, not an authz bug — de-scoped as
      seed-reachability work).
+   - `raFullList` — identity-bound via **`BindingUID` only**. Its single key source
+     (`seedFullListRAKey`, `resolvers/widgets/apiref/ra_full_list.go` → `RAFullListKeyInputs`,
+     `cache/ra_full_list_slice.go`) never sets `RBACSubGen`, so every `raFullList` cell hashes
+     `RBACSubGen==0` on Put *and* Get — the sub-gen term is folded as a constant, semantically
+     inert. These cells rotate only when the `BindingUID` itself changes; there is no
+     grant/revoke sub-gen rotation for this class.
+   - `apistage` — **identity-free content cells**: `contentKeyInputs`
+     (`resolvers/restactions/api/apistage.go`) never sets either field, so both fold as
+     empty/zero constants and the cell is identity-invariant. It is populated SA-maximal and
+     RBAC-narrowed per request at serve time, fail-closed (the ADR 0003 pattern).
 5. `PerPage` / `Page`.
 6. `Stage` — only for `apistage` entries; written with a `0x01` sentinel and skipped when empty
    so non-apistage keys hash byte-identically across the field's introduction.
@@ -335,8 +348,9 @@ records silently and relies on TTL for correctness.
    and is bypassed entirely for RBAC-sensitive `widgetData` widgets. The cached body is the
    shell; the body that leaves the pod is per-user.
 3. **Per-user (per-binding) keying, never cohort-only — and never the empty row.** Identity-bound
-   classes fold `BindingUID` + `RBACSubGen`; only `widgetContent` is identity-free, and only
-   because its served body is re-stamped per request. Every member of a `BindingUID` equivalence
+   classes fold `BindingUID` (`restactions`/`widgets` additionally `RBACSubGen`); the
+   identity-free classes — `widgetContent` and `apistage` — are so only
+   because their served bodies are re-narrowed per request. Every member of a `BindingUID` equivalence
    class resolves to byte-identical output. An empty `BindingUID` (deny / no snapshot / cache
    off) is **not cache-eligible** on the dispatch path — `serveFromCacheEligible` blocks both
    the read and the write, closing the #95 cross-identity leak through the shared `""` row.

--- a/go/snowplow/docs/architecture/caching.md
+++ b/go/snowplow/docs/architecture/caching.md
@@ -1,10 +1,20 @@
+---
+type: Architecture
+title: snowplow — caching (the three-tier cache)
+description: The read-path cache that lets /call serve resolved RESTAction/Widget JSON without re-hitting the apiserver — L3 informer, L1 resolved-entry store, dispatcher seam, keying, invalidation, invariants.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [cache, l1, informer, keying, invalidation]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Caching architecture — the three-tier cache
 
 > **Audience:** snowplow maintainers.
 > **Scope:** the read-path cache that lets `/call` serve resolved `RESTAction` / `Widget`
 > JSON without re-hitting the apiserver on every request.
-> **Status:** code-traced against commit `a42b072` (`main`). Every claim below cites a
-> `file:line` in the current tree; where a working note disagreed with the code, the code won.
+> **Status:** re-derived from the current tree (docs-standard, 2026-08-06). Anchors are
+> `file` + function names; where a prior revision of this doc disagreed with the code, the
+> code won.
 
 Snowplow stacks three caches in the request path. They are layered, not alternatives:
 
@@ -18,8 +28,8 @@ Snowplow stacks three caches in the request path. They are layered, not alternat
   uses is L1.
 
 The whole stack is gated behind one master toggle, `CACHE_ENABLED`
-(`internal/cache/cache.go:37`). With it off, all three tiers vanish and every read goes straight
-to the apiserver — same data, same UI, same RBAC, just slower (see *Invariants*).
+(`internal/cache/cache.go` `Disabled()`). With it off, all three tiers vanish and every read goes
+straight to the apiserver — same data, same UI, same RBAC, just slower (see *Invariants*).
 
 ---
 
@@ -34,7 +44,7 @@ to the apiserver — same data, same UI, same RBAC, just slower (see *Invariants
                     │  widgets.go / restactions.go                   │
                     │                                                │
                     │  1. fetch dispatched CR (objects → L3)         │
-                    │  2. EvaluateRBAC gate  (cache=on only)         │ restactions.go:96
+                    │  2. EvaluateRBAC gate  (cache=on only)         │ checkDispatchRBAC
                     │     ── deny → 403, never cached ───────────────│
                     │  3. compute L1 key + consult L1                │
                     └──────────────────────────────────────────────┘
@@ -44,286 +54,330 @@ to the apiserver — same data, same UI, same RBAC, just slower (see *Invariants
         │                                 │                                  │
    (a) widgetContent key  ──hit──▶ gateWidgetEnvelope (re-stamp `allowed`)   │
        identity-FREE               ──▶ write per-user body, return           │
-       (gvr,ns,name,page,extras)        widgets.go:134-164                   │
+       (gvr,ns,name,page,extras)                                             │
             │ miss / RBAC-sensitive widget → fall through                    │
             ▼                                                                │
-   (b) widgets key (per-binding) ──hit──▶ write RawJSON, return              │
-       BindingUID folded in              widgets.go:183-196                  │
+   (b) widgets key (per-binding  ──hit──▶ write RawJSON, return              │
+       UID + RBAC sub-gen)                                                   │
             │ miss                                                           │
         ────┴────────────────────────────────────────────────────────────┐ │
                                          │ (restactions: single per-binding key)
                                          ▼                                  │
                     ┌──────────────────────────────────────────────┐       │
                     │  L1  ResolvedCacheStore  (resolved.go)         │◀──────┘
-                    │  Get(key) → (*ResolvedEntry, bool)             │  resolved.go:738
+                    │  Get(key) → (*ResolvedEntry, bool)             │
                     └──────────────────────────────────────────────┘
                                          │ miss
                                          ▼
                     ┌──────────────────────────────────────────────┐
                     │  RESOLVER  (resolvers/…)                       │
                     │  reads cluster objects from ──────────────────┼──▶ L3 informer
-                    │                                                │   watcher.go:1609 GetObject
-                    │                                                │   watcher.go:1669 ListObjects
-                    │  records dep edges as it reads (WithL1Key)     │   deps.go:421 Record / :443 RecordList
+                    │                                                │   GetObject / ListObjects
+                    │  records dep edges as it reads (WithL1Key)     │   Deps().Record / RecordList
                     └──────────────────────────────────────────────┘
                                          │
                                          ▼
                     encode once → write to response
                     → L1.Put(key, entry)  + Deps().Record(self-edge)
-                       restactions.go:264-281
+                       (Put gated — see §4 step 4)
 
   ── invalidation (async, informer event → DepTracker) ────────────────────────
      L3 informer event ──▶ depEventHandlers ──▶ Deps().OnAdd / OnUpdate / OnDelete
-       (watcher.go AddFunc/UpdateFunc/DeleteFunc → deps.go:504/516/590)
-       ADD/UPDATE → dirty-mark (refresher re-resolve)   deps.go:524 onChange
-       DELETE     → evict self-entry, dirty-mark deps    deps.go:590 OnDelete
+       ADD/UPDATE → dirty-mark (refresher re-resolve), never evict
+       DELETE     → evict self-entry, dirty-mark deps
+     L1 commit    ──▶ cache.PublishRefresh(key) → /refreshes SSE subscribers
 ```
 
 ---
 
 ## 2. L3 — the informer cache (`watcher.go`)
 
-`ResourceWatcher` (`internal/cache/watcher.go:298` `NewResourceWatcher`) owns a
-`dynamicinformer.DynamicSharedInformerFactory` (`watcher.go:344`) plus a per-GVR map of
-`GenericInformer`s (`watcher.go:118`). Resolvers do not call the apiserver directly; they call:
+`ResourceWatcher` (`internal/cache/watcher.go` `NewResourceWatcher`) owns a
+`dynamicinformer.DynamicSharedInformerFactory` plus a per-GVR map of `GenericInformer`s.
+Resolvers do not call the apiserver directly; they call:
 
-- `GetObject(gvr, ns, name)` — `watcher.go:1609`. In `modeInformer` it reads
-  `gi.Informer().GetIndexer().GetByKey(...)` (`watcher.go:1639`) — an in-memory map lookup, no
-  network. In `modePassthrough` (cache off) it falls back to a live `rw.dyn.Resource(gvr).Get`
-  apiserver call (`watcher.go:1616-1618`).
-- `ListObjects(gvr, ns)` — `watcher.go:1669`. `modeInformer` materialises the namespace
-  partition from the indexer (`listFromIndexer`, `watcher.go:1680/1683`); `modePassthrough`
-  issues a fresh paged apiserver LIST (`listPassthrough`, `watcher.go:1670-1671`) with **no**
-  in-process caching.
+- `GetObject(gvr, ns, name)` — in `modeInformer` it reads
+  `gi.Informer().GetIndexer().GetByKey(...)` — an in-memory map lookup, no network. In
+  `modePassthrough` (cache off) it falls back to a live `rw.dyn.Resource(gvr).Get` apiserver
+  call.
+- `ListObjects(gvr, ns)` — `modeInformer` materialises the namespace partition from the indexer
+  (`listFromIndexer`); `modePassthrough` issues a fresh paged apiserver LIST
+  (`listPassthrough`) with **no** in-process caching.
 
 The mode split is the L3 half of the toggle invariant: same `GetObject`/`ListObjects` surface,
 two backing implementations chosen once at construction. `NewResourceWatcher` logs
 `"CACHE_ENABLED=false — typed-RBAC + informer cache + L1 ALL disabled"` and sets
-`informer.get_list_path=apiserver` when the toggle is off (`watcher.go:316-323`).
+`informer.get_list_path=apiserver` when the toggle is off.
 
-Each informer also registers DepTracker event handlers (`watcher.go:845`
-`gi.Informer().AddEventHandler(rw.depEventHandlers(gvr))`) so cluster mutations drive L1
-invalidation (§5). The handler contract is `UpdateFunc → Deps().OnUpdate`,
-`DeleteFunc → Deps().OnDelete` (`watcher.go:571-572`, `753-754`).
+Every serve from L3 is additionally guarded by the **servability assertion**
+(`internal/cache/serve_assert.go`): an authoritative cache hit about to be served from a
+not-synced / watch-broken informer trips `serve_requires_servable` (P1) rather than serving
+silently stale data.
+
+Each informer also registers DepTracker event handlers (`depEventHandlers`) so cluster
+mutations drive L1 invalidation (§5).
 
 ---
 
 ## 3. L1 — the resolved-entry cache (`resolved.go`)
 
-`ResolvedCacheStore` (`resolved.go:393`) is a single-mutex bounded LRU: a
-`container/list` for recency order + a `map[string]*list.Element` index (`resolved.go:397-399`),
-with three caps — `maxEntries`, `maxBytes`, `ttl` (`resolved.go:401-403`) — plus a separate
-*pinned* resident byte budget (`maxResidentBytes`, `resolved.go:415`) for expensive prewarmed
-entries that LRU pressure must not evict.
+`ResolvedCacheStore` is a single-mutex bounded LRU: a `container/list` for recency order + a
+`map[string]*list.Element` index, with three caps — `maxEntries`, `maxBytes`, `ttl` — plus a
+separate *pinned* resident byte budget (`maxResidentBytes`) for expensive prewarmed entries that
+LRU pressure must not evict.
 
-The value is a `ResolvedEntry` (`resolved.go:185`): pre-encoded `RawJSON` bytes ready to write,
-a `CreatedAt` for TTL, and the canonical `Inputs *ResolvedKeyInputs` the refresher re-resolves
-from. Storing the *encoded* form (not the live object) keeps the hit path race-free — readers
-get an immutable `[]byte` (`resolved.go:177-184`).
+The value is a `ResolvedEntry`: pre-encoded `RawJSON` bytes ready to write, a `CreatedAt` for
+TTL, the canonical `Inputs *ResolvedKeyInputs` the refresher re-resolves from, and an optional
+per-entry `TTLOverride` (see §3.4). Storing the *encoded* form (not the live object) keeps the
+hit path race-free — readers get an immutable `[]byte`.
 
-- `Get` (`resolved.go:738`): index lookup; a TTL-expired entry is dropped and counted as a miss
-  in the same call (`resolved.go:751-756`); a hit moves the element to the LRU front
-  (`resolved.go:758`).
-- `Put` (`resolved.go:767`): stamps `CreatedAt`, computes `entryBytes` (`resolved.go:912`),
-  resolves final pin status under `mu` (`resolved.go:783-799`), then inserts and evicts the LRU
-  tail until under caps.
+- `Get`: index lookup; a TTL-expired entry is dropped and counted as a miss in the same call; a
+  hit moves the element to the LRU front. The effective TTL is
+  `min(entry.TTLOverride, store.ttl)` when an override is set.
+- `Put`: stamps `CreatedAt`, computes the entry byte cost, resolves final pin status under the
+  mutex (a `Pinned` entry that does not fit the resident budget is demoted to transient), then
+  inserts and evicts the LRU tail until under caps.
 
 ### 3.1 Key structure — `ComputeKey`
 
-`ComputeKey(in ResolvedKeyInputs) string` (`resolved.go:608`) is a hex-encoded SHA-256 over a
-versioned, NUL-delimited byte stream. The fields folded in, in order (`resolved.go:609-691`):
+`ComputeKey(in ResolvedKeyInputs) string` (`resolved.go`) is a hex-encoded SHA-256 over a
+versioned, NUL-delimited byte stream. The fields folded in, in order:
 
-1. `resolvedKeyVersion` salt — currently `"v4"` (`resolved.go:384`). Bumping it rotates the
-   entire key space on a rolling restart so no stale-shape entry ever serves as a hit.
-2. `CacheEntryClass` — the entry-class discriminant (`resolved.go:277`), one of
-   `"restactions"`, `"widgets"`, `"apistage"`, `"widgetContent"`, `"raFullList"`. The string
-   *values* are load-bearing (hashed into the key + used as refresher registry keys).
-3. The dispatched object's `Group / Version / Resource / Namespace / Name`
-   (`resolved.go:278-282`).
-4. **Identity** — `BindingUID` (`resolved.go:303`), folded in for *every class except*
-   `widgetContent` (`resolved.go:652-655`). This is the load-bearing keying decision (§3.2).
-5. `PerPage` / `Page` (`resolved.go:657-660`).
+1. `resolvedKeyVersion` salt — currently **`"v6"`** (`resolved.go`). Bumping it rotates the
+   entire key space on a rolling restart so no stale-shape entry ever serves as a hit. The
+   lineage is documented on the constant: v4 = per-binding `BindingUID` replaced the per-cohort
+   `BindingSetHash`; v5 = `RBACSubGen` folded in (#118 (c)); v6 = the sub-gen bump moved from
+   RBAC-delta-time to snapshot-publish-time (#118 (c)-v2).
+2. `CacheEntryClass` — the entry-class discriminant, one of `"restactions"`, `"widgets"`,
+   `"apistage"`, `"widgetContent"`, `"raFullList"`. The string *values* are load-bearing
+   (hashed into the key + used as refresher registry keys).
+3. The dispatched object's `Group / Version / Resource / Namespace / Name`.
+4. **Identity** — folded for *every class except* `widgetContent`, as **two** terms:
+   - `BindingUID` — the first-match binding that authorised this layer's GET (§3.2);
+   - `RBACSubGen` — the requesting identity's per-subject RBAC **sub-generation**
+     (`cache.RBACSubGenForSubject` over the user + groups + SA counters). A grant/revoke that
+     touches this user's own bindings bumps a subject counter at snapshot publish
+     (`rbac_subgen_pending.go`) → the term changes → cold miss → fresh resolve + fresh UAF
+     refilter. Blast radius is herd-proportional (only subjects whose own bindings changed),
+     which is why this replaced a global RBAC generation. The seed writes `RBACSubGen==0`
+     (a warm-miss perf gap for a moved-sub-gen subject, not an authz bug — de-scoped as
+     seed-reachability work).
+5. `PerPage` / `Page`.
 6. `Stage` — only for `apistage` entries; written with a `0x01` sentinel and skipped when empty
-   so non-apistage keys hash byte-identically across the field's introduction
-   (`resolved.go:669-673`).
-7. `Extras` — canonicalised via `canonicaliseExtras` (`resolved.go:697`): a recursively
-   sorted-key JSON surrogate, so two requests with the same extras content but different map
-   iteration order produce the same key, and distinct extras produce distinct entries (no
-   cross-request collision). On marshal failure it falls back to a deterministic
-   `fmt.Sprintf("%v", …)` (`resolved.go:686`).
+   so non-apistage keys hash byte-identically across the field's introduction.
+7. `Extras` — canonicalised via `canonicaliseExtras`: a recursively sorted-key JSON surrogate,
+   so two requests with the same extras content but different map iteration order produce the
+   same key, and distinct extras produce distinct entries. On marshal failure it falls back to a
+   deterministic `fmt.Sprintf("%v", …)`. **Which request extras are allowed to reach the key at
+   all is governed by the F6 allowlist** (§3.5).
 
-`RepresentativeUsername` / `RepresentativeGroups` are carried on `Inputs` but **excluded from
-`ComputeKey`** (`resolved.go:322-327`) — they are bookkeeping for the refresher's re-resolve,
-not key material; two members of the same equivalence class must not shift the cell's identity.
+Fields carried on `Inputs` but **excluded from `ComputeKey`**:
+`RepresentativeUsername` / `RepresentativeGroups` (the refresher's re-resolve identity — two
+members of the same equivalence class must not shift the cell's identity) and `HasUAF` (a
+bookkeeping bit that re-stamps the UAF short-TTL on refresher re-Puts, §3.4).
 
 ### 3.2 The two widget L1 keys
 
 A widget `/call` can hit L1 by two different keys, tried in order in `widgets.go`:
 
-1. **Identity-free content key** (`CacheEntryClassWidgetContent`, `resolved.go:147`). Built by
-   `dispatchWidgetContentKey` (`helpers.go:147`) with `Username`/`Groups` left zero;
-   `ComputeKey` skips the identity fold for this class (`resolved.go:652`). So admin and a
-   narrow-RBAC user hit the **same cell**, keyed only on
-   `(gvr, ns, name, perPage, page, extras)`. The stored body is a *shell* with SA-evaluated
-   `status.resourcesRefs.items[].allowed` flags; it is **never served verbatim** — on hit,
-   `gateWidgetEnvelope` re-stamps every `allowed` flag under the request's own identity before
-   the body is written (`widgets.go:139-153`, rationale at `resolved.go:127-147`). This path is
-   skipped for RBAC-sensitive apiRef widgets (those whose `status.widgetData` is RBAC-narrowed
-   and would leak the SA-maximal aggregate) — `isRBACSensitiveApiRefWidget`, `widgets.go:134`.
+1. **Identity-free content key** (`CacheEntryClassWidgetContent`). Built by
+   `dispatchWidgetContentKey` (`helpers.go`) with `Username`/`Groups` left zero; `ComputeKey`
+   skips the identity fold for this class. So admin and a narrow-RBAC user hit the **same
+   cell**, keyed only on `(gvr, ns, name, perPage, page, extras)`. The stored body is a *shell*
+   with SA-evaluated `status.resourcesRefs.items[].allowed` flags; it is **never served
+   verbatim** — on hit, `gateWidgetEnvelope` (`widget_content.go`) re-stamps every `allowed`
+   flag under the request's own identity before the body is written. This path is skipped for
+   RBAC-sensitive apiRef widgets (those whose `status.widgetData` is RBAC-narrowed and would
+   leak the SA-maximal aggregate) — `isRBACSensitiveApiRefWidget`.
 
 2. **Per-binding key** (`CacheEntryClass=="widgets"`). Built by `dispatchCacheLookupKey`
-   (`helpers.go:200`), which calls `rbac.EvaluateRBAC` to derive the **`BindingUID`** of the
-   first-match binding that authorised this layer's GET (`helpers.go:212-220`) and folds it into
-   the key (`helpers.go:228`). Two users granted by the *same* binding share one cell; a deny or
-   error fails closed to `bindingUID=""` (`helpers.go:197-199`) — the same empty-identity row
-   that cache-off produces. RESTActions use only this per-binding path (`restactions.go:123`).
+   (`helpers.go`), which calls `rbac.EvaluateRBAC` to derive the **`BindingUID`** of the
+   first-match binding that authorised this layer's GET, reads the subject's `RBACSubGen`, and
+   folds both into the key. Two users granted by the *same* binding (at the same sub-gen) share
+   one cell; a deny or error fails closed to `bindingUID=""` — and an empty-`BindingUID` cell is
+   **neither served nor written** on the dispatch path (`serveFromCacheEligible`, the #95
+   cross-identity-leak closure; see §6.3). RESTActions use only this per-binding path.
 
-The widget fast-path falls from (1) to (2) to a full resolve on successive misses
-(`widgets.go:159-196`). The `BindingUID` derivation site of record is
-`cache.BindingUIDFromCRB` / `BindingUIDFromRB` in `match_subject.go` (`resolved.go:300-302`);
-prefixes `"C:<uid>"` / `"R:<ns>/<uid>"` keep ClusterRoleBinding and RoleBinding UIDs from
-aliasing and carry namespace scope into the identifier (`resolved.go:289-298`).
+The widget fast-path falls from (1) to (2) to a full resolve on successive misses. The
+`BindingUID` derivation site of record is `cache.BindingUIDFromCRB` / `BindingUIDFromRB` in
+`match_subject.go`; prefixes `"C:<uid>"` / `"R:<ns>/<uid>"` keep ClusterRoleBinding and
+RoleBinding UIDs from aliasing and carry namespace scope into the identifier.
 
 ### 3.3 Value-dedup
 
 Dedup here is **cell-sharing by equivalence class**, not byte-interning:
 
 - *Across users*: per-binding keying means every user authorised by the same binding resolves to
-  byte-identical output and lands on one cell (`resolved.go:312-320`) — the
-  per-user-keyed-never-cohort invariant satisfied at binding granularity.
-- *Across pages*: the `raFullList` class (`resolved.go:149-175`) caches the RA's full
-  unpaginated result with `PerPage/Page` forced to 0; every paginated `/call` differing only in
-  slice shares that one cell and the page is applied as a cheap Go-slice at serve time
-  (`ra_full_list_slice.go`). Widgets feeding the same RA under the same binding share the same
-  cell — "the chokepoint dedupe across widgets" (`resolved.go:160-163`).
+  byte-identical output and lands on one cell — the per-user-keyed-never-cohort invariant
+  satisfied at binding granularity.
+- *Across pages*: the `raFullList` class caches the RA's full unpaginated result with
+  `PerPage/Page` forced to 0; every paginated `/call` differing only in slice shares that one
+  cell and the page is applied as a cheap Go-slice at serve time (`ra_full_list_slice.go`).
+  Widgets feeding the same RA under the same binding share the same cell — the chokepoint
+  dedupe across widgets.
 - *Across cohorts (widgets)*: the identity-free content cell collapses all cohorts onto one
   stored shell, re-personalised at serve time (§3.2).
+
+### 3.4 Per-entry TTL overrides
+
+Three mechanisms shorten (never lengthen) an entry's lifetime via `TTLOverride`; the effective
+TTL is always `min(override, store TTL)`:
+
+- **UAF short-TTL (interim #118 (d))** — a cell whose RESTAction declares a `userAccessFilter`
+  carries `Inputs.HasUAF`; when `UAF_RESOLVED_TTL_SECONDS > 0` both Put sites (customer
+  dispatch and refresher re-Put) stamp the short override (`uaf_shortttl.go`), capping the
+  RBAC-staleness window the per-object refilter can otherwise accumulate. Default 0 =
+  disabled — the durable fix is the `RBACSubGen` key fold (§3.1).
+- **External-widget bounded-TTL (opt-in)** — see §4 step 4 and `external_ttl.go`.
+- **Partial-result TTL** — `partial_result_ttl.go`, a short TTL for deliberately-partial
+  bodies.
 
 ---
 
 ## 4. The dispatcher seam (`handlers/dispatchers/`)
 
-`/call` routes to a per-kind handler from the `dispatchers.All()` registry
-(`dispatchers.go:14`). The handler (`restactions.go`, `widgets.go`) is where the cache is
-*consulted* — the ordering here is load-bearing:
+`/call` routes to a per-kind handler from the `dispatchers.All()` registry (`dispatchers.go`).
+The handler (`restactions.go`, `widgets.go`) is where the cache is *consulted* — the ordering
+here is load-bearing:
 
 1. Fetch + convert the dispatched CR (reads L3).
-2. **EvaluateRBAC gate runs BEFORE the L1 lookup** (`restactions.go:96-108`,
-   `widgets.go` equivalent) so a cache hit can never short-circuit the permission check
-   (`restactions.go:112-116`). Cache-off skips this in-process gate because the per-user
-   apiserver fetch enforces RBAC inline (`restactions.go:92-95`).
-3. Compute key + `Get`; on hit, `writeResolvedJSON(entry.RawJSON)` and return
-   (`restactions.go:135-147`).
-4. On miss: attach `WithL1KeyContext(ctx, cacheKey)` (`restactions.go:194-195`) so the resolver
-   records dep edges against this key as it reads L3; resolve; encode once; serve; then `Put`
-   **gated on zero per-item stage errors** (`restactions.go:249-267`) — a partial-with-errors
-   body is served (200) but never persisted, so transient item failures self-heal on the next
-   resolve. Finally `Deps().Record(cacheKey, gvr, ns, name)` records the self-edge
-   (`restactions.go:281`) after `ensureWatcherInformerForGVR` guarantees the GVR's informer is
-   wired (`restactions.go:280`).
+2. **EvaluateRBAC gate runs BEFORE the L1 lookup** (`checkDispatchRBAC`) so a cache hit can
+   never short-circuit the permission check. Cache-off skips this in-process gate because the
+   per-user apiserver fetch enforces RBAC inline.
+3. Compute key + `Get` — but only when `serveFromCacheEligible(inputs)` holds (a non-empty
+   `BindingUID`; the #95 guard). On hit, `writeResolvedJSON(entry.RawJSON)` and return.
+4. On miss: attach `WithL1KeyContext(ctx, cacheKey)` so the resolver records dep edges against
+   this key as it reads L3; attach a `StageErrorSink` and an `ExternalTouchedSink`; resolve;
+   encode once; serve; then **Put only when every gate passes**:
+   - `stageErrSink.Count() == 0` — a partial-with-errors body is served (200) but never
+     persisted, so transient item failures self-heal on the next resolve;
+   - `extTouchedSink.Count() == 0` — a resolve that reached a genuine external endpoint
+     (`httpFetchAllowingNonJSON`, ADR 0006) has **no dep edge to invalidate it**, so the Put is
+     declined and every `/call` re-fetches live (`external_touched_sink.go`). *Exception:* a
+     widget annotated `krateo.io/external-cache-ttl-seconds: <n>` opts into a bounded-staleness
+     Put with `TTLOverride = min(n, 120s)` (`external_ttl.go`) — general opt-in, no hardcoded
+     widget names;
+   - `serveFromCacheEligible(inputs)` — never write the shared empty-`BindingUID` row from the
+     dispatch path;
+   - the **F6 undeclared-extras quarantine** — request extras must all be declared in the
+     widget's `spec.keyExtras` or belong to the identity axis (`spec.identityContext`
+     username/groups), else the Put is skipped
+     (`filterDeclaredKeyExtras` / `snowplow_widget_skipped_undeclared_extras_put_total`).
+   Finally `Deps().Record(cacheKey, gvr, ns, name)` records the self-edge after
+   `ensureWatcherInformerForGVR` guarantees the GVR's informer is wired, and
+   `cache.PublishRefresh(key)` signals any `/refreshes` SSE subscriber of the committed entry.
 
-The refresher hooks are registered once at startup (`dispatchers.go:73-112`
-`RegisterRefreshFunc` for each class), all pointing at the shared `resolveAndPopulateL1`, which
+The refresher hooks are registered once at startup (`dispatchers.go` `RegisterRefreshFunc` for
+each class), all pointing at the shared `resolveAndPopulateL1` (`resolve_populate.go`), which
 re-resolves an entry from its own `Inputs` and re-`Put`s — it only ever `Put`s, never `Get`s.
 
 ---
 
 ## 5. Invalidation (`deps.go`)
 
-L1 entries are invalidated by L3 informer events flowing through `DepTracker` (`deps.go:369`
-`Deps()`). The tracker holds a forward index (DepKey → set of L1 keys) and a reverse index
-(L1 key → set of DepKeys) (`deps.go:458-491`). Dependencies are recorded at resolve time:
+L1 entries are invalidated by L3 informer events flowing through `DepTracker` (`Deps()`). The
+tracker holds a forward index (DepKey → set of L1 keys) and a reverse index (L1 key → set of
+DepKeys). Dependencies are recorded at resolve time:
 
-- `Record(l1Key, gvr, ns, name)` — exact-object edge (`deps.go:421`).
+- `Record(l1Key, gvr, ns, name)` — exact-object edge.
 - `RecordList(l1Key, gvr, ns)` — list-scope edge encoded as the `(gvr, ns, "*")` wildcard
-  bucket (`deps.go:443-453`).
+  bucket.
 
-The three event handlers enforce the **invalidation rules** (header `deps.go:14-18`):
+The three event handlers enforce the **invalidation rules**:
 
-- **ADD / UPDATE → dirty-mark only, never evict.** `OnAdd` and `OnUpdate` both call
-  `onChange` (`deps.go:504-518`), which enqueues every dependent L1 key into the refresher for
-  stale-while-revalidate (`deps.go:524-559`). ADD is treated identically to UPDATE because a
-  freshly-created object can satisfy a LIST-dep that previously resolved empty
-  (`deps.go:497-502`).
-- **DELETE → three-way classification** (`OnDelete`, `deps.go:590`):
+- **ADD / UPDATE → dirty-mark only, never evict.** `OnAdd` and `OnUpdate` both call `onChange`,
+  which enqueues every dependent L1 key into the refresher for stale-while-revalidate. ADD is
+  treated identically to UPDATE because a freshly-created object can satisfy a LIST-dep that
+  previously resolved empty.
+- **DELETE → three-way classification** (`OnDelete`):
   1. *self-representation* — the entry's own dispatched object is the deleted object →
      **EVICT** (the only authorised eviction trigger). Classified by `isSelfRepresentation`,
-     which reads the entry's `Inputs` and compares GVR/ns/name (`deps.go:658-669`).
+     which reads the entry's `Inputs` and compares GVR/ns/name.
   2. *LIST-dep* — matched via the `(gvr, ns, "*")` wildcard; the entry's own object still
      exists but a list member went away → **DIRTY-MARK**.
   3. *dependent-GET-dep* — matched via an exact bucket but the entry's own object is a
      *different* object (e.g. a widget GET-depending on a deleted RESTAction) → **DIRTY-MARK**.
-  Buckets 2 and 3 take the identical action, so `OnDelete` only needs the self-vs-non-self split
-  (`deps.go:607-624`); it returns the evicted count and dirty-marks the rest (`deps.go:625-645`).
-  `isSelfRepresentation` fails conservatively to `false` when the store/entry/Inputs is missing
-  (`deps.go:653-665`) — missing an eviction merely leaves a stale entry until TTL, whereas
-  over-eviction is the regression the falsifier catches.
+  Buckets 2 and 3 take the identical action, so `OnDelete` only needs the self-vs-non-self
+  split; it returns the evicted count and dirty-marks the rest. `isSelfRepresentation` fails
+  conservatively to `false` when the store/entry/Inputs is missing — missing an eviction merely
+  leaves a stale entry until TTL, whereas over-eviction is the regression the falsifier catches.
 
-This is the precise statement of the plan's rule: **DELETE evicts only the deleted object's own
-entry; LIST-deps and dependent GET-deps are dirty-marked; ADD/UPDATE dirty-mark.** TTL
-(`resolved.go:751`) is the outer safety net for any change the dep tracker cannot see.
+This is the precise statement of the rule: **DELETE evicts only the deleted object's own entry;
+LIST-deps and dependent GET-deps are dirty-marked; ADD/UPDATE dirty-mark.** TTL is the outer
+safety net for any change the dep tracker cannot see (external data being the structural case —
+hence the external Put-decline in §4).
 
-The tracker and the store are kept in lock-step: `Deps().SetStore(...)` wires the L1 store
-(`resolved.go:572`), and every L1 eviction path (LRU/TTL/DELETE) calls `Deps().RemoveL1Key` so
-dep records never outlive their entry. The dep-record forward map is bounded by `maxRecords`;
-on cap it drops new records silently and relies on TTL for correctness (`deps.go:466-480`).
+The tracker and the store are kept in lock-step: `Deps().SetStore(...)` wires the L1 store, and
+every L1 eviction path (LRU/TTL/DELETE) calls `Deps().RemoveL1Key` so dep records never outlive
+their entry. The dep-record forward map is bounded (`DEPS_MAX_RECORDS`); on cap it drops new
+records silently and relies on TTL for correctness.
 
 ---
 
 ## 6. Invariants
 
-1. **Provisionality / toggle (transparent fallback).** `CACHE_ENABLED=false`
-   (`cache.go:37` `Disabled()`) must be a transparent fallback to the direct apiserver path —
-   **same data, same UI, same RBAC, only slower** — not a degraded mode. It is enforced at every
-   tier: L3 switches to `modePassthrough` live apiserver reads (`watcher.go:1610`, `1670`); L1's
-   `ResolvedCache()` returns `nil` and every consumer nil-checks and resolves directly
-   (`resolved.go:547-550`, `484-494`); the dispatcher's in-process EvaluateRBAC gate is skipped
-   because per-user apiserver fetches enforce RBAC inline (`restactions.go:92-108`). The whole
-   subsystem stays cleanly removable per `cache.go:10-13`. `CACHE_ENABLED` is the single master
-   gate — prewarm, the informer-serve pivot, and the api-stage L1 (Ship E) are implicit under it
-   (the latter folded per #57; `RESOLVED_CACHE_APISTAGE_ENABLED` retired); only fine-grained
-   back-out knobs (`RESOLVED_CACHE_ENABLED`, `WIDGET_CONTENT_L1_ENABLED`)
-   remain (`cache.go:15-24`).
-2. **RBAC is never short-circuited by a hit.** The EvaluateRBAC gate runs *before* the L1 lookup
-   (`restactions.go:96-116`); the identity-free widget cell is re-personalised per request by
-   `gateWidgetEnvelope` (`widgets.go:139-153`) and is bypassed entirely for RBAC-sensitive
-   `widgetData` widgets (`widgets.go:134`). The cached body is the shell; the body that leaves
-   the pod is per-user.
-3. **Per-user (per-binding) keying, never cohort-only.** Identity-bound classes fold `BindingUID`
-   (`resolved.go:652-655`); only `widgetContent` is identity-free, and only because its served
-   body is re-stamped per request. Every member of a `BindingUID` equivalence class resolves to
-   byte-identical output (`resolved.go:312-320`).
+1. **Provisionality / toggle (transparent fallback).** `CACHE_ENABLED=false` (`cache.go`
+   `Disabled()`) must be a transparent fallback to the direct apiserver path — **same data,
+   same UI, same RBAC, only slower** — not a degraded mode. It is enforced at every tier: L3
+   switches to `modePassthrough` live apiserver reads; L1's `ResolvedCache()` returns `nil` and
+   every consumer nil-checks and resolves directly; the dispatcher's in-process EvaluateRBAC
+   gate is skipped because per-user apiserver fetches enforce RBAC inline. The whole subsystem
+   stays cleanly removable. `CACHE_ENABLED` is the single master gate — prewarm (the whole
+   family), the informer-serve pivot, and the api-stage L1 are implicit under it; the retired
+   per-feature envs (`PREWARM_ENABLED`, `RESOLVER_USE_INFORMER`,
+   `RESOLVED_CACHE_APISTAGE_ENABLED`, `PREWARM_CONTENT_ENABLED`, `PREWARM_PIP_ENABLED`,
+   `PREWARM_ENGINE_ENABLED`, `PROACTIVE_RA_SEED_ENABLED`) are ignored with a one-shot audit log
+   (`retired_flags.go`). Fine-grained back-out knobs that remain explicit:
+   `RESOLVED_CACHE_ENABLED`, `WIDGET_CONTENT_L1_ENABLED`, `REFRESH_SSE_ENABLED`,
+   `UAF_RESOLVED_TTL_SECONDS`.
+2. **RBAC is never short-circuited by a hit.** The EvaluateRBAC gate runs *before* the L1
+   lookup; the identity-free widget cell is re-personalised per request by `gateWidgetEnvelope`
+   and is bypassed entirely for RBAC-sensitive `widgetData` widgets. The cached body is the
+   shell; the body that leaves the pod is per-user.
+3. **Per-user (per-binding) keying, never cohort-only — and never the empty row.** Identity-bound
+   classes fold `BindingUID` + `RBACSubGen`; only `widgetContent` is identity-free, and only
+   because its served body is re-stamped per request. Every member of a `BindingUID` equivalence
+   class resolves to byte-identical output. An empty `BindingUID` (deny / no snapshot / cache
+   off) is **not cache-eligible** on the dispatch path — `serveFromCacheEligible` blocks both
+   the read and the write, closing the #95 cross-identity leak through the shared `""` row.
 4. **DELETE-only eviction.** UPDATE/ADD use stale-while-revalidate dirty-marking; eviction is
-   reserved for a DELETE of an entry's own object (`deps.go:14-18`, `590`).
-5. **Never persist an under-served result.** `Put` is gated on zero per-item stage errors
-   (`restactions.go:249-267`), so a partial body is served but never pins itself for the TTL.
-6. **No per-resource special cases.** Key shape is per *class*, uniform across every GVR
-   (`resolved.go:646-651`); behaviour is expressed via the entry-class discriminant, not
-   hardcoded resource names.
+   reserved for a DELETE of an entry's own object.
+5. **Never persist an under-served or un-invalidatable result.** `Put` is gated on zero per-item
+   stage errors AND zero external touches (unless the bounded-TTL opt-in applies), so a partial
+   or dep-edge-less body is served but never pins itself for the TTL.
+6. **Author-declared key surface.** Request extras partition the key only where the widget
+   author declared them (`spec.keyExtras`) or on the identity axis (`spec.identityContext`);
+   an undeclared-extras resolve is served-but-not-cached, never a silent cell fork.
+7. **No per-resource special cases.** Key shape is per *class*, uniform across every GVR;
+   behaviour is expressed via the entry-class discriminant (or a general annotation like the
+   external TTL), never hardcoded resource names.
 
 ---
 
 ## 7. Known failure modes
 
-- **Seed→serve key divergence.** If the prewarm seed `Put`s under a different `BindingUID`
-  (or extras / page) than the dispatcher `Get` computes, the warm cell is missed and the
-  request falls through to a cold resolve. The `emitDispatchCacheKeyDiag` lines
-  (`helpers.go:281-339`, sites `dispatcher_get` / `per_user_fallback_put` and the PIP-seed Put)
-  exist specifically to diff the folded components for one object. Symptom: `l1=miss` on a
-  request you expected to be warm; check the `binding_uid` field across the three sites.
+- **Seed→serve key divergence.** If the prewarm seed `Put`s under a different `BindingUID`,
+  `RBACSubGen`, extras or page than the dispatcher `Get` computes, the warm cell is missed and
+  the request falls through to a cold resolve. The `emitDispatchCacheKeyDiag` lines
+  (`helpers.go`) exist specifically to diff the folded components for one object. Symptom:
+  `l1=miss` on a request you expected to be warm; check the `binding_uid` field across the
+  sites. (The seed's `RBACSubGen==0` is a known warm-miss for subjects whose sub-gen has
+  moved.)
 - **Stale content past dirty-mark.** Dirty-marking only *enqueues* a refresher re-resolve; until
   the refresher runs, a hit serves the prior bytes (stale-while-revalidate by design). A wedged
   or back-pressured refresher leaves stale content until TTL.
-- **Dep-record cap drop.** Past `maxRecords`, new dep edges are dropped silently
-  (`deps.go:466-480`) and a one-shot WARN (`deps.cache.cap_reached`) fires; affected entries then
-  rely on TTL rather than event-driven invalidation.
+- **Dep-record cap drop.** Past the cap, new dep edges are dropped silently and a one-shot WARN
+  (`deps.cache.cap_reached`) fires; affected entries then rely on TTL rather than event-driven
+  invalidation.
 - **Conservative under-eviction on DELETE.** When `isSelfRepresentation` cannot read the entry's
-  `Inputs` (e.g. legacy entry, store not wired) it returns `false` and the entry is dirty-marked
-  instead of evicted (`deps.go:653-665`) — correct-but-slower; the entry clears at TTL.
+  `Inputs` it returns `false` and the entry is dirty-marked instead of evicted —
+  correct-but-slower; the entry clears at TTL.
 - **Pin demotion under resident-budget pressure.** A `Put` that requests `Pinned` but does not
-  fit the resident byte budget (or `maxResidentBytes==0`) is demoted to transient and counted in
-  `residentDemoteTotal` (`resolved.go:783-799`, `460`) — an expensive prewarmed cell can then be
+  fit the resident byte budget is demoted to transient — an expensive prewarmed cell can then be
   LRU-evicted, reintroducing a cold navigation.
+- **External-TTL staleness window.** An annotated external widget serves up to
+  `min(annotation, 120s)`-stale external data by design; a fat-fingered large value is clamped
+  by the cap.
 
 ---
 
@@ -331,11 +385,18 @@ on cap it drops new records silently and relies on TTL for correctness (`deps.go
 
 | Concern | File | Key anchors |
 |---|---|---|
-| Master toggle | `internal/cache/cache.go` | `Disabled()` :37 |
-| L1 store, keys, dedup | `internal/cache/resolved.go` | `ComputeKey` :608, `canonicaliseExtras` :697, `ResolvedKeyInputs` :271, classes :125/:147/:175, `Get` :738, `Put` :767 |
-| Invalidation | `internal/cache/deps.go` | `Record` :421, `RecordList` :443, `OnAdd/OnUpdate` :504/:516, `onChange` :524, `OnDelete` :590, `isSelfRepresentation` :658 |
-| L3 informer | `internal/cache/watcher.go` | `NewResourceWatcher` :298, `GetObject` :1609, `ListObjects` :1669, dep handlers :845 |
-| Dispatcher seam — keys | `internal/handlers/dispatchers/helpers.go` | `dispatchCacheLookupKey` :200, `dispatchWidgetContentKey` :147, diag :315 |
-| Dispatcher seam — RESTAction | `internal/handlers/dispatchers/restactions.go` | RBAC gate :96, L1 lookup :135, Put :264 |
-| Dispatcher seam — Widget | `internal/handlers/dispatchers/widgets.go` | content fast-path :134, per-binding lookup :170 |
-| Refresher wiring | `internal/handlers/dispatchers/dispatchers.go` | `RegisterRefreshFunc` :73-112 |
+| Master toggle | `internal/cache/cache.go` | `Disabled()` |
+| Retired-flag audit | `internal/cache/retired_flags.go` | `AuditRetiredFlags` |
+| L1 store, keys, dedup, TTL overrides | `internal/cache/resolved.go` | `ComputeKey`, `canonicaliseExtras`, `ResolvedKeyInputs` (`BindingUID`, `RBACSubGen`, `HasUAF`), `resolvedKeyVersion="v6"`, entry classes, `Get`, `Put` |
+| RBAC sub-generation | `internal/cache/rbac_subgen.go`, `rbac_subgen_pending.go` | `RBACSubGenForSubject`, publish-deferred bumps |
+| Invalidation | `internal/cache/deps.go` | `Record`, `RecordList`, `OnAdd`/`OnUpdate` → `onChange`, `OnDelete`, `isSelfRepresentation` |
+| External Put-gate | `internal/cache/external_touched_sink.go` | `WithExternalTouchedSink` |
+| L3 informer | `internal/cache/watcher.go` | `NewResourceWatcher`, `GetObject`, `ListObjects`, `depEventHandlers` |
+| Servability tripwire | `internal/cache/serve_assert.go` | `serve_requires_servable` |
+| Dispatcher seam — keys | `internal/handlers/dispatchers/helpers.go` | `dispatchCacheLookupKey`, `dispatchWidgetContentKey`, `serveFromCacheEligible`, `filterDeclaredKeyExtras` |
+| Dispatcher seam — RESTAction | `internal/handlers/dispatchers/restactions.go` | RBAC gate, L1 lookup, gated Put |
+| Dispatcher seam — Widget | `internal/handlers/dispatchers/widgets.go` | content fast-path, per-binding lookup, external-TTL Put arm |
+| External bounded-TTL opt-in | `internal/handlers/dispatchers/external_ttl.go` | `krateo.io/external-cache-ttl-seconds`, 120s cap |
+| UAF short-TTL | `internal/handlers/dispatchers/uaf_shortttl.go` | `UAF_RESOLVED_TTL_SECONDS` |
+| Refresher wiring | `internal/handlers/dispatchers/dispatchers.go`, `resolve_populate.go` | `RegisterRefreshFunc`, `resolveAndPopulateL1` |
+| Live-refresh signal | `internal/cache/refresh_broadcaster.go` | `PublishRefresh`, `REFRESH_SSE_ENABLED` |

--- a/go/snowplow/docs/architecture/north-star.md
+++ b/go/snowplow/docs/architecture/north-star.md
@@ -1,14 +1,48 @@
+---
+type: Architecture
+title: snowplow — north-star performance contract
+description: The performance contract the cache project exists to satisfy — what is aspirational vs what is implemented and enforced today by the Playwright bench harness, and exactly how it is measured.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [performance, benchmark, north-star, ledger, playwright]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # North-star: the performance contract and how it is measured
 
 This is the contract the snowplow cache project exists to satisfy, and — more
-importantly — the *exact* harness that decides whether a build meets it. Every
-number below is traced to the code that encodes or enforces it. Where the
-aspirational target and the enforced verdict tier differ, both are stated and
-the divergence is explained (the harness wins; the dated bench notes are leads).
+importantly — the *exact* harness that decides whether a build meets it. The
+north-star is **aspirational by nature**; this document separates, explicitly,
+what is **implemented and enforced today** from what remains **aspirational**.
+Every number below is traced to the code that encodes or enforces it (the
+harness has not changed since these anchors were verified; the `file:line`
+references are current).
 
-All `file:line` anchors are in the current tree at commit `a42b072`. The harness
-is the Python package under `e2e/bench/bench/` (driven by `python -m bench`); it
-drives a **real headless Chromium via Playwright**, not `curl`.
+The harness is the Python package under `e2e/bench/bench/` (driven by
+`python -m bench`); it drives a **real headless Chromium via Playwright**, not
+`curl`.
+
+## Implemented vs aspirational — the summary
+
+**Implemented today (real, enforced):**
+
+- The full measurement harness: real-Chromium page-load `waterfallMs`, the
+  cold/warm/fresh methodology, sample-validity gating, the canonical ledger
+  row + frozen schema, per-stage proofs, resumable runs (§2, §4).
+- The mix-weighted scoring (0.95 narrow-RBAC + 0.05 admin) (§3).
+- The enforced verdict tiers: **2200 ms cold / 1000 ms warm-p50 / 30000 ms
+  convergence**, zero restarts, `FLOOR` detection for a broken cache toggle,
+  the S7 delete-convergence band+slope gate (§1, §2).
+
+**Aspirational (stated goal, NOT the enforced gate):**
+
+- **1000 ms cold / 500 ms warm / 1000 ms fresh** at 50K compositions × 1000
+  users. Retained as desiderata; the tiers were relaxed to the
+  measured-achievable floor only after data proved the residual warm latency
+  is the SPA fetch-waterfall fan-out (a frontend-scoped limit), with
+  per-call server compute sub-millisecond.
+- A canonical re-captured baseline: the in-tree `.baseline.json` is a
+  semantic-mismatch placeholder (§4), so the ±15% regression gate is not yet
+  binding.
 
 ---
 
@@ -24,32 +58,32 @@ drives a **real headless Chromium via Playwright**, not `curl`.
 Operating point the contract is asserted at:
 
 - **Scale = 50 000 compositions.** The scale is a run parameter (`--scale` /
-  `SCALE`, resolved at `e2e/bench/bench/cli.py:574` and `:662`; default 5000).
-  The 50K operating point is hard-wired into the EXPECTED_CALLS calibration
-  comments and formula, e.g. `e2e/bench/bench/expected.py:49`
+  `SCALE`, resolved in `e2e/bench/bench/cli.py`; default 5000). The 50K
+  operating point is hard-wired into the EXPECTED_CALLS calibration comments
+  and formula, e.g. `e2e/bench/bench/expected.py:49`
   (`admin S6 (N=50K): actual_calls=30 → 10 + 4×min(50000, 5)`).
 - **1000 concurrent users.** The user-scaling ramp tops out at 1000 synthetic
   users: `USER_COUNTS = [10, 50, 100, 500, 1000]` at
   `e2e/bench/bench/lifecycle.py:1394`; the full cold-start warmup is run at
-  `max(USER_COUNTS)` = 1000 (`e2e/bench/bench/storm.py:429-432`, "Full warmup
-  with 1000 users (cold start)"). User scaling is Phase 7 (`storm.py`); the
-  scored latency tiers are measured in Phase 6 (`phases.py`).
+  `max(USER_COUNTS)` = 1000 (`e2e/bench/bench/storm.py`, "Full warmup with
+  1000 users (cold start)"). User scaling is Phase 7 (`storm.py`); the scored
+  latency tiers are measured in Phase 6 (`phases.py`).
 - **Mix weighting = 0.95 narrow-RBAC + 0.05 admin.** See §3.
 
 > **Verdict tiers ≠ north-star.** The aspirational 1000ms-cold / 500ms-warm /
 > 1000ms-fresh targets are explicitly retained as desiderata and were *relaxed
 > to the measured-achievable floor only after data proved a structural limit*
 > outside the snowplow+chart control surface. The derivation is recorded inline
-> in `e2e/bench/bench/ledger.py:329-385` (warm/cold) and `:369-383` (conv):
-> per-call server compute is sub-millisecond; the residual warm page latency
-> (~908–914ms p50) is the SPA fetch-waterfall fan-out (browser↔ingress RTT ×
-> wave count + render), which is a frontend problem, not server overhead. The
-> tiers are set to `~1.06–1.09× worst-observed clean run` (run-variance
-> headroom), not to a magic number.
+> in `e2e/bench/bench/ledger.py:329-385`: per-call server compute is
+> sub-millisecond; the residual warm page latency (~908–914ms p50) is the SPA
+> fetch-waterfall fan-out (browser↔ingress RTT × wave count + render), which is
+> a frontend problem, not server overhead. The tiers are set to
+> `~1.06–1.09× worst-observed clean run` (run-variance headroom), not to a
+> magic number.
 
 ---
 
-## 2. How it is measured — real Chrome page-load, not curl
+## 2. How it is measured — real Chrome page-load, not curl (implemented)
 
 The single load-bearing measurement is **`waterfallMs`**: the wall-clock span of
 the `/call` request waterfall observed *inside a real Chromium page*, from the
@@ -60,37 +94,34 @@ Playwright page:
 
 - `e2e/bench/bench/browser.py:2039-2084` — `page.evaluate(...)` reads
   `performance.getEntriesByType('resource')`, filters to `/call`, and returns
-  `waterfallMs = Math.round(last - first)` (`:2080`) where `first` is the first
-  call's `startTime` and `last` is `max(startTime + duration)` across all
-  `/call` entries (`:2046-2047`).
+  `waterfallMs = Math.round(last - first)` where `first` is the first call's
+  `startTime` and `last` is `max(startTime + duration)` across all `/call`
+  entries.
 - The navigation itself is a real browser navigation:
-  `page.goto(f"{FRONTEND}{page_path}", wait_until="domcontentloaded", …)` at
-  `e2e/bench/bench/browser.py:2008`, followed by a `/call`-count stability poll
-  (`:2018-2031`) so the waterfall is read only after the SPA's fan-out settles.
+  `page.goto(f"{FRONTEND}{page_path}", wait_until="domcontentloaded", …)`,
+  followed by a `/call`-count stability poll so the waterfall is read only
+  after the SPA's fan-out settles.
 
-This is **deliberately a page-load, not a `curl p50`**: the comment block at
-`e2e/bench/bench/browser.py:1400` states the harness "deliberately does NOT read
-the /call performance timeline" via a synthetic client — the metric is the
-browser's own resource-timing view, which is why warm latency is dominated by
-the SPA's per-card / per-child fetch waves (the fan-out), exactly the user-felt
-page-load latency the north-star is scoped to.
+This is **deliberately a page-load, not a `curl p50`**: the harness does not
+read the `/call` performance timeline via a synthetic client — the metric is
+the browser's own resource-timing view, which is why warm latency is dominated
+by the SPA's per-card / per-child fetch waves (the fan-out), exactly the
+user-felt page-load latency the north-star is scoped to.
 
 ### Cold vs warm vs fresh
 
 - **Cold** = the first navigation of a stage. **Warm** = every subsequent
-  navigation (the cache is hot). The split is set per nav at
-  `e2e/bench/bench/browser.py:2366-2374`: inside `browser_measure_stage`'s nav
-  loop, `cold_warm = 'COLD' if nav_num == 1 else 'WARM'`. Default `num_navs=3`
-  (`browser.py:2268`), so each (stage, user, page) cell yields 1 cold + 2 warm
-  samples. The cold nav also sets `min_calls` so warm navs don't exit the
-  stability poll early (`browser.py:2377`, `:1965-1967`).
-- **Fresh** (`convergence_ms`) is measured separately: after a cluster mutation,
-  `browser_measure_stage` runs a VERIFY poll until the rendered UI count AND the
-  API count both equal cluster truth, then records
-  `convergence_ms = int((time.time() - verify_start) * 1000)`
-  (`e2e/bench/bench/browser.py:2472-2475`; `-1` sentinel when it never matched).
-  This is the eventually-consistent serve-stale settle time, gated by
-  `CONV_TIER_MS` against the S8 p99 (`ledger.py:514`).
+  navigation (the cache is hot). The split is set per nav inside
+  `browser_measure_stage`'s nav loop:
+  `cold_warm = 'COLD' if nav_num == 1 else 'WARM'`. Default `num_navs=3`, so
+  each (stage, user, page) cell yields 1 cold + 2 warm samples. The cold nav
+  also sets `min_calls` so warm navs don't exit the stability poll early.
+- **Fresh** (`convergence_ms`) is measured separately: after a cluster
+  mutation, `browser_measure_stage` runs a VERIFY poll until the rendered UI
+  count AND the API count both equal cluster truth, then records
+  `convergence_ms = int((time.time() - verify_start) * 1000)` (`-1` sentinel
+  when it never matched). This is the eventually-consistent serve-stale settle
+  time, gated by `CONV_TIER_MS` against the S8 p99.
 
 ### Sample validity gate
 
@@ -100,35 +131,33 @@ percentiles unless it reached a clean terminal state:
 - widget-scoped `.ant-skeleton` count must be 0 (hard fail),
 - the actual `/call` count must equal `expected_calls(user, page, n_visible=N)`
   within `EXPECTED_CALLS_TOLERANCE = 0` (`e2e/bench/bench/expected.py:112`),
-- enforced in `_validate_widget_terminal_state`
-  (`e2e/bench/bench/browser.py:1483-1535`) and applied at
-  `browser.py:2086-2092` (`incomplete=True` ⇒ `waterfallMs=0`).
+- enforced in `_validate_widget_terminal_state` (`e2e/bench/bench/browser.py`)
+  (`incomplete=True` ⇒ `waterfallMs=0`).
 
 `waterfallMs <= 0` or `incomplete` samples are filtered before percentile
-computation in the ledger (`e2e/bench/bench/ledger.py:581-589`); a cell with
-navs but zero valid samples reports `terminal_fail_rate` and null latencies
-(`:594-602`), which forces the run verdict to `INVALID` (`ledger.py:709-710`).
+computation in the ledger; a cell with navs but zero valid samples reports
+`terminal_fail_rate` and null latencies, which forces the run verdict to
+`INVALID`.
 
 ### From samples to verdict
 
 Per (user, cache_mode) cell, the ledger computes
 `cold_ms = pct(cold_samples, 50)`, `warm_p50_ms = pct(warm_samples, 50)`,
-`warm_p99_ms = pct(warm_samples, 99)` (`e2e/bench/bench/ledger.py:604-606`).
-The verdict is then computed from the **mix-weighted** cell:
+`warm_p99_ms = pct(warm_samples, 99)`. The verdict is then computed from the
+**mix-weighted** cell:
 
-- `compute_verdict(...)` at `e2e/bench/bench/ledger.py:436-520`:
-  a tier is "missed" only when strictly greater than its threshold
-  (`:510` warm, `:512` cold, `:514` conv); `restarts > 0` short-circuits to
-  `FAIL` (`:481-482`).
+- `compute_verdict(...)` at `e2e/bench/bench/ledger.py:436-520`: a tier is
+  "missed" only when strictly greater than its threshold; `restarts > 0`
+  short-circuits to `FAIL`.
 - **PASS** = 0 tiers missed; **WEAK_PASS** = exactly 1 missed; **FAIL** = ≥2
   missed, or a restart, or the S7 delete-convergence band+slope gate fires
-  (`:493-496`, `S7_CONV_BAND_MS`/`S7_SLOPE_FLOOR_PER_S` at `:425-426`).
+  (`S7_CONV_BAND_MS`/`S7_SLOPE_FLOOR_PER_S`, `ledger.py:425-426`).
 - `FLOOR` = the deployed chart has no working `CACHE_ENABLED` toggle (cache-ON
-  cells are zero while cache-OFF cells have data) — `:502-508`.
+  cells are zero while cache-OFF cells have data).
 
 ---
 
-## 3. The mix-weighting (0.95 narrow-RBAC + 0.05 admin)
+## 3. The mix-weighting (0.95 narrow-RBAC + 0.05 admin) (implemented)
 
 The scored latency is **not** admin's; it is weighted toward the narrow-RBAC end
 user, because the north-star is the *frontend UX of a normal portal user*, not an
@@ -145,50 +174,48 @@ The mix is applied per field in `build_canonical_ledger_row`:
 mix_weighted[field] = round(0.95 * cyber + 0.05 * admin)
 ```
 
-`e2e/bench/bench/ledger.py:658` (inside `_mw_pick`, `:645-663`), declared in the
-module docstring at `e2e/bench/bench/ledger.py:3`
-(*"Mix-weighted = 0.95 * cyberjoker + 0.05 * admin"*). For each field the picker
-prefers the cache-ON cell and falls back to cache-OFF (`:646-651`); if only one
-subject has data the other's weight collapses to it (`:652-657`). When `cj` has
-no navs its cell is mirrored from admin first (`ledger.py:630-638`).
+(`e2e/bench/bench/ledger.py` `_mw_pick`, declared in the module docstring:
+*"Mix-weighted = 0.95 * cyberjoker + 0.05 * admin"*.) For each field the picker
+prefers the cache-ON cell and falls back to cache-OFF; if only one subject has
+data the other's weight collapses to it. When `cj` has no navs its cell is
+mirrored from admin first.
 
-The four cells (`admin_on`, `admin_off`, `cyber_on`, `cyber_off`) are built at
-`e2e/bench/bench/ledger.py:612-617`; the mix-weighted dict (`cold_ms`,
-`warm_p50_ms`, `warm_p99_ms`) at `:659-663` is what `compute_verdict` consumes
-(`:704-708`).
+The four cells (`admin_on`, `admin_off`, `cyber_on`, `cyber_off`) are built in
+the ledger; the mix-weighted dict (`cold_ms`, `warm_p50_ms`, `warm_p99_ms`) is
+what `compute_verdict` consumes.
 
 ---
 
-## 4. The measurement ledger
+## 4. The measurement ledger (implemented; baseline capture pending)
 
 Each scored run emits a canonical ledger row (the durable record of whether the
 contract was met):
 
-- **Builder:** `build_canonical_ledger_row(...)` in
-  `e2e/bench/bench/ledger.py` (the `cells` / `mix_weighted` / `verdict`
-  assembly described in §2–§3, `:569-712`).
+- **Builder:** `build_canonical_ledger_row(...)` in `e2e/bench/bench/ledger.py`
+  (the `cells` / `mix_weighted` / `verdict` assembly described in §2–§3).
 - **Schema (frozen):** `e2e/bench/bench/ledger_row.schema.json` is the
-  machine-readable surface for the row (ledger.py docstring `:4-5`).
+  machine-readable surface for the row.
 - **Run bundle:** `write_run_bundle(...)` serializes the full run tree
   (proofs, per-stage `pod_logs/S<N>.txt[.gz]`, screenshots, `--video` `.webm`/
-  `.gif`); nothing is dropped — the 200MB cap was removed (ledger.py `:26-35`).
+  `.gif`); nothing is dropped — the 200MB cap was removed.
 - **Per-stage proofs:** every stage persists a `StageProof` to
   `proofs/S<N>.json` with a required `what_breaks_if_skipped`
-  (`e2e/bench/bench/phases.py:180-208`, `:244-273`); `state.json` round-trips
-  the run (`phases.py:218-265`) so `--from-stage` can resume.
-- **Baseline / regression gate:** the last-known-good is pinned in
-  `e2e/bench/.baseline.json` (`baseline_warm_p50_ms`); `read_baseline` /
-  `compute_baseline_delta` apply a ±15% gate (ledger.py `:23-24`). NOTE — the
-  in-tree `.baseline.json` carries `baseline_warm_p50_ms = 2233` captured
+  (`e2e/bench/bench/phases.py`); `state.json` round-trips the run so
+  `--from-stage` can resume.
+- **Baseline / regression gate — PROVISIONAL:** the last-known-good is pinned
+  in `e2e/bench/.baseline.json` (`baseline_warm_p50_ms = 2233`, captured
   2026-06-02 against the *portal-chart Chrome-MCP `lastCall_ms`* metric, whose
   own `_notes` field flags it as a *semantic-mismatch placeholder* for the
-  field-literal `mix_weighted.warm_p50_ms`; treat it as provisional until a
-  full Phase-6 lifecycle re-captures the canonical baseline.
+  field-literal `mix_weighted.warm_p50_ms`). `read_baseline` /
+  `compute_baseline_delta` apply a ±15% gate — but treat it as provisional
+  until a full Phase-6 lifecycle re-captures the canonical baseline. This is
+  the one piece of the ledger machinery that is *not* yet grounded in a
+  canonical measurement.
 - **EXPECTED_CALLS overlay freshness:** a scored run refuses to start if the
-  calibration overlay at `/tmp/snowplow-runs/calibration/expected_calls.json` is
-  older than 14 days (`overlay_freshness_or_die`,
-  `e2e/bench/bench/expected.py:263-280`); freshness is the file's `st_mtime`, not
-  a forgeable JSON field (`:246-260`).
+  calibration overlay at `/tmp/snowplow-runs/calibration/expected_calls.json`
+  is older than 14 days (`overlay_freshness_or_die`,
+  `e2e/bench/bench/expected.py`); freshness is the file's `st_mtime`, not a
+  forgeable JSON field.
 
 ---
 
@@ -197,42 +224,41 @@ contract was met):
 **Invariants the harness defends:**
 
 1. **The scored metric is browser page-load latency, not synthetic client
-   latency.** `waterfallMs` is read from the Chromium Resource Timing API
-   (`browser.py:2039-2084`). A change that "improves" a `curl`/server p50 but
-   adds a fetch wave to the SPA fan-out moves nothing the gate measures — the
-   gate only sees the browser waterfall span.
+   latency.** `waterfallMs` is read from the Chromium Resource Timing API. A
+   change that "improves" a `curl`/server p50 but adds a fetch wave to the SPA
+   fan-out moves nothing the gate measures — the gate only sees the browser
+   waterfall span.
 2. **The end user, not the operator, sets the bar.** 95% of the weight is the
-   narrow-RBAC `cj` (`ledger.py:658`). A regression that only hurts admin barely
-   moves the verdict; one that hurts `cj` is amplified 19×.
+   narrow-RBAC `cj`. A regression that only hurts admin barely moves the
+   verdict; one that hurts `cj` is amplified 19×.
 3. **Cache must stay a transparent toggle.** If cache-ON shows no benefit while
-   cache-OFF has data, the verdict is `FLOOR` (`ledger.py:502-508`), surfacing a
-   broken/absent `CACHE_ENABLED` rather than silently passing.
+   cache-OFF has data, the verdict is `FLOOR`, surfacing a broken/absent
+   `CACHE_ENABLED` rather than silently passing.
 4. **Tiers move only on proven structural limits.** The relaxations from
    1000→2200 (cold) and 500→1000 (warm) carry inline derivations citing the
-   measured floor + headroom (`ledger.py:329-385`); the aspirational targets are
-   retained, not deleted.
-5. **No restarts, zero call-count drift.** `restarts > 0` ⇒ `FAIL`
-   (`ledger.py:481-482`); `/call` count must hit `expected_calls(...)` exactly
-   (`EXPECTED_CALLS_TOLERANCE = 0`, `expected.py:112`) or the sample is voided.
+   measured floor + headroom (`ledger.py:329-385`); the aspirational targets
+   are retained, not deleted.
+5. **No restarts, zero call-count drift.** `restarts > 0` ⇒ `FAIL`; `/call`
+   count must hit `expected_calls(...)` exactly (`EXPECTED_CALLS_TOLERANCE =
+   0`) or the sample is voided.
 
 **How a regression surfaces:**
 
 - **Added SPA fetch wave / lost cache hit** → warm `waterfallMs` p50 climbs;
   `mix_weighted.warm_p50_ms > 1000` ⇒ one miss (`WEAK_PASS`), two misses
-  (e.g. cold too) ⇒ `FAIL` (`ledger.py:510-520`).
-- **Cold-path regression** → `cold_ms > 2200` (`ledger.py:512`).
+  (e.g. cold too) ⇒ `FAIL`.
+- **Cold-path regression** → `cold_ms > 2200`.
 - **Serve-stale / refresher regression** → S8 convergence p99 `> 30000ms`
-  counts as a miss (`ledger.py:514`); a *delete-path* refresher stall is caught
-  specifically by the S7 band+slope gate (above the 270s band AND drain slope
-  `< 3.0/s`) ⇒ hard `FAIL` (`ledger.py:493-496`, `:425-426`).
-- **Cache toggle broke** → `FLOOR` (`ledger.py:502-508`).
-- **Pod crash / OOM under 50K×1000** → restart count > 0 ⇒ `FAIL`
-  (`ledger.py:481-482`); also surfaced as mid-stage re-roll annotation
-  (`phases.py:509-557`).
+  counts as a miss; a *delete-path* refresher stall is caught specifically by
+  the S7 band+slope gate (above the 270s band AND drain slope `< 3.0/s`) ⇒
+  hard `FAIL`.
+- **Cache toggle broke** → `FLOOR`.
+- **Pod crash / OOM under 50K×1000** → restart count > 0 ⇒ `FAIL`; also
+  surfaced as mid-stage re-roll annotation (`phases.py`).
 - **Unusable samples** (skeletons never resolved, call-count drift, terminal
-  fail) → cells null, `navs_terminal_fail > 0` ⇒ `INVALID` (`ledger.py:709-710`),
-  i.e. the run is thrown out rather than scored — a regression can't hide behind
-  a half-rendered page.
+  fail) → cells null, `navs_terminal_fail > 0` ⇒ `INVALID`, i.e. the run is
+  thrown out rather than scored — a regression can't hide behind a
+  half-rendered page.
 
 ---
 
@@ -244,19 +270,17 @@ the harness is authoritative. Verified divergences:
 - **Cold tier 1300 vs 2200.** Several notes/comment fragments reference a cold
   tier of 1300ms (the original Task #121 value). The live constant is
   **`COLD_TIER_MS = 2200`** (`ledger.py:385`), re-baselined 2026-06-11 for the
-  lazy-context two-window cold methodology (commits e6feee1 / 8a69848). The
-  inline comment at `ledger.py:358-367` documents the 1300→2200 change; 1300
-  now applies only to pre-methodology rows.
+  lazy-context two-window cold methodology. The inline comment at
+  `ledger.py:358-367` documents the 1300→2200 change; 1300 now applies only to
+  pre-methodology rows.
 - **Aspirational vs enforced tiers.** `ARCHITECTURE.md`'s north-star bullet and
   several notes state "1s cold / 500ms warm / 1s fresh". Those are the
-  *aspirational* targets (correct as the contract's stated goal) but are **not**
-  the values the gate enforces — the harness enforces 2200 / 1000 / 30000
-  (`ledger.py:383-385`), explicitly relaxed-on-proof. This doc states both.
-- **`.baseline.json` metric mismatch.** `e2e/bench/.baseline.json` is itself
-  annotated (`_notes`) as a portal-chart Chrome-MCP `lastCall_ms` placeholder,
-  not the canonical `mix_weighted.warm_p50_ms` field; the ±15% baseline gate
-  becomes binding only once a full Phase-6 lifecycle re-captures it.
-- **`docs/scaling-roadmap.md` is not in the current tree** (it exists only under
-  `.claude/worktrees/*`), so it was not used as a current-tree anchor; the 50K /
-  1000-user operating point is grounded in `expected.py:49`,
-  `lifecycle.py:1394`, and `storm.py:429-432` instead.
+  *aspirational* targets (correct as the contract's stated goal) but are
+  **not** the values the gate enforces — the harness enforces 2200 / 1000 /
+  30000 (`ledger.py:383-385`), explicitly relaxed-on-proof. This doc states
+  both.
+- **`.baseline.json` metric mismatch.** See §4 — the ±15% baseline gate becomes
+  binding only once a full Phase-6 lifecycle re-captures it.
+- **`docs/scaling-roadmap.md` is not in the current tree**, so it was not used
+  as an anchor; the 50K / 1000-user operating point is grounded in
+  `expected.py`, `lifecycle.py`, and `storm.py` instead.

--- a/go/snowplow/docs/architecture/observability.md
+++ b/go/snowplow/docs/architecture/observability.md
@@ -1,153 +1,200 @@
+---
+type: Architecture
+title: snowplow — observability
+description: The runtime observability surface — expvars at /debug/vars, structured slog events, pprof, the default-off OTel export (traces/metrics/logs + audit), and the probe endpoints.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [observability, expvar, otel, metrics, logging, pprof]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Observability
 
-Snowplow's runtime observability surface is three things, all on the single HTTP
+Snowplow's runtime observability surface is four things, all on the single HTTP
 port the server listens on (`main.go` `server.Addr = :<port>`):
 
-1. **expvars** at `GET /debug/vars` — the metric surface (`main.go:869`).
+1. **expvars** at `GET /debug/vars` — the metric surface.
 2. **structured `slog` events** on stdout — the event log.
-3. **pprof** at `GET /debug/pprof/*` — runtime profiling (`main.go:837-841`).
+3. **pprof** at `GET /debug/pprof/*` — runtime profiling.
+4. **OTel export** — traces, metrics and logs to an OTLP collector,
+   **default-off** behind the `OTEL_ENABLED` master switch (see below).
 
-Plus two probe endpoints used by the chart:
+Plus the diagnostic endpoints `GET /debug/servable`, `GET /debug/apistage`
+and the auth-gated `GET /debug/refreshes` (the live-refresh subscription
+registry, wrapped in the same `RefreshAuth` as `/refreshes`), and two probe
+endpoints used by the chart:
 
 | Path | Handler | Returns | Meaning |
 |---|---|---|---|
-| `GET /health` | `internal/handlers/health.go:34` | always `200 {"status":"alive"}` | liveness only — process is up; a still-warming pod is alive and must NOT be restarted |
-| `GET /readyz` | `internal/handlers/readyz.go:49` | `200 {"status":"ready"}` once `cache.IsPhase1Done()`, else `503 {"status":"warming"}` | readiness — safe to receive traffic (prewarm Phase 1 has completed) |
+| `GET /health` | `internal/handlers/health.go` | always `200 {"status":"alive"}` — a static pre-encoded body, zero allocation, no apiserver read | liveness only — process is up; a still-warming pod is alive and must NOT be restarted |
+| `GET /readyz` | `internal/handlers/readyz.go` | `200 {"status":"ready"}` once `cache.IsPhase1Done()`, else `503 {"status":"warming"}` | readiness — safe to receive traffic. Since the prewarm-gated-readiness reversal this flips only after the synchronous boot seed (or its fire-regardless backstop) — a pod can be **Ready-degraded** (flipped via backstop with cold cells); `snowplow_readyz_backstop_fired` distinguishes that from a healthy boot |
 
-The chart wires the **livenessProbe → `/health`** and **readinessProbe + startupProbe → `/readyz`** (`readyz.go:38-40`).
+The chart wires **livenessProbe → `/health`**, **startupProbe → `/health`**
+(long `failureThreshold` budget), and **readinessProbe → `/readyz`**
+(`helm/snowplow/values.yaml`).
+
+---
+
+## OTel export (default-off)
+
+`main.go` wires three gated pipelines at boot, all no-ops unless enabled:
+
+| Env | Meaning |
+|---|---|
+| `OTEL_ENABLED` | master switch (default `false`) |
+| `OTEL_TRACING_ENABLED` | gate tracing (defaults to the value of `OTEL_ENABLED`) |
+| `OTEL_METRICS_ENABLED` | gate metrics (defaults to the value of `OTEL_ENABLED`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | collector OTLP/HTTP endpoint (standard contract) |
+
+- **Traces** (`internal/tracing/tracing.go` `Setup`): registers a global
+  TracerProvider + the W3C trace-context/baggage propagators; the whole mux is
+  wrapped in `otelhttp.NewHandler` (no-op spans when disabled). The CORS
+  options in `main.go` allow the browser to send
+  `traceparent`/`tracestate`/`baggage`.
+- **Metrics** (`internal/metrics/metrics.go` `Setup`): an **OTLP mirror of the
+  expvar surface** — observable instruments read the same live counter
+  snapshots the expvar closures read (families: fallthrough, dispatch L1,
+  prewarm/phase-1, refresher, discovery, upstream health, …). The expvar
+  surface at `/debug/vars` is unchanged and remains the scrape-free ground
+  truth; the OTLP export is additive.
+- **Logs + audit** (`internal/logging/logging.go` + `internal/support/audit`):
+  an OTLP LogRecord bridge on the shared `otel_logs` plane, plus the audit
+  middleware. The audit correlation id (D19a) rides **W3C `baggage`
+  (`session.id`)** — minted/accepted by `audit.Middleware()` and serialized
+  downstream by the Baggage propagator. It **replaces** the old
+  `X-Krateo-Correlation-Id` header entirely; the shortid `X-Krateo-TraceId`
+  and the OTel `traceparent` coexist.
 
 ---
 
 ## Cache-off contract (read before interpreting any expvar)
 
-Under `CACHE_ENABLED=false` the cache subsystem does not exist (transparent-fallback,
-`project_cache_off_is_transparent_fallback`). Almost every `snowplow_*` expvar is registered
-in an `init()` guarded by `if cache.Disabled() { return }`, so under cache-off **the key is
-absent from `/debug/vars` entirely** — not present-but-zero. An absent key under cache-off is
-expected, not a defect.
+Under `CACHE_ENABLED=false` the cache subsystem does not exist
+(transparent-fallback). Almost every `snowplow_*` expvar is registered in an
+`init()` guarded by `if cache.Disabled() { return }`, so under cache-off **the
+key is absent from `/debug/vars` entirely** — not present-but-zero. An absent
+key under cache-off is expected, not a defect.
 
-The exceptions, **registered unconditionally** in `main.go`'s HTTP bootstrap so a bench probe
-gets `0` rather than a missing-key error under cache-off:
+The exceptions, **registered unconditionally** in `main.go`'s HTTP bootstrap so
+a bench probe gets `0` rather than a missing-key error under cache-off:
 
-- `snowplow_rbac_publish_seq` — `cache.RegisterRBACSnapshotExpvar()` (`main.go:862`)
-- `snowplow_authz_memo_*` — `rbac.RegisterAuthzMemoExpvar()` (`main.go:868`)
+- `snowplow_rbac_publish_seq` — `cache.RegisterRBACSnapshotExpvar()`
+- `snowplow_authz_memo_*` — `rbac.RegisterAuthzMemoExpvar()`
 
 ---
 
 ## expvars at `/debug/vars`
 
-Every value is an `expvar.Func` evaluated lazily at scrape time (zero per-`/call` cost). Names
-are stable for grep/Prometheus tooling. Grouped by subsystem.
+Every value is an `expvar.Func` (or counter) evaluated lazily at scrape time
+(zero per-`/call` cost). Names are stable for grep/Prometheus tooling. Grouped
+by subsystem.
 
 ### Fallthrough meter — "is the cache actually serving, or punting to the apiserver?"
 Defined in `internal/cache/fallthrough_meter_expvar.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_apiserver_fallthrough_total` (`:57`) | grand-total `uint64` of read requests that bypassed the cache and hit the apiserver directly | climbs during boot/cold; should plateau once warm. A steadily climbing total on a warm pod = cache not covering the live request mix |
-| `snowplow_apiserver_fallthrough_cells` (`:68`) | per-cell `map["path\|gvr\|reason"]→uint64` breakdown of the above | use to attribute fallthrough to a specific path/GVR/reason |
-| `snowplow_assertion_violations_total` (`:60`) | per-check `map[string]→uint64` of architectural-invariant breaches. Keys: `read_paths_scoped` (a `/call`-class route not wrapped with `FallthroughScopeMiddleware`), `serve_requires_servable` (an authoritative cache HIT was about to be served from a not-servable informer — not-synced / watch-broken / unconfirmed) | **0** for every key. Non-zero = an invariant is broken in prod (logged ERROR, pod stays up). **`serve_requires_servable` > 0 is P1** — the never-serve-from-not-synced invariant is the most load-bearing cache guarantee; a non-zero count means a refactor reached a serve path that bypasses `servableLocked` (the tripwire's whole purpose). `read_paths_scoped` asserted at boot by `cache.AssertReadPathsScoped()` (`main.go:908`); `serve_requires_servable` asserted per-serve in `GetObject`/`GetTypedObject`/`ListObjectsServable` (`internal/cache/serve_assert.go`) |
+| `snowplow_apiserver_fallthrough_total` | grand-total `uint64` of read requests that bypassed the cache and hit the apiserver directly | climbs during boot/cold; should plateau once warm. A steadily climbing total on a warm pod = cache not covering the live request mix |
+| `snowplow_apiserver_fallthrough_cells` | per-cell `map["path\|gvr\|reason"]→uint64` breakdown of the above | use to attribute fallthrough to a specific path/GVR/reason |
+| `snowplow_assertion_violations_total` | per-check `map[string]→uint64` of architectural-invariant breaches. Keys: `read_paths_scoped` (a `/call`-class route not wrapped with `FallthroughScopeMiddleware`, asserted at boot by `cache.AssertReadPathsScoped()`), `serve_requires_servable` (an authoritative cache HIT was about to be served from a not-servable informer — asserted per-serve in `internal/cache/serve_assert.go`) | **0** for every key. Non-zero = an invariant is broken in prod (logged ERROR, pod stays up). **`serve_requires_servable` > 0 is P1** — never-serve-from-not-synced is the most load-bearing cache guarantee |
 
 ### Dispatch L1 lookups — resolved-output cache hit rate
 Defined in `internal/handlers/dispatchers/l1_lookup_metrics.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_dispatch_l1_lookups` (`:116`) | `map["<handlerKind>\|<gvr>"→{"hit_total","miss_total"}]`; handlerKind ∈ {restactions, widgets, widgetContent} | high hit_total/(hit+miss) on a warm pod. Sustained low hit ratio = prewarm not covering the served mix |
+| `snowplow_dispatch_l1_lookups` | `map["<handlerKind>\|<gvr>"→{"hit_total","miss_total"}]`; handlerKind ∈ {restactions, widgets, widgetContent} | high hit ratio on a warm pod. Sustained low hit ratio = prewarm not covering the served mix |
+| `snowplow_widget_content_skipped_rbac_sensitive_total` / `snowplow_widget_content_skipped_empty_shell_total` (`widget_content_metrics.go`) | widgetContent fast-path skip counters (RBAC-sensitive widget; empty-shell decline) | informational — attribute content-cell misses |
+| `snowplow_widget_skipped_undeclared_extras_put_total` | Puts quarantined by the F6 undeclared-request-extras allowlist | non-zero means a client sends extras the widget author has not declared in `spec.keyExtras` |
 
 ### RAFullList serve path — the cheap Go-slice serve for big LISTs
 Defined in `internal/cache/bindings_by_gvr_metrics.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_ra_full_list_serve` (`:50`) | `map{hit, repopulate, verified_slice, fallback}` serve-outcome counters for the RAFullList cell | admin's first compositions `/call` should drive `hit`+1 over a warm prewarm-pinned cell; rising `fallback` = the cheap path is not engaging |
-| `snowplow_ra_full_list_memo` (`:71`) | per-(RA × sliceShape) sliceability verdict snapshot | diagnostic for the three RAFullList failure modes (boot empty-full self-heal, prewarm not reaching widget, first-sight byte mismatch) |
-| `snowplow_sliceability_reverify` (`:78`) | async sliceability-reverify worker counters | evidence the stuck-false reverify path is firing (informer event → re-verify within ≤60s) |
-| `snowplow_bindings_by_gvr_delta_skipped_non_typed` (`:60`) | `uint64` — delta-event objects neither typed nor convertible, and DROPPED | **0**. Non-zero = the bindings-by-GVR index is drifting until the next boot rebuild (a silent-data-staleness canary) |
+| `snowplow_ra_full_list_serve` | `map{hit, repopulate, verified_slice, fallback}` serve-outcome counters for the RAFullList cell | admin's first compositions `/call` should drive `hit`+1 over a warm prewarm-pinned cell; rising `fallback` = the cheap path is not engaging |
+| `snowplow_ra_full_list_memo` | per-(RA × sliceShape) sliceability verdict snapshot | diagnostic for the RAFullList failure modes |
+| `snowplow_sliceability_reverify` | async sliceability-reverify worker counters | evidence the stuck-false reverify path is firing (informer event → re-verify) |
+| `snowplow_bindings_by_gvr_delta_skipped_non_typed` | `uint64` — delta-event objects neither typed nor convertible, and DROPPED | **0**. Non-zero = the bindings-by-GVR index is drifting until the next boot rebuild (a silent-data-staleness canary) |
 
 ### Prewarm — boot warm-up completion + walk coverage
+
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_prewarm_complete` (`internal/cache/prewarm_complete_metric.go:106`) | `map{done:0/1, elapsed_ms}` — `done=1` once `Phase1Done` flips (same atomic `/readyz` reads); `elapsed_ms` = process-start→done, `-1` until flip | `done` reaches `1`; `elapsed_ms` is the cold-start-to-ready time |
-| `snowplow_phase1_units_planned` (`internal/handlers/dispatchers/phase1_walk_pagination_metrics.go:133`) | `uint64` — widgetContent cells the apiRef pagination walk planned to seed | at 50K must climb toward the reachable widget-CR count; pinned near `500 × widget-count` = page cap still binding |
-| `snowplow_phase1_units_seeded` (`:136`) | `uint64` — page cells handed to `populateWidgetContentL1` with a non-nil envelope (lower bound on L1 writes) | reconciles with units_planned minus the skip counters below |
-| `snowplow_phase1_apiref_pages_total` (`:139`) | `uint64` — extra apiRef pages (page 2..N) resolved across all paginated widgets | ≫ `500 × widget-count` confirms the page backstop raise took effect |
-| `snowplow_phase1_eligible_no_continue_total` (`:142`) | `uint64` — distinct eligible widgets whose page-1 resolve produced no continuation | tracks genuinely single-page apiRef widgets; a SPIKE on a post-storm boot = re-collection had retry work |
-| `snowplow_phase1_walk_children` (`internal/handlers/dispatchers/phase1_walk_metrics.go:175`) | `map[root→{children-count entry}]` per-root boot walk fan-out | diagnostic for which navigation roots produced children |
-| `snowplow_phase1_walk_zero_children_total` (`:186`) | `uint64` — walk observations that found zero children | a high count = roots resolving empty (possible RBAC/data gap) |
-| `snowplow_phase1_walk_observations_total` (`:189`) | `uint64` — total walk children-count observations | denominator for the zero-children ratio |
+| `snowplow_prewarm_complete` (`internal/cache/prewarm_complete_metric.go`) | `map{done:0/1, elapsed_ms}` — `done=1` once `Phase1Done` flips (same atomic `/readyz` reads); `elapsed_ms` = process-start→done, `-1` until flip | `done` reaches `1`; `elapsed_ms` is the cold-start-to-ready time |
+| `snowplow_readyz_backstop_fired` (`internal/handlers/dispatchers/readiness_backstop_metrics.go`) | `int` — readiness flipped via a backstop arm (seed error / timeout / panic / boot error) instead of the first-nav happy path; each fire also emits a `readyz.backstop.fired` ERROR with the reason | **0** on a healthy boot; any non-zero = a FAILED-but-serving (Ready-degraded) boot — alert |
+| `snowplow_phase1_units_planned` / `snowplow_phase1_units_seeded` / `snowplow_phase1_apiref_pages_total` / `snowplow_phase1_eligible_no_continue_total` (`phase1_walk_pagination_metrics.go`) | apiRef-pagination walk planning/seeding counters (widgetContent cells planned, seeded, extra pages resolved, single-page widgets) | `units_seeded` reconciles with `units_planned` minus skips; pages ≫ page-cap × widget-count confirms the backstop raise |
+| `snowplow_phase1_walk_children` / `snowplow_phase1_walk_zero_children_total` / `snowplow_phase1_walk_observations_total` (`phase1_walk_metrics.go`) | per-root boot-walk fan-out + zero-children observations | high zero-children ratio = roots resolving empty (RBAC/data gap, or the pre-barrier pass — the engine re-walk covers it) |
+| `snowplow_phase1_configvars_skipped_total` (`phase1_configvars_watch.go`) | config-vars watch events skipped by the data-change gate (metadata-only churn, e.g. CDC traceparent re-stamps) | climbs harmlessly under CR churn; a boot re-drive fires only on real `config.json` change |
 
-### Prewarm engine — the unified walk/seed worker (the production path)
+### Prewarm engine — the unified walk/seed worker
 Defined in `internal/handlers/dispatchers/prewarm_engine_metrics.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_prewarm_engine_enqueued_total` (`:56`) | `uint64` — cumulative `enqueueScope` calls (every enqueue, even dedup-coalesced) | climbs during boot/re-walk |
-| `snowplow_prewarm_engine_processed_total` (`:59`) | `uint64` — scopes fully processed by the worker | `processed ≈ enqueued − dedups` means the queue drained |
-| `snowplow_prewarm_engine_yield_total` (`:62`) | `uint64` — worker parked because a customer `/call` was in flight (customer-priority yield) | >0 under customer load = the yield hook is working |
-| `snowplow_prewarm_engine_pending_depth` (`:65`) | live `len(e.pending)` | **0** once the worker drains; sustained non-zero across many scrapes = worker dead |
+| `snowplow_prewarm_engine_enqueued_total` | `uint64` — cumulative `enqueueScope` calls (every enqueue, even dedup-coalesced) | climbs during boot/re-walk/keepwarm |
+| `snowplow_prewarm_engine_processed_total` | `uint64` — scopes fully processed by the worker | `processed ≈ enqueued − dedups` means the queue drained |
+| `snowplow_prewarm_engine_requeued_total` | `uint64` — engine-owned boot-scope requeues (the F.4 deadline-cut resume) | small; unbounded climb = the resume bound regressed |
+| `snowplow_prewarm_engine_yield_total` | `uint64` — worker parked because a customer `/call` was in flight (customer-priority yield) | >0 under customer load = the yield hook is working |
+| `snowplow_prewarm_engine_pending_depth` | live queue depth | **0** once the worker drains; sustained non-zero across many scrapes = worker dead |
 
-### Phase-1 seed — per-cohort/per-target seed outcomes
-Defined in `internal/handlers/dispatchers/phase1_pip_metrics.go`.
+### Phase-1 seed — per-target seed outcomes
+Defined in `internal/handlers/dispatchers/phase1_pip_metrics.go` (+ siblings).
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_phase1_bindingset_seed_resolves_total` (`:181`) | `uint64` — seed UNITS resolved + written to per-user L1 (one per successful `handle.Put` in seedOneRestaction/seedOneWidget) | climbs during seed; `0` after boot means no seed unit was written (wired 2026-07-04 — was dead-at-0 before) |
-| `snowplow_phase1_bindingset_seed_failures_total` (`:184`) | `uint64` — grand-total seed failures (= rbac_deny + operational; back-compat) | interpret via the split below |
-| `snowplow_phase1_seed_rbac_deny_total` (`:192`) | `uint64` — EXPECTED narrow-RBAC denies (403/401); cohort genuinely can't read the target | non-zero is **normal**; these need no L1 entry, not re-enqueued |
-| `snowplow_phase1_seed_operational_fail_total` (`:195`) | `uint64` — UNEXPECTED failures (ctx timeout/cancel, 5xx, transport, panic) | **0**. Non-zero = a real hole; these ARE re-enqueued |
-| `snowplow_phase1_widget_seed_failure_total` (`:203`) | `map["cohort\|name\|gvr"→uint64]` — which widget broke which cohort | pinpoints a per-widget per-cohort seed failure |
-| `snowplow_phase1_restaction_seed_failure_total` (`:211`) | `map["cohort\|namespace/name"→uint64]` — same for RESTActions | pinpoints a per-RESTAction per-cohort seed failure |
+| `snowplow_phase1_bindingset_seed_resolves_total` | `uint64` — seed UNITS resolved + written to per-binding L1 | climbs during seed; `0` after boot means no seed unit was written |
+| `snowplow_phase1_bindingset_seed_failures_total` | `uint64` — grand-total seed failures (= rbac_deny + operational; back-compat) | interpret via the split below |
+| `snowplow_phase1_seed_rbac_deny_total` | `uint64` — EXPECTED narrow-RBAC denies; cohort genuinely can't read the target | non-zero is **normal**; not re-enqueued |
+| `snowplow_phase1_seed_operational_fail_total` | `uint64` — UNEXPECTED failures (ctx timeout/cancel, 5xx, transport, panic) | **0**. Non-zero = a real hole; these ARE re-enqueued |
+| `snowplow_phase1_seed_fresh_skip_total` | `uint64` — seed units skipped because the cell is still fresh (boot-resume / keepwarm passes) | evidence the resume/sweep is incremental, not redundant |
+| `snowplow_phase1_keepwarm_age_skip_total` | `uint64` — keepwarm sweep age-skips (cell young enough) | climbs with sweeps over a warm store |
+| `snowplow_phase1_seed_skipped_stage_error_total` | `uint64` — seed Puts declined by the error-aware Put-gate | low; a climb = a systematically-degraded seed target |
+| `snowplow_phase1_widget_seed_failure_total` / `snowplow_phase1_restaction_seed_failure_total` | per-cohort×object failure maps | pinpoint which widget/RA broke which cohort |
+| `snowplow_resolved_cache_hits_seed_attributable` | hits on cells the seed wrote (seed attribution) | the seed-is-actually-useful signal |
 
 ### Refresher — background re-resolve worker pool
 Defined in `internal/cache/refresher_metrics.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_refresher_enqueue_total` (`:67`) | `uint64` — re-resolve tasks enqueued | climbs with CRUD churn |
-| `snowplow_refresher_completed_total` (`:70`) | `uint64` — tasks completed | tracks enqueue under steady state |
-| `snowplow_refresher_failed_total` (`:73`) | `uint64` — tasks failed | low/stable |
-| `snowplow_refresher_retried_total` (`:76`) | `uint64` — tasks retried | low |
-| `snowplow_refresher_dropped_total` (`:79`) | `uint64` — tasks dropped | low |
-| `snowplow_refresher_skipped_no_entry_total` (`:82`) | `uint64` — skipped, no L1 entry to refresh | informational |
-| `snowplow_refresher_skipped_no_handler_total` (`:85`) | `uint64` — skipped, no handler | informational |
-| `snowplow_refresher_skipped_stage_error_total` (`:88`) | `uint64` — skipped due to stage error | low |
-| `snowplow_refresher_queue_depth` (`:95`) | live workqueue `Len()` | near 0; climbing depth with stagnant `completed_total` = workers stuck (back-pressure) |
-| `snowplow_refresher_yielded_total` (`:111`) | `uint64` — worker yield-parked for a customer `/call` | >0 under customer burst (if 0, hook broken) |
-| `snowplow_refresher_capped_total` (`:114`) | `uint64` — yield max-parked cap fired (proceeded anyway) | **near 0**; steady climb = inflight counter leaking or sustained pressure |
-| `snowplow_refresher_floored_total` (`:126`) | `uint64` — dequeue rate-floor deferred a key (entry younger than floor) | >0 under install-churn storm = the floor gate is protecting against re-resolve storms |
+| `snowplow_refresher_enqueue_total` / `_completed_total` / `_failed_total` / `_retried_total` / `_dropped_total` | task lifecycle counters | completed tracks enqueue under steady state; failed/retried/dropped low |
+| `snowplow_refresher_skipped_no_entry_total` / `_skipped_no_handler_total` / `_skipped_stage_error_total` | skip reasons | informational |
+| `snowplow_refresher_queue_depth` | live workqueue `Len()` | near 0; climbing depth with stagnant `completed_total` = workers stuck (back-pressure) |
+| `snowplow_refresher_yielded_total` | worker yield-parked for a customer `/call` | >0 under customer burst (if 0, hook broken) |
+| `snowplow_refresher_capped_total` | yield max-parked cap fired (proceeded anyway) | **near 0**; steady climb = inflight counter leaking or sustained pressure |
+| `snowplow_refresher_floored_total` | dequeue rate-floor deferred a key (entry younger than floor) | >0 under install-churn storm = the floor gate is protecting against re-resolve storms |
+
+### Live refresh (SSE)
+Defined in `internal/cache/refresh_broadcaster_expvar.go`.
+
+| expvar | meaning | healthy range |
+|---|---|---|
+| `snowplow_refresh_broadcaster` | broadcaster counter snapshot (publishes, deliveries, subscriber counts, drops) | drops near 0; publishes track L1 commits under churn |
 
 ### RBAC snapshot + authz memo — subject-index freshness and serve-time eval cache
+
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_rbac_publish_seq` (`internal/cache/rbac_snapshot_expvar.go:54`) | `uint64` — incremented once per successful RBAC-snapshot publish | bumps within ~30s of a RoleBinding ADD/DELETE; `0` = no snapshot published (cache-off or pre-readiness) |
-| `snowplow_authz_memo_hits` (`internal/rbac/snapshot_authz_memo.go:236`) | `uint64` — authz-memo hits | hit rate = hits/(hits+misses); target ≥0.85 warm |
-| `snowplow_authz_memo_misses` (`:237`) | `uint64` — authz-memo misses | — |
-| `snowplow_authz_memo_swaps` (`:238`) | `uint64` — generation shard swaps | bumps on RBAC-snapshot generation change |
-| `snowplow_authz_memo_refused` (`:239`) | `uint64` — cap-breach refused inserts | low; sustained climb = memo cap pressure |
-| `snowplow_authz_memo_entries` (`:240`) | `int` — live entry count of the current shard | bounded by cap |
-| `snowplow_authz_memo_deny_uncached_total` (`:242`) | `uint64` — denies (never cached) | informational; denies are deliberately not memoized |
+| `snowplow_rbac_publish_seq` (`internal/cache/rbac_snapshot_expvar.go`) | `uint64` — incremented once per successful RBAC-snapshot publish (also the point per-subject sub-generation bumps land) | bumps within ~30s of a RoleBinding ADD/DELETE; `0` = no snapshot published (cache-off or pre-readiness) |
+| `snowplow_authz_memo_hits` / `_misses` / `_swaps` / `_refused` / `_entries` (`internal/rbac/snapshot_authz_memo.go` via `RegisterAuthzMemoExpvar`) | memo hit/miss, generation shard swaps, cap-breach refusals, live entry count | hit rate ≥0.85 warm; swaps bump on snapshot generation change; refused low |
+| `snowplow_authz_memo_deny_uncached_total` | `uint64` — denies (never cached, by design) | informational; should be > 0 and rising on a live cluster — a flat 0 with denied traffic would suggest the PERMITS-only rule regressed |
 
 ### Informer / discovery surface
+
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_plurals_registered_gvrs` (`internal/cache/registered_gvrs_expvar.go:97`) | `{count, gvrs:[group/version/resource…], last_register_unix_ns}` — live set of GVRs with a registered informer | `count` tracks the cluster's served GVR set (~≤50); two scrapes with identical `last_register_unix_ns` = informer set quiesced |
-| `snowplow_crd_discovery` (`internal/cache/crd_discovery_expvar.go:51`) | `map{events_enqueued, events_dropped, events_processed, discovery_invoked, discovery_skipped_ng, deletes_processed, delete_skipped_ng, panics_recovered}` | `events_dropped`/`*_skipped_ng`/`panics_recovered` should be **0** on a healthy cluster — a non-zero `discovery_skipped_ng` is a flashing red flag (silent-skip defect class) |
-| `snowplow_crd_schema_memo_hits_total` (`internal/resolvers/crds/schema/schema_cache_metrics.go:59`) | `uint64` — compiled-CRD-schema memo hits | high hit ratio warm |
-| `snowplow_crd_schema_memo_misses_total` (`:62`) | `uint64` — memo misses | — |
-| `snowplow_crd_schema_memo_stale_dropped_total` (`:70`) | `uint64` — generation-fence drops (CRD lifecycle moved gen during GET+compile) | expected under concurrent CRD install; steady climb without installs = generation churn |
-| `snowplow_crd_schema_memo_invalidations_total` (`:78`) | `uint64` — full-reset count (CRD-lifecycle bridge clears) | bumps on CRD lifecycle events |
-| `snowplow_sa_discovery_builds_total` (`internal/dynamic/cached_client_metrics.go:59`) | `uint64` — SA-discovery client builds | informational |
-| `snowplow_sa_discovery_invalidations_total` (`:62`) | `uint64` — SA-discovery cache invalidations | informational |
-| `snowplow_sa_discovery_fallbacks_total` (`:65`) | `uint64` — SA-discovery fallbacks | low; climb = discovery degrading to fallback |
+| `snowplow_plurals_registered_gvrs` (`internal/cache/registered_gvrs_expvar.go`) | `{count, gvrs:[…], last_register_unix_ns}` — live set of GVRs with a registered informer | `count` tracks the cluster's served GVR set; two scrapes with identical `last_register_unix_ns` = informer set quiesced |
+| `snowplow_crd_discovery` (`internal/cache/crd_discovery_expvar.go`) | `map{events_enqueued, events_dropped, events_processed, discovery_invoked, discovery_skipped_ng, deletes_processed, delete_skipped_ng, panics_recovered}` | `events_dropped`/`*_skipped_ng`/`panics_recovered` should be **0** — a non-zero `discovery_skipped_ng` is a flashing red flag (silent-skip defect class) |
+| `snowplow_crd_schema_memo_hits_total` / `_misses_total` / `_stale_dropped_total` / `_invalidations_total` (`internal/resolvers/crds/schema/schema_cache_metrics.go`) | compiled-CRD-schema memo counters | high hit ratio warm; stale-drops expected under concurrent CRD install |
+| `snowplow_sa_discovery_builds_total` / `_invalidations_total` / `_fallbacks_total` (`internal/dynamic/cached_client_metrics.go`) | SA-discovery client lifecycle | fallbacks low; climb = discovery degrading |
 
 ### Upstream controller health — "is snowplow broken, or is an upstream controller crash-looping?"
-Defined in `internal/cache/controller_health_expvar.go`; entry shapes in `internal/cache/controller_health.go:78-94`.
+Defined in `internal/cache/controller_health_expvar.go` / `controller_health.go`.
 
 | expvar | meaning | healthy range |
 |---|---|---|
-| `snowplow_upstream_controller_health` (`:58`) | `map["<ns>/<name>"→{Healthy, Reason, PodRestartCount, EndpointReadyCount, Namespace, Name, LastObserved}]` for auto-discovered controllers | every entry `Healthy=1`, `Reason=""`. `Reason` enum (`controller_health.go:108-114`): `pod-restart-within-window`, `endpoints-zero-ready`, `both`, `unwired` |
-| `snowplow_upstream_webhook_failurepolicy` (`:59`) | `map["<webhookName>"→{Policy:"Fail"/"Ignore", Configuration, Type:"Mutating"/"Validating"}]` | a `Fail`-policy webhook on a crash-looping controller explains apiserver pressure / write hangs |
+| `snowplow_upstream_controller_health` | `map["<ns>/<name>"→{Healthy, Reason, PodRestartCount, EndpointReadyCount, …}]` for auto-discovered controllers | every entry `Healthy=1`, `Reason=""`. `Reason` enum: `pod-restart-within-window`, `endpoints-zero-ready`, `both`, `unwired` |
+| `snowplow_upstream_webhook_failurepolicy` | `map["<webhookName>"→{Policy:"Fail"/"Ignore", Configuration, Type}]` | a `Fail`-policy webhook on a crash-looping controller explains apiserver pressure / write hangs |
 
 ---
 
@@ -158,32 +205,37 @@ operator-notable ones:
 
 | Event (message) | Level | Site | What it tells an operator |
 |---|---|---|---|
-| `phase1.warmup.completed` | Info | `internal/handlers/dispatchers/phase1_walk.go:818` | the prewarm walk finished — the boundary `/readyz` and `snowplow_prewarm_complete` track; carries the elapsed and counts |
-| `cache.prewarm.completed` | Info | `internal/cache/prewarm.go:168` | the cache-side prewarm seed finished |
-| `prewarm.engine.boot.complete` / `.started` | Info | `internal/handlers/dispatchers/` (prewarm engine) | engine boot lifecycle |
-| `phase1.seed.cohort.operational_failure` | (failure) | dispatchers phase1 seed | a cohort hit an UNEXPECTED seed failure — pairs with `snowplow_phase1_seed_operational_fail_total`; actionable |
-| `phase1.seed.cohort.expected_deny` | (info) | dispatchers phase1 seed | EXPECTED narrow-RBAC deny — normal, pairs with `snowplow_phase1_seed_rbac_deny_total` |
-| `phase1.walk.apiref_pagination.backstop_hit` | Warn | `internal/handlers/dispatchers/phase1_walk_pagination.go:597` | a widget's apiRef pagination hit the anti-runaway page ceiling — coverage may be capped |
-| `apiserver_fallthrough` | Warn | `internal/cache/fallthrough_meter.go:359` | a read punted to the apiserver — the log companion to `snowplow_apiserver_fallthrough_total`; includes path/gvr/reason |
-| `cache.read_paths_scoped.violation` | Error | `internal/cache/fallthrough_assert.go:123` | architectural invariant breach — a `/call` route is not scope-wrapped; bumps `snowplow_assertion_violations_total{check="read_paths_scoped"}` |
-| `cache.serve_requires_servable.violation` | Error | `internal/cache/serve_assert.go` | **P1** invariant breach — a cache HIT was about to be served from a not-servable informer; bumps `snowplow_assertion_violations_total{check="serve_requires_servable"}` (names the gvr + serve_path) |
-| `cache.bindings_by_gvr.delta_skipped_non_typed` | Warn | `internal/cache/bindings_by_gvr_delta.go:117` | an index delta event was dropped — index is drifting; pairs with the same-named expvar |
-| `cache.crd_discovery.event_dropped` | Warn | `internal/cache/crd_discovery_side_effect.go:253` | a CRD-discovery event was dropped (queue full / shutdown); pairs with `snowplow_crd_discovery.events_dropped` |
-| `cache.controller_health.watch.broken` | Warn | `internal/cache/controller_health.go:369` | an upstream controller-health watch broke — the health gauge may go stale |
+| `phase1.warmup.completed` | Info | `dispatchers/phase1_walk.go` | the prewarm walk finished — the boundary `/readyz` and `snowplow_prewarm_complete` track |
+| `phase1.warmup.roots_list_failed` | Warn | `dispatchers/phase1_walk.go` | the frontend config-vars ConfigMap was absent at boot; the config-vars informer will re-drive a boot re-walk when it lands (self-heal, no restart) |
+| `readyz.backstop.fired` | Error | `dispatchers/readiness_backstop_metrics.go` | readiness flipped **Ready-degraded** via a backstop arm (reason attached); pairs with `snowplow_readyz_backstop_fired` — alert |
+| `phase1.seed.sync_incomplete` / `phase1.seed.panic` | Warn / Error | `dispatchers/phase1_walk.go` | the synchronous boot seed erred/panicked; readiness still flipped (backstop) with cold cells |
+| `phase1.seed.cohort.operational_failure` | Warn+ | dispatchers phase1 seed | a cohort hit an UNEXPECTED seed failure — pairs with `snowplow_phase1_seed_operational_fail_total`; actionable |
+| `phase1.seed.cohort.expected_deny` | Info | dispatchers phase1 seed | EXPECTED narrow-RBAC deny — normal, pairs with `snowplow_phase1_seed_rbac_deny_total` |
+| `phase1.walk.apiref_pagination.backstop_hit` | Warn | `dispatchers/phase1_walk_pagination.go` | a widget's apiRef pagination hit the anti-runaway page ceiling — coverage may be capped |
+| `apiserver_fallthrough` | Warn | `internal/cache/fallthrough_meter.go` | a read punted to the apiserver — the log companion to `snowplow_apiserver_fallthrough_total`; includes path/gvr/reason |
+| `cache.read_paths_scoped.violation` | Error | `internal/cache/fallthrough_assert.go` | architectural invariant breach — a `/call` route is not scope-wrapped |
+| `cache.serve_requires_servable.violation` | Error | `internal/cache/serve_assert.go` | **P1** invariant breach — a cache HIT was about to be served from a not-servable informer (names the gvr + serve_path) |
+| `cache.bindings_by_gvr.delta_skipped_non_typed` | Warn | `internal/cache/bindings_by_gvr_delta.go` | an index delta event was dropped — index is drifting; pairs with the same-named expvar |
+| `cache.crd_discovery.event_dropped` | Warn | `internal/cache/crd_discovery_side_effect.go` | a CRD-discovery event was dropped (queue full / shutdown) |
+| `cache.controller_health.watch.broken` | Warn | `internal/cache/controller_health.go` | an upstream controller-health watch broke — the health gauge may go stale |
 | `cache.rbac.snapshot.published` | Info | `internal/cache/` rbac snapshot | a new RBAC subject-index snapshot published; pairs with `snowplow_rbac_publish_seq` |
-| `cache.secrets.informer.assertion_violation` | Error | `internal/cache/secrets_informer.go:377,392` | secrets-informer invariant breach |
+| `config.retired_flag_ignored` | Warn/Info | `internal/cache/retired_flags.go` | a retired prewarm/pivot env var is still set; Warn when the value is `false` (a silent behavior change the operator did not consent to — the flag is implicit-on-cache now) |
+| `dispatcher.call.complete` | Info | `dispatchers/per_call_log.go` | per-dispatch structured timing (the per-call diagnostic) |
+| `cache.secrets.informer.assertion_violation` | Error | `internal/cache/secrets_informer.go` | secrets-informer invariant breach |
 
-There are many more dotted events in the `phase1.*`, `prewarm.engine.*`, `cache.crd_discovery.*`,
-`cache.rbac.snapshot.*`, and `cache.discovery.*` families (full set is greppable with
-`grep -rhoE '"(phase1|prewarm|cache)\.[a-z_.]+"' internal main.go`); the table above lists the
-ones that map to an alarm-worthy condition or pair directly with an expvar.
+There are many more dotted events in the `phase1.*`, `prewarm.engine.*`,
+`cache.crd_discovery.*`, `cache.rbac.snapshot.*`, and `cache.discovery.*`
+families (full set is greppable with
+`grep -rhoE '"(phase1|prewarm|cache)\.[a-z_.]+"' internal main.go`); the table
+above lists the ones that map to an alarm-worthy condition or pair directly
+with an expvar.
 
 ---
 
 ## pprof
 
-Registered on the custom server mux (the server does **not** use `http.DefaultServeMux`),
-`main.go:837-841`:
+Registered on the custom server mux (the server does **not** use
+`http.DefaultServeMux`), `main.go`:
 
 | Path | Profile |
 |---|---|
@@ -193,9 +245,8 @@ Registered on the custom server mux (the server does **not** use `http.DefaultSe
 | `GET /debug/pprof/symbol` | symbol lookup |
 | `GET /debug/pprof/trace` | execution trace |
 
-The index path also serves the goroutine/heap/allocs/mutex/block/threadcreate sub-profiles (the
-comment at `main.go:836` enumerates them). `main.go:101` notes mutex + block profiling fractions
-are set at startup so `/debug/pprof/mutex` and `/debug/pprof/block` return non-empty data.
+Mutex + block profiling fractions are set at startup so `/debug/pprof/mutex`
+and `/debug/pprof/block` return non-empty data.
 
 Typical use:
 
@@ -205,15 +256,24 @@ go tool pprof http://<pod>:<port>/debug/pprof/profile       # CPU (30s)
 curl http://<pod>:<port>/debug/pprof/goroutine?debug=2      # goroutine dump (deadlock/leak)
 ```
 
+Note: responses are gzip-compressed only when the client sends
+`Accept-Encoding: gzip` (the `gzhttp` wrapper); plain `curl` diagnostics are
+byte-identical to pre-compression behaviour, and the SSE routes are excluded
+from compression buffering.
+
 ---
 
-## Notes / discrepancies vs. the documentation plan
+## Notes / discrepancies vs. earlier revisions
 
-- The plan (§4 / §3) names a single `observability.md`; this is it. The expvar/event tables
-  above are built from the code, not from prose.
-- The plan's `ARCHITECTURE.md` trace-anchor list (§4) cites `/debug/vars` only and does not
-  enumerate the expvars — that enumeration is this document.
-- Several phase-1 seed expvars referenced in older notes (`snowplow_phase1_seed_restactions_total`,
-  `snowplow_phase1_seed_widgets_total` and their `_by_cohort` maps; the binding-set
-  classes / powerset-skipped counters) were **deleted** as always-zero in production and are
-  intentionally NOT in the code today (`phase1_pip_metrics.go:156-180`) — they are excluded here.
+- Several phase-1 seed expvars referenced in older notes
+  (`snowplow_phase1_seed_restactions_total`, `snowplow_phase1_seed_widgets_total`
+  and their `_by_cohort` maps; the binding-set classes / powerset-skipped
+  counters; the cohort_seed_status gauge) were **deleted** as always-zero or
+  orphaned and are intentionally NOT in the code today — they are excluded
+  here.
+- An earlier revision of this doc claimed the chart wires the startupProbe to
+  `/readyz`; the chart actually points **startupProbe → `/health`** (with a
+  long failure budget) and only the readinessProbe at `/readyz`.
+- The observability surface used to be expvar/slog/pprof only; the OTel export
+  (traces + expvar-mirror metrics + log/audit bridge) is additive and
+  default-off — enabling it changes no expvar semantics.

--- a/go/snowplow/docs/architecture/prewarm.md
+++ b/go/snowplow/docs/architecture/prewarm.md
@@ -1,13 +1,22 @@
+---
+type: Architecture
+title: snowplow — prewarm
+description: How snowplow makes the first page-load warm — the Phase-1 navigation walk, the sync barrier, the prewarm-gated readiness, the dynamic per-binding seed, and the steady-state keepwarm/refresh mechanisms.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [prewarm, boot, readiness, seed, cohort]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Prewarm
 
 How snowplow makes the *first* page-load warm: it replays the frontend's own
 navigation under the service-account identity at boot, populates the informer
-set and the per-user L1 cache, and keeps those cells fresh as objects change —
+set and the per-binding L1 cache, and keeps those cells fresh as objects change —
 without ever hardcoding a navigation path, a cohort list, or a GVR.
 
 This is a maintainer deep-dive. It leads with the flow, then traces the named
-files at `file:line`, then states the invariants and the known failure modes.
-Every claim below is verified against the tree at commit `a42b072`.
+files, then states the invariants and the known failure modes. Re-derived from
+the current tree (docs-standard, 2026-08-06); anchors are file + function names.
 
 ---
 
@@ -17,33 +26,43 @@ Every claim below is verified against the tree at commit `a42b072`.
  BOOT (Phase1Warmup → phase1WarmupWith, internal/handlers/dispatchers/phase1_walk.go)
  ┌──────────────────────────────────────────────────────────────────────────────┐
  │ Step 1  RegisterMetaQuerySeeds()           ── the ONLY hardcoded GVRs at boot  │
- │           (cache/phase1.go:277 — bare meta-query anchors, no business GVR)     │
+ │           (cache/phase1.go — bare meta-query anchors, no business GVR)         │
  │ Step 3  lister(ctx)  ── READ nav roots from the frontend ConfigMap            │
  │           config.json .api.INIT + .api.ROUTES_LOADER → 2 widget CRs           │
- │           (phase1_roots.go:125 listNavigationRootsFromConfigMap)              │
+ │           (phase1_roots.go listNavigationRootsFromConfigMap)                  │
+ │           roots missing? LOG + PROCEED — the config-vars ConfigMap informer   │
+ │           (phase1_configvars_watch.go) re-drives a boot re-walk when it lands │
  │ Step 4  for each root:  resolveNavigationRoot → phase1Walker.walk()           │
- │           recursive replay of frontend nav (phase1_walk.go:1116)              │
+ │           recursive replay of frontend nav (phase1_walk.go)                   │
  │             • harvestApiRef + harvestNavWidget on every walked widget         │
  │             • widgets.Resolve → status.resourcesRefs.items[]                  │
- │             • recurse ONLY items where verb=="GET"  (walkShouldRecurse,       │
- │               phase1_walk.go:1480) — load-bearing read-only gate              │
+ │             • recurse ONLY items where verb=="GET"  (walkShouldRecurse)       │
+ │               — load-bearing read-only gate                                   │
  │             • lazyRegister + DiscoverGroupResources register informers        │
  │ Step 6  settleRegisteredSet  ── let the discovered informer set stop growing  │
- │ Step 7  WaitAllInformersSynced  ── the SYNC BARRIER (cache/phase1.go:297)     │
+ │ Step 7  WaitAllInformersSynced  ── the SYNC BARRIER (cache/phase1.go)         │
  │ Step 7.5 content pre-warm + cluster_list pre-warm   (behind 503 readiness)    │
- │ Step 8  MarkPhase1Done()        ── /readyz flips 200 (phase1_walk.go:720)     │
+ │ Step 7.6 ENGINE BOOT SEED — SYNCHRONOUS, before readiness:                    │
+ │           StartPrewarmEngine → scopeKindBoot → rePrewarmBoot                  │
+ │             ① RE-WALK both roots, FRESH visited map, AFTER the sync barrier   │
+ │             ② settleRegisteredSet  ③ BuildBindingsByGVRIndex                  │
+ │             ④ seedScopeYielding: rank-major, class-interleaved per-binding    │
+ │                seed from the live index, yielding to customer /call           │
+ │           /readyz unblocks on the FIRST of:                                   │
+ │             • firstNav latch — every cohort's NAV WIDGETS warm (happy path)   │
+ │             • bootDone (early end) / pipGlobalTimeout / PHASE1_TIMEOUT        │
+ │               → Ready-DEGRADED backstop (snowplow_readyz_backstop_fired)      │
+ │ Step 8  MarkPhase1Done()        ── /readyz flips 200 (deferred, fire-         │
+ │           regardless: normal return, error, timeout, even seed panic)         │
+ │ Step 7.7 apiRef pagination drain (background, post-Ready)                     │
  └───────────────────────────────────────────────┬──────────────────────────────┘
                                                   │  (BACKGROUND, post-Ready)
                                                   ▼
- SEED — one of two paths (PREWARM_ENGINE_ENABLED selects):
-   ┌─ engine (default-off flag ON)  ─ StartPrewarmEngine → worker → rePrewarmBoot
-   │     ① RE-WALK both roots, FRESH visited map, AFTER the sync barrier
-   │        (so the dynamic navmenu children — empty pre-sync — are now present)
-   │     ② settleRegisteredSet  ③ BuildBindingsByGVRIndex over navigated GVRs
-   │     ④ seedScopeYielding: per-binding TARGETS from the live index
-   │        (cache.EnumeratePrewarmTargetsForGVR), seeds per-user L1 cells,
-   │        yields to in-flight customer /call between every target
-   └─ legacy runPIPSeed (flag OFF) ─ same harvested set, global cohort enumeration
+ ENGINE (implicit-on-cache; worker outlives boot on the process-lifetime ctx):
+   scopeKindBoot           ─ boot seed + any config-vars-driven re-drive
+   scopeKindGVRDiscovered  ─ new GVR registered post-boot → re-walk + seed
+   scopeKindKeepwarm       ─ TTL×3/4-cadenced quiet-page re-seed sweep
+   (scopeKindWidgetCR / scopeKindRBACShift: declared, still NOT wired)
 
  COHORT MODEL: one dynamic engine. Targets come from the LIVE BindingsByGVR
    index per (GVR, verb) — NO static cohort list, and when the index yields
@@ -55,69 +74,81 @@ Every claim below is verified against the tree at commit `a42b072`.
                           → refresher RE-RESOLVES (never evicts)
    informer DELETE     ─ self entry evicted; LIST/dependent deps dirty-marked
    new GVR discovered  ─ cache GVR-discovered hook → engine scopeKindGVRDiscovered
-                          → rePrewarmBoot re-walk (records the new dep edge)
+   quiet cells         ─ keepwarm sweep re-Puts before TTL expiry
 ```
 
 ---
 
 ## Trace
 
+### One knob: the whole prewarm family is implicit-on-cache
+
+There is **no prewarm env flag any more**. The formerly-standalone gates —
+`PREWARM_ENABLED`, `PREWARM_CONTENT_ENABLED`, `PREWARM_PIP_ENABLED`,
+`PREWARM_ENGINE_ENABLED`, `PROACTIVE_RA_SEED_ENABLED` — are **retired**: each
+helper now returns `cache.PrewarmEnabled()` (== cache on), and a stale value in
+the environment is ignored with a one-shot audit log (`cache/retired_flags.go`;
+`=false` logs a WARN because the operator asked for OFF and now gets ON).
+The legacy `runPIPSeed` global-cohort seed path is **deleted**
+(`prewarm_engine_boot.go`); the engine is the only seed path. Back-out for the
+whole family is `CACHE_ENABLED=false`, which nils the harvesters and makes the
+walk/seed a no-op.
+
 ### Boot seed — the only hardcoded GVRs
 
-`phase1WarmupWith` (`internal/handlers/dispatchers/phase1_walk.go:594`) is the
-boot orchestrator. **Step 1** is the entire "boot seed":
-`rw.RegisterMetaQuerySeeds()` (`phase1_walk.go:605`). That call
-(`internal/cache/phase1.go:277`) registers only `MetaQuerySeeds()` —
-described in its own log line as *"bare meta-query anchors only — every business
-GVR is discovered by resolution"* (`cache/phase1.go:292`). Ship 0/0.5
-(`phase1_walk.go:598-616`) deleted the `customresourcedefinitions` seed and the
-CRD informer entirely; composition GVRs are now discovered as a synchronous
-side-effect of the walk (`cache.DiscoverGroupResources`), not pre-seeded.
+`phase1WarmupWith` (`internal/handlers/dispatchers/phase1_walk.go`) is the boot
+orchestrator. **Step 1** is the entire "boot seed": `rw.RegisterMetaQuerySeeds()`
+(`internal/cache/phase1.go`) registers only the bare meta-query anchors —
+*"every business GVR is discovered by resolution"*. Ship 0/0.5 deleted the
+`customresourcedefinitions` seed and the CRD informer entirely; composition
+GVRs are discovered as a synchronous side-effect of the walk
+(`cache.DiscoverGroupResources`), not pre-seeded.
 
 ### Phase-1 walker roots — read from the frontend ConfigMap, not hardcoded
 
-The roots are NOT `navmenus` / `routesloaders` literals. **Step 3**
-(`phase1_walk.go:621`) calls the lister, which is
-`listNavigationRootsFromConfigMap` (`phase1_roots.go:125`). It:
+The roots are NOT `navmenus` / `routesloaders` literals. **Step 3** calls the
+lister, which is `listNavigationRootsFromConfigMap` (`phase1_roots.go`). It:
 
 1. Reads the frontend ConfigMap — name from env `FRONTEND_CONFIG_CONFIGMAP`
-   (default `frontend-config-vars`, `phase1_roots.go:66-71,101-106`), namespace
-   = `AUTHN_NAMESPACE` (`phase1_walk.go:333`).
-2. Parses its `config.json` key into `frontendConfig`, reading the two fields
-   `.api.INIT` and `.api.ROUTES_LOADER` (`phase1_roots.go:90-95`,
-   `readFrontendConfig` at `:235`). These are the two `/call?...` URLs the
-   frontend itself dispatches on login.
+   (default `frontend-config-vars`), namespace = `AUTHN_NAMESPACE`.
+2. Parses its `config.json` key, reading `.api.INIT` and `.api.ROUTES_LOADER` —
+   the two `/call?...` URLs the frontend itself dispatches on login.
 3. Decodes each URL into an `ObjectReference` via
-   `objects.ParseCallPathToObjectRef` (`phase1_roots.go:166`) — the same generic
-   `/call` decoder the recursive walk uses; not a path special-case.
+   `objects.ParseCallPathToObjectRef` — the same generic `/call` decoder the
+   recursive walk uses; not a path special-case.
 4. Fetches each named root widget CR via `objects.Get` and returns
-   `navigationRoot{Root, GVR}` pairs (`phase1_roots.go:208-230`).
+   `navigationRoot{Root, GVR}` pairs.
 
 The strings `navmenus`/`routesloaders` appear **nowhere** as Go literals driving
-root selection (`phase1_roots.go:24-27`). If the frontend changes its INIT
-widget, Phase 1 follows with zero Go change. A missing/unparseable ConfigMap is
-**degraded, not fatal**: it returns an error, and the warmup still runs the sync
-barrier and flips readiness (`phase1_walk.go:622-633`) — lazy
-register-on-navigation covers every GVR on the first real request.
+root selection. If the frontend changes its INIT widget, Phase 1 follows with
+zero Go change.
+
+**A missing ConfigMap is self-healing, not just degraded.** When snowplow boots
+before the frontend (fresh-install boot race), the eager read finds nothing; the
+warmup logs `phase1.warmup.roots_list_failed`, proceeds through the sync barrier
+and the normal readiness flip — and a dedicated single-object ConfigMap informer
+(`phase1_configvars_watch.go`, registered on the process-lifetime ctx) enqueues
+a `scopeKindBoot` re-walk the instant the ConfigMap appears or its
+`config.json` data changes (a data-change gate ignores metadata-only churn such
+as CDC traceparent re-stamps). The re-drive works before OR after the readiness
+backstop, with zero pod restart.
 
 ### The recursive walk — replaying navigation, GET-only
 
-**Step 4** (`phase1_walk.go:640-666`) calls `resolve(ctx, root)` per root, which
-threads into `phase1Walker.walk()` (`phase1_walk.go:1116`). Per walked widget:
+**Step 4** calls `resolve(ctx, root)` per root, which threads into
+`phase1Walker.walk()` (`phase1_walk.go`). Per walked widget:
 
-- `harvestApiRef(in)` + `harvestNavWidget(in, gvr, …)` collect the widget's
-  apiRef RESTAction and the widget CR + its (GVR, pagination) tuple into the two
-  shared harvesters the seed later drains (`phase1_walk.go:1138,1152`).
+- `harvestApiRef` + `harvestNavWidget` collect the widget's apiRef RESTAction
+  and the widget CR + its (GVR, pagination) tuple into the shared harvesters the
+  engine seed later drains.
 - `widgets.Resolve` runs the widget under the SA identity; its inner-call walk
   auto-registers an informer per touched GVR and invokes
-  `cache.DiscoverGroupResources` for templated apiserver paths
-  (`phase1_walk.go:1201-1207`, Step-4 comment `:640-644`).
-- It reads `status.resourcesRefs.items[]` — the child widget endpoints —
-  via `extractResourcesRefsItems` (`phase1_walk.go:1287,1489`).
+  `cache.DiscoverGroupResources` for templated apiserver paths.
+- It reads `status.resourcesRefs.items[]` — the child widget endpoints — via
+  `extractResourcesRefsItems`.
 
 **The recursion gate is `verb == "GET"` only.** Before descending into a child,
-the loop calls `walkShouldRecurse(child)` (`phase1_walk.go:1331`), which is
-exactly:
+the loop calls `walkShouldRecurse(child)`, which is exactly:
 
 ```go
 func walkShouldRecurse(child navChildRef) bool {
@@ -125,191 +156,235 @@ func walkShouldRecurse(child navChildRef) bool {
 }
 ```
 
-(`phase1_walk.go:1480-1482`). This is load-bearing for both correctness and
-safety (`phase1_walk.go:1426-1435`): a non-GET `resourcesRefs` item is a
-mutation/action endpoint (POST/PUT/PATCH/DELETE) bound to a widget's `actions`,
-and because the walk runs with the SA's *privileged* credentials, following one
-would issue a destructive apiserver mutation. The `allowed` RBAC flag is
-**deliberately not** a recursion gate (`phase1_walk.go:1437-1467`): Phase 1 is
-identity-independent informer *discovery*; the per-user `allowed` render gate is
-applied later, at real request time. Recursion bounds are only the visited-set
-(`phase1_walk.go:1342-1350`) and `phase1MaxWalkDepth` (`:1124`); child fan-out is
-bounded by the declared `slice` or `prewarmPageLimit()` (`:1367`).
+This is load-bearing for both correctness and safety: a non-GET
+`resourcesRefs` item is a mutation/action endpoint (POST/PUT/PATCH/DELETE)
+bound to a widget's `actions`, and because the walk runs with the SA's
+*privileged* credentials, following one would issue a destructive apiserver
+mutation. The `allowed` RBAC flag is **deliberately not** a recursion gate:
+Phase 1 is identity-independent informer *discovery*; the per-user `allowed`
+render gate is applied later, at real request time. Recursion bounds are the
+visited-set and `phase1MaxWalkDepth`; child fan-out is bounded by the declared
+`slice` or `prewarmPageLimit()`.
 
-### The sync barrier and readiness
+### The sync barrier
 
-After the walk, `settleRegisteredSet` (Step 6, `phase1_walk.go:681`) waits for
-the discovered informer set to stop growing, then `WaitAllInformersSynced`
-(Step 7, `phase1_walk.go:686` → `cache/phase1.go:297`) blocks until every
-registered informer `HasSynced` AND no new informer appeared during the wait
-(the re-snapshot loop, `cache/phase1.go:306-319`). `MarkPhase1Done()`
-(Step 8, `phase1_walk.go:720`) flips `/readyz` to 200 — *before* the per-cohort
-seed, so boot wall-clock is cohort-count-independent (`phase1_walk.go:710-720`).
+After the walk, `settleRegisteredSet` (Step 6) waits for the discovered
+informer set to stop growing, then `WaitAllInformersSynced` (Step 7,
+`cache/phase1.go`) blocks until every registered informer `HasSynced` AND no
+new informer appeared during the wait (the re-snapshot loop).
 
-### The seed — one dynamic engine
+### Readiness gates on prewarm-complete (the 2026-07-02 reversal)
 
-The seed runs **after** `MarkPhase1Done`, on a bounded background goroutine
-(`phase1_walk.go:739-762`), and never withholds readiness. Two implementations,
-selected by `PREWARM_ENGINE_ENABLED` (default `"false"`,
-`prewarm_engine.go:76-83`); the flag is the documented one-knob back-out
-(`phase1_walk.go:477-484`).
+This is the part that **reversed** relative to older revisions of this doc.
+The per-cohort seed used to run in the background *after* `MarkPhase1Done`
+("readiness precedes the seed; boot is cohort-count-independent"). Empirically,
+an informer-synced-but-cold pod serializes/503s the compositions-page fan-out
+under the aggregate-OOM admission gate — "synced ≠ safe to route". So the seed
+now runs **synchronously at Step 7.6, before `MarkPhase1Done`** (shape A,
+`docs/readiness-gate-prewarm-complete-2026-07-02.md`), and `/readyz` gates on
+prewarm-complete:
 
-When the engine is on (and the PIP harvesters exist), `engineSeed`
-(`phase1_walk.go:419-474`) calls `StartPrewarmEngine`
-(`prewarm_engine.go:317`) and enqueues exactly one `scopeKindBoot`
-(`phase1_walk.go:455`). The worker (`prewarm_engine.go:382`) yields to any
-in-flight customer `/call` before each scope (`yieldToCustomer`,
-`prewarm_engine.go:437`) and runs `rePrewarmBoot` (`prewarm_engine_boot.go:182`):
+- `engineSeed` (`phase1_walk.go`) starts the engine on the **process-lifetime
+  ctx** (`SetEngineProcessContext`, wired from `main.go` — the fix for the
+  worker dying at boot-scope completion), enqueues one `scopeKindBoot`, and
+  waits on the **first** of:
+  - the **first-nav latch** (`prewarm_first_nav_latch.go`): fires the instant
+    every cohort's **nav widgets** have seeded (or provably has none) — the
+    happy path. Ready flips with every cohort's navigation warm while the boot
+    scope keeps seeding the RESTAction content tail in background.
+  - `bootDone` — the boot scope finished/failed before the latch could fire
+    (e.g. roots-list failure); a genuine boot error still surfaces.
+  - the `pipGlobalTimeout` / `PHASE1_TIMEOUT` backstop.
+- `MarkPhase1Done` is a **defer placed before the seed call**, so it fires on
+  every exit — normal return, error, timeout, even a seed panic (the recover
+  runs first). Readiness is therefore **never withheld forever**; a failed or
+  timed-out seed flips the pod **Ready-degraded** and the failure is surfaced
+  loudly (`recordReadinessBackstop` → `snowplow_readyz_backstop_fired` +
+  ERROR logs — the F5 "backstop-Ready is an explicit failure signal" ship).
+- With prewarm off entirely (cache off), a nil seed flips Ready right after the
+  sync barrier — the byte-identical no-seed behaviour.
 
-1. **RE-WALK both roots with a FRESH `phase1Walker` per root** (new visited map,
-   `prewarm_engine_boot.go:222-229`). This is the boot-race fix
-   (`prewarm_engine.go:24-31`): the Step-4 walk runs *before* the sync barrier
-   and is single-pass, so the navmenu's *dynamic* children
-   (`resourcesRefsTemplate` over the apiRef) resolve to 0 while fallthrough data
-   is empty. The re-walk runs *after* the barrier, when the data is present, so
-   the full nav tree is discovered and the harvesters are populated. Reusing the
-   old visited map would short-circuit and descend nothing
-   (`prewarm_engine_boot.go:211-213`).
-2. `settleRegisteredSet` once (`prewarm_engine_boot.go:243`).
-3. `cache.BuildBindingsByGVRIndex(rw.RegisteredGVRs())`
-   (`prewarm_engine_boot.go:249-250`) — the cohort-scoping substrate, built over
-   the *navigated* GVRs.
-4. `seedScopeYielding` (`prewarm_engine_boot.go:279,333`) drains the harvested
-   restactions + widgets and seeds the per-user top-level L1 cells.
+**Step 7.7** — the deferred apiRef pagination drain — runs *after* the flip on
+a bounded background goroutine (page 2..N of paginated apiRef widgets, plus the
+post-storm re-collection pass); it fills widgetContent page cells without
+blocking `/readyz`.
+
+### The seed — one dynamic engine, rank-major and class-interleaved
+
+The engine worker (`prewarm_engine.go`) yields to any in-flight customer
+`/call` before and during each scope (`yieldToCustomer`,
+`engineYieldCheckpoint`) and runs `rePrewarmBoot` (`prewarm_engine_boot.go`):
+
+1. **RE-WALK both roots with a FRESH `phase1Walker` per root** (new visited
+   map). This is the boot-race fix: the Step-4 walk runs *before* the sync
+   barrier and is single-pass, so the navmenu's *dynamic* children
+   (`resourcesRefsTemplate` over the apiRef) resolve to 0 while fallthrough
+   data is empty. The re-walk runs *after* the barrier, when the data is
+   present, so the full nav tree is discovered and the harvesters are
+   populated. Reusing the old visited map would short-circuit and descend
+   nothing. (F4b Lever B additionally reuses the boot discovery snapshot on a
+   resume re-walk, and Lever A marks declined-external targets so a resume does
+   not re-resolve external whales in a loop.)
+2. `settleRegisteredSet` once.
+3. `cache.BuildBindingsByGVRIndex(rw.RegisteredGVRs())` — the cohort-scoping
+   substrate, built over the *navigated* GVRs.
+4. `seedScopeYielding` drains the harvested widgets + restactions and seeds the
+   per-binding top-level L1 cells, in a **rank-major, class-interleaved**
+   order: identities are ranked widget-capable-first (deterministic rank
+   hygiene over both classes' target sets — Fix-3), and for each rank the
+   widgets seed in first-nav walk order, then that rank's RESTActions (cheap
+   RAs first by target count). The F3 login-cohort coverage work makes every
+   login-cohort-shaped identity reachable (with an intended ServiceAccount
+   exclusion), and the all-nav-widget latch (F3b-r2) is what feeds the
+   first-nav readiness latch above. A per-seed-pass RA-resolve memo
+   (`cache/seed_resolve_memo.go`, F4) dedups repeated RA resolves within one
+   pass.
+
+Seed-unit resource use is bounded adaptively: `seed_bound.go` applies the
+shared `cache.AdmissionCeiling()` headroom gate (GOMEMLIMIT − live heap −
+reserve) at the `seedOneWidget` / `seedOneRestaction` choke points — a separate
+semaphore instance from the nested-resolve bound so the stacked seed→nested
+case cannot deadlock. External fetches inside the boot seed carry a wall-clock
+bound (`api/external_seed_bound.go`). The error-aware Put-gate declines a
+degraded re-resolve rather than overwrite a good warm entry.
 
 ### The cohort model — dynamic, no static list, no cold-fill
 
 `seedScopeYielding` does **not** iterate a cohort list. For each harvested
-widget it scopes on the widget's GVR; for each harvested RESTAction it scopes on
-the RA's *target* GVR derived from its `userAccessFilter`
-(`restActionTargetGVR`, `prewarm_engine_boot.go:498-530`). It then asks the
-**live index** for the per-binding targets via
-`enumeratePrewarmTargetsForGVRFn` → `cache.EnumeratePrewarmTargetsForGVR(gvr,
-"list")` (`prewarm_engine_boot.go:393` → `cache/prewarm_enumeration.go:91`). Each
-authorising RBAC binding yields exactly one `PrewarmTarget`
-(`prewarm_enumeration.go:60-65,129-135`); the representative subject identity is
-drawn from the binding's subjects.
+widget it scopes on the widget's GVR; for each harvested RESTAction it scopes
+on the RA's *target* GVR derived from its `userAccessFilter`
+(`restActionTargetGVR`). It then asks the **live index** for the per-binding
+targets via `cache.EnumeratePrewarmTargetsForGVR(gvr, "list")`
+(`cache/prewarm_enumeration.go`). Each authorising RBAC binding yields exactly
+one `PrewarmTarget`; the representative subject identity is drawn from the
+binding's subjects.
 
 Three "no static / no cold-fill" facts, verified in code:
 
-- **No static cohort list.** Targets are read from `BindingsByGVR` per snapshot;
-  there is no Go-literal cohort set (`prewarm_engine_boot.go:32-35`,
-  `prewarm_enumeration.go:22-35`).
+- **No static cohort list.** Targets are read from `BindingsByGVR` per
+  snapshot; there is no Go-literal cohort set.
 - **No global fallback.** The v3 `EnumerateBindingSetClasses()` global-cohort
-  fallback was **removed** (`prewarm_engine_boot.go:303-310`). When the per-GVR
-  enumerator returns empty (no authorising binding, or the target GVR is
-  runtime-discovered with no static literal), the seed **skips** that GVR rather
-  than widening to a universe of identities that can't authorise it
-  (`targetsFor` returns `nil` at `prewarm_engine_boot.go:389-396`;
-  `prewarm_enumeration.go:75-83`).
+  fallback was **removed**. When the per-GVR enumerator returns empty (no
+  authorising binding, or the target GVR is runtime-discovered), the seed
+  **skips** that GVR rather than widening to a universe of identities that
+  can't authorise it.
 - **No lazy cold-fill.** A skipped target is not back-filled by a background
-  job; runtime-discovered RA targets are explicitly *"resolved cold-then-warm
-  via the on-demand dispatcher"* at first `/call`
-  (`prewarm_engine_boot.go:311-314`).
+  job; runtime-discovered RA targets are resolved cold-then-warm via the
+  on-demand dispatcher at first `/call`.
 
-Customer priority is enforced throughout the seed: `engineYieldCheckpoint(ctx)`
-runs between every target (`prewarm_engine_boot.go:418,430,460`), so a customer
-burst arriving mid-seed defers the remaining work.
+An empty-`BindingUID` target is never seeded (`prewarm_seed_empty_binding_skip`
+— the #95 leak closure), and the seed Puts stamp `RBACSubGen==0` (a known
+warm-miss for subjects whose sub-generation has moved; dispatch keys stay
+correct).
 
-### CRUD-triggered re-prewarm
+Customer priority is enforced throughout: `engineYieldCheckpoint(ctx)` runs
+between every target, so a customer burst arriving mid-seed defers the
+remaining work.
 
-Two distinct mechanisms keep prewarmed cells correct as the cluster changes:
+### Steady state — three re-prewarm mechanisms
 
 1. **Existing cells stay fresh via the refresher (object CRUD).** An informer
-   ADD/UPDATE event calls `DepTracker.OnAdd`/`OnUpdate` →
-   `onChange` (`internal/cache/deps.go:504-558`), which dirty-marks every
-   dependent L1 key (exact-object deps + LIST-scope deps) into the refresher.
-   The refresher **re-resolves** the entry — never evicts on ADD/UPDATE
-   (`deps.go:500-501,520-523`; `internal/cache/refresher.go:4-7`). DELETE evicts
-   only the deleted object's own self entry and dirty-marks its dependents
-   (`refresher.go:711-716`). This is the steady-state "re-prewarm" of cells the
-   boot seed populated.
+   ADD/UPDATE event calls `DepTracker.OnAdd`/`OnUpdate` → `onChange`
+   (`internal/cache/deps.go`), which dirty-marks every dependent L1 key
+   (exact-object + LIST-scope deps) into the refresher. The refresher
+   **re-resolves** the entry — never evicts on ADD/UPDATE. DELETE evicts only
+   the deleted object's own self entry and dirty-marks its dependents. Each
+   refresher commit publishes a `/refreshes` SSE signal.
 2. **New navigation structure via the engine (CRD/GVR CRUD).** When a genuinely
    new GVR is first registered post-boot, the cache fires its GVR-discovered
-   hook (`cache.RegisterGVRDiscoveredHook`), which the engine wires at start
-   (`registerEngineGVRDiscoveredHook`, `prewarm_engine_boot.go:112-119`) to
-   enqueue a `scopeKindGVRDiscovered` scope (`prewarm_engine.go:151`). That scope
-   runs the **same** `rePrewarmBoot` core (`prewarm_engine_boot.go:157-177`):
-   re-walking the nav tree with a fresh visited set and re-reading the
-   now-widened index records the dep edge against the new GVR, so subsequent CR
-   events propagate via the normal `onChange` → dirty-mark → refresher path. The
-   queue dedups distinct GVRs as distinct work and coalesces repeats
-   (`prewarm_engine.go:185-190`).
+   hook (`cache.RegisterGVRDiscoveredHook`), which the engine wires at start to
+   enqueue a `scopeKindGVRDiscovered` scope. That scope runs the same
+   re-walk + seed core; re-reading the now-widened index records the dep edge
+   against the new GVR, so subsequent CR events propagate via the normal
+   `onChange` → dirty-mark → refresher path. The queue keys distinct GVRs as
+   distinct work and coalesces repeats.
+3. **Quiet cells via the keepwarm sweep (#102).** A cell whose data goes quiet
+   dies at TTL by design (CreatedAt slides only on Put; there is no store
+   janitor), so a >TTL-returning user would pay a full cold resolve. A ticker
+   (`prewarm_keepwarm_sweep.go`) enqueues `scopeKindKeepwarm` at **TTL×3/4**
+   (derived from `RESOLVED_CACHE_TTL_SECONDS` — no new env knob);
+   `rePrewarmKeepwarm` re-runs the walk + seed for the **widget-capable prefix
+   of the identity ranking** (every login-cohort-shaped identity — the c2
+   coverage fix), with an age-skip for still-fresh cells. Each sweep Put
+   re-resolves fresh bytes (never TTL-extends), preserving the staleness
+   backstop by construction; the queue coalesces to at most one pending sweep.
 
 The placeholder scope kinds `scopeKindWidgetCR` / `scopeKindRBACShift` are
-**declared but not wired** this ship (`prewarm_engine.go:153-157`): a
-widget/RESTAction *CR* add/update/delete does not yet enqueue an engine re-walk
-of its subtree. Today such changes are caught by the refresher (for already-cached
-dependent keys) and by lazy resolve-on-navigation at `/call`.
+**declared but not wired** (`prewarm_engine.go`): a widget/RESTAction *CR*
+add/update/delete does not enqueue an engine re-walk of its subtree. Today such
+changes are caught by the refresher (for already-cached dependent keys) and by
+lazy resolve-on-navigation at `/call`.
 
 ---
 
 ## Invariants
 
 - **No special cases / no hardcoded navigation.** The only hardcoded GVRs at
-  boot are the meta-query seeds (`cache/phase1.go:277-294`). Navigation roots,
-  the cohort set, and every business GVR are read from config / the live RBAC
-  index / the walk — never Go literals (`phase1_roots.go:24-27`,
-  `prewarm_engine_boot.go:32-35`).
+  boot are the meta-query seeds. Navigation roots, the cohort set, and every
+  business GVR are read from config / the live RBAC index / the walk — never Go
+  literals.
 - **The walk is strictly read-only.** Recursion is gated on `verb == "GET"`
-  alone (`walkShouldRecurse`, `phase1_walk.go:1480`); the SA's privileged
-  credentials never reach a mutation endpoint.
+  alone (`walkShouldRecurse`); the SA's privileged credentials never reach a
+  mutation endpoint.
 - **Discovery is identity-independent; rendering is not.** `allowed` is never a
-  recursion gate during prewarm (`phase1_walk.go:1437-1467`). The per-user
-  `allowed` render verdict is re-derived at request time — prewarmed
-  SA-evaluated `allowed=true` flags are never served verbatim
-  (`phase1_walk.go:1227-1234`).
-- **Readiness precedes the seed.** `MarkPhase1Done` flips `/readyz`
-  *before* the per-cohort seed (`phase1_walk.go:710-720`); boot wall-clock is
-  cohort-count-independent and the seed can never make a pod not-Ready.
+  recursion gate during prewarm. The per-user `allowed` render verdict is
+  re-derived at request time — prewarmed SA-evaluated `allowed=true` flags are
+  never served verbatim.
+- **Readiness gates on prewarm-complete, with a fire-regardless backstop.**
+  `/readyz` flips 200 at min(first-nav-warm, seed-complete, backstop); a
+  failed/stuck/panicking seed yields **Ready-degraded** (loudly surfaced via
+  `snowplow_readyz_backstop_fired`), never not-Ready-forever. This *reverses*
+  the earlier "readiness precedes the seed" design — boot wall-clock is no
+  longer cohort-count-independent by construction; the latch + backstops bound
+  it instead.
 - **The re-walk MUST use a fresh visited map and the same `walk()`.** Reusing
-  the boot pass's visited set descends nothing
-  (`prewarm_engine.go:18-31`, `prewarm_engine_boot.go:211-213`).
+  the boot pass's visited set descends nothing.
 - **Customer `/call` has absolute priority.** Both the engine worker and the
-  steady-state refresher yield on `customerInFlight()`
-  (`prewarm_engine.go:118-120,437-451`).
-- **The whole feature is toggle-off-able.** `PREWARM_ENGINE_ENABLED=false`
-  reverts to the legacy `runPIPSeed` path in one helm `--set`
-  (`phase1_walk.go:477-484`); `cache.PrewarmEnabled()`/`CACHE_ENABLED=false`
-  makes the walk's harvesters nil and the seed a no-op (`phase1_walk.go:351-395`).
+  steady-state refresher yield on `customerInFlight()`.
+- **The whole feature is toggle-off-able — via `CACHE_ENABLED` only.** The
+  per-stage prewarm envs are retired; setting one is ignored (audited). The
+  seed's memory use is bounded by the shared adaptive admission ceiling, not by
+  capacity knobs.
 
 ## Known failure modes
 
 - **Pre-sync single-pass dynamic-children miss (the boot-race).** The Step-4
   walk runs before the sync barrier, so a navmenu whose children are
   `resourcesRefsTemplate`-driven sees empty fallthrough data and harvests only
-  the 2 roots. *Mitigation:* the engine's post-barrier re-walk
-  (`prewarm_engine.go:24-31`). With the engine OFF, the legacy seed runs on the
-  single pre-barrier pass and under-warms dynamic subtrees.
-- **Missing / unparseable frontend ConfigMap.** Yields no roots; warmup still
-  syncs and flips readiness, and lazy register-on-navigation covers GVRs on
-  first request (`phase1_roots.go:35-40`, `phase1_walk.go:622-633`). Degraded
-  first-load latency, not an outage.
-- **Engine worker killed at boot-seed return (the 0.30.247 regression).** If the
-  worker were bound to the boot-seed orchestration ctx, it would die the instant
-  the boot scope completes — dropping later `scopeKindGVRDiscovered` events
-  (admin-path defect). *Fix v2:* the worker uses the process-lifetime ctx wired
-  via `SetEngineProcessContext` (`prewarm_engine.go:295-316`,
-  `phase1_walk.go:427-467`).
+  the roots. *Mitigation:* the engine's post-barrier re-walk (always on).
+- **Missing / late frontend ConfigMap.** No longer a permanent cold pod: the
+  config-vars informer re-drives `scopeKindBoot` when the ConfigMap appears or
+  its data changes, before or after the readiness backstop, no restart.
+  Until then, lazy register-on-navigation covers GVRs on first request.
+- **Ready-degraded boot.** A seed error, `pipGlobalTimeout`/`PHASE1_TIMEOUT`
+  expiry, or a seed panic flips readiness with cold cells;
+  `snowplow_readyz_backstop_fired` (+ `readyz.backstop.fired` ERROR) is the
+  signal. First `/call` per affected cohort falls back to per-user resolve.
+- **Engine worker lifetime.** The worker is bound to the process-lifetime ctx
+  via `SetEngineProcessContext` — binding it to the boot-seed ctx (the 0.30.247
+  regression) would drop post-boot `scopeKindGVRDiscovered`/keepwarm work.
 - **Six HARD REVERTs from a missing `rc` field.** A `phase1Walker` struct
   literal that omitted `rc` (the SA `*rest.Config`) fail-closed at
-  `discoverPluralInfo`. *Fix:* `newPhase1Walker` makes `rc` a required positional
-  parameter (`phase1_walker_new.go:78-104`); the boot re-walk site uses it
-  (`prewarm_engine_boot.go:222`).
+  `discoverPluralInfo`. *Fix:* `newPhase1Walker` makes `rc` a required
+  positional parameter (`phase1_walker_new.go`).
 - **Empty per-GVR index → skipped seed.** If `BuildBindingsByGVRIndex` runs
   before the RBAC snapshot is ready, or a navigated GVR has no authorising
   binding, `EnumeratePrewarmTargetsForGVR` returns nil and the seed skips that
-  GVR by design (`prewarm_enumeration.go:75-83`). Those targets fall back to
-  cold-then-warm at first `/call` — never to a global-cohort universe (that
-  fallback was an RBAC-leak risk and was removed,
-  `prewarm_engine_boot.go:303-310`).
+  GVR by design. Those targets fall back to cold-then-warm at first `/call` —
+  never to a global-cohort universe (that fallback was an RBAC-leak risk and
+  was removed).
 - **Transient apiserver pressure during seed.** An operational (non-RBAC-deny)
   per-target seed failure re-enqueues a single coalesced `scopeKindBoot` to
-  retry after pressure clears (`classifyEngineSeedErr`,
-  `prewarm_engine_boot.go:353-381`); RBAC-deny failures are expected and not
+  retry after pressure clears (`phase1_seed_classify.go`); the F.4 boot-scope
+  resume chunks the re-walk with a fresh-skip so a deadline-cut pass resumes
+  instead of restarting, and the re-enqueue is bounded against deterministic
+  seed failures (no infinite redrive). RBAC-deny failures are expected and not
   retried.
+- **External whales.** Boot-seed external fetches are wall-clock-bounded, and
+  declined-external markers (F4b Lever A) stop a resume loop from re-resolving
+  the same external target; an external RA is never L1-cached anyway (see
+  caching.md §4) unless TTL-annotated.
 - **Widget/RESTAction CR edits do not re-walk their subtree (gap, not bug).**
-  `scopeKindWidgetCR`/`scopeKindRBACShift` are declared but unwired
-  (`prewarm_engine.go:153-157`); such edits are covered only by the refresher
-  (cached dependents) and lazy resolve-on-navigation until a future ship wires
-  them.
+  `scopeKindWidgetCR`/`scopeKindRBACShift` are declared but unwired; such edits
+  are covered only by the refresher (cached dependents) and lazy
+  resolve-on-navigation until a future ship wires them.

--- a/go/snowplow/docs/architecture/rbac-uaf.md
+++ b/go/snowplow/docs/architecture/rbac-uaf.md
@@ -221,9 +221,11 @@ the cell left the cache (#118). The durable fix is the **per-subject sub-generat
   (`rbac_subgen_pending.go`) so the counter and the published snapshot move together (the
   (c)-v2 ordering fix — this is what bumped the key salt to v6).
 - `cache.RBACSubGenForSubject(username, groups)` folds the subject's effective counters into one
-  `uint64`, and `dispatchCacheLookupKey` stamps it into `ResolvedKeyInputs.RBACSubGen`, which
-  `ComputeKey` hashes for every identity-bound class. A change to *your* RBAC → *your* keys
-  rotate → cold miss → fresh resolve + fresh refilter. Blast radius is herd-proportional.
+  `uint64`, and `dispatchCacheLookupKey` — the only stamping site — stamps it into
+  `ResolvedKeyInputs.RBACSubGen` for the dispatch-keyed classes (`restactions`, `widgets`),
+  where `ComputeKey` hashes it (`raFullList` hashes the field as a constant `0` — §3.1). A
+  change to *your* RBAC → *your* `restactions`/`widgets` keys rotate → cold miss → fresh
+  resolve + fresh refilter. Blast radius is herd-proportional.
 - The interim exposure cap — a short TTL override on UAF-bearing cells
   (`UAF_RESOLVED_TTL_SECONDS`, `dispatchers/uaf_shortttl.go`) — remains available,
   default-disabled.
@@ -234,16 +236,34 @@ the cell left the cache (#118). The durable fix is the **per-subject sub-generat
 
 ### 3.1 What gets keyed
 
-`ComputeKey` (`cache/resolved.go`) builds the L1 cell key. For every identity-bound entry class
-(`restactions`, `widgets`, `apistage`, `raFullList`) it folds **two identity terms**: the
-**`BindingUID`** — the first-match binding that authorised *this layer's* GET for *this
-request's* identity — and the subject's **`RBACSubGen`** (§2.7). `dispatchCacheLookupKey`
-derives the UID with a direct `EvaluateRBAC(verb=get, …)` call leaving `SkipBindingUID` at its
-safe zero value so the returned UID is the deterministic sorted first-match.
+`ComputeKey` (`cache/resolved.go`) builds the L1 cell key. Mechanically it hashes the
+`BindingUID` and `RBACSubGen` fields for every class except `widgetContent`; what those fields
+actually *carry* is per-class:
 
-The result: **two users granted by the SAME binding (at the same sub-generation) share one cell;
-the same user authorised by DIFFERENT bindings on different layers gets different cells; a
-grant/revoke touching a user's own bindings rotates that user's cells.** This is finer-grained
+- **`restactions`, `widgets` — identity-bound, two live terms.** `dispatchCacheLookupKey`
+  (`dispatchers/helpers.go`) derives the **`BindingUID`** — the first-match binding that
+  authorised *this layer's* GET for *this request's* identity — with a direct
+  `EvaluateRBAC(verb=get, …)` call leaving `SkipBindingUID` at its safe zero value (so the
+  returned UID is the deterministic sorted first-match), and stamps the subject's
+  **`RBACSubGen`** (§2.7) alongside it. That is the *only* `RBACSubGen` stamping site; a
+  grant/revoke touching the user's own bindings rotates these cells via the sub-gen fold.
+- **`raFullList` — identity-bound via `BindingUID` ONLY.** Its single key source is
+  `seedFullListRAKey` (`resolvers/widgets/apiref/ra_full_list.go`), which derives the
+  first-match `BindingUID` on the RA's own coordinates but never sets `RBACSubGen`
+  (`RAFullListKeyInputs`, `cache/ra_full_list_slice.go`), so every `raFullList` cell hashes
+  `RBACSubGen == 0` on Put *and* Get. The sub-gen term is mechanically folded but semantically
+  inert: these cells rotate only when the `BindingUID` itself changes — there is no
+  grant/revoke sub-gen rotation for this class.
+- **`apistage` — identity-free content cells, NOT identity-bound.** `contentKeyInputs`
+  (`resolvers/restactions/api/apistage.go`) never sets `BindingUID` or `RBACSubGen`, so both
+  fold as empty/zero constants and the cell is identity-invariant. It is populated SA-maximal
+  and RBAC-narrowed **per request at serve time**, fail-closed — the ADR 0003 pattern, same
+  family as `widgetContent` (§3.3).
+
+For the identity-bound classes the result is: **two users granted by the SAME binding (for
+`restactions`/`widgets`, at the same sub-generation) share one cell; the same user authorised
+by DIFFERENT bindings on different layers gets different cells; a grant/revoke touching a
+user's own bindings rotates that user's `restactions`/`widgets` cells.** This is finer-grained
 than the v3 cohort hash (`BindingSetHash`) it replaced. The key salt is `resolvedKeyVersion =
 "v6"` — see caching.md §3.1 for the v1→v6 lineage.
 
@@ -270,7 +290,9 @@ serve-time gate `gateWidgetEnvelope` (`dispatchers/widget_content.go`) **overwri
 `allowed` flag per-request via `rbac.UserCan` under the requesting identity before
 serialisation.** So the body is shared but the bytes that leave the pod are per-user — the
 identity narrowing moves from the *key* to a *serve-time rewrite*. This is the
-identity-free-content-key + serve-time-UAF pattern (ADR 0003). The general rule holds: an entry
+identity-free-content-key + serve-time-UAF pattern (ADR 0003). `apistage` reaches the same
+identity-free end state by different mechanics — its identity fields are never set and fold as
+constants (§3.1) — and is governed by the same ADR 0003 rule. The general rule holds: an entry
 is identity-free in the key **only if** it is re-narrowed per-user at serve time.
 
 ### 3.4 The empty-UID biconditional — and the #95 serve/Put guard
@@ -328,9 +350,10 @@ are the ones that leave `SkipBindingUID` false and keep the deterministic UID.
 
 ## 5. Invariants
 
-1. **Identity-bound L1 cells are keyed by `BindingUID` + `RBACSubGen`, never cohort/content
-   alone.** Violation = cross-user leak (§3.2). The sole identity-free class, `widgetContent`,
-   is re-narrowed per-user at serve time (§3.3). (ADR 0002 / 0003.)
+1. **Identity-bound L1 cells are keyed by `BindingUID` (`restactions`/`widgets` additionally by
+   `RBACSubGen`), never cohort/content alone.** Violation = cross-user leak (§3.2). The
+   identity-free classes — `widgetContent` and `apistage` — are re-narrowed per-user at serve
+   time (§3.1, §3.3). (ADR 0002 / 0003.)
 2. **Zero `SubjectAccessReview` to the apiserver in cache=on mode.** All checks resolve against
    the informer-cached typed RBAC snapshot. A nil watcher or nil snapshot **degrades to deny**,
    never to apiserver fallback. The hard rollback trigger for the tag.

--- a/go/snowplow/docs/architecture/rbac-uaf.md
+++ b/go/snowplow/docs/architecture/rbac-uaf.md
@@ -1,15 +1,25 @@
+---
+type: Architecture
+title: snowplow — RBAC & user-aware filtering (UAF)
+description: How every byte that leaves the pod is narrowed to the requesting user without per-request SubjectAccessReviews — the in-process evaluator, the subject index, per-binding+sub-generation L1 keying, and the serve-time per-item gates.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [rbac, uaf, security, cache-keying, evaluator]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # RBAC & User-Aware Filtering (UAF)
 
-**Audience:** maintainer · **Status:** code-traced against commit `a42b072` (snowplow 1.0.1 line)
-· **Subsystem:** `internal/rbac/` (evaluator) + `internal/cache/` (snapshot, subject index, L1
-keying) + the serve-time filter sites in `internal/resolvers/` and `internal/objects/`.
+**Audience:** maintainer · **Status:** re-derived from the current tree (docs-standard,
+2026-08-06) · **Subsystem:** `internal/rbac/` (evaluator) + `internal/cache/` (snapshot, subject
+index, L1 keying, sub-generation) + the serve-time filter sites in `internal/resolvers/` and
+`internal/objects/`.
 
 Snowplow serves Krateo frontend content out of an in-process cache. Every byte that leaves the pod
 must be exactly what the *requesting user* is permitted to see — no more. This document traces how
 that guarantee is enforced without a per-request `SubjectAccessReview` to the apiserver, and
 captures the one invariant whose violation caused a six-revert retrospective: **the L1 resolved
-cache must be keyed by the binding that authorised the request, never by a cohort/content key
-alone.**
+cache must be keyed by the binding that authorised the request (plus the subject's RBAC
+sub-generation), never by a cohort/content key alone.**
 
 ---
 
@@ -22,33 +32,34 @@ alone.**
         │                                                             │
    (A) CACHE-KEY DERIVATION                                  (B) SERVE-TIME UAF
    dispatchCacheLookupKey                                    per-item gate on the served body
-   helpers.go:200                                            (list/get drop, widget allowed-flag)
+   (dispatchers/helpers.go)                                  (list/get drop, widget allowed-flag)
         │                                                             │
-        │ EvaluateRBAC(verb=get, …, SkipBindingUID=false)             │ EvaluateRBAC(verb=list/get,
+        │ EvaluateRBAC(verb=get, …, SkipBindingUID=false)             │ EvaluateRBAC(verb, …,
         │   → (allowed, matchedBindingUID)                            │   SkipBindingUID=true)
-        ▼                                                             ▼   → allowed only
-   BindingUID folded into ComputeKey  ───────────► L1 cell        keep / drop each item
-   (resolved.go:608 ComputeKey)                    keyed by       (refilter.go, informer_serve.go,
-        │                                          BindingUID     informer_dispatch_rbac.go,
-        │                                          NOT cohort     cluster_list.go)
-        ▼                                                             │
+        │ + cache.RBACSubGenForSubject(user, groups)                  │   → allowed only
+        ▼                                                             ▼
+   BindingUID + RBACSubGen folded into ComputeKey ──► L1 cell     keep / drop each item
+   (cache/resolved.go ComputeKey, v6)                keyed by     (refilter.go, informer_serve.go,
+        │                                            binding+     informer_dispatch_rbac.go,
+        │                                            sub-gen      cluster_list.go)
+        ▼                                            NOT cohort       │
    two users on the SAME binding share a cell                        │
    two users on DIFFERENT bindings get DIFFERENT cells               │
-                                                                      ▼
+   a grant/revoke on YOUR bindings bumps YOUR sub-gen → cold miss    ▼
                                                               body that leaves the pod
                                                               is per-user-correct
 
-        ┌──────────────────────── EvaluateRBAC (evaluate.go:167) ─────────────────────────┐
+        ┌──────────────────────── EvaluateRBAC (evaluate.go) ─────────────────────────────┐
         │  cache.Disabled()?  ──yes──►  UserCan → SelfSubjectAccessReview (SAR baseline)   │
-        │       │ no                                  (rbac.go:65 userCanViaSAR)           │
+        │       │ no                                  (rbac.go userCanViaSAR)              │
         │       ▼                                                                          │
         │  rw.Snapshot()  (cache.RBACSnapshot, single Load, threaded through the walk)     │
-        │       │ nil → degrade-to-DENY (evaluate.go:198 / :216)                           │
+        │       │ nil → degrade-to-DENY                                                    │
         │       ▼                                                                          │
         │  L2 authz memo lookup  (snapshot_authz_memo.go, keyed by snap.PublishSeq)        │
         │       │ hit → return cached (allowed, uid)                                       │
         │       ▼ miss                                                                     │
-        │  evaluateAgainstInformerFirstMatch (evaluate.go:334)                             │
+        │  evaluateAgainstInformerFirstMatch                                               │
         │       1. selectCRBCandidates (subject index union)  ──► anySubjectMatches        │
         │       2. selectRBCandidates (ns-scoped)             ──► roleRefPermits           │
         │                                                          → rulesPermit           │
@@ -67,52 +78,48 @@ only in whether they consume `matchedBindingUID` (A) or just `allowed` (B).
 
 ### 2.1 Entry points: `UserCan` and `EvaluateRBAC`
 
-`UserCan` (`rbac.go:32`) is the per-item yes/no API. With cache on it delegates to `EvaluateRBAC`
-and discards the binding UID (`rbac.go:44`); with cache off it falls to `userCanViaSAR`
-(`rbac.go:59`), which issues a `SelfSubjectAccessReview` against the user's own kubeconfig
-(`rbac.go:86-103`). That SAR path is the correctness baseline that keeps `CACHE_ENABLED=false` a
-transparent fallback, and `userCanViaSAR` "MUST be reachable only when `cache.Disabled() == true`"
-(`rbac.go:62-64`).
+`UserCan` (`rbac.go`) is the per-item yes/no API. With cache on it delegates to `EvaluateRBAC`
+and discards the binding UID; with cache off it falls to `userCanViaSAR`, which issues a
+`SelfSubjectAccessReview` against the user's own kubeconfig. That SAR path is the correctness
+baseline that keeps `CACHE_ENABLED=false` a transparent fallback, and `userCanViaSAR` MUST be
+reachable only when `cache.Disabled() == true`.
 
-`EvaluateRBAC` (`evaluate.go:167`) is the core. Signature: `(bool allowed, string
-matchedBindingUID, error)` (`evaluate.go:120-166`). Decision order:
+`EvaluateRBAC` (`evaluate.go`) is the core. Signature: `(bool allowed, string
+matchedBindingUID, error)`. Decision order:
 
-1. **`cache.Disabled()`** → route to `UserCan`/SAR, return `("", )` empty UID (`evaluate.go:171-183`).
-   No snapshot exists, so there is no binding to identify.
-2. **`rw := cache.Global()` nil** → cache flagged on but watcher not wired: **degrade to deny**, do
-   *not* silently fall back to the apiserver (`evaluate.go:185-199`). Falling back here would violate
-   the "zero `SubjectAccessReview` in cache=on" rule.
-3. **`snap := rw.Snapshot()` nil** → typed-RBAC snapshot not yet published: **degrade to deny**
-   (`evaluate.go:206-217`). A single `Snapshot()` load is threaded through the entire walk so one
-   evaluation observes one coherent snapshot generation (`evaluate.go:201-206`).
-4. **L2 authz memo lookup** keyed on `snap.PublishSeq` (`evaluate.go:231-250`) — see §2.5.
-5. **Cold walk** via `evaluateAgainstInformerFirstMatch` (`evaluate.go:252`).
-6. **Store PERMITS only** (`evaluate.go:282-289`) — see §2.5; denies are never cached.
+1. **`cache.Disabled()`** → route to `UserCan`/SAR, return an empty UID. No snapshot exists, so
+   there is no binding to identify.
+2. **`rw := cache.Global()` nil** → cache flagged on but watcher not wired: **degrade to deny**,
+   do *not* silently fall back to the apiserver. Falling back here would violate the "zero
+   `SubjectAccessReview` in cache=on" rule.
+3. **`snap := rw.Snapshot()` nil** → typed-RBAC snapshot not yet published: **degrade to deny**.
+   A single `Snapshot()` load is threaded through the entire walk so one evaluation observes one
+   coherent snapshot generation.
+4. **L2 authz memo lookup** keyed on `snap.PublishSeq` — see §2.5.
+5. **Cold walk** via `evaluateAgainstInformerFirstMatch`.
+6. **Store PERMITS only** — see §2.5; denies are never cached.
 
 ### 2.2 The candidate walk — `evaluateAgainstInformerFirstMatch`
 
-`evaluate.go:334`. Two phases, mirroring the upstream Kubernetes RBAC authorizer:
+Two phases, mirroring the upstream Kubernetes RBAC authorizer:
 
 - **Phase 1 — ClusterRoleBindings.** `selectCRBCandidates(snap, opts)` returns a superset of the
-  matching CRBs from the subject index (`evaluate.go:340`, §2.3). When the caller consumes the UID
-  (`SkipBindingUID == false`) the candidates are stable-sorted by `(Name, UID)` via `sortCRBsStable`
-  (`evaluate.go:344-346`, `:397`) so the first match is deterministic. Each candidate is gated
-  through `anySubjectMatches` (the post-index correctness barrier, `evaluate.go:352`) and then
-  `roleRefPermits` (`evaluate.go:355`). **First permit wins**, returning `cache.BindingUIDFromCRB(crb)`
-  (`evaluate.go:359-361`).
-- **Phase 2 — RoleBindings in `opts.Namespace`,** only when `Namespace != ""` (`evaluate.go:368`).
-  Same structure via `selectRBCandidates` / `sortRBsStable` / `BindingUIDFromRB`
-  (`evaluate.go:369-384`).
+  matching CRBs from the subject index (§2.3). When the caller consumes the UID
+  (`SkipBindingUID == false`) the candidates are stable-sorted by `(Name, UID)` via
+  `sortCRBsStable` so the first match is deterministic. Each candidate is gated through
+  `anySubjectMatches` (the post-index correctness barrier) and then `roleRefPermits`. **First
+  permit wins**, returning `cache.BindingUIDFromCRB(crb)`.
+- **Phase 2 — RoleBindings in `opts.Namespace`,** only when `Namespace != ""`. Same structure
+  via `selectRBCandidates` / `sortRBsStable` / `BindingUIDFromRB`.
 
-No match in either phase → `(false, "", nil)` (`evaluate.go:387`). There are **no deny rules in RBAC
-v1**, so any single matching permit short-circuits the whole walk — which is why the candidate sort
-is purely for UID determinism and never changes the yes/no verdict (`evaluate.go:341-343`).
+No match in either phase → `(false, "", nil)`. There are **no deny rules in RBAC v1**, so any
+single matching permit short-circuits the whole walk — which is why the candidate sort is purely
+for UID determinism and never changes the yes/no verdict.
 
 ### 2.3 The subject index — `selectCRBCandidates` / `selectRBCandidates`
 
-The index lives on the snapshot (`cache/rbac_snapshot.go:157-169`) and is built once per rebuild by
-`rebuildSubjectIndexes` (`cache/rbac_snapshot.go:536`). It maps a subject to the bindings that name
-it:
+The index lives on the snapshot (`cache/rbac_snapshot.go`) and is built once per rebuild by
+`rebuildSubjectIndexes`. It maps a subject to the bindings that name it:
 
 | Subject kind | CRB index field | RB index field (per-ns) |
 |---|---|---|
@@ -121,95 +128,105 @@ it:
 | `ServiceAccount` | `CRBsByServiceAccount["<ns>/<name>"]` | `RBsByServiceAccountByNS[ns]["<ns>/<name>"]` |
 | unrecognised kind | `CRBsCatchAll` | `RBsCatchAllByNS[ns]` |
 
-`selectCRBCandidates` (`evaluate.go:453`) unions the routes that apply to the request identity,
-deduplicating by pointer (a multi-subject binding appears once, `evaluate.go:466-476`):
+`selectCRBCandidates` unions the routes that apply to the request identity, deduplicating by
+pointer (a multi-subject binding appears once):
 
-1. `CRBsByUser[Username]` when `Username != ""` (`evaluate.go:478-480`)
-2. `CRBsByGroup[g]` for every `g` in `effectiveGroups(opts)` (`evaluate.go:481-483`)
-3. `CRBsByGroup["system:authenticated"]`, gated on `Username != ""` so an unauthenticated identity
-   never lands the implicit group (`evaluate.go:488-490`)
-4. `CRBsByServiceAccount["<ns>/<name>"]` when the username is a canonical SA (`evaluate.go:491-493`)
-5. `CRBsCatchAll` — always (`evaluate.go:497`)
+1. `CRBsByUser[Username]` when `Username != ""`
+2. `CRBsByGroup[g]` for every `g` in `effectiveGroups(opts)`
+3. `CRBsByGroup["system:authenticated"]`, gated on `Username != ""` so an unauthenticated
+   identity never lands the implicit group
+4. `CRBsByServiceAccount["<ns>/<name>"]` when the username is a canonical SA
+5. `CRBsCatchAll` — always
 
-The index is a **pre-filter only**: it is allowed to over-include, and `anySubjectMatches`
-(`evaluate.go:694`) is the authoritative equality barrier after lookup
-(`cache/rbac_snapshot.go:149-152`). The hard invariant is the *other* direction: the index must
-never **under**-include — a binding the linear scan would match must appear in the candidate union,
-or a permit is silently lost. The `CRBsCatchAll` arm exists exactly so an unrecognised future
-`Subject.Kind` cannot be dropped (`evaluate.go:494-497`). `selectRBCandidates`
-(`evaluate.go:507`) is the namespace-scoped analogue; a missing namespace returns nil and yields an
-empty candidate set with no allocations (`evaluate.go:502-506`).
+The index is a **pre-filter only**: it is allowed to over-include, and `anySubjectMatches` is the
+authoritative equality barrier after lookup. The hard invariant is the *other* direction: the
+index must never **under**-include — a binding the linear scan would match must appear in the
+candidate union, or a permit is silently lost. The `CRBsCatchAll` arm exists exactly so an
+unrecognised future `Subject.Kind` cannot be dropped. `selectRBCandidates` is the
+namespace-scoped analogue; a missing namespace yields an empty candidate set with no allocations.
 
 ### 2.4 Predicate symmetry: User AND Group (and ServiceAccount)
 
-The load-bearing symmetry rule is that **every place the verdict depends on a subject kind, both the
-index route and the matcher route handle User, Group, and ServiceAccount the same way.** If the
-index routes a User but the matcher only checks Groups (or vice-versa), the answer is wrong. The
-matcher `anySubjectMatches` (`evaluate.go:694`) is the canonical statement of the predicate:
+The load-bearing symmetry rule is that **every place the verdict depends on a subject kind, both
+the index route and the matcher route handle User, Group, and ServiceAccount the same way.** If
+the index routes a User but the matcher only checks Groups (or vice-versa), the answer is wrong.
+The matcher `anySubjectMatches` is the canonical statement of the predicate:
 
-- `UserKind` → exact `s.Name == opts.Username` (`evaluate.go:700-703`)
+- `UserKind` → exact `s.Name == opts.Username`
 - `GroupKind` → membership test against `effectiveGroups`, **plus** the implicit
-  `system:authenticated` for any authenticated identity (`evaluate.go:704-715`)
+  `system:authenticated` for any authenticated identity
 - `ServiceAccountKind` → `(Namespace, Name)` match on a parsed canonical SA username
-  (`evaluate.go:716-719`)
-- any other kind → no case → no match (`evaluate.go:698-721`)
+- any other kind → no case → no match
 
-`effectiveGroups` (`evaluate.go:743`) is the single source of group expansion: for a ServiceAccount
-identity it appends the two Kubernetes synthetic groups `system:serviceaccounts` and
-`system:serviceaccounts:<ns>` (`evaluate.go:728-730`, `:743-754`); for a non-SA identity it returns
-`opts.Groups` unchanged with no allocation. Crucially **`selectCRBCandidates` reuses the same
-`effectiveGroups`** (`evaluate.go:462`, `:481`) so the index and the matcher agree on group
-expansion — the symmetry is enforced by shared code, not by two parallel implementations.
+`effectiveGroups` is the single source of group expansion: for a ServiceAccount identity it
+appends the two Kubernetes synthetic groups `system:serviceaccounts` and
+`system:serviceaccounts:<ns>`; for a non-SA identity it returns `opts.Groups` unchanged with no
+allocation. Crucially **`selectCRBCandidates` reuses the same `effectiveGroups`** so the index
+and the matcher agree on group expansion — the symmetry is enforced by shared code, not by two
+parallel implementations.
 
-`rulesPermit` (`evaluate.go:597`) walks the resolved role's `PolicyRule`s with Kubernetes wildcard
-semantics (`stringSliceMatches`, `evaluate.go:670`: `"*"` matches everything) over Verbs, APIGroups,
-Resources, and honours `resourceNames`. `resourceNameMatches` (`evaluate.go:651`) implements the
-upstream `ResourceNameMatches` rule: a non-empty `rule.ResourceNames` can only ever grant a
-**name-specific verb** (`get`/`update`/`patch`/`delete`, `nameSpecificVerbs` at `evaluate.go:624`)
-and only when `opts.Name` is in the list — a `resourceNames`-scoped rule **never** grants `list`.
-This was added in 0.30.109; its absence had over-exposed every object on a `resourceNames`-scoped
-rule — a cross-user leak in `filterListByRBAC` (`evaluate.go:591-596`).
+`rulesPermit` walks the resolved role's `PolicyRule`s with Kubernetes wildcard semantics
+(`stringSliceMatches`: `"*"` matches everything) over Verbs, APIGroups, Resources, and honours
+`resourceNames`. `resourceNameMatches` implements the upstream `ResourceNameMatches` rule: a
+non-empty `rule.ResourceNames` can only ever grant a **name-specific verb**
+(`get`/`update`/`patch`/`delete`) and only when `opts.Name` is in the list — a
+`resourceNames`-scoped rule **never** grants `list`. This was added in 0.30.109; its absence had
+over-exposed every object on a `resourceNames`-scoped rule — a cross-user leak in
+`filterListByRBAC`.
 
 ### 2.5 The L2 authz memo — `snapshot_authz_memo.go`
 
-The candidate walk at 50K scale re-walks the same ~18K same-subject CRBs on every call for a verdict
-that repeats thousands of times within a generation. The L2 memo collapses that
-(`snapshot_authz_memo.go:1-12`). Properties that keep it correct:
+The candidate walk at 50K scale re-walks the same ~18K same-subject CRBs on every call for a
+verdict that repeats thousands of times within a generation. The L2 memo collapses that.
+Properties that keep it correct:
 
 - **Generation-scoped.** A single `atomic.Pointer[snapshotAuthzShard]`; each shard carries the
-  `snap.PublishSeq` it is valid for (`snapshot_authz_memo.go:108-116`). Lookup compares the shard
-  gen to the `PublishSeq` of the snapshot the caller *already holds* — no second snapshot load, no
-  TTL (`evaluate.go:231-242`, `snapshot_authz_memo.go:22-34`). A `PublishSeq` change CAS-swaps a
-  fresh empty shard (`currentAuthzShard`, `snapshot_authz_memo.go:141-157`), so no entry outlives its
-  snapshot. `Gen` is also in the key (`snapshot_authz_memo.go:84-94`) to close the store-race window.
-- **PERMITS only — never cache a deny** (`evaluate.go:259-289`). A deny can be transiently wrong
-  under snapshot churn (a momentarily-incoherent rebuild yields a fail-closed `false`); caching it
-  would pin the wrong deny for the whole generation on a hot key (the snowplow SA's wildcard CRB can
-  never be correctly denied), starving the refresher — the #301 incident. Permits are
-  monotone-correct within a generation (a binding removal bumps `PublishSeq`), so they are safe to
-  cache. Denies fall back to the walk every call and self-heal; `authzMemoDenyUncached` counts them
-  (`snapshot_authz_memo.go:120-131`, `evaluate.go:288`).
-- **`SkipBindingUID` is part of the key** (`snapshot_authz_memo.go:93`) so a UID-consumer and a
-  verdict-only consumer never share an entry (`evaluate.go:219-230`).
-- **Capacity-capped** at `16384` with insert-refusal on breach — never evict-to-OOM
-  (`snapshot_authz_memo.go:62-67`, `:182-192`).
-- **Below the cache=off short-circuit** so `CACHE_ENABLED=false` never reaches it
-  (`snapshot_authz_memo.go:49-52`).
+  `snap.PublishSeq` it is valid for. Lookup compares the shard gen to the `PublishSeq` of the
+  snapshot the caller *already holds* — no second snapshot load, no TTL. A `PublishSeq` change
+  CAS-swaps a fresh empty shard, so no entry outlives its snapshot. `Gen` is also in the key to
+  close the store-race window.
+- **PERMITS only — never cache a deny.** A deny can be transiently wrong under snapshot churn (a
+  momentarily-incoherent rebuild yields a fail-closed `false`); caching it would pin the wrong
+  deny for the whole generation on a hot key (the snowplow SA's wildcard CRB can never be
+  correctly denied), starving the refresher — the #301 incident. Permits are monotone-correct
+  within a generation (a binding removal bumps `PublishSeq`), so they are safe to cache. Denies
+  fall back to the walk every call and self-heal; `authzMemoDenyUncached` counts them.
+- **`SkipBindingUID` is part of the key** so a UID-consumer and a verdict-only consumer never
+  share an entry.
+- **Capacity-capped** at 16384 with insert-refusal on breach — never evict-to-OOM.
+- **Below the cache=off short-circuit** so `CACHE_ENABLED=false` never reaches it.
 
-Groups fold into the key via `canonicalGroupsHash` (`groups_hash.go:68`): order-independent
+Groups fold into the key via `canonicalGroupsHash` (`groups_hash.go`): order-independent
 (sort-first) FNV-1a with a per-element **length prefix** so distinct set partitions like
-`["a","bc"]` vs `["ab","c"]` cannot alias (`groups_hash.go:14-23`, `:79-86`). Hashing the *raw*
-`opts.Groups` is sufficient because `effectiveGroups` is a pure function of `(Username, Groups)`
-(`groups_hash.go:25-39`). Counters are exposed read-only over `/debug/vars` via
-`RegisterAuthzMemoExpvar` (`snapshot_authz_memo_expvar.go:35`).
+`["a","bc"]` vs `["ab","c"]` cannot alias. Hashing the *raw* `opts.Groups` is sufficient because
+`effectiveGroups` is a pure function of `(Username, Groups)`. Counters are exposed read-only over
+`/debug/vars` via `RegisterAuthzMemoExpvar`.
 
 ### 2.6 BindingUID derivation — `cache/match_subject.go`
 
-`BindingUIDFromCRB` (`match_subject.go:83`) returns `"C:<uid>"`; `BindingUIDFromRB`
-(`match_subject.go:107`) returns `"R:<ns>/<uid>"`. The `C:`/`R:` prefixes keep CRB and RB UIDs from
-aliasing and the `R:<ns>/` prefix carries namespace scope into the identifier. Empty UID (synthetic
-fixtures / pre-stamp gap) falls back to a content tuple framed with a `\x1f` separator
-(`match_subject.go:90-93`, `:114-115`). Both return `""` iff the pointer is nil.
+`BindingUIDFromCRB` returns `"C:<uid>"`; `BindingUIDFromRB` returns `"R:<ns>/<uid>"`. The
+`C:`/`R:` prefixes keep CRB and RB UIDs from aliasing and the `R:<ns>/` prefix carries namespace
+scope into the identifier. Empty UID (synthetic fixtures / pre-stamp gap) falls back to a content
+tuple framed with a `\x1f` separator. Both return `""` iff the pointer is nil.
+
+### 2.7 The per-subject RBAC sub-generation — `cache/rbac_subgen.go`
+
+The single dispatch-authorizing `BindingUID` is blind to a dependency the `userAccessFilter`
+refilter has: it re-evaluates RBAC *per object, per that object's own namespace*. An out-of-band
+grant/revoke used to evict zero resolved cells — the user's own stale UAF view was served until
+the cell left the cache (#118). The durable fix is the **per-subject sub-generation**:
+
+- Every subject (user, group, SA) has a counter; an RBAC delta that touches a subject's own
+  bindings marks it pending, and the bump is applied **at snapshot publish**
+  (`rbac_subgen_pending.go`) so the counter and the published snapshot move together (the
+  (c)-v2 ordering fix — this is what bumped the key salt to v6).
+- `cache.RBACSubGenForSubject(username, groups)` folds the subject's effective counters into one
+  `uint64`, and `dispatchCacheLookupKey` stamps it into `ResolvedKeyInputs.RBACSubGen`, which
+  `ComputeKey` hashes for every identity-bound class. A change to *your* RBAC → *your* keys
+  rotate → cold miss → fresh resolve + fresh refilter. Blast radius is herd-proportional.
+- The interim exposure cap — a short TTL override on UAF-bearing cells
+  (`UAF_RESOLVED_TTL_SECONDS`, `dispatchers/uaf_shortttl.go`) — remains available,
+  default-disabled.
 
 ---
 
@@ -217,49 +234,59 @@ fixtures / pre-stamp gap) falls back to a content tuple framed with a `\x1f` sep
 
 ### 3.1 What gets keyed
 
-`ComputeKey` (`cache/resolved.go:608`) builds the L1 cell key. For every identity-bound entry class
-(`restactions`, `widgets`, `apistage`, `raFullList`) it folds the **`BindingUID`** — the first-match
-binding that authorised *this layer's* GET for *this request's* identity — into the key
-(`resolved.go:652-655`). `dispatchCacheLookupKey` (`helpers.go:200`) derives that UID with a direct
-`EvaluateRBAC(verb=get, …)` call leaving `SkipBindingUID` at its safe zero value so the returned UID
-is the deterministic sorted first-match (`helpers.go:211-220`, `:228`).
+`ComputeKey` (`cache/resolved.go`) builds the L1 cell key. For every identity-bound entry class
+(`restactions`, `widgets`, `apistage`, `raFullList`) it folds **two identity terms**: the
+**`BindingUID`** — the first-match binding that authorised *this layer's* GET for *this
+request's* identity — and the subject's **`RBACSubGen`** (§2.7). `dispatchCacheLookupKey`
+derives the UID with a direct `EvaluateRBAC(verb=get, …)` call leaving `SkipBindingUID` at its
+safe zero value so the returned UID is the deterministic sorted first-match.
 
-The result (`resolved.go:256-267`, `:284-303`): **two users granted by the SAME binding share one
-cell; the same user authorised by DIFFERENT bindings on different layers gets different cells.** This
-is finer-grained than the v3 cohort hash (`BindingSetHash`) it replaced.
+The result: **two users granted by the SAME binding (at the same sub-generation) share one cell;
+the same user authorised by DIFFERENT bindings on different layers gets different cells; a
+grant/revoke touching a user's own bindings rotates that user's cells.** This is finer-grained
+than the v3 cohort hash (`BindingSetHash`) it replaced. The key salt is `resolvedKeyVersion =
+"v6"` — see caching.md §3.1 for the v1→v6 lineage.
 
 ### 3.2 The cross-user leak it prevents
 
-The invariant is: **an identity-bound L1 cell must never be keyed by a cohort/content key alone.**
+The invariant is: **an identity-bound L1 cell must never be keyed by a cohort/content key
+alone.**
 
 If the cell were keyed only by content (gvr/ns/name/page/extras) and *not* by the authorising
 binding, then user A — broadly authorised, e.g. an admin or the wildcard-CRB snowplow SA — would
-write a cell holding rows A is permitted to see. User B, narrowly authorised, would then **read A's
-cell** because the content key matches, and receive rows B has no grant for. That is a direct
-cross-user RBAC leak. Folding `BindingUID` into the key means B's request (authorised by a different
-binding, or denied → `BindingUID == ""`) computes a *different* key and never lands on A's cell. The
-`feedback_l1_per_user_keyed_never_cohort` retrospective records that attempts to collapse this to a
-cohort/content-only key were reverted six times; the binding-keyed cell is the durable fix and is the
-substance of ADR 0002/0003.
+write a cell holding rows A is permitted to see. User B, narrowly authorised, would then **read
+A's cell** because the content key matches, and receive rows B has no grant for. That is a direct
+cross-user RBAC leak. Folding `BindingUID` into the key means B's request (authorised by a
+different binding, or denied → `BindingUID == ""`) computes a *different* key and never lands on
+A's cell. The `feedback_l1_per_user_keyed_never_cohort` retrospective records that attempts to
+collapse this to a cohort/content-only key were reverted six times; the binding-keyed cell is the
+durable fix and is the substance of ADR 0002/0003.
 
 ### 3.3 The one exception that proves the rule: `widgetContent`
 
-`widgetContent` is the **only** class that skips the identity fold (`resolved.go:652`,
-`:127-147`). Its cached body is a *shell*: `status.resourcesRefs.items[].allowed` flags are stored as
-populated by the SA walker, but the serve-time gate `gateWidgetEnvelope`
-(`dispatchers/widgets.go:109-114`, `:141`) **overwrites every `allowed` flag per-request via
-`rbac.UserCan` under the requesting identity before serialisation.** So the body is shared but the
-bytes that leave the pod are per-user — the identity narrowing moves from the *key* to a *serve-time
-rewrite*. This is the identity-free-content-key + serve-time-UAF pattern (ADR 0003). The general rule
-holds: an entry is identity-free in the key **only if** it is re-narrowed per-user at serve time.
+`widgetContent` is the **only** class that skips the identity fold. Its cached body is a *shell*:
+`status.resourcesRefs.items[].allowed` flags are stored as populated by the SA walker, but the
+serve-time gate `gateWidgetEnvelope` (`dispatchers/widget_content.go`) **overwrites every
+`allowed` flag per-request via `rbac.UserCan` under the requesting identity before
+serialisation.** So the body is shared but the bytes that leave the pod are per-user — the
+identity narrowing moves from the *key* to a *serve-time rewrite*. This is the
+identity-free-content-key + serve-time-UAF pattern (ADR 0003). The general rule holds: an entry
+is identity-free in the key **only if** it is re-narrowed per-user at serve time.
 
-### 3.4 The empty-UID biconditional
+### 3.4 The empty-UID biconditional — and the #95 serve/Put guard
 
 `BindingUID == ""` iff (cache off) OR (deny / no snapshot) — verified both directions by the F7
-invariant tests (`evaltest/empty_binding_uid_invariant_test.go:94`, `:122`, `:161`, `:194`, `:240`).
-A non-empty UID for a deny would leak the matched-binding identity into the cache key and is treated
-as a broken invariant. Fail-closed: an empty UID collapses the cell to the empty-identity row — the
-same shape as cache=off's transparent fallback (`helpers.go:197-199`).
+invariant tests (`internal/rbac/evaltest/empty_binding_uid_invariant_test.go`). A non-empty UID
+for a deny would leak the matched-binding identity into the cache key and is treated as a broken
+invariant.
+
+The empty-UID *cell* itself proved to be a leak vector (#95): a broad identity could populate the
+shared `""` row (e.g. via a legacy seed) and a *different* ""-deriving identity could then read
+it. Closure is enforced at the dispatch seam: `serveFromCacheEligible`
+(`dispatchers/helpers.go`) blocks **both** the L1 read and the L1 write for empty-`BindingUID`
+inputs, and the seed skips empty-binding targets entirely
+(`prewarm_seed_empty_binding_skip`). An identity that derives `""` simply resolves per-request —
+the same shape as cache-off's transparent fallback.
 
 ---
 
@@ -269,57 +296,63 @@ Serve-time UAF is the second guarantee: even on a correctly-keyed cell, every it
 re-checked against the requesting identity. The sites, all calling `EvaluateRBAC(…,
 SkipBindingUID=true)` and consuming only `allowed`:
 
-- **`refilter.go`** — `applyUserAccessFilter` (`refilter.go:71`) / `refilterSlice`
-  (`refilter.go:182`) / `evalSingle` (`refilter.go:226`, `EvaluateRBAC` at `:257`): the
-  `userAccessFilter` dispatch path. SA-dispatched list results are filtered per-object; a JQ error,
-  an `EvaluateRBAC` error, or a deny **drops** the item (fail-closed, `refilter.go:178-182`,
-  `:269`). This is the authoritative gate — if it drops, the user does not see the item.
-- **`informer_dispatch_rbac.go`** — `filterListByRBAC` (`:93`, eval at `:155`) and `filterGetByRBAC`
-  (`:231`, eval at `:267`): post-LIST per-item drop and single-object GET gate for the informer-served
-  path. Errors fail closed (item dropped).
-- **`cluster_list.go`** — the cluster-scoped list gate (`EvaluateRBAC` at `:238`); a not-yet-published
-  snapshot degrades to deny (`cluster_list.go:181-183`).
-- **`objects/informer_serve.go`** — `filterGetByRBAC` (`:229`, eval at `:257`): no identity, an
-  `EvaluateRBAC` error, or a deny all fail closed (`informer_serve.go:200-214`).
-- **`dispatchers/helpers.go`** — `checkDispatchRBAC` (eval at `:108`): the per-request dispatch gate.
+- **`refilter.go`** (`internal/resolvers/restactions/api/`) — `applyUserAccessFilter` /
+  `refilterSlice` / `evalSingle`: the `userAccessFilter` dispatch path. SA-dispatched list
+  results are filtered per-object; a JQ error, an `EvaluateRBAC` error, or a deny **drops** the
+  item (fail-closed). This is the authoritative gate — if it drops, the user does not see the
+  item. Per item: `NamespaceFrom` jq resolves the namespace (default `.metadata.namespace`);
+  the resource-plural set is resolved once per dispatch (static `uaf.Resource` XOR jq-derived
+  `ResourcesFrom`, OR-semantics across the set); and — **#123** — when `uaf.Verb` is a
+  name-specific verb (`get`/`update`/`patch`/`delete`), the once-compiled `NameFrom` expression
+  (default `.metadata.name`) derives the per-object name so a `resourceNames`-scoped grant
+  matches the objects it names. `NameFrom` is evaluated *only* for name-specific verbs — for
+  `list`/`watch` the evaluator never consults `Name` (a `resourceNames` rule cannot grant
+  collection verbs), so an irrelevant `NameFrom` jq error cannot fail-close a list refilter.
+- **`informer_dispatch_rbac.go`** — `filterListByRBAC` and `filterGetByRBAC`: post-LIST per-item
+  drop and single-object GET gate for the informer-served path. Errors fail closed (item
+  dropped).
+- **`cluster_list.go`** — the cluster-scoped list gate; a not-yet-published snapshot degrades to
+  deny.
+- **`objects/informer_serve.go`** — `filterGetByRBAC`: no identity, an `EvaluateRBAC` error, or
+  a deny all fail closed.
+- **`dispatchers/helpers.go`** — `checkDispatchRBAC`: the per-request dispatch gate.
 
-Because every per-item site discards `matchedBindingUID`, they pass `SkipBindingUID: true` to skip
-the CRB/RB stable-sort — the ~43% pod-CPU lever at 50K scale (`evaluate.go:107-111`,
-`:153-166`). Correctness is unaffected: the sort only affects which UID is returned, not the verdict.
+Because every per-item site discards `matchedBindingUID`, they pass `SkipBindingUID: true` to
+skip the CRB/RB stable-sort — the ~43% pod-CPU lever at 50K scale. Correctness is unaffected:
+the sort only affects which UID is returned, not the verdict.
 
-The cache-key callers — `dispatchCacheLookupKey` (`helpers.go:212`), the `helpers.go` diagnostic
-(`:339`), `ra_full_list` — are the ones that leave `SkipBindingUID` false and keep the deterministic
-UID.
+The cache-key callers — `dispatchCacheLookupKey`, the `helpers.go` diagnostic, `ra_full_list` —
+are the ones that leave `SkipBindingUID` false and keep the deterministic UID.
 
 ---
 
 ## 5. Invariants
 
-1. **Identity-bound L1 cells are keyed by `BindingUID`, never cohort/content alone.** Violation =
-   cross-user leak (§3.2). The sole identity-free class, `widgetContent`, is re-narrowed per-user at
-   serve time (§3.3). (ADR 0002 / 0003.) `ComputeKey` `resolved.go:652-655`.
-2. **Zero `SubjectAccessReview` to the apiserver in cache=on mode.** All checks resolve against the
-   informer-cached typed RBAC snapshot. A nil watcher or nil snapshot **degrades to deny**, never to
-   apiserver fallback (`evaluate.go:185-199`, `:206-217`). The hard rollback trigger for the tag
-   (`evaluate.go:5-8`).
+1. **Identity-bound L1 cells are keyed by `BindingUID` + `RBACSubGen`, never cohort/content
+   alone.** Violation = cross-user leak (§3.2). The sole identity-free class, `widgetContent`,
+   is re-narrowed per-user at serve time (§3.3). (ADR 0002 / 0003.)
+2. **Zero `SubjectAccessReview` to the apiserver in cache=on mode.** All checks resolve against
+   the informer-cached typed RBAC snapshot. A nil watcher or nil snapshot **degrades to deny**,
+   never to apiserver fallback. The hard rollback trigger for the tag.
 3. **cache=off is a transparent correctness baseline.** `CACHE_ENABLED=false` routes through
-   `UserCan` → `SelfSubjectAccessReview` and returns an empty `BindingUID`; the memo and the snapshot
-   are never reached (`rbac.go:62-64`, `evaluate.go:171-183`, `snapshot_authz_memo.go:49-52`).
-4. **One snapshot generation per evaluation.** A single `Snapshot()` load is threaded through the
-   whole walk and the memo key (`evaluate.go:201-206`, `:231-242`), so reads are coherent across a
-   republish.
-5. **Memo caches PERMITS only.** A deny can be transiently wrong under churn and must self-heal by
-   re-walking every call (`evaluate.go:259-289`). Caching a deny is the #301 incident.
+   `UserCan` → `SelfSubjectAccessReview` and returns an empty `BindingUID`; the memo and the
+   snapshot are never reached.
+4. **One snapshot generation per evaluation.** A single `Snapshot()` load is threaded through
+   the whole walk and the memo key, so reads are coherent across a republish.
+5. **Memo caches PERMITS only.** A deny can be transiently wrong under churn and must self-heal
+   by re-walking every call. Caching a deny is the #301 incident.
 6. **Predicate symmetry across subject kinds.** The subject index and `anySubjectMatches` route
-   User, Group, and ServiceAccount identically, sharing `effectiveGroups` for group expansion
-   (`evaluate.go:462`/`:481` vs `:694`/`:743`).
+   User, Group, and ServiceAccount identically, sharing `effectiveGroups` for group expansion.
 7. **The subject index may over-include but never under-include.** `anySubjectMatches` is the
-   post-lookup equality barrier; `CRBsCatchAll` guards unrecognised kinds
-   (`cache/rbac_snapshot.go:149-152`, `evaluate.go:494-497`).
+   post-lookup equality barrier; `CRBsCatchAll` guards unrecognised kinds.
 8. **`BindingUID == ""` ⟺ (cache off) ∨ (deny / no snapshot)** — both directions
-   (`evaltest/empty_binding_uid_invariant_test.go`).
-9. **`resourceNames`-scoped rules never grant collection verbs.** A non-empty `rule.ResourceNames`
-   matches only name-specific verbs and only the named object (`evaluate.go:651-666`).
+   (`evaltest/empty_binding_uid_invariant_test.go`) — and the empty-UID row is never served
+   from or written to on the dispatch path (`serveFromCacheEligible`, #95).
+9. **`resourceNames`-scoped rules never grant collection verbs.** A non-empty
+   `rule.ResourceNames` matches only name-specific verbs and only the named object; the UAF
+   refilter honours such grants per-object via `NameFrom` (#123).
+10. **Sub-generation moves with the snapshot.** Subject counters bump at snapshot publish, not
+    at raw delta time, so a key never encodes RBAC state the evaluator cannot yet see.
 
 ---
 
@@ -327,15 +360,16 @@ UID.
 
 | Symptom | Likely cause | Where to look |
 |---|---|---|
-| Cross-user content leak (user sees rows they lack a grant for) | An identity-bound class lost its `BindingUID` fold, or a cohort/content-only key was reintroduced. | `ComputeKey` `resolved.go:652-655`; the `feedback_l1_per_user_keyed_never_cohort` retrospective; F7 tests. |
-| Admin list stuck empty under load; refresher starved | A transiently-wrong deny got cached (regression of the PERMITS-only rule). | `evaluate.go:259-289`; `snowplow_authz_memo_deny_uncached_total` expvar should be > 0 and rising. |
-| Everything denied right after pod start | Snapshot not yet published — degrade-to-deny pre-readiness gate firing as designed; self-heals once the first rebuild publishes. | `evaluate.go:206-217`; `cluster_list.go:181-183`. |
-| Permits silently lost for one subject kind | Subject index under-includes (index/matcher predicate drift); or a future `Subject.Kind` not routed to `CRBsCatchAll`. | `selectCRBCandidates` `evaluate.go:453`; `anySubjectMatches` `evaluate.go:694`; `rebuildSubjectIndexes` `cache/rbac_snapshot.go:536`. |
-| Wrong verdict for a ServiceAccount caller | Synthetic SA groups not expanded, or index/matcher disagree on expansion. | `effectiveGroups` `evaluate.go:743`; `parseServiceAccountUsername` `evaluate.go:759`. |
-| `resourceNames`-scoped rule over-exposes a list | `resourceNameMatches` regressed (pre-0.30.109 behaviour). | `evaluate.go:651-666`. |
-| Stale verdict served across a binding change | Memo generation-binding broke (gen not in key, or shard not swapped on `PublishSeq` change). | `snapshot_authz_memo.go:84-94`, `:141-157`; `evaluate.go:231-242`. |
-| Group-set hash collision (two different group sets share an entry) | A second, non-length-prefixed groups hasher was introduced (the 0.30.239 two-hasher drift). | `canonicalGroupsHash` `groups_hash.go:68`; do not inline a second hasher. |
-| Loud `rbac.indexer.read fallback=true` WARN | Typed transform did not fire on an RBAC object; the defensive `as{Kind}` conversion path ran. | `asClusterRoleBinding` etc. `evaluate.go:788-859`. |
+| Cross-user content leak (user sees rows they lack a grant for) | An identity-bound class lost its `BindingUID`/`RBACSubGen` fold, a cohort/content-only key was reintroduced, or the #95 empty-UID guard regressed. | `ComputeKey` (`resolved.go`); `serveFromCacheEligible` (`helpers.go`); the `feedback_l1_per_user_keyed_never_cohort` retrospective; F7 + `compute_key_identity_invariants` tests. |
+| Stale UAF view survives a grant/revoke | Sub-gen not bumped (publish-deferral wedge) or the seed's `RBACSubGen==0` cell pinned by a hot refresher without the UAF TTL cap. | `rbac_subgen_pending.go`; `uaf_shortttl.go`; `snowplow_rbac_publish_seq`. |
+| Admin list stuck empty under load; refresher starved | A transiently-wrong deny got cached (regression of the PERMITS-only rule). | `evaluate.go` memo-store site; `snowplow_authz_memo_deny_uncached_total` should be > 0 and rising. |
+| Everything denied right after pod start | Snapshot not yet published — degrade-to-deny pre-readiness gate firing as designed; self-heals once the first rebuild publishes. | `evaluate.go`; `cluster_list.go`. |
+| Permits silently lost for one subject kind | Subject index under-includes (index/matcher predicate drift); or a future `Subject.Kind` not routed to `CRBsCatchAll`. | `selectCRBCandidates`; `anySubjectMatches`; `rebuildSubjectIndexes` (`cache/rbac_snapshot.go`). |
+| Wrong verdict for a ServiceAccount caller | Synthetic SA groups not expanded, or index/matcher disagree on expansion. | `effectiveGroups`; `parseServiceAccountUsername` (`evaluate.go`). |
+| `resourceNames`-scoped rule over-exposes a list, or its named objects vanish from a UAF list | `resourceNameMatches` regressed; or `NameFrom` mis-derives the per-object name. | `evaluate.go` `resourceNameMatches`; `refilter.go` `compileNameFrom`/`evalSingle`. |
+| Stale verdict served across a binding change | Memo generation-binding broke (gen not in key, or shard not swapped on `PublishSeq` change). | `snapshot_authz_memo.go`. |
+| Group-set hash collision (two different group sets share an entry) | A second, non-length-prefixed groups hasher was introduced (the 0.30.239 two-hasher drift). | `canonicalGroupsHash` (`groups_hash.go`); do not inline a second hasher. |
+| Loud `rbac.indexer.read fallback=true` WARN | Typed transform did not fire on an RBAC object; the defensive `as{Kind}` conversion path ran. | `asClusterRoleBinding` etc. (`evaluate.go`). |
 
 > **Testing caution.** Do **not** run `go test ./internal/rbac/...` against a remote kubeconfig — its
 > `TestMain` destructively deletes the RESTAction CRD. Use the `evaltest/` sub-package or a kind

--- a/go/snowplow/docs/architecture/request-lifecycle.md
+++ b/go/snowplow/docs/architecture/request-lifecycle.md
@@ -1,9 +1,18 @@
+---
+type: Architecture
+title: snowplow — request lifecycle
+description: How a /call request becomes JSON — routes and middleware, dispatch, object fetch, RBAC gates, L1 lookup, resolvers, serialization, and the invariants of the read path.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [request-path, dispatch, resolver, rbac, serialization]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Request lifecycle: `/call` → dispatch → resolve → RBAC → serialize
 
 How a single `/call` request becomes JSON the Krateo frontend renders. This
-traces the *current* code at commit `a42b072`; every claim below cites a
-`file:line` you can open. Where a verb-specific or cache-mode-specific branch
-matters, it is called out — the path is not uniform.
+traces the *current* code (docs-standard, 2026-08-06); anchors are file +
+function names. Where a verb-specific or cache-mode-specific branch matters, it
+is called out — the path is not uniform.
 
 snowplow resolves two CR kinds into JSON over `/call`: a `RESTAction`
 (`templates.krateo.io/restactions`) emits raw, *unordered* data assembled from
@@ -19,14 +28,15 @@ other GVR falls through to a raw apiserver passthrough.
                          HTTP GET/POST/PUT/PATCH/DELETE /call?apiVersion=&resource=&namespace=&name=&page=&perPage=&extras=
                                               │
             ┌─────────────────────────────────┴──────────────────────────────────┐
-            │  main.go:797  mux.Handle("GET /call", chain.Append(                  │
+            │  main.go  mux.Handle("GET /call", chain.Append(                      │
             │     middleware.UserConfig(signKey, authnNS)   ← authn: JWT → UserInfo│
             │     cache.FallthroughScopeMiddleware(ScopeCallGeneric)               │
             │     handlers.Dispatcher(dispatchers.All()))   ← routes by GVR group  │
             │   .Then(handlers.Call()))                     ← fallthrough handler  │
+            │  (outermost wrappers: CORS → otelhttp → gzip → audit middleware)     │
             └─────────────────────────────────┬──────────────────────────────────┘
                                               │
-                       proxy.go:11 Dispatcher: GET only; key by gv.Group
+                       proxy.go Dispatcher: GET only; key by gv.Group
                        (restactions → "restactions."+group; widget → group)
                                               │
         ┌──────────────────────┬──────────────┴───────────────────┬──────────────────────────┐
@@ -35,47 +45,50 @@ other GVR falls through to a raw apiserver passthrough.
         │  templates.krateo.io"│                                  │                           │
         ▼                      ▼                                  ▼                           ▼
   RESTAction()           Widgets()                          handlers.Call()             (write verbs:
-  restactions.go:60      widgets.go:50                      call.go:63                    POST/PUT/PATCH/
+  restactions.go         widgets.go                         call.go                       POST/PUT/PATCH/
         │                      │                            raw apiserver passthrough     DELETE skip the
         │                      │                            under the USER's own token    dispatcher entirely)
         │                      │                            RecordApiserverFallthrough
-        ▼                      ▼                            (call.go:114)
-  fetchObject (helpers.go:27) ─ objects.Get (objects/get.go:28)
-   cache-on: informer-served + filterGetByRBAC (get.go:102)
-   cache-off: getFromAPIServer under user token (get.go:159)
+        ▼                      ▼
+  fetchObject (helpers.go) ─ objects.Get (objects/get.go)
+   cache-on: informer-served + filterGetByRBAC
+   cache-off: getFromAPIServer under user token
         │
         ▼
-  checkDispatchRBAC  (helpers.go:93) — cache-on ONLY; gate the GET on the dispatch-target CR
-   rbac.EvaluateRBAC (evaluate.go:167); deny → 403  (restactions.go:96 / widgets.go:90)
+  checkDispatchRBAC  (helpers.go) — cache-on ONLY; gate the GET on the dispatch-target CR
+   rbac.EvaluateRBAC; deny → 403
         │
         ▼
-  L1 resolved-output cache lookup (cache-on)
-   widgets: identity-FREE content cell FIRST (widgets.go:134, gated by isRBACSensitiveApiRefWidget)
-            then per-binding-UID cell        (widgets.go:170, dispatchCacheLookupKey helpers.go:200)
-   restactions: per-binding-UID cell         (restactions.go:123)
+  L1 resolved-output cache lookup (cache-on, and only when serveFromCacheEligible)
+   widgets: identity-FREE content cell FIRST (gated by isRBACSensitiveApiRefWidget)
+            then per-binding cell (BindingUID + RBACSubGen, dispatchCacheLookupKey)
+   restactions: per-binding cell only
         │ HIT → write cached bytes (widgets content-hit re-runs serve-time UAF gate first)
         │ MISS ↓
         ▼
   RESOLVE
-   RESTAction: restactions.Resolve (restactions.go:35) → api.Resolve (per-stage)
+   RESTAction: restactions.Resolve → api.Resolve (per-stage)
                per-stage userAccessFilter → refilter.go (per-item EvaluateRBAC, fail-closed)
                → spec.Filter jq projection → status.Raw
-   Widget:    widgets.Resolve (widgets/resolve.go:38)
-               apiRef → widgetDataTemplate → resourcesRefs (per-item rbac.UserCan → allowed flag)
-               → resourcesRefsTemplate → CRD-schema validate status
+   Widget:    widgets.Resolve
+               A2 identity injection → apiRef → widgetDataTemplate → resourcesRefs
+               (per-item rbac.UserCan → allowed flag) → resourcesRefsTemplate
+               → CRD-schema validate status
         │
         ▼
-  SERIALIZE  encodeResolvedJSON (helpers.go:390, json.Encoder, no indent)
-   stageErrSink.Count()==0 ? Put into L1 + record dep edges : decline to cache (partial body still served)
+  SERIALIZE  encodeResolvedJSON (helpers.go, json.Encoder, no indent)
+   Put gates: zero stage errors AND zero external touches (or TTL-annotated)
+   AND cache-eligible AND declared extras — else serve without persisting
         │
         ▼
-  writeResolvedJSON (helpers.go:413) — Content-Type: application/json, 200, single buffered Write
+  writeResolvedJSON (helpers.go) — Content-Type: application/json, 200, single buffered Write
+  → cache.PublishRefresh(key) on a committed Put (the /refreshes SSE signal)
 ```
 
 For a widget served from the identity-free content cell the cached bytes are a
 *shell*: `gateWidgetEnvelope` re-derives every
 `status.resourcesRefs.items[].allowed` flag under the requester before the
-bytes leave the pod (widget_content.go:469). The shell is never served verbatim.
+bytes leave the pod (`widget_content.go`). The shell is never served verbatim.
 
 ---
 
@@ -83,304 +96,356 @@ bytes leave the pod (widget_content.go:469). The shell is never served verbatim.
 
 ### 2.1 Server wiring and routes — `main.go`
 
-`main()` builds one `http.ServeMux` (main.go:769) and registers the full route
-table:
+`main()` builds one `http.ServeMux` and registers the full route table:
 
-- `GET /health` → `handlers.HealthCheck(...)` (main.go:774)
-- `GET /readyz` → `handlers.ReadyCheck()` (main.go:775) — gated on Phase-1
-  prewarm completion; returns 503 `{"status":"warming"}` until
-  `cache.MarkPhase1Done()` fires (main.go:761-767 startup safety-net, and the
-  `Phase1Warmup` goroutine at main.go:664-675).
-- `GET /call` (main.go:797) — the canonical read path. Its middleware chain is
+- `GET /health` → `handlers.HealthCheck(...)` — liveness only, a static
+  `{"status":"alive"}` with zero allocation per probe.
+- `GET /readyz` → `handlers.ReadyCheck()` — returns 503 `{"status":"warming"}`
+  until `cache.MarkPhase1Done()` fires. Since the prewarm-gated-readiness
+  reversal this flips only after the synchronous boot seed (or its backstop) —
+  see [prewarm.md](prewarm.md).
+- `GET /call` — the canonical read path. Its middleware chain is
   `middleware.UserConfig(signKey, authnNS)` → `FallthroughScopeMiddleware(ScopeCallGeneric)`
   → `handlers.Dispatcher(dispatchers.All())`, finally `.Then(handlers.Call())`.
-- `POST/PUT/PATCH/DELETE /call` (main.go:809-831) — same `UserConfig` middleware
-  and a write-scope `FallthroughScopeMiddleware`, but **no** `Dispatcher` in the
+- `POST/PUT/PATCH/DELETE /call` — same `UserConfig` middleware and a
+  write-scope `FallthroughScopeMiddleware`, but **no** `Dispatcher` in the
   chain; they go straight to `handlers.Call()`.
-- `GET /refreshes` (main.go:810) — the per-subject live-refresh **SSE** stream
-  (Ship 1, option A). Uses `middleware.RefreshAuth` and issues **zero** apiserver
-  reads (no `<user>-clientconfig` lookup). The connection re-derives each
-  subscription key under the caller's own JWT (`DeriveSubscriptionKey`), so a
+- `GET /list` — the list surface (`handlers.List()`), same UserConfig + scope
+  chain (`ScopeList`).
+- `GET /export` — generic export: any `/call`-resolvable list serialized as a
+  CSV/JSON attachment. It **re-dispatches in-process through the same
+  dispatcher lane** the GET `/call` route uses (identical auth, RBAC gate and
+  serve-time UAF — export can never see more than the caller's own `/call`),
+  then serializes the extracted rows (`handlers.Export`).
+- `GET /api-info/names` — plural-name resolution (`handlers.Plurals()`),
+  scope-classified as `plurals`.
+- `GET /refreshes` — the per-subject live-refresh **SSE** stream. Uses
+  `middleware.RefreshAuth` (cookie-or-header JWT; a browser `EventSource`
+  cannot set `Authorization`) and issues **zero** apiserver reads. The
+  connection re-derives each subscription key under the caller's own JWT
+  (`DeriveSubscriptionKey`, `dispatchers/refresh_subscription.go`), so a
   `?sub=` coordinate cannot forge another subject's stream. The cache calls
   `PublishRefresh(key)` after an L1 commit; the matching subscriber receives a
-  signal and refetches a guaranteed-fresh entry (instead of racing the cache).
-- `GET /debug/vars` → `expvar.Handler()` (main.go:869), with snapshot/authz-memo
-  expvars registered just before the mount (main.go:862, :868).
-- `GET /debug/pprof/*` (main.go:837-841) registered on this mux directly (the
-  server does not use `http.DefaultServeMux`).
+  signal and refetches a guaranteed-fresh entry. Gated by
+  `REFRESH_SSE_ENABLED` (a clean idle stream when off). Deliberately NOT
+  scope-registered — with no apiserver reads it sits outside the
+  read-path-scoped invariant.
+- `GET /rbac` — RESTAction read-set enumeration for core-provider RBAC
+  pre-generation: resolves a referenced RESTAction's `api[]` stages to the
+  (group, version, resource, verb) tuples a `/call` WOULD read, without
+  dispatching; runs under the SA so it is computable before any binding
+  exists.
+- `POST /jq` — a jq evaluation helper (`handlers.JQ()`).
+- `GET /swagger/` — swagger UI; `GET /debug/vars` → `expvar.Handler()`;
+  `GET /debug/pprof/*` registered on this mux directly (the server does not
+  use `http.DefaultServeMux`); `GET /debug/servable` and `GET /debug/apistage`
+  — cache diagnostics; `GET /debug/refreshes` — the refresh-subscription
+  registry, auth-gated with the same `RefreshAuth` as `/refreshes`.
 
-The `http.Server` uses `WriteTimeout = 300s` (main.go:58, :898). That deadline is
+The mux is wrapped (inner → outer) by **gzip** (`gzhttp` via
+`middleware/compression.go` — Accept-Encoding-gated, SSE-excluded so
+`/refreshes` keeps per-event flush; non-gzip clients are byte-identical), then
+**otelhttp** (no-op spans unless tracing is enabled — see
+[observability.md](observability.md)), then the **audit middleware**
+(`internal/support/audit` — session correlation rides W3C `baggage`
+`session.id`), then **CORS** (`snowplowCORSOptions` in `main.go`: exposes the
+live-refresh signalling headers `X-Snowplow-Refresh-Key` /
+`X-Snowplow-Refresh-Class` + `Link`, and allows the W3C `traceparent` /
+`tracestate` / `baggage` request headers).
+
+The `http.Server` uses `WriteTimeout = 300s` (`main.go`). That deadline is
 anchored to request-read time, sized to clear the cache-OFF heavy compute path
-(measured ~159s at 50K) before the handler's single buffered `Write`; cache-ON is
-sub-4s and never approaches it (main.go:47-58).
+(measured ~159s at 50K) before the handler's single buffered `Write`; cache-ON
+is sub-4s and never approaches it.
 
 ### 2.2 Authentication — `middleware.UserConfig` (`internal/handlers/middleware/userconfig.go`)
 
 `UserConfig` is snowplow's cache-aware sibling of plumbing's `use.UserConfig`,
-pinned to a transcribed copy of plumbing's control flow (userconfig.go:13, :57).
-It validates the JWT with `jwtutil.Validate(signingKey, token)` and installs
-`WithAccessToken` / `WithUserInfo` / the per-user endpoint onto the request
-context (userconfig.go:71, :104). Downstream the identity is read with
-`xcontext.UserInfo(ctx)` (e.g. helpers.go:96, refilter.go:80) and the per-user
-apiserver endpoint with `xcontext.UserConfig(ctx)` (call.go:80, get.go:170).
+pinned to a transcribed copy of plumbing's control flow. It validates the JWT
+with `jwtutil.Validate(signingKey, token)` and installs `WithAccessToken` /
+`WithUserInfo` / the per-user endpoint onto the request context. Downstream the
+identity is read with `xcontext.UserInfo(ctx)` and the per-user apiserver
+endpoint with `xcontext.UserConfig(ctx)`.
 
 ### 2.3 Dispatch — `handlers.Dispatcher` (`internal/handlers/proxy.go`)
 
-`Dispatcher` (proxy.go:11) is a middleware, not a handler. It:
+`Dispatcher` is a middleware, not a handler. It:
 
 1. Passes any **non-GET** request straight to `next` (= `handlers.Call()`)
-   without routing (proxy.go:14-17). Write verbs are therefore never resolved —
-   they are raw apiserver passthroughs.
-2. Parses `apiVersion` + `resource` query params into a GVR (proxy.go:21-36).
-3. Computes the lookup key: `key = gv.Group`, except for `resource == "restactions"`
-   where `key = "restactions." + gv.Group` (proxy.go:38-42). This is the "Hack
-   caused by new Widgets handlers" — a widget CR's group *is*
-   `widgets.templates.krateo.io`, so it keys on the group; a RESTAction's group is
-   `templates.krateo.io`, so the `restactions.`-prefix disambiguates.
-4. Looks the key up in the `dispatchers.All()` map (dispatchers.go:14-19):
+   without routing. Write verbs are therefore never resolved — they are raw
+   apiserver passthroughs.
+2. Parses `apiVersion` + `resource` query params into a GVR.
+3. Computes the lookup key: `key = gv.Group`, except for
+   `resource == "restactions"` where `key = "restactions." + gv.Group`. This is
+   the "Hack caused by new Widgets handlers" — a widget CR's group *is*
+   `widgets.templates.krateo.io`, so it keys on the group; a RESTAction's group
+   is `templates.krateo.io`, so the `restactions.`-prefix disambiguates.
+4. Looks the key up in the `dispatchers.All()` map:
    `"restactions.templates.krateo.io"` → `RESTAction()`,
    `"widgets.templates.krateo.io"` → `Widgets()`. On a hit it forwards to that
-   handler; on a miss it falls through to `next` = `handlers.Call()` (proxy.go:44-51).
+   handler; on a miss it falls through to `next` = `handlers.Call()`.
 
 ### 2.4 Fallthrough — `handlers.Call` (`internal/handlers/call.go`)
 
-`handlers.Call()` (call.go:27) is the raw passthrough for every GVR not in the
-dispatch map and for all write verbs. It validates the request (call.go:141),
-builds an apiserver URI path (`/apis/<g>/<v>/namespaces/<ns>/<res>[/<name>]`,
-call.go:194), then issues the call under the **user's own** endpoint via
-`request.Do` (call.go:115) — RBAC is enforced inline by the apiserver. It records
-`cache.RecordApiserverFallthrough(..., ReasonClientBuild, "")` *before* the call
-so a panicking plumbing call still counts (call.go:114). The response is decoded
-into a dict (list responses land under `items`, call.go:240-261) and JSON-encoded
-to the wire (call.go:134).
+`handlers.Call()` is the raw passthrough for every GVR not in the dispatch map
+and for all write verbs. It validates the request, builds an apiserver URI path
+(`/apis/<g>/<v>/namespaces/<ns>/<res>[/<name>]`), then issues the call under
+the **user's own** endpoint via `request.Do` — RBAC is enforced inline by the
+apiserver. It records `cache.RecordApiserverFallthrough(..., ReasonClientBuild,
+"")` *before* the call so a panicking plumbing call still counts. The response
+is decoded into a dict (list responses land under `items`) and JSON-encoded to
+the wire (with two-space indent — see §5).
 
 ### 2.5 The two dispatchers — `internal/handlers/dispatchers/{restactions,widgets}.go`
 
-Both handlers are constructed once (`RESTAction()` restactions.go:22 /
-`Widgets()` widgets.go:22) and capture the snowplow ServiceAccount transport pair
-(`saEP`, `saRC`) at construction time, not per request — the per-request
-`snowplowSACtx()` was found to serialize dispatches on the SA-singleton mutexes
-(restactions.go:23-43). Out-of-cluster runs get `(nil, nil)` and skip the attach.
+Both handlers are constructed once (`RESTAction()` / `Widgets()`) and capture
+the snowplow ServiceAccount transport pair (`saEP`, `saRC`) at construction
+time, not per request — the per-request `snowplowSACtx()` was found to
+serialize dispatches on the SA-singleton mutexes. Out-of-cluster runs get
+`(nil, nil)` and skip the attach.
 
 Both `ServeHTTP` methods follow the same skeleton:
 
 1. `beginPerCall` / deferred `pcEmit` — structured `dispatcher.call.complete`
-   timing log (restactions.go:70, per_call_log.go:39-53).
-2. `defer markCustomerInFlight()()` — signals the prewarm engine to yield
-   background work for the dispatch's duration (restactions.go:77, widgets.go:62).
+   timing log (`per_call_log.go`).
+2. `defer markCustomerInFlight()()` — signals the prewarm engine and refresher
+   to yield background work for the dispatch's duration.
 3. `util.ParseExtras(req)` — parses the `?extras=<json>` query param into a
-   `map[string]any` (restactions.go:79; util/extras.go:9).
-4. `fetchObject(req)` — fetch the dispatch-target CR (helpers.go:27 →
+   `map[string]any`.
+4. `fetchObject(req)` — fetch the dispatch-target CR (`helpers.go` →
    `objects.Get`, §2.6).
 5. **RBAC dispatch gate** — cache-on only (§2.7).
-6. **L1 cache lookup** — cache-on only (§2.8).
+6. **L1 cache lookup** — cache-on only, guarded by `serveFromCacheEligible`
+   (§2.8).
 7. On miss, build the resolve context (attach SA transport, the L1 key, a
-   stage-error sink), call the resolver, encode, conditionally cache, write.
+   stage-error sink, an external-touched sink), call the resolver, encode,
+   conditionally cache, write.
 
 ### 2.6 Object fetch — `objects.Get` (`internal/objects/get.go`)
 
-`fetchObject` (helpers.go:27) delegates to `objects.Get` (get.go:28). The fetch
-is cache-mode-routed:
+`fetchObject` delegates to `objects.Get`. The fetch is cache-mode-routed:
 
 - **cache-off** (`cache.Disabled()`): `getFromAPIServer` under the user's own
-  endpoint/token (get.go:51-52, :159). RBAC is enforced inline by the apiserver.
+  endpoint/token. RBAC is enforced inline by the apiserver.
 - **cache-on**: served from the in-process informer cache *iff* the GVR is
-  servable (registered + `HasSynced`, get.go:90) **and** the requester passes
-  `filterGetByRBAC` (get.go:102). A miss, a not-yet-synced informer, or an
-  RBAC-denied GET all fall through to `getFromAPIServer` under the user's token,
-  which returns the authoritative 403/404 (get.go:137-151).
+  servable (registered + `HasSynced`) **and** the requester passes
+  `filterGetByRBAC` (`objects/informer_serve.go`). A miss, a not-yet-synced
+  informer, or an RBAC-denied GET all fall through to `getFromAPIServer` under
+  the user's token, which returns the authoritative 403/404.
 
-When `ctx` carries an L1 key (`cache.WithL1KeyContext`), a successful Get records
-a dependency edge `(GVR, ns, name)` so a later DELETE/ADD/UPDATE of that object
-invalidates the L1 entry (get.go:39-41, :249-258).
+When `ctx` carries an L1 key (`cache.WithL1KeyContext`), a successful Get
+records a dependency edge `(GVR, ns, name)` so a later DELETE/ADD/UPDATE of
+that object invalidates the L1 entry.
 
-### 2.7 The RBAC dispatch gate — `checkDispatchRBAC` (`helpers.go:93`)
+### 2.7 The RBAC dispatch gate — `checkDispatchRBAC` (`dispatchers/helpers.go`)
 
-In cache-on mode `objects.Get`'s informer branch bypasses the per-user token, so
-the GET on the dispatch-target CR is re-checked explicitly. Both dispatchers call
-`checkDispatchRBAC` and return **403** on deny (restactions.go:96-108,
-widgets.go:90-100). It extracts `UserInfo`, calls `rbac.EvaluateRBAC` with verb
-`get` and `SkipBindingUID: true` (it discards the binding UID), and returns the
-allow bit; any error fails closed to deny (helpers.go:96-128). In cache-off mode
-the gate is skipped — the per-user apiserver fetch in `objects.Get` already
-enforced it.
+In cache-on mode `objects.Get`'s informer branch bypasses the per-user token,
+so the GET on the dispatch-target CR is re-checked explicitly. Both dispatchers
+call `checkDispatchRBAC` and return **403** on deny. It extracts `UserInfo`,
+calls `rbac.EvaluateRBAC` with verb `get` and `SkipBindingUID: true` (it
+discards the binding UID), and returns the allow bit; any error fails closed to
+deny. In cache-off mode the gate is skipped — the per-user apiserver fetch in
+`objects.Get` already enforced it.
 
 ### 2.8 L1 lookup keys
 
 The dispatch-target lookup runs **strictly after** the RBAC gate so a cache hit
-can never short-circuit the permission check (restactions.go:112-116).
+can never short-circuit the permission check.
 
-- `dispatchCacheLookupKey` (helpers.go:200) builds the per-request key. It reads
+- `dispatchCacheLookupKey` (`helpers.go`) builds the per-request key. It reads
   `UserInfo`; **a missing/unparseable identity makes the request uncacheable**
-  (nil handle, helpers.go:205-209) — the resolve still runs, but nothing is read
-  from or written to L1. Identity is folded as a **per-binding UID**: a direct
+  (nil handle) — the resolve still runs, but nothing is read from or written to
+  L1. Identity is folded as **two terms**: the **per-binding UID** — a direct
   `rbac.EvaluateRBAC(verb=get, …)` returns the first-match binding UID that
-  authorized the GET, and that UID — *not* the literal username — is the
-  `BindingUID` field in the key (helpers.go:211-228). Two users authorized by the
-  same binding share the cell. `Username`/`Groups` are carried only as the
+  authorized the GET, and that UID (*not* the literal username) is the
+  `BindingUID` field in the key — and the subject's **RBAC sub-generation**
+  (`cache.RBACSubGenForSubject`), which rotates the user's keys when their own
+  bindings change. Two users authorized by the same binding (at the same
+  sub-gen) share the cell. `Username`/`Groups` are carried only as the
   refresher's `Representative*` re-resolve identity, **not** folded into
-  `ComputeKey` (helpers.go:229-237, resolved.go:305-327).
+  `ComputeKey`. A deny/error derives `BindingUID == ""`, and an empty-UID cell
+  is **neither read nor written** on the dispatch path (`serveFromCacheEligible`
+  — the #95 leak closure).
 - Widgets additionally try an **identity-free** content cell first
-  (`dispatchWidgetContentKey`, helpers.go:147; widgets.go:134-164). Its key is
-  `(gvr, ns, name, perPage, page, extras)` with username/groups omitted entirely
-  (`CacheEntryClassWidgetContent`; resolved.go:131, :652). This shared cell is
-  **skipped** for an apiRef-driven render widget classified RBAC-sensitive by
-  `isRBACSensitiveApiRefWidget` (widgets.go:134, widget_content.go:348), because
-  its `status.widgetData` aggregate is not narrowed at serve time and would leak
+  (`dispatchWidgetContentKey`). Its key is `(gvr, ns, name, perPage, page,
+  extras)` with username/groups omitted entirely
+  (`CacheEntryClassWidgetContent`). This shared cell is **skipped** for an
+  apiRef-driven render widget classified RBAC-sensitive by
+  `isRBACSensitiveApiRefWidget` (`widget_content.go`), because its
+  `status.widgetData` aggregate is not narrowed at serve time and would leak
   cross-user. On a content-cell hit, `gateWidgetEnvelope` re-derives every
-  `items[].allowed` flag under the requester (widgets.go:141; widget_content.go:469)
-  before writing.
+  `items[].allowed` flag under the requester before writing.
 
-`extras` is folded into every L1 key via `canonicaliseExtras` (a sorted-key JSON
-encoding) inside `ComputeKey` (resolved.go:680-718) — so distinct `extras` values
-never collide on one cell.
+`extras` fold into every L1 key via `canonicaliseExtras` (a sorted-key JSON
+encoding) inside `ComputeKey` — so distinct `extras` values never collide on
+one cell. **Which extras may reach the key** is author-declared: the effective
+key extras are the union of the widget's inline template extras and the request
+extras filtered by `spec.keyExtras` (F6, `filterDeclaredKeyExtras`) plus the
+`spec.identityContext` identity axis (username/groups — server-injected, so a
+client-supplied `extras.username` can never spoof it). A resolve fed
+undeclared request extras is served but its Put is quarantined.
 
 ### 2.9 Resolve — RESTAction (`internal/resolvers/restactions/`)
 
-`restactions.Resolve` (restactions.go:35) runs the typed CR's `spec.api[]` stages
-through `api.Resolve`, producing a `dict` of per-stage outputs. Each stage that
+`restactions.Resolve` runs the typed CR's `spec.api[]` stages through
+`api.Resolve`, producing a `dict` of per-stage outputs. Each stage that
 declares `userAccessFilter` is RBAC-filtered **per item** by the api package's
-refilter (refilter.go). Then `spec.Filter` (if present) is a single jq projection
-over the dict (restactions.go:58-68); otherwise the dict is marshalled as-is
-(restactions.go:69-74). The result is written to `status.Raw` as a
-`runtime.RawExtension` (restactions.go:77-79), with `last-applied-configuration`
-and `managedFields` stripped (restactions.go:81-86).
+refilter (`refilter.go`). Then `spec.Filter` (if present) is a single jq
+projection over the dict; otherwise the dict is marshalled as-is. The result is
+written to `status.Raw` as a `runtime.RawExtension`, with
+`last-applied-configuration` and `managedFields` stripped.
 
 A stage that targets an external `endpointRef` is dispatched through snowplow's
-own HTTP fetch (`api/external_fetch.go` `httpFetchAllowingNonJSON`), which reuses
-plumbing's client / auth roundtrippers / retry but drops the JSON-only `406` gate
-— so the stage may receive **YAML or JSON**, and a YAML body is converted to JSON
-before the stage jq. See [ADR 0006](../adr/0006-snowplow-owned-external-fetch.md).
+own HTTP fetch (`api/external_fetch.go` `httpFetchAllowingNonJSON`), which
+reuses plumbing's client / auth roundtrippers / retry but drops the JSON-only
+`406` gate — so the stage may receive **YAML or JSON**, and a YAML body is
+converted to JSON before the stage jq. See
+[ADR 0006](../adr/0006-snowplow-owned-external-fetch.md). A resolve that
+touched an external endpoint is not L1-cached (no dep edge can invalidate it)
+unless the widget carries the bounded-TTL annotation — see caching.md §4. An
+api-step's `endpointRef.name` may itself be templated from request extras (the
+hub-spoke pattern).
 
-The RESTAction emits *unordered* data. It contains **no widget-shaping logic** —
-the layering boundary is asserted in the refilter package doc (refilter.go:16-18):
-RBAC narrowing lives in the resolver/per-API-stage layer, never in widget
-canonicalization.
+A stage that fetches a snowplow RESTAction/Widget CR from a **direct apiserver
+path** may set `resolve: true` (`spec.api[].resolve`, **default false / opt-in**
+— the 2026-07-02 contract flip aligned with progressive rendering) to run the
+fetched CR through the resolver **in-process** and substitute the resolved
+envelope for the stage output. The old `/call?resource=…` HTTP-loopback
+dispatch branch is **retired** (2026-06-22 corpus audit: zero live loopback
+paths); the in-process resolver behind the seam
+(`dispatchers/nested_call.go` `ResolveNestedCall`, wired via
+`api.RegisterNestedCallResolver`) replicates the dispatcher minus the HTTP
+edge — and its explicit `checkDispatchRBAC` call is the single most important
+correctness line on that path (the in-process resolve bypasses the per-user
+apiserver edge). Nested resolves are cycle-stopped by an ancestor set, depth-
+gated, and admission-bounded by the process-wide adaptive headroom gate
+(`api/nested_resolve_bound.go`: GOMEMLIMIT − live heap; blocks, never drops;
+on ctx expiry the outer `/call` returns an honest 503-class error).
+
+The RESTAction emits *unordered* data. It contains **no widget-shaping logic**
+— the layering boundary is asserted in the refilter package doc: RBAC narrowing
+lives in the resolver/per-API-stage layer, never in widget canonicalization.
 
 ### 2.10 Resolve — RBAC refilter (`internal/resolvers/restactions/api/refilter.go`)
 
-`userAccessFilter` is the per-item RBAC filter for a SA-dispatched LIST. The list
-is fetched under the snowplow SA, then narrowed to what the *requesting user* may
-see (refilter.go:1-30). For each item:
+`userAccessFilter` is the per-item RBAC filter for a SA-dispatched LIST. The
+list is fetched under the snowplow SA, then narrowed to what the *requesting
+user* may see. For each item:
 
-- `NamespaceFrom` jq resolves the namespace (default `.metadata.namespace`,
-  refilter.go:237-240).
+- `NamespaceFrom` jq resolves the namespace (default `.metadata.namespace`).
 - The resource-plural set is resolved once per dispatch — static `uaf.Resource`
-  or jq-derived `ResourcesFrom` (refilter.go:303). An item is kept iff
-  `rbac.EvaluateRBAC` permits the user for **any** resource in the set
-  (OR-semantics, refilter.go:254-284).
+  or jq-derived `ResourcesFrom`. An item is kept iff `rbac.EvaluateRBAC`
+  permits the user for **any** resource in the set (OR-semantics).
+- For a **name-specific verb** (`get`/`update`/`patch`/`delete`), the
+  once-compiled `NameFrom` expression (default `.metadata.name`) derives the
+  per-object name so `resourceNames`-scoped grants match (#123); for
+  `list`/`watch` the name is never consulted.
 
-Every failure mode fails **closed**: missing `UserInfo` drops all items
-(refilter.go:80-90); an unresolvable resource set drops all items
-(refilter.go:101-106); a jq error or an unrecognized item shape denies that item
-(refilter.go:182-207, :241-248). The production callsite is
-`applyUserAccessFilterOnPig` (refilter.go:428), which resolves `ResourcesFrom`
-against the full resolver `dict` (so it can reference upstream stage outputs like
-`.crds`) while refiltering the per-stage items.
+Every failure mode fails **closed**: missing `UserInfo` drops all items; an
+unresolvable resource set drops all items; a jq error or an unrecognized item
+shape denies that item. The production callsite is
+`applyUserAccessFilterOnPig`, which resolves `ResourcesFrom` against the full
+resolver `dict` (so it can reference upstream stage outputs like `.crds`)
+while refiltering the per-stage items.
 
 ### 2.11 Resolve — Widget (`internal/resolvers/widgets/resolve.go`)
 
-`widgets.Resolve` (resolve.go:38) canonicalizes into the render-ready envelope,
-in fixed phases (each wall-clocked, resolve.go:69-160):
+`widgets.Resolve` canonicalizes into the render-ready envelope, in fixed
+phases (each wall-clocked for the seed's timing sink):
 
-1. `resolveApiRef` (resolve.go:175) — fetch the widget's apiRef RESTAction (under
-   SA transport), yielding the data source `ds`. `extras` flows
-   widget → apiref → restactions → api here (resolve.go:181-201).
-2. `injectSlice(ds, perPage, page)` (resolve.go:88, :304) — re-inject the
-   pagination triple stripped by the RA's `spec.Filter` projection.
-3. `mergeExtras(ds, extras)` (resolve.go:96, :348) — fold extras into `ds`,
-   **non-overwriting** (apiRef results and the slice triple win on collision);
-   this also makes extras available to apiRef-less widgets.
-4. `resolveWidgetData` → `status.widgetData` (resolve.go:99-112). A
-   `widgetDataTemplate` read error **fails soft** to static-only data
-   (resolve.go:220-224) — kept symmetric with `isRBACSensitiveApiRefWidget`'s
-   de-classification so a read error never lands a SA-maximal aggregate in the
-   shared identity-free cell (resolve.go:209-219).
-5. `resolveResourceRefs` → `status.resourcesRefs.items` (resolve.go:115-148).
-   Each ref gets an `allowed` flag from `rbac.UserCan` under the *resolving*
-   identity (resourcesrefs/resolve.go:108).
-6. `crdschema.ValidateObjectStatus` validates the status against the widget's CRD
-   schema; a failure returns a 400 `StatusError` (resolve.go:159-170).
+1. **A2 identity injection** — for a widget declaring `spec.identityContext`,
+   the declared subset of the *authenticated* principal (`DeclaredIdentity`) is
+   folded into `opts.Extras`, **overwriting** any client-supplied value for the
+   declared keys (the anti-spoof quarantine). Runs cache-on and cache-off
+   identically; inert for the identity-free corpus.
+2. `resolveApiRef` — fetch the widget's apiRef RESTAction (under SA
+   transport), yielding the data source `ds`. `extras` flows
+   widget → apiref → restactions → api here.
+3. `injectSlice(ds, perPage, page)` — re-inject the pagination triple stripped
+   by the RA's `spec.Filter` projection.
+4. `mergeExtras(ds, extras)` — fold extras into `ds`, **non-overwriting**
+   (apiRef results and the slice triple win on collision); this also makes
+   extras available to apiRef-less widgets.
+5. `resolveWidgetData` → `status.widgetData`. A `widgetDataTemplate` read error
+   **fails soft** to static-only data — kept symmetric with
+   `isRBACSensitiveApiRefWidget`'s de-classification so a read error never
+   lands a SA-maximal aggregate in the shared identity-free cell.
+6. `resolveResourceRefs` → `status.resourcesRefs.items`. Each ref gets an
+   `allowed` flag from `rbac.UserCan` under the *resolving* identity
+   (`resourcesrefs/resolve.go`). The #72 inline-rendered-children producer
+   (`widgets_inline.go`, opt-in) can additionally attach resolved child
+   envelopes.
+7. `crdschema.ValidateObjectStatus` validates the status against the widget's
+   CRD schema; a failure returns a 400 `StatusError`.
 
 ### 2.12 RBAC evaluator — `internal/rbac/`
 
-`rbac.UserCan` (rbac.go:32) routes through `rbac.EvaluateRBAC` in cache-on mode
-and through a SubjectAccessReview only in cache-off mode (rbac.go:25-44).
-
-`EvaluateRBAC` (evaluate.go:167) is the in-process evaluator:
-
-- **cache-off**: falls through to `UserCan` → SelfSubjectAccessReview, returns no
-  binding UID (evaluate.go:171-183). This is the correctness baseline that keeps
-  `CACHE_ENABLED=false` a transparent fallback.
-- **cache-on**: reads a single coherent `*cache.RBACSnapshot`
-  (evaluate.go:206); a nil watcher or nil snapshot **degrades to deny**, never to
-  apiserver (evaluate.go:185-217) — the "zero SubjectAccessReview in cache-on"
-  rule. A per-generation authz memo short-circuits the candidate walk on a hit;
-  only **permits** are memoized — a deny can be transiently wrong under snapshot
-  churn and must re-walk every call (evaluate.go:231-289).
-- The walk (`evaluateAgainstInformerFirstMatch`, evaluate.go:334) checks
-  ClusterRoleBindings first, then namespaced RoleBindings; first permitting rule
-  wins (RBAC v1 has no deny rules). Candidate sets come from subject indexes
-  (`selectCRBCandidates` / `selectRBCandidates`, evaluate.go:453, :507) and are
-  post-filtered by `anySubjectMatches` (evaluate.go:694) for **User**, **Group**
-  (including the implicit `system:authenticated` and SA synthetic groups), and
-  **ServiceAccount** subjects symmetrically. `rulesPermit` honors verb/apiGroup/
-  resource wildcards and `resourceNames` scoping (evaluate.go:597, :651).
+`rbac.UserCan` routes through `rbac.EvaluateRBAC` in cache-on mode and through
+a SubjectAccessReview only in cache-off mode. `EvaluateRBAC` is the in-process
+evaluator — snapshot-based candidate walk, L2 permit-only memo, degrade-to-deny
+on a missing snapshot. See [rbac-uaf.md](rbac-uaf.md) for the full trace.
 
 ### 2.13 Serialize and conditional cache write
 
-Both dispatchers encode with `encodeResolvedJSON` (helpers.go:390) — a
-`json.Encoder` with **no** indentation, deliberately matched between the cache-Put
-bytes and the wire bytes so "cache-on warm == cache-off" holds (helpers.go:386-396;
-note `handlers.Call` at call.go:135 does indent — that path is the raw passthrough,
-not a resolver result). The write is a single buffered
-`writeResolvedJSON` (helpers.go:413) — no streaming (helpers.go:402-412).
+Both dispatchers encode with `encodeResolvedJSON` (`helpers.go`) — a
+`json.Encoder` with **no** indentation, deliberately matched between the
+cache-Put bytes and the wire bytes so "cache-on warm == cache-off" holds (note
+`handlers.Call` does indent — that path is the raw passthrough, not a resolver
+result). The write is a single buffered `writeResolvedJSON` — no streaming.
 
-The L1 **Put** is gated on `stageErrSink.Count() == 0`: if any per-item stage
-error fired during resolve, the partial body is still **served** (200) but **not
-persisted**, so transient item failures self-heal on the next resolve
-(restactions.go:211, :249-256; widgets.go:224, :266-271). On a clean resolve the
-bytes are Put under the computed key and dependency edges are recorded — the
-self-dep on the dispatch-target CR (restactions.go:280-281) and, for widgets, the
-apiRef→RESTAction and render-eligible resourcesRefs deps
-(`recordWidgetDeps`, widgets.go:291).
+The L1 **Put** is gated (see caching.md §4): `stageErrSink.Count() == 0` (a
+partial body is served (200) but not persisted), `extTouchedSink.Count() == 0`
+(external results have no invalidation edge; the per-widget
+`krateo.io/external-cache-ttl-seconds` annotation opts into a bounded-TTL Put
+instead), `serveFromCacheEligible` (never write the empty-`BindingUID` row),
+and the F6 declared-extras check. On a clean resolve the bytes are Put under
+the computed key, dependency edges are recorded — the self-dep on the
+dispatch-target CR and, for widgets, the apiRef→RESTAction and render-eligible
+resourcesRefs deps (`recordWidgetDeps`) — and `cache.PublishRefresh` signals
+`/refreshes` subscribers.
 
 ---
 
 ## 3. Invariants
 
 1. **RBAC gate precedes the cache.** The L1 lookup is always after
-   `checkDispatchRBAC`, so a cache hit can never bypass a permission check
-   (restactions.go:112-116, widgets.go:166-167).
-2. **Layering: RESTAction emits unordered data; the widget canonicalizes.** RBAC
-   narrowing lives in the resolver / per-API-stage layer (refilter.go:16-18); the
-   RESTAction has no widget-shaping logic.
-3. **Per-binding-UID L1 keying — never identity-free for sensitive content.** The
-   per-cohort cell keys on the authorizing binding UID, not username
-   (helpers.go:211-228). The identity-free widget-content cell is used only for
-   non-RBAC-sensitive widgets and is always passed through serve-time
-   `gateWidgetEnvelope`, which re-derives `allowed` per requester
-   (widgets.go:134, widget_content.go:469). A request with no identity is
-   uncacheable (helpers.go:205-209).
+   `checkDispatchRBAC`, so a cache hit can never bypass a permission check.
+2. **Layering: RESTAction emits unordered data; the widget canonicalizes.**
+   RBAC narrowing lives in the resolver / per-API-stage layer; the RESTAction
+   has no widget-shaping logic.
+3. **Per-binding(+sub-gen) L1 keying — never identity-free for sensitive
+   content, never the empty row.** The identity-bound cell keys on the
+   authorizing binding UID + the subject's RBAC sub-generation, not username.
+   The identity-free widget-content cell is used only for non-RBAC-sensitive
+   widgets and is always passed through serve-time `gateWidgetEnvelope`. A
+   request with no identity is uncacheable; a deny (`BindingUID==""`) is
+   neither served from nor written to L1.
 4. **Cache-off is a transparent fallback.** `CACHE_ENABLED=false` makes
    `objects.Get`, `EvaluateRBAC`, and `UserCan` route to the apiserver /
-   SubjectAccessReview under the user's own token (get.go:51, evaluate.go:171,
-   rbac.go:35) — same data and RBAC, just slower. No dispatch RBAC gate runs
-   because the per-user fetch already enforced it (restactions.go:96).
+   SubjectAccessReview under the user's own token — same data and RBAC, just
+   slower. No dispatch RBAC gate runs because the per-user fetch already
+   enforced it.
 5. **Fail-closed everywhere RBAC is evaluated.** Missing identity, evaluator
-   error, nil snapshot, unparseable item shape → deny / drop, never allow-all
-   (refilter.go:80, :182-207; evaluate.go:185-217; widget_content.go:526-559).
-6. **Serve bytes == cache bytes.** Resolver responses are encoded identically on
-   the Put path and the write path (helpers.go:386-396).
-7. **Only clean resolves are cached.** A per-item stage error serves the partial
-   body but declines the Put (restactions.go:249, widgets.go:266).
-8. **A per-item feed/decode error does not truncate the resolve.** On every served
-   dispatch branch (external fetch, in-process nested `/call`, informer-pivot,
-   internal-rest-config), a stage whose body fails to decode / jq-filter records
-   the error into `errorKey` (or surfaces it per `continueOnError`) and returns
-   `nil` for that item — remaining items and downstream stages still run (the #313
-   Option C-A contract). Branches that previously raw-`return err`'d and abandoned
-   the whole resolve were corrected in snowplow 1.2.0.
+   error, nil snapshot, unparseable item shape → deny / drop, never allow-all.
+6. **Serve bytes == cache bytes.** Resolver responses are encoded identically
+   on the Put path and the write path.
+7. **Only clean, invalidatable, declared resolves are cached.** A per-item
+   stage error, an external touch (unless TTL-annotated), an empty binding
+   UID, or undeclared request extras serve the body but decline the Put.
+8. **A per-item feed/decode error does not truncate the resolve.** On every
+   served dispatch branch (external fetch, in-process nested resolve,
+   informer-pivot, internal-rest-config), a stage whose body fails to decode /
+   jq-filter records the error into `errorKey` (or surfaces it per
+   `continueOnError`) and returns `nil` for that item — remaining items and
+   downstream stages still run (the #313 Option C-A contract).
+9. **In-process resolves are explicitly RBAC-gated.** Every `resolve: true`
+   nested resolve passes `checkDispatchRBAC` before resolving — the in-process
+   path must reconstruct the RBAC enforcement the HTTP edge would have
+   provided.
+10. **Server-injected identity beats client extras.** For
+    `spec.identityContext` widgets the JWT-derived identity overwrites any
+    client-supplied identity extras — extras can shape content only where the
+    author declared them (`spec.keyExtras`).
 
 ---
 
@@ -388,45 +453,45 @@ apiRef→RESTAction and render-eligible resourcesRefs deps
 
 | Symptom | Likely cause | Where it surfaces in code |
 |---|---|---|
-| `/call` returns 403 for a widget/RESTAction the user expects | `checkDispatchRBAC` denied the GET on the dispatch-target CR (cache-on); or in-process snapshot not yet built (degrade-to-deny) | restactions.go:96-108, widgets.go:90-100; evaluate.go:207-217 |
-| All list items vanish for a narrow-RBAC user | `userAccessFilter` fail-closed: missing `UserInfo`, unresolvable `ResourcesFrom`, or a `NamespaceFrom` jq error dropped every item | refilter.go:80-90, :101-106, :241-248 |
-| Widget panel renders 0 rows for one user, full for admin | working as designed: `gateWidgetEnvelope` set `allowed=false` per requester; the frontend renders only `allowed==true` items | widget_content.go:449-507 |
-| `/call` hangs then client gets HTTP 0 under cache-OFF at scale | heavy compute exceeded `WriteTimeout`; the t0-anchored 300s deadline is the bound | main.go:47-58, :898 |
-| Cross-user data leak from a shared widget cell | an RBAC-sensitive apiRef widget incorrectly routed to the identity-free content cell — the `isRBACSensitiveApiRefWidget` / `resolveWidgetData` error-direction symmetry was broken | widgets.go:134; resolve.go:209-224; widget_content.go:348 |
-| Stale content after an object change | dependency edges not recorded (Get ran without an L1 key in ctx, or cache off); TTL is the outer safety net | get.go:39-41, :249-258; restactions.go:268-281 |
-| Cache never serves; everything hits apiserver | cache disabled, informer not servable (`!HasSynced`), or a nil/passthrough/metadata-only watcher | get.go:51, :80-90; evaluate.go:185-198 |
-| `/readyz` stuck `{"status":"warming"}` | Phase-1 prewarm never flipped `Phase1Done`; the startup safety-net's 3-disjunct guard should cover cache-off | main.go:761-767, :664-675 |
+| `/call` returns 403 for a widget/RESTAction the user expects | `checkDispatchRBAC` denied the GET on the dispatch-target CR (cache-on); or in-process snapshot not yet built (degrade-to-deny) | `dispatchers/restactions.go`, `widgets.go`; `rbac/evaluate.go` |
+| All list items vanish for a narrow-RBAC user | `userAccessFilter` fail-closed: missing `UserInfo`, unresolvable `ResourcesFrom`, or a `NamespaceFrom` jq error dropped every item | `api/refilter.go` |
+| Widget panel renders 0 rows for one user, full for admin | working as designed: `gateWidgetEnvelope` set `allowed=false` per requester; the frontend renders only `allowed==true` items | `dispatchers/widget_content.go` |
+| `/call` hangs then client gets HTTP 0 under cache-OFF at scale | heavy compute exceeded `WriteTimeout`; the t0-anchored 300s deadline is the bound | `main.go` |
+| A cold compositions-page fan-out returns 503-class errors | the adaptive aggregate admission bound serialized the outermost nested resolves and the ctx expired — honest backpressure, not silent truncation | `api/nested_resolve_bound.go` |
+| Cross-user data leak from a shared widget cell | an RBAC-sensitive apiRef widget incorrectly routed to the identity-free content cell — the `isRBACSensitiveApiRefWidget` / `resolveWidgetData` error-direction symmetry was broken; or the #95 empty-UID guard regressed | `dispatchers/widgets.go`; `widgets/resolve.go`; `helpers.go` `serveFromCacheEligible` |
+| A nested `resolve: true` stage returns raw instead of resolved (or vice versa) | the stage's `resolve` field vs the opt-in default-false contract; the resolver's `ptr.Deref(…Resolve, false)` is the single default site | `apis/templates/v1/core.go`; `api/resolve.go` |
+| Stale content after an object change | dependency edges not recorded (Get ran without an L1 key in ctx, or cache off); TTL is the outer safety net | `objects/get.go`; `dispatchers/restactions.go` |
+| External-API widget hammers the upstream on every `/call` | by design: external resolves are never cached; opt into the bounded-TTL annotation if staleness ≤120s is acceptable | `cache/external_touched_sink.go`; `dispatchers/external_ttl.go` |
+| Cache never serves; everything hits apiserver | cache disabled, informer not servable (`!HasSynced`), or a nil/passthrough/metadata-only watcher | `objects/get.go`; `rbac/evaluate.go` |
+| `/readyz` stuck `{"status":"warming"}` | Phase-1 warmup (incl. the sync seed) never flipped `Phase1Done` — should be impossible past the fire-regardless backstop; check `snowplow_readyz_backstop_fired` and the `phase1.*` logs | `dispatchers/phase1_walk.go` |
 
 ---
 
-## 5. Notes where code diverged from the documentation plan
+## 5. Notes where code diverged from earlier documentation
 
-These are flagged because the plan's prose did not match the current tree:
-
-- **"per-user L1 keying."** The plan (§3 ADR-0002, §4) describes the L1 cell as
-  *per-user*-keyed. The current code keys the per-cohort cell on the **first-match
-  binding UID** returned by `EvaluateRBAC` (`BindingUID`, helpers.go:211-228),
-  with username/groups deliberately removed from `ComputeKey`
-  (resolved.go:256-269, :305-327). Username/groups survive only as the refresher's
-  `Representative*` re-resolve identity. "Per-binding-UID" is the accurate
-  description; "per-user" is correct only in the sense that the key is still
-  identity-derived and never shared across permission boundaries.
-
-- **`handlers.Call` is the fallthrough, not the resolver entry.** The plan frames
-  `/call` as "dispatcher → resolver." In code the `handlers.Call()` handler
-  (call.go:27) is the **raw apiserver passthrough** for unmatched GVRs and for all
-  write verbs; the resolvers are reached only through the `Dispatcher` middleware's
-  `All()` map (proxy.go:44, dispatchers.go:14). Write verbs bypass the dispatcher
-  entirely (proxy.go:14-17) and are never resolved.
-
-- **`internal/handlers/dispatchers/` is not a thin layer.** The plan's anchor list
-  treats it as the dispatch site; in practice this package also owns the entire L1
-  key/lookup/Put logic, the prewarm engine, and the background refresher. The pure
-  routing decision is the small `proxy.go` middleware in `internal/handlers/`, not
-  in the `dispatchers/` subpackage.
-
+- **"per-user L1 keying."** Older prose describes the L1 cell as *per-user*-keyed.
+  The current code keys the cell on the **first-match binding UID** plus the
+  subject's **RBAC sub-generation**, with username/groups deliberately removed
+  from `ComputeKey`. Username/groups survive only as the refresher's
+  `Representative*` re-resolve identity. "Per-binding-UID (+sub-gen)" is the
+  accurate description; "per-user" is correct only in the sense that the key is
+  still identity-derived and never shared across permission boundaries.
+- **`handlers.Call` is the fallthrough, not the resolver entry.** The resolvers
+  are reached only through the `Dispatcher` middleware's `All()` map. Write
+  verbs bypass the dispatcher entirely and are never resolved.
+- **The `/call` HTTP loopback is retired.** Earlier revisions documented a
+  nested `/call?resource=…` loopback dispatch branch (with its forge-guard and
+  self-host matching). The 2026-06-22 corpus audit found zero live loopback
+  paths and the branch was retired; nested resolution is now the direct
+  apiserver path + `resolve: true` through the in-process seam
+  (`nested_call.go`), which is where the RBAC gate and the adaptive OOM bound
+  live.
+- **`internal/handlers/dispatchers/` is not a thin layer.** This package owns
+  the entire L1 key/lookup/Put logic, the prewarm engine, the refresher hooks,
+  and the live-refresh subscription derivation. The pure routing decision is
+  the small `proxy.go` middleware in `internal/handlers/`.
 - **Widget serialization indents differently from the passthrough.**
   `encodeResolvedJSON` (resolver path) emits compact JSON deliberately for
-  cache-byte parity (helpers.go:390); `handlers.Call` (passthrough) emits
-  two-space-indented JSON (call.go:135). The two `/call` response shapes are not
-  byte-identical across the resolver vs. passthrough lanes.
+  cache-byte parity; `handlers.Call` (passthrough) emits two-space-indented
+  JSON. The two `/call` response shapes are not byte-identical across the
+  resolver vs. passthrough lanes.

--- a/go/snowplow/docs/configvars-update-datagate-design-2026-07-07.md
+++ b/go/snowplow/docs/configvars-update-datagate-design-2026-07-07.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "#106 — Config-vars watcher data-change redrive gate (design memo v2)"
+description: "Design memo (#106): gate the config-vars watcher's boot re-drive on an actual data change, so byte-identical config.json re-applies stop re-walking."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-07T00:00:00Z
+---
+
 # #106 — Config-vars watcher data-change redrive gate (design memo v2)
 
 Author: architect (archC2d), 2026-07-07. PM gate: ACCEPT (pmC2d, C106-1..4; INFO skip line binding).

--- a/go/snowplow/docs/corpus-audit-call-loopback-2026-06-22.md
+++ b/go/snowplow/docs/corpus-audit-call-loopback-2026-06-22.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Corpus audit — `/call`-loopback retirement blast radius (2026-06-22)
+description: "Corpus audit gating the /call-loopback retirement: zero live api-step usages found; retirement is dead-code removal."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-22T00:00:00Z
+---
+
 # Corpus audit — `/call`-loopback retirement blast radius (2026-06-22)
 
 **Purpose:** the durable, inspectable artifact behind the empirical claims that gate (C) retiring the `/call` loopback and (B) shipping `spec.api[].resolve` default-true. Prerequisite for the unified ship in `external-ra-no-l1-cache-proposal-2026-06-22.md`. Author: cache-architect (arch-corpus-audit). All findings TRACED.

--- a/go/snowplow/docs/external-ra-no-l1-cache-proposal-2026-06-22.md
+++ b/go/snowplow/docs/external-ra-no-l1-cache-proposal-2026-06-22.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: Unified proposal — internal references resolve in-process (cacheable); external endpoints take HTTP + skip L1 (2026-06-22)
+description: "Ratified proposal: internal references resolve in-process and stay cacheable (spec.api[].resolve, default true); genuine external endpoints take HTTP and skip L1."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-22T00:00:00Z
+---
+
 # Unified proposal — internal references resolve in-process (cacheable); external endpoints take HTTP + skip L1 (2026-06-22)
 
 **Status:** Internal-half mechanism **RATIFIED by Diego 2026-06-22** (direct-apiserver-path + `spec.api[].resolve`, default true). External half: PROPOSAL → PM gate → dev. Plan only.

--- a/go/snowplow/docs/f2-content-prewarm-informer-serve-design-2026-07-11.md
+++ b/go/snowplow/docs/f2-content-prewarm-informer-serve-design-2026-07-11.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F2 — Content-prewarm informer-serve wiring (Fix #130 F2)"
+description: "Fix #130 F2 design: content-prewarm informer-serve wiring."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-11T00:00:00Z
+---
+
 # F2 — Content-prewarm informer-serve wiring (Fix #130 F2)
 
 Date: 2026-07-11

--- a/go/snowplow/docs/f3-login-cohort-seed-coverage-design-2026-07-11.md
+++ b/go/snowplow/docs/f3-login-cohort-seed-coverage-design-2026-07-11.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F3 — Login-cohort seed coverage (Fix #130 F3)"
+description: "Fix #130 F3 design: login-cohort seed coverage (admin first-nav hit-rate analysis)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-11T00:00:00Z
+---
+
 # F3 — Login-cohort seed coverage (Fix #130 F3)
 
 Date: 2026-07-11

--- a/go/snowplow/docs/f3b-r2-agnostic-seed-order-design-2026-07-12.md
+++ b/go/snowplow/docs/f3b-r2-agnostic-seed-order-design-2026-07-12.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F3b-r2 — Agnostic seed order (Fix #130 F3b, redesign)"
+description: "Fix #130 F3b redesign: NavOrder-ascending agnostic seed order, superseding the rejected RootIndex phase split."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-12T00:00:00Z
+---
+
 # F3b-r2 — Agnostic seed order (Fix #130 F3b, redesign)
 
 Date: 2026-07-12

--- a/go/snowplow/docs/f4-boot-scope-budget-design-2026-07-07.md
+++ b/go/snowplow/docs/f4-boot-scope-budget-design-2026-07-07.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F.4 — Resumable boot scope: surviving the per-scope budget without knobs"
+description: "F.4 design: resumable boot scope surviving the per-scope budget without knobs."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-07T00:00:00Z
+---
+
 # F.4 — Resumable boot scope: surviving the per-scope budget without knobs
 
 Date: 2026-07-07 · Author: cache-architect · Ref: main @ 701c2e3 (1.6.1)

--- a/go/snowplow/docs/f4-statwidget-apiref-cost-design-2026-07-12.md
+++ b/go/snowplow/docs/f4-statwidget-apiref-cost-design-2026-07-12.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F4 — statistics/tag-widget apiRef seed cost (the #130 binding constraint)"
+description: "F4 analysis: statistics/tag-widget apiRef seed cost as the #130 binding constraint."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-12T00:00:00Z
+---
+
 # F4 — statistics/tag-widget apiRef seed cost (the #130 binding constraint)
 
 Date: 2026-07-12

--- a/go/snowplow/docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md
+++ b/go/snowplow/docs/f4b-leverb-discovery-snapshot-reuse-design-2026-07-22.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F4b Lever B — reuse the harvested discovery snapshot on boot RESUME passes (#135)"
+description: "F4b Lever B design (#135): reuse the harvested discovery snapshot on boot RESUME passes."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-22T00:00:00Z
+---
+
 # F4b Lever B — reuse the harvested discovery snapshot on boot RESUME passes (#135)
 
 Date: 2026-07-22

--- a/go/snowplow/docs/f4b-seed-overshoot-design-2026-07-14.md
+++ b/go/snowplow/docs/f4b-seed-overshoot-design-2026-07-14.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F4b — the single-pass seed overshoot (TASK #132)"
+description: "F4b design (#132): the single-pass seed overshoot; source of Levers A (declined-external set) and B (snapshot reuse)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-14T00:00:00Z
+---
+
 # F4b — the single-pass seed overshoot (TASK #132)
 
 Date: 2026-07-14

--- a/go/snowplow/docs/f6-chrome-route-key-design-2026-07-12.md
+++ b/go/snowplow/docs/f6-chrome-route-key-design-2026-07-12.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "F6 — Chrome-widget route-context cache-key gap (#130 final gap-chain)"
+description: "F6 design (#130): chrome-widget route-context cache-key gap — the origin of spec.keyExtras."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-12T00:00:00Z
+---
+
 # F6 — Chrome-widget route-context cache-key gap (#130 final gap-chain)
 
 Date: 2026-07-12 · snowplow 1.7.9 · repo @ origin/main 26b48b3

--- a/go/snowplow/docs/f6-portal-handoff-2026-07-13.md
+++ b/go/snowplow/docs/f6-portal-handoff-2026-07-13.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "F6 (#130) — portal handoff: land the 104 `spec.keyExtras` declarations"
+description: "F6 portal handoff pack: the 104 spec.keyExtras declarations the portal chart had to land before the F6 cut."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-13T00:00:00Z
+---
+
 # F6 (#130) — portal handoff: land the 104 `spec.keyExtras` declarations
 
 Date: 2026-07-13 · snowplow side @ `828ac8e` (PR #109, merged to main @ `fcd45f9`, **not cut**) · audit source: `docs/f6-keyextras-audit-2026-07-12.md` + `/tmp/f6-audit/definitive-table.txt`

--- a/go/snowplow/docs/feature-113-templated-endpointref-2026-07-15.md
+++ b/go/snowplow/docs/feature-113-templated-endpointref-2026-07-15.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Feature journal — #113 templated api-step endpointRef (hub-spoke)"
+description: "Feature journal for the #113 templated endpointRef ship (1.7.13 candidate, dual-gate accept)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-15T00:00:00Z
+---
+
 # Feature journal — #113 templated api-step endpointRef (hub-spoke)
 
 Date: 2026-07-15

--- a/go/snowplow/docs/fix3-rank-hygiene-design-2026-07-07.md
+++ b/go/snowplow/docs/fix3-rank-hygiene-design-2026-07-07.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Fix-3 rank hygiene — deterministic, widget-capable-first identity ranking (design, 2026-07-07)
+description: "Fix-3 design: deterministic, widget-capable-first identity ranking for the prewarm walk."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-07T00:00:00Z
+---
+
 # Fix-3 rank hygiene — deterministic, widget-capable-first identity ranking (design, 2026-07-07)
 
 Repo: main @ bbaba28 (1.6.2). Origin: docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md §3a/§4

--- a/go/snowplow/docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md
+++ b/go/snowplow/docs/fixf-rootindex-redrive-walk-trace-2026-07-06.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: FIX-F first-nav latch zero-fire — root-cause trace (2026-07-06)
+description: "FIX-F root-cause trace: first-nav latch zero-fire on the 60K corpus."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-06T00:00:00Z
+---
+
 # FIX-F first-nav latch zero-fire — root-cause trace (2026-07-06)
 
 Repo: main @ 70b9fba (== tag 1.6.0, verified `git merge-base --is-ancestor` + empty

--- a/go/snowplow/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
+++ b/go/snowplow/docs/keepwarm-c2-cohort-coverage-design-2026-07-07.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: keepwarm c2 — cohort-coverage extension of the G-TTL sweep (design, 2026-07-07)
+description: "keepwarm c2 design: cohort-coverage extension of the G-TTL quiet-page sweep."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-07T00:00:00Z
+---
+
 # keepwarm c2 — cohort-coverage extension of the G-TTL sweep (design, 2026-07-07)
 
 Repo: main @ 6d8af79 (1.6.3 line, Fix-3 rank hygiene at tip). Design + BUILD (as-built note §9). Prior docs: docs/g-ttl-quiet-page-keepwarm-design-2026-07-04.md (c1),

--- a/go/snowplow/docs/live-refresh-coherence-design-2026-06-18.md
+++ b/go/snowplow/docs/live-refresh-coherence-design-2026-06-18.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Snowplow per-key live-refresh-coherence — file:line implementation design"
+description: Implementation design for per-key live-refresh coherence (the /refreshes SSE ship).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-18T00:00:00Z
+---
+
 # Snowplow per-key live-refresh-coherence — file:line implementation design
 
 **Date:** 2026-06-18

--- a/go/snowplow/docs/live-refresh-stalewindow-phase0-2026-06-18.md
+++ b/go/snowplow/docs/live-refresh-stalewindow-phase0-2026-06-18.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Live-refresh coherence — Phase-0 falsifier artifact + floor-ON amplification baseline
+description: Phase-0 falsifier artifact + floor-ON amplification baseline for the live-refresh-coherence ship.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-18T00:00:00Z
+---
+
 # Live-refresh coherence — Phase-0 falsifier artifact + floor-ON amplification baseline
 
 **Date:** 2026-06-18

--- a/go/snowplow/docs/llms.txt
+++ b/go/snowplow/docs/llms.txt
@@ -1,18 +1,19 @@
-# snowplow (code repo) — LLM doc index
+# snowplow (go/snowplow — app internals) — LLM doc index
 
 > snowplow is the Krateo content bridge: it resolves `RESTAction` and `Widget` custom resources into
 > the JSON the Krateo frontend renders, served over `/call`, with a removable three-tier cache. This
 > index is the agent entry point to the **internals & runtime** view. The **deployment, CRD and
-> wiring** view lives in the chart repo `krateo-platformops/snowplow` `docs/`.
+> wiring** view lives in this same monorepo: the Helm charts under `helm/` and the standard doc
+> bundle at the repo root (`docs/`, indexed by the root `docs/llms.txt`).
 
 ## How to use this index (agents)
 
 You are reading the docs for a SPECIFIC deployed version. Fetch every file below **at the tag that
-matches the running build**, not `main`:
-- chart version = `CompositionDefinition.spec.chart.version` for snowplow (→ the `krateo-snowplow-chart` repo tag);
-- image version = the snowplow Deployment's container image tag (→ THIS repo's tag, == the chart `appVersion`).
-Read this repo's docs at the **image-version** tag. If something isn't in the docs, read the source
-at that same tag — don't guess, and don't trust `main` for a deployed older version.
+matches the running build**, not `main`. This is a monorepo with one version line: the chart
+version (`CompositionDefinition.spec.chart.version`), the chart `appVersion`, and the snowplow
+Deployment's container image tag are all the SAME repo tag (plain semver, no `v` prefix). Read the
+docs at that tag. If something isn't in the docs, read the source at that same tag — don't guess,
+and don't trust `main` for a deployed older version.
 
 ## Start here
 
@@ -56,7 +57,9 @@ at that same tag — don't guess, and don't trust `main` for a deployed older ve
 
 ## Reference
 
-- [README.md](../README.md): product overview + signposts.
+- [README.md](../../../README.md): repo front door (repo root) — install, config, docs map.
+- [docs/index.md](../../../docs/index.md): the root doc bundle (Krateo Documentation Standard) —
+  deployment, configuration, API contract, examples, release runbook.
 - [CONTRIBUTING.md](../CONTRIBUTING.md): build / test (the rbac TestMain trap) / release / invariants.
 - `apis/templates/` — the `RESTAction` / `Widget` Go types (source of truth for CRD fields).
 

--- a/go/snowplow/docs/notes/README.md
+++ b/go/snowplow/docs/notes/README.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Engineering notes — archive charter
+description: "Charter of the notes archive: dated point-in-time engineering logs, kept for historical record; where the authoritative documentation lives."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-08-03T00:00:00Z
+---
+
 # Engineering notes — append-only logs, NOT authoritative documentation
 
 These are dated, point-in-time engineering logs (ship-*, path3-*, task-*, bench-*, …) kept for

--- a/go/snowplow/docs/notes/bench-path-b-block-1-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-path-b-block-1-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Path B / Block 1 — Pre-commit Diff Artifact
+description: Bench-harness restructure Path B, block 1 pre-commit diff artifact.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Path B / Block 1 — Pre-commit Diff Artifact
 
 **Date:** 2026-06-02

--- a/go/snowplow/docs/notes/bench-path-b-block-2-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-path-b-block-2-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Path B — Block 2 pre-commit diff (2026-06-02)
+description: Bench-harness restructure Path B, block 2 pre-commit diff artifact.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Path B — Block 2 pre-commit diff (2026-06-02)
 
 Branch: `bench-path-b-block-2-2026-06-02` off `bench-path-b-block-1-2026-06-02` (tip `d6e856e`).

--- a/go/snowplow/docs/notes/bench-path-b-block-3-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-path-b-block-3-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Path B Block 3 — pre-commit diff artifact
+description: Bench-harness restructure Path B, block 3 pre-commit diff artifact.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Path B Block 3 — pre-commit diff artifact
 
 **Date:** 2026-06-02

--- a/go/snowplow/docs/notes/bench-path-b-block-4-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-path-b-block-4-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Path B Block 4 — pre-commit diff artifact
+description: Bench-harness restructure Path B, block 4 pre-commit diff artifact.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Path B Block 4 — pre-commit diff artifact
 
 **Date:** 2026-06-02

--- a/go/snowplow/docs/notes/bench-path-b-block-5-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-path-b-block-5-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Path B — Block 5 (FINAL) — precommit diff
+description: Bench-harness restructure Path B, block 5 (final) pre-commit diff artifact.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Path B — Block 5 (FINAL) — precommit diff
 
 **Date**: 2026-06-02

--- a/go/snowplow/docs/notes/bench-restructure-path-b-plan-2026-06-02.md
+++ b/go/snowplow/docs/notes/bench-restructure-path-b-plan-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Bench Harness Restructure — Path B Detailed Implementation Plan
+description: Bench-harness restructure Path B — detailed implementation plan.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Bench Harness Restructure — Path B Detailed Implementation Plan
 
 **Sign:** cache-architect

--- a/go/snowplow/docs/notes/path3-1-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-1-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.1 — pre-commit diff summary (0.30.217 candidate)
+description: Path 3.1 (0.30.217 candidate) pre-commit diff summary.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.1 — pre-commit diff summary (0.30.217 candidate)
 
 **Author**: cache-developer

--- a/go/snowplow/docs/notes/path3-2-1-canonical-results-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-1-canonical-results-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.1 / 0.30.219 — Canonical results
+description: Path 3.2.1 (0.30.219) canonical benchmark results.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2.1 / 0.30.219 — Canonical results
 
 Date: 2026-05-31 22:35 CEST

--- a/go/snowplow/docs/notes/path3-2-1-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-1-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.1 / 0.30.219 — Pre-commit diff (Phase 3 ACK)
+description: Path 3.2.1 (0.30.219) pre-commit diff (Phase 3 ACK).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2.1 / 0.30.219 — Pre-commit diff (Phase 3 ACK)
 
 Date: 2026-05-31

--- a/go/snowplow/docs/notes/path3-2-2-b-precommit-diff-2026-06-01.md
+++ b/go/snowplow/docs/notes/path3-2-2-b-precommit-diff-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.2.b — Precommit Diff + Phase 2 Bench Probe Evidence
+description: Path 3.2.2.b (0.30.221) pre-commit diff + Phase-2 bench-probe evidence.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Path 3.2.2.b — Precommit Diff + Phase 2 Bench Probe Evidence
 
 **Ship**: 0.30.221 — defer apiRef pagination to a background drain (scheduling fix for Path 3.2.2 0.30.220 HARD REVERT).

--- a/go/snowplow/docs/notes/path3-2-2-closeout-2026-06-01.md
+++ b/go/snowplow/docs/notes/path3-2-2-closeout-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.2 — Closeout (0.30.220 HARD REVERT)
+description: "Path 3.2.2 closeout: the 0.30.220 walker-pagination HARD REVERT."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Path 3.2.2 — Closeout (0.30.220 HARD REVERT)
 
 ## Verdict

--- a/go/snowplow/docs/notes/path3-2-2-design-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-2-design-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.2 — Walker Pagination Design (0.30.220)
+description: Path 3.2.2 walker-pagination design (0.30.220 — later hard-reverted).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2.2 — Walker Pagination Design (0.30.220)
 
 ## Pivot from (B)+(C) to walker extension

--- a/go/snowplow/docs/notes/path3-2-2-phase0-baselines-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-2-phase0-baselines-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.2 — Phase 0 Baselines (0.30.219 helm rev 378)
+description: Path 3.2.2 Phase-0 baselines (0.30.219, helm rev 378).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2.2 — Phase 0 Baselines (0.30.219 helm rev 378)
 
 Captured 2026-05-31 ~23:50 UTC via port-forward → /debug/vars.

--- a/go/snowplow/docs/notes/path3-2-2-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-2-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2.2 — Pre-commit Diff (0.30.220)
+description: Path 3.2.2 (0.30.220) pre-commit diff.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2.2 — Pre-commit Diff (0.30.220)
 
 Branch: `ship-0.30.220-path3-2-2-walker-pagination`

--- a/go/snowplow/docs/notes/path3-2-canonical-chrome-mcp-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-canonical-chrome-mcp-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2 / 0.30.218 — Phase 6 canonical Chrome MCP + ship closeout
+description: Path 3.2 (0.30.218) Phase-6 canonical Chrome-MCP validation + ship closeout.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2 / 0.30.218 — Phase 6 canonical Chrome MCP + ship closeout
 
 **Author**: cache-developer

--- a/go/snowplow/docs/notes/path3-2-cluster-list-prewarm-refresher-discipline-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-cluster-list-prewarm-refresher-discipline-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2 — cluster_list collapse + PIP pre-warm + refresher discipline
+description: "Path 3.2 design: cluster_list collapse + PIP pre-warm + refresher discipline."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2 — cluster_list collapse + PIP pre-warm + refresher discipline
 
 **Author**: cache-architect

--- a/go/snowplow/docs/notes/path3-2-phase0-baselines-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-phase0-baselines-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2 — Phase 0 baselines (snowplow 0.30.215)
+description: Path 3.2 Phase-0 baselines (0.30.215).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2 — Phase 0 baselines (snowplow 0.30.215)
 
 **Author**: cache-developer

--- a/go/snowplow/docs/notes/path3-2-pm-gate-verdict-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-pm-gate-verdict-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: Path 3.2 — PM Gate Verdict
+description: Path 3.2 PM gate verdict.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2 — PM Gate Verdict
 
 **Author**: cache-pm

--- a/go/snowplow/docs/notes/path3-2-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/path3-2-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Path 3.2 — pre-commit diff summary (0.30.218 candidate)
+description: Path 3.2 (0.30.218 candidate) pre-commit diff summary.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Path 3.2 — pre-commit diff summary (0.30.218 candidate)
 
 **Author**: cache-developer

--- a/go/snowplow/docs/notes/ship-0.30.231-drop-withskipmapper-precommit-diff-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship-0.30.231-drop-withskipmapper-precommit-diff-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 0.30.231 — drop WithSkipMapper — pre-commit diff
+description: "Ship 0.30.231 pre-commit diff: drop WithSkipMapper from the dynamic client."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 diff --git a/internal/dynamic/client.go b/internal/dynamic/client.go
 index 352fab5..c35300d 100644
 --- a/internal/dynamic/client.go

--- a/go/snowplow/docs/notes/ship-0.30.232-attempt7-design-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship-0.30.232-attempt7-design-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship 0.30.232 — Attempt #7 nil-rc whack-a-mole — phase1Walker boot literal + type-safety enforcement"
+description: "Ship 0.30.232 attempt #7 design: phase1Walker boot literal + type-safety enforcement."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Ship 0.30.232 — Attempt #7 nil-rc whack-a-mole — phase1Walker boot literal + type-safety enforcement
 
 date: 2026-06-01

--- a/go/snowplow/docs/notes/ship-0.30.232-attempt7-precommit-diff-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship-0.30.232-attempt7-precommit-diff-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship 0.30.232 attempt #7 — pre-commit diff"
+description: "Ship 0.30.232 attempt #7 pre-commit diff."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 diff --git a/internal/handlers/dispatchers/phase1_walk.go b/internal/handlers/dispatchers/phase1_walk.go
 index 7257f9c..09fd596 100644
 --- a/internal/handlers/dispatchers/phase1_walk.go

--- a/go/snowplow/docs/notes/ship-0.30.232-postdeploy-gates-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship-0.30.232-postdeploy-gates-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: Ship 0.30.232 — post-deploy gate sequence (HARD)
+description: Ship 0.30.232 post-deploy gate sequence.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Ship 0.30.232 — post-deploy gate sequence (HARD)
 
 date: 2026-06-01

--- a/go/snowplow/docs/notes/ship-0.30.233-precommit-diff-2026-06-02.md
+++ b/go/snowplow/docs/notes/ship-0.30.233-precommit-diff-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 0.30.233 — Pre-commit Diff Artifact
+description: Ship 0.30.233 pre-commit diff (S4 cache invalidation).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Ship 0.30.233 — Pre-commit Diff Artifact
 
 **Date**: 2026-06-02

--- a/go/snowplow/docs/notes/ship-0.30.233-s4-cache-invalidation-trace-2026-06-02.md
+++ b/go/snowplow/docs/notes/ship-0.30.233-s4-cache-invalidation-trace-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 0.30.233 — S4 cache-invalidation defect TRACE & fix design
+description: Ship 0.30.233 S4 cache-invalidation defect trace + fix design.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Ship 0.30.233 — S4 cache-invalidation defect TRACE & fix design
 
 **Author**: cache-architect

--- a/go/snowplow/docs/notes/ship-0.30.235-rbac-reindex-live-trace-2026-06-02.md
+++ b/go/snowplow/docs/notes/ship-0.30.235-rbac-reindex-live-trace-2026-06-02.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 0.30.235 — UAF refilter sees post-filter-projected items (LIVE TRACE)
+description: "Ship 0.30.235 live trace: UAF refilter seeing post-filter-projected items."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-02T00:00:00Z
+---
+
 # Ship 0.30.235 — UAF refilter sees post-filter-projected items (LIVE TRACE)
 
 **Author:** cache-architect

--- a/go/snowplow/docs/notes/ship-97-pm-gate-verdict-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-97-pm-gate-verdict-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: "Ship #97 — PM Gate Verdict"
+description: "Ship #97 PM gate verdict."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #97 — PM Gate Verdict
 
 Signed: cache-pm. Date: 2026-05-31. Status: gating, not building. Read-only audit.

--- a/go/snowplow/docs/notes/ship-97-postfix-validation-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-97-postfix-validation-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #97 — Phase 6 post-fix validation"
+description: "Ship #97 Phase-6 post-fix validation (CPU mechanism validated)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #97 — Phase 6 post-fix validation
 
 Signed: cache-developer. Date: 2026-05-31. Status: **SHIPPED + CPU MECHANISM VALIDATED.**

--- a/go/snowplow/docs/notes/ship-97-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-97-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #97 — Pre-commit diff + acceptance self-verification"
+description: "Ship #97 pre-commit diff + acceptance self-verification."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #97 — Pre-commit diff + acceptance self-verification
 
 Signed: cache-developer. Date: 2026-05-31. Status: AWAITING ARCHITECT + PM ACK.

--- a/go/snowplow/docs/notes/ship-97-prefix-falsifier-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-97-prefix-falsifier-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #97 — Phase 1 Pre-flight Falsifier"
+description: "Ship #97 Phase-1 pre-flight falsifier."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #97 — Phase 1 Pre-flight Falsifier
 
 Signed: cache-developer. Date: 2026-05-31. Status: PROCEED.

--- a/go/snowplow/docs/notes/ship-97-r3-hot-path-fix-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-97-r3-hot-path-fix-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #97 — R3 hot-path inert at apistage.go:140 — design"
+description: "Ship #97 design: R3 hot-path inert at apistage.go:140 (0.30.214)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #97 — R3 hot-path inert at apistage.go:140 — design
 
 Signed: cache-architect. Date: 2026-05-31. Status: design-only (no code, no commits).

--- a/go/snowplow/docs/notes/ship-98-pm-gate-verdict-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-98-pm-gate-verdict-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: "Ship #98 — PM Gate Verdict"
+description: "Ship #98 PM gate verdict."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #98 — PM Gate Verdict
 
 Signed: cache-pm. Date: 2026-05-31. Status: gating, not building. Read-only audit.

--- a/go/snowplow/docs/notes/ship-98-precommit-diff-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-98-precommit-diff-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #98 — Pre-commit Diff + 12-AC Self-Verification Grid"
+description: "Ship #98 pre-commit diff + 12-AC self-verification grid."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #98 — Pre-commit Diff + 12-AC Self-Verification Grid
 
 Signed: cache-developer. Date: 2026-05-31. Phase 4 / PM C3.

--- a/go/snowplow/docs/notes/ship-98-prefix-falsifier-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-98-prefix-falsifier-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #98 — Phase 1 Pre-flight Falsifier"
+description: "Ship #98 Phase-1 pre-flight falsifier."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #98 — Phase 1 Pre-flight Falsifier
 
 Signed: cache-developer. Date: 2026-05-31. Status: **PROCEED**.

--- a/go/snowplow/docs/notes/ship-98-refresher-rate-limiter-fix-2026-05-31.md
+++ b/go/snowplow/docs/notes/ship-98-refresher-rate-limiter-fix-2026-05-31.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Ship #98 — Refresher customer-priority yield (cooperative)"
+description: "Ship #98 design: refresher customer-priority cooperative yield."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-31T00:00:00Z
+---
+
 # Ship #98 — Refresher customer-priority yield (cooperative)
 
 Signed: cache-architect. Date: 2026-05-31. Status: design + PM gate.

--- a/go/snowplow/docs/notes/ship0-precommit-diff-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship0-precommit-diff-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 0 (0.30.222) — pre-commit diff
+description: "Ship 0 (0.30.222) pre-commit diff: handler-extension registry + walker-spawn."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 diff --git a/internal/cache/crdwatch.go b/internal/cache/crdwatch.go
 index 77df69b..48574c8 100644
 --- a/internal/cache/crdwatch.go

--- a/go/snowplow/docs/notes/ship1-precommit-diff-2026-06-01.md
+++ b/go/snowplow/docs/notes/ship1-precommit-diff-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship 1 / 0.30.225 — pre-commit diff + gates (2026-06-01)
+description: Ship 1 (0.30.225) pre-commit diff + gates.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Ship 1 / 0.30.225 — pre-commit diff + gates (2026-06-01)
 
 **Branch**: `ship-0.30.222-handler-extension-registry-walker-spawn`

--- a/go/snowplow/docs/notes/task-194-ship-L-0.30.246-implementation-spec-2026-06-04.md
+++ b/go/snowplow/docs/notes/task-194-ship-L-0.30.246-implementation-spec-2026-06-04.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Task #194 — Ship L (0.30.246) implementation spec: CRD lifecycle bytesObject fix (ADD + UPDATE + DELETE)"
+description: "Task #194 Ship L (0.30.246) implementation spec: CRD-lifecycle bytesObject fix."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-04T00:00:00Z
+---
+
 # Task #194 — Ship L (0.30.246) implementation spec: CRD lifecycle bytesObject fix (ADD + UPDATE + DELETE)
 
 **Author:** architect

--- a/go/snowplow/docs/notes/task-262-s8-cj-tablist-trace-2026-06-09.md
+++ b/go/snowplow/docs/notes/task-262-s8-cj-tablist-trace-2026-06-09.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Task #262 — S8 cyberjoker widget-error TRACE (re-run on aligned-window data)"
+description: "Task #262 S8 widget-error trace (tab-list, aligned-window data)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-09T00:00:00Z
+---
+
 # Task #262 — S8 cyberjoker widget-error TRACE (re-run on aligned-window data)
 
 **Date:** 2026-06-09

--- a/go/snowplow/docs/notes/task-273-s8-second-defect-trace-2026-06-09.md
+++ b/go/snowplow/docs/notes/task-273-s8-second-defect-trace-2026-06-09.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: "Task #273 — S8 cyberjoker SECOND-DEFECT TRACE (call_count 20 vs 30)"
+description: "Task #273 S8 second-defect trace (call_count 20 vs 30)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-09T00:00:00Z
+---
+
 # Task #273 — S8 cyberjoker SECOND-DEFECT TRACE (call_count 20 vs 30)
 
 **Date:** 2026-06-09

--- a/go/snowplow/docs/prewarm-boot-race-tolerant-2026-07-03.md
+++ b/go/snowplow/docs/prewarm-boot-race-tolerant-2026-07-03.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Boot-race-tolerant, self-healing Phase-1 prewarm — design
+description: "Design: boot-race-tolerant, self-healing Phase-1 prewarm (shape A)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-03T00:00:00Z
+---
+
 # Boot-race-tolerant, self-healing Phase-1 prewarm — design
 
 Date: 2026-07-03

--- a/go/snowplow/docs/prewarm-engine-implicit-on-cache-2026-07-03.md
+++ b/go/snowplow/docs/prewarm-engine-implicit-on-cache-2026-07-03.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: Fold the prewarm flag FAMILY implicit-on-cache — design
+description: "Design/decision: fold the prewarm flag family implicit-on-cache (single-flag surface)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-03T00:00:00Z
+---
+
 # Fold the prewarm flag FAMILY implicit-on-cache — design
 
 Date: 2026-07-03

--- a/go/snowplow/docs/prewarm-refresher-open-questions.md
+++ b/go/snowplow/docs/prewarm-refresher-open-questions.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: Prewarm + Runtime-Refresher — Open-Question Register
+description: "Open-question register for the prewarm + runtime-refresher campaign (task #102 consolidation, 0.30.11x era; undated — timestamp approximate). Rulings R1-R6 + the O-item ledger."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Prewarm + Runtime-Refresher — Open-Question Register
 
 > Durable reconstruction of the architect's task-#102 consolidation.

--- a/go/snowplow/docs/proactive-cr-warm-design-2026-06-20.md
+++ b/go/snowplow/docs/proactive-cr-warm-design-2026-06-20.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: Proactive CR warm — design (plan only, READ-ONLY trace) — 2026-06-20
+description: "PARKED design: proactive CR warm — per-call-variable extras make the controller /call un-cacheable by construction; do not build."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-20T00:00:00Z
+---
+
 # Proactive CR warm — design (plan only, READ-ONLY trace) — 2026-06-20
 
 **Author**: cache architect

--- a/go/snowplow/docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md
+++ b/go/snowplow/docs/rca-stale-delete-compositiondefinitions-informer-2026-06-25.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: RCA + design — deleted CompositionDefinition persists in /blueprints (informer/invalidation gap) — 2026-06-25
+description: "RCA: deleted CompositionDefinition persisted in /blueprints — informer/invalidation gap (refutes the cache-key-divergence hypothesis)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-25T00:00:00Z
+---
+
 # RCA + design — deleted CompositionDefinition persists in /blueprints (informer/invalidation gap) — 2026-06-25
 
 **Author**: cache architect

--- a/go/snowplow/docs/regression-f4b-inert-lifetime-2026-07-14.md
+++ b/go/snowplow/docs/regression-f4b-inert-lifetime-2026-07-14.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "Regression journal — #132 F4b Lever A first build (2dc46ae) was correctness-inert (caught at gate, never shipped)"
+description: "Regression journal (#132): the first F4b Lever A build was correctness-inert (pass-lived marker set); caught at gate, never shipped."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-14T00:00:00Z
+---
+
 # Regression journal — #132 F4b Lever A first build (2dc46ae) was correctness-inert (caught at gate, never shipped)
 
 Date: 2026-07-14

--- a/go/snowplow/docs/regression-refreshes-delivery-saga-2026-06-29.md
+++ b/go/snowplow/docs/regression-refreshes-delivery-saga-2026-06-29.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "Regression journal — `/refreshes` zero-delivery saga (4 cycles, #61 → #64)"
+description: "Regression journal: the /refreshes zero-delivery saga (4 fix cycles, #61-#64, fixed in 1.5.13)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-29T00:00:00Z
+---
+
 # Regression journal — `/refreshes` zero-delivery saga (4 cycles, #61 → #64)
 
 Date: 2026-06-29. Final fix shipped **1.5.13** (snowplow `6a221d4`, chart `1.0.39`).

--- a/go/snowplow/docs/restaction-rbac-endpoint-design.md
+++ b/go/snowplow/docs/restaction-rbac-endpoint-design.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Snowplow `/rbac` endpoint — RESTAction→GVR inspect-only enumeration (REVISED design)
+description: "Revised design for GET /rbac: RESTAction-to-GVR inspect-only read-set enumeration for core-provider RBAC."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-23T00:00:00Z
+---
+
 # Snowplow `/rbac` endpoint — RESTAction→GVR inspect-only enumeration (REVISED design)
 
 Date: 2026-06-23

--- a/go/snowplow/docs/ship-a-jq-roundtrip-design.md
+++ b/go/snowplow/docs/ship-a-jq-roundtrip-design.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship A — Eliminate the jq string round-trip (D3 + D4)
+description: "Ship A design (A+B+C resolver-path rebuild): eliminate the jq string round-trip."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-19T00:00:00Z
+---
+
 # Ship A — Eliminate the jq string round-trip (D3 + D4)
 
 **Status:** GATE-PASSED — GO for development (PM gate, 2026-05-19).

--- a/go/snowplow/docs/ship-b-typed-rbac-snapshot-design.md
+++ b/go/snowplow/docs/ship-b-typed-rbac-snapshot-design.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship B — Typed RBAC snapshot (D2)
+description: "Ship B design (A+B+C resolver-path rebuild): typed RBAC snapshot."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-20T00:00:00Z
+---
+
 # Ship B — Typed RBAC snapshot (D2)
 
 **Status:** GATE-PASSED — GO for development (PM gate, 2026-05-20).

--- a/go/snowplow/docs/ship-c-monomorphic-jsoncopy-design.md
+++ b/go/snowplow/docs/ship-c-monomorphic-jsoncopy-design.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Ship C — Monomorphic JSON-tree copier (D1)
+description: "Ship C design (A+B+C resolver-path rebuild): monomorphic JSON-tree copier."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-05-20T00:00:00Z
+---
+
 # Ship C — Monomorphic JSON-tree copier (D1)
 
 **Status:** TEAM-LEAD GATE PASSED (post-§2 revision, 2026-05-20). Awaiting PM

--- a/go/snowplow/docs/test-coverage-audit-2026-07-30.md
+++ b/go/snowplow/docs/test-coverage-audit-2026-07-30.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Snowplow Test-Coverage Audit — 2026-07-30
+description: "Test-coverage audit: 131-feature coverage-vs-gap inventory driving the test-suite build."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-07-30T00:00:00Z
+---
+
 # Snowplow Test-Coverage Audit — 2026-07-30
 
 Feature × existing-coverage × gap inventory across all packages, produced to drive an extensive

--- a/go/snowplow/docs/troubleshoot-boot-oom-composition-fanout-2026-06-23.md
+++ b/go/snowplow/docs/troubleshoot-boot-oom-composition-fanout-2026-06-23.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: Troubleshooting — snowplow 1.4.3 boot-OOM (concurrent composition fan-out) — 2026-06-23
+description: "Troubleshooting: 1.4.3 boot OOM from unbounded concurrent composition fan-out."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-23T00:00:00Z
+---
+
 # Troubleshooting — snowplow 1.4.3 boot-OOM (concurrent composition fan-out) — 2026-06-23
 
 **Cluster:** bs-test-ger-03 (operations-dev-krateo-io, europe-west10), snowplow 1.4.3, read-only via `/tmp/bs-test-ger-03.kubeconfig`. Diagnosis TRACED to canonical code @ 1.4.3 + live runtime artifacts (`/tmp/bs-sp-prev.log`, expvar `http://34.32.39.90:8081/debug/vars`).

--- a/go/snowplow/docs/troubleshoot-composition-detail-discovery-storm-2026-06-22.md
+++ b/go/snowplow/docs/troubleshoot-composition-detail-discovery-storm-2026-06-22.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: Troubleshooting — snowplow slow composition-detail `/call` (discovery storm) — 2026-06-22
+description: "Troubleshooting: slow composition-detail /call caused by a hot-path discovery storm (1.4.1)."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-22T00:00:00Z
+---
+
 # Troubleshooting — snowplow slow composition-detail `/call` (discovery storm) — 2026-06-22
 
 **Cluster:** `gke_integration-test-431120_europe-west1-b_krateo-enterprise`, snowplow **1.4.1**, CACHE_ENABLED=true. Diagnosis read-only (no pod exec, no remote `go test`). All claims TRACED to live logs/expvar + code:line.

--- a/go/snowplow/docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md
+++ b/go/snowplow/docs/troubleshoot-discovery-url-apistep-x509-2026-06-23.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "Troubleshooting — x509 \"unknown authority\" on a bare group-discovery api-step — 2026-06-23"
+description: "Troubleshooting: x509 unknown-authority on a bare group-discovery api-step path."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-23T00:00:00Z
+---
+
 # Troubleshooting — x509 "unknown authority" on a bare group-discovery api-step — 2026-06-23
 
 **Symptom:** `Get "https://kubernetes.default.svc/apis/templates.krateo.io/v1": tls: failed to verify certificate: x509: certificate signed by unknown authority` (500). Seen on snowplow **1.1.0**.

--- a/go/snowplow/docs/walker-driven-informer-design-2026-06-01.md
+++ b/go/snowplow/docs/walker-driven-informer-design-2026-06-01.md
@@ -1,3 +1,12 @@
+---
+type: Architecture
+title: Walker-driven informer / plurals-based design (v6) — 2026-06-01
+description: "Walker-driven informer design v6 (basis of ADR 0005): delete the CRD-watch backplane; per-group one-shot discovery from the walker."
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [archive]
+timestamp: 2026-06-01T00:00:00Z
+---
+
 # Walker-driven informer / plurals-based design (v6) — 2026-06-01
 
 Status: Design captured through v6. Three ships: Ship 0 deployed 0.30.222, Ship 0.5 deletes crdwatch.go (v6), Ship 1 plurals additive, Ship 2 plurals replacement.

--- a/go/snowplow/howto/audit-correlation.md
+++ b/go/snowplow/howto/audit-correlation.md
@@ -1,61 +1,87 @@
-# Audit correlation (`X-Krateo-Correlation-Id` + `AuditEvent`)
+---
+type: Architecture
+title: Audit correlation (session.id baggage + AuditEvent)
+description: How snowplow correlates and audits actions — the W3C baggage session.id business-correlation id and the trace-correlated OTLP AuditEvent LogRecord emitted for /call writes and /export downloads.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, audit, otel, observability]
+timestamp: 2026-08-06T00:00:00Z
+---
+
+# Audit correlation (`session.id` baggage + `AuditEvent`)
 
 Snowplow implements a generic end-to-end audit correlation mechanism
-(`internal/support/audit`):
+(`internal/support/audit`). There is **no bespoke correlation header**: the
+cross-request business/session correlation id rides **W3C baggage** (the
+`session.id` member), and the audit record itself is a **trace-correlated OTLP
+LogRecord** on the shared OTel Collector → ClickHouse `otel_logs` plane — not a
+stdout JSON line.
 
-## Correlation id
+## Session correlation id
 
-- Every request may carry an **`X-Krateo-Correlation-Id`** header. The
-  portal (or any API client) injects it at the edge to tag one *logical
-  business action*; unlike the per-request `X-Krateo-TraceId` shortid
-  and the OTel `traceparent`, the same correlation id is reused across
-  all the requests that make up that action.
-- When the header is absent, snowplow falls back to the request trace
-  id (or mints a random id), so the id is always non-empty.
-- The id is **echoed on the response** (and CORS-exposed) so the caller
-  can persist and link it.
-- It is **propagated into every downstream external call** an api-step
-  performs (`internal/resolvers/restactions/api/external_fetch.go`), so
-  a downstream service/adapter can log its own records under the same
-  id and an auditor can link portal action → resolved calls →
-  downstream effect.
-- Inbound ids are sanitized (max 128 chars, `[A-Za-z0-9._-]`); anything
-  else is replaced, never logged raw.
+- The id tags one *logical business action*; unlike the per-request
+  `X-Krateo-TraceId` shortid and the OTel `traceparent` (both untouched — the
+  coexistence contract), the same session id is reused across all the requests
+  that make up that action.
+- **Snowplow is the id origin** (`audit.Middleware`, wired in `main.go`): if
+  the inbound `baggage` header already carries a `session.id` member (seeded by
+  the portal or any API client), it is kept; otherwise snowplow falls back to
+  the request trace id, and failing that mints a random 16-hex-char id — so
+  the id is always non-empty. The id is written into the request context's
+  baggage.
+- It **propagates into every downstream external call** an api-step performs:
+  the global `propagation.Baggage` propagator (installed by `tracing.Setup`)
+  serializes the context baggage into the outbound `baggage` header on the
+  otelhttp transport (`internal/resolvers/restactions/api/external_fetch.go`
+  documents the contract), so a downstream service/adapter can log its own
+  records under the same id and an auditor can link portal action → resolved
+  calls → downstream effect.
+- Inbound ids are sanitized (`SanitizeID`: max 128 chars, `[A-Za-z0-9._-]`);
+  anything else is rejected and replaced, never used raw — a hostile caller
+  cannot inject baggage/pipeline control characters.
 
 ## `AuditEvent` records
 
-Snowplow emits a normalized **`AuditEvent`** as a structured JSON log
-line on stdout for:
+Snowplow emits a normalized **`AuditEvent`** as an OTLP LogRecord
+(`audit.Emit` → the process-wide `Emitter`) for:
 
-- every **write** through `/call` (POST/PUT/PATCH/DELETE), and
-- every **`/export`** download.
+- every **write** through `/call` (POST/PUT/PATCH/DELETE — reads are
+  deliberately not audited: volume, and they are already covered by the
+  request log + trace id), and
+- every **`/export`** download (`action=export`).
 
-Record shape (under the `audit` group):
+The record is an `event.name="audit"` LogRecord with semconv-style attributes
+(landing in ClickHouse `otel_logs.LogAttributes`):
 
-```json
-{
-  "msg": "audit event",
-  "audit": {
-    "kind": "AuditEvent",
-    "correlationId": "…",
-    "action": "call | export",
-    "verb": "POST",
-    "group": "…", "version": "…", "resource": "…",
-    "name": "…", "namespace": "…",
-    "user": "…", "userGroups": ["…"],
-    "outcome": "success | failure",
-    "code": 200,
-    "timestamp": "RFC3339Nano"
-  }
-}
-```
+| Attribute | Content |
+|---|---|
+| `event.name` | `audit` — the discriminator every audit row is filtered on |
+| `krateo.action` | `call` \| `export` |
+| `http.request.method` | the HTTP verb |
+| `k8s.resource.group` / `.version` / `.resource` / `.name`, `k8s.namespace.name` | the object acted on |
+| `enduser.id` / `user.name`, `user.roles` | the authenticated username and groups (from the request JWT) |
+| `outcome` | `success` \| `failure` \| `denied` (drives severity: Info on success, Error otherwise) |
+| `http.response.status_code` | the outcome HTTP code |
+| `session.id` | the business correlation id, read from ctx baggage |
+| `krateo.audit.no_trace_context` | `true` only in the pathological case of an emit with no active span |
 
-## Shipping / immutability
+`TraceId`/`SpanId` are stamped onto the LogRecord by the Logs SDK from the
+active request span (snowplow wraps every HTTP request in an otelhttp server
+span), so an audit row **joins on `otel_logs.idx_trace_id`** to the traces and
+logs the action caused — an id-space parallel to `traceparent` would be
+un-joinable in the very index the stack is built on. The record body carries an
+optional human-readable message; the timestamp is set by the SDK.
 
-Deliberately, snowplow takes **no sink dependency**: the records ride
-the existing stdout → log-collector (filelog / Vector / Fluent Bit) →
-ClickHouse pipeline (see `internal/tracing` coexistence contract).
-Routing `kind=AuditEvent` records to a dedicated audit view **and to an
-immutable/WORM sink** is log-pipeline configuration in the
-observability stack, not application code — any deployment can add it
-without touching snowplow.
+## Enablement / shipping / immutability
+
+The audit pipeline follows the same `OTEL_ENABLED` gate and endpoint contract
+as tracing (`logging.Setup` in `main.go`): when the gate is off, no
+LoggerProvider is built and `audit.Emit` is a **no-op** — the off path is
+byte-identical. When on, records ship as OTLP/HTTP to the collector with the
+same `service.name=snowplow` resource as the traces.
+
+Snowplow takes no sink dependency beyond that: routing `event.name=audit`
+records to a dedicated audit view **and to an immutable/WORM sink** is
+log-pipeline configuration in the observability stack, not application code —
+any deployment can add it without touching snowplow. The pre-existing
+stdout → otel-daemonset per-call diagnostic log is a separate signal and is
+untouched.

--- a/go/snowplow/howto/decoupling-authn-from-snowplow-for-testing.md
+++ b/go/snowplow/howto/decoupling-authn-from-snowplow-for-testing.md
@@ -1,43 +1,54 @@
-# Decoupling [`authn`][authn] from `snowplow` for Testing and Operations
+---
+type: Decision
+title: Decoupling authn from snowplow for testing and operations
+description: ADR (2025-10-22) — test snowplow without deploying the authn service by minting Bearer tokens directly with the shared auth library. Superseded in place by ADR 0001.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [authn, testing, adr, jwt]
+status: superseded-by:../docs/adr/0001-decouple-authn.md
+timestamp: 2026-08-06T00:00:00Z
+---
 
-> Architecture Decision Record (ADR): 2025-10-22 
+# Decoupling `authn` from `snowplow` for Testing and Operations
 
+> Architecture Decision Record, 2025-10-22.
+> **This record is superseded**: it is preserved in ADR form as
+> [`docs/adr/0001-decouple-authn.md`](../docs/adr/0001-decouple-authn.md),
+> which is now the authoritative version. What follows is the original
+> decision plus the verified current state.
 
-## Context
+## The decision (2025-10-22)
 
-Service `snowplow` depends on the [`authn`][authn] service for authentication and token issuance.  
-Both are deployed on Kubernetes and use custom setup and CRDs, which makes isolated testing complex and fragile.  
-Setting up [`authn`][authn] just to test `snowplow` introduces unnecessary overhead, frequent configuration issues, and slows down iteration.
+Snowplow depends on the `authn` service for authentication and Bearer-token
+issuance; standing up `authn` (its setup and CRDs) just to test snowplow was
+fragile and slow. The decision: perform a one-time user registration and token
+generation with the **shared authentication library**, without deploying
+`authn` — originally via the `krateoctl add-user` CLI command.
 
+## Current state (verified against the tree)
 
-## Decision
+The *decoupling* stands and is how snowplow is tested and quick-started today;
+the *tool* has changed:
 
-Use the existing [`krateoctl`][krateoctl] tool (already used and distributed across environments) with the new command:  `krateoctl add-user`.
+- Snowplow validates tokens entirely in-process: a Krateo access token is a
+  plain **HS256 JWT** signed with the `JWT_SIGN_KEY` snowplow is started with
+  (`main.go` — `middleware.UserConfig(*signKey, *authnNS)`), carrying
+  `username` and `groups` claims. The shape is defined by the shared auth
+  library (`github.com/krateo-platformops/plumbing` `jwtutil` —
+  `CreateToken` / `Validate`). No `authn` deployment is needed to obtain or
+  validate one.
+- `krateoctl` is **not published under the `krateo-platformops` org** and is
+  not referenced anywhere in this tree. The supported tool-free path is the
+  inline mint in [`install.md`](install.md) §4 (a stdlib-only Python HS256
+  signer producing the same token the shared library would).
 
-This command performs a _one-time user registration and token generation_ using the shared authentication library, without requiring the [`authn`][authn] service to be deployed.
+## Consequences (unchanged)
 
-It enables developers — and admins — to create valid users and obtain Bearer tokens directly from the CLI.
-
-
-## Consequences
-
-- ✅ **Simplified testing:** Services that depend on authentication can now be tested independently of [`authn`][authn].  
-- ✅ **Reduced operational overhead:** No need to deploy or maintain [`authn`][authn] in local or CI environments.  
-- ✅ **Consistency:** The command reuses the shared auth library, ensuring compatibility with real authentication flows.  
-- ✅ **Admin utility:** The same tool helps administrators quickly bootstrap or manage users.  
-
-
-## Outcome
-
-This decision improves service isolation, test reliability, and development velocity, while maintaining alignment with the actual authentication mechanism.
-
-It follows microservice testing best practices by reducing inter-service coupling and leveraging existing operational tools.
-
-
-> **Note (post org migration):** `krateoctl` is not published under the
-> `krateo-platformops` org. The token it mints is a plain HS256 JWT from the shared
-> auth library (`github.com/krateo-platformops/plumbing` `jwtutil`); see
-> [install.md](install.md) for a tool-free way to mint the same token.
+- **Simplified testing:** services that depend on authentication are testable
+  independently of `authn`.
+- **Reduced operational overhead:** no need to deploy or maintain `authn` in
+  local or CI environments.
+- **Consistency:** the token shape is the shared library's, so hand-minted
+  tokens are compatible with real authentication flows.
+- **Admin utility:** the same mechanism bootstraps users for quickstarts.
 
 [authn]: https://github.com/krateo-platformops/authn
-[krateoctl]: install.md

--- a/go/snowplow/howto/decoupling-authn-from-snowplow-for-testing.md
+++ b/go/snowplow/howto/decoupling-authn-from-snowplow-for-testing.md
@@ -34,5 +34,10 @@ This decision improves service isolation, test reliability, and development velo
 It follows microservice testing best practices by reducing inter-service coupling and leveraging existing operational tools.
 
 
-[authn]: https://github.com/krateoplatformops/authn
-[krateoctl]: https://github.com/krateoplatformops/krateoctl/releases
+> **Note (post org migration):** `krateoctl` is not published under the
+> `krateo-platformops` org. The token it mints is a plain HS256 JWT from the shared
+> auth library (`github.com/krateo-platformops/plumbing` `jwtutil`); see
+> [install.md](install.md) for a tool-free way to mint the same token.
+
+[authn]: https://github.com/krateo-platformops/authn
+[krateoctl]: install.md

--- a/go/snowplow/howto/developer-guide.md
+++ b/go/snowplow/howto/developer-guide.md
@@ -1,14 +1,43 @@
+---
+type: Usage
+title: "Developer Guide: building and running snowplow from source"
+description: Build the snowplow image with ko, load it into a local Kind cluster and run the in-repo development deployment (manifests/ + scripts/), then create a test user and exercise RESTActions.
+resource: snowplow
+tags:
+  - snowplow
+  - development
+  - kind
+  - ko
+  - build
+timestamp: 2026-08-06T00:00:00Z
+---
 
 # Developer Guide: Building and Installing `snowplow`
 
-This guide walks you through creating a local Kubernetes cluster with [kind](https://kind.sigs.k8s.io/), building the `snowplow` image with [`ko`](https://ko.build/), setting up `jq` custom modules, deploying `snowplow`, and waiting until it’s ready.
+This guide walks you through creating a local Kubernetes cluster with
+[kind](https://kind.sigs.k8s.io/), building the `snowplow` image with
+[`ko`](https://ko.build/), and running the **in-repo development deployment**.
+Everything here mirrors the maintained dev assets in the repo — `scripts/` and
+`manifests/` — so the guide and the tooling cannot drift apart:
 
+| Repo asset | What it does |
+|---|---|
+| `scripts/kind-up.sh` / `scripts/kind-down.sh` | create / delete the Kind cluster |
+| `scripts/build.sh` | `ko` build into the Kind-internal registry (`kind.local`) |
+| `scripts/jqmodule-to-configmap.sh` | package `testdata/custom-modules.jq` as the `jq-custom-modules` ConfigMap |
+| `manifests/deploy.snowplow.yaml` | namespace + ServiceAccount + NodePort Service + Deployment + RBAC |
+| `scripts/reboot.sh` | the whole loop above, from scratch, in one command |
+| `scripts/test-restactions.sh` | apply the `RESTAction` CRD + sample RESTActions + `devs`-group RBAC from `testdata/` |
+
+All commands below run from the module root (`go/snowplow/` in the monorepo) —
+that is where `.ko.yaml`, `crds/`, `manifests/`, `scripts/` and `testdata/`
+live.
 
 ## 1. Start a local Kind cluster
 
-Create a local Kubernetes cluster using **Kind**.
-
-The cluster exposes ports `30081` and `30082` on the host for easy access to `snowplow` services.
+Create a local Kubernetes cluster using **Kind** (`scripts/kind-up.sh` does
+exactly this). The cluster exposes ports `30081` and `30082` on the host for
+easy access to `snowplow` services.
 
 ```sh {name=kind-up}
 kind get kubeconfig >/dev/null 2>&1 || \
@@ -22,174 +51,93 @@ nodes:
     hostPort: 30081
     listenAddress: "127.0.0.1"
     protocol: TCP
+  - containerPort: 30082
+    hostPort: 30082
+    listenAddress: "127.0.0.1"
+    protocol: TCP
 EOF
 ```
 
 ## 2. Create a namespace
 
-Create a dedicated namespace where `snowplow` and its related resources will live.
+The dev deployment is pinned to the `demo-system` namespace (it is hard-coded
+throughout `manifests/deploy.snowplow.yaml`).
 
 ```sh {name=create-namespace depends=kind-up}
 export NAMESPACE="demo-system"
-kubectl create namespace ${NAMESPACE}
+kubectl create namespace ${NAMESPACE} || true
 ```
 
 ## 3. Build the `snowplow` image with `ko`
 
-Use [`ko`](https://ko.build/) to build and push the `snowplow` Docker image directly to the **Kind internal registry** (`kind.local`).
+Use [`ko`](https://ko.build/) to build the `snowplow` image directly into the
+**Kind internal registry** (`kind.local`) — this is `scripts/build.sh`:
 
 ```sh {name=build depends=kind-up}
 KO_DOCKER_REPO=kind.local ko build --base-import-paths .
 ```
 
-## 4. Create a ConfigMap for custom `jq` modules
+## 4. Create the ConfigMap for custom `jq` modules
 
-`Snowplow` uses custom `jq` modules during runtime. Create a ConfigMap to store them.
+`snowplow` loads custom `jq` modules from the path given by
+`--jq-modules-path` / `JQ_MODULES_PATH` at runtime. The dev deployment mounts
+them from a `jq-custom-modules` ConfigMap; `scripts/jqmodule-to-configmap.sh`
+builds it from the in-repo sample modules:
 
 ```sh {name=jq-custom-modules depends=create-namespace}
-cat <<'EOF' | kubectl create configmap jq-custom-modules \
-  --from-file=custom.jq=/dev/stdin \
+kubectl create configmap jq-custom-modules \
+  --from-file=custom.jq=testdata/custom-modules.jq \
   --namespace=${NAMESPACE}
-def shout($s): ($s | ascii_upcase + "!!!");
-
-def flipchar($c):
-  {
-    "a": "ɐ", "b": "q", "c": "ɔ", "d": "p", "e": "ǝ", "f": "ɟ", "g": "ƃ", "h": "ɥ", "i": "ᴉ",
-    "j": "ɾ", "k": "ʞ", "l": "ʃ", "m": "ɯ", "n": "u", "o": "o", "p": "d", "q": "b", "r": "ɹ",
-    "s": "s", "t": "ʇ", "u": "n", "v": "ʌ", "w": "ʍ", "x": "x", "y": "ʎ", "z": "z",
-    "A": "∀", "B": "𐐒", "C": "Ɔ", "D": "p", "E": "Ǝ", "F": "Ⅎ", "G": "פ", "H": "H",
-    "I": "I", "J": "ſ", "K": "ʞ", "L": "˥", "M": "W", "N": "N", "O": "O", "P": "Ԁ",
-    "Q": "Q", "R": "ᴚ", "S": "S", "T": "┴", "U": "∩", "V": "Λ", "W": "M", "X": "X",
-    "Y": "⅄", "Z": "Z", ".": "˙", ",": "'", "'": ",", "\"": ",,", "_": "‾", "?": "¿",
-    "!": "¡", "(": ")", ")": "(", "[": "]", "]": "[", "{": "}", "}": "{"
-  }[$c] // $c;
-
-def flip($s):
-  $s
-  | explode
-  | map([.] | implode | flipchar(.))
-  | reverse
-  | join("");
-EOF
 ```
 
-## 5. Deploy `snowplow`
+## 5. Apply the `RESTAction` CRD
 
-Deploy `snowplow` using a single manifest that includes:
+The CRD must exist **before** you create any `RESTAction` (and before granting
+RBAC on the resource):
 
-* a `ServiceAccount`
-* a `Service` exposed on `NodePort`
-* a `Deployment` for the `snowplow` app
-* RBAC roles and bindings
+```sh {name=install-restaction-crd depends=kind-up}
+kubectl apply -f ./crds/templates.krateo.io_restactions.yaml
+```
+
+## 6. Deploy `snowplow`
+
+`manifests/deploy.snowplow.yaml` deploys:
+
+* a `ServiceAccount` (`snowplow`)
+* a `Service` exposed on `NodePort` `30081`, targeting the single `http` port `8081`
+* a `Deployment` running the `kind.local/snowplow:latest` image you just built,
+  with the dev flags:
+  `--debug=false --blizzard=false --port=8081 --authn-namespace=demo-system`
+  `--jwt-sign-key=AbbraCadabbra --pretty-log=false --jq-modules-path=/jq-modules`
+* a narrow read-only `ClusterRole`/`ClusterRoleBinding` for the snowplow
+  ServiceAccount, plus a sample `devs`-group role
 
 ```sh {name=deploy depends=jq-custom-modules}
-export JWT_SECRET=AbbraCadabbra
-
-cat <<EOF | kubectl apply -f -
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: snowplow
-  namespace: ${NAMESPACE}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: snowplow
-  namespace: ${NAMESPACE}
-spec:
-  selector:
-    app: snowplow
-  type: NodePort
-  ports:
-  - name: http
-    port: 8081
-    targetPort: http
-    protocol: TCP
-    nodePort: 30081
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: snowplow
-  namespace: ${NAMESPACE}
-  labels:
-    app: snowplow
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: snowplow
-  template:
-    metadata:
-      labels:
-        app: snowplow
-    spec:
-      serviceAccountName: snowplow
-      volumes:
-      - name: jq-modules
-        configMap:
-          name: jq-custom-modules
-      containers:
-      - name: snowplow
-        image: kind.local/snowplow:latest
-        imagePullPolicy: Never
-        args:
-          - --debug=true
-          - --blizzard=false
-          - --port=8081
-          - --authn-namespace=${NAMESPACE}
-          - --jwt-sign-key=${JWT_SECRET}
-          - --pretty-log=false
-          - --jq-modules-path=/jq-modules
-        ports:
-        - name: http
-          containerPort: 8081
-        volumeMounts:
-        - name: jq-modules
-          mountPath: /jq-modules
-          readOnly: true
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: snowplow
-rules:
-- apiGroups: ["core.krateo.io"]
-  resources: ["compositiondefinitions", "schemadefinitions"]
-  verbs: ["get", "list"]
-- apiGroups: ["templates.krateo.io"]
-  resources: ["*"]
-  verbs: ["get", "list"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["namespaces", "configmaps", "secrets"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: snowplow
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: snowplow
-subjects:
-- kind: ServiceAccount
-  name: snowplow
-  namespace: ${NAMESPACE}
-EOF
+kubectl apply -f manifests/deploy.snowplow.yaml
 ```
 
-## 6. Wait until the `snowplow` deployment is ready
+Notes on how this dev deployment differs from the production Helm chart
+(`helm/snowplow`):
 
-Finally, wait for the `snowplow` deployment to become **available**.
-This ensures all pods are up and running before proceeding.
+* **Cache is off.** `CACHE_ENABLED` is not set, and the binary treats anything
+  but `"true"`/`"1"`/`"yes"` as disabled (`internal/cache/cache.go`). Every
+  read goes straight to the apiserver under the caller's own credentials —
+  same data, same RBAC, just slower (see
+  [operating.md](operating.md)). That is also why the dev ServiceAccount can
+  run with a narrow read-only role, while the chart's ClusterRole grants
+  cluster-wide `get`/`list`/`watch` + `SubjectAccessReview` create for the
+  informer/RBAC-snapshot machinery.
+* **The JWT signing key is a hard-coded dev literal** (`AbbraCadabbra`) passed
+  as a flag; the chart consumes it from the `jwt-sign-key` Secret via
+  `envFrom`.
+* No prewarm-seed / `authn` loopback artifacts are deployed — the chart's
+  `seedAuthn` machinery needs the `authn` operator and its CRDs.
+
+> `scripts/reboot.sh` runs steps 1-6 (minus the CRD) from scratch:
+> kind-down, kind-up, namespace, `ko` build, jq-modules ConfigMap,
+> `kubectl apply -f manifests/`.
+
+## 7. Wait until the `snowplow` deployment is ready
 
 ```sh {name=wait-for-snowplow depends=deploy}
 kubectl wait deployment/snowplow \
@@ -198,34 +146,41 @@ kubectl wait deployment/snowplow \
   --timeout=90s
 ```
 
-## 9. Apply the `RESTAction` CRD
+A quick smoke test (no auth needed on `/health`):
 
-```sh {name=install-restaction-crd depends=wait-for-snowplow}
-kubectl apply -f ./crds/templates.krateo.io_restactions.yaml
+```sh
+curl http://127.0.0.1:30081/health
 ```
 
-## 8. Create a Krateo PlatformOps User
+## 8. Create a Krateo PlatformOps user
 
-To quickly create a Krateo PlatformOps user, install [`krateoctl`][krateoctl] and run the following command:
+`/call` authenticates with **two** artifacts, both keyed to the same username:
 
-```sh {name=create-krateo-user}
-export KRATEO_USER=cyberjoker
-export KRATEO_ACCESS_TOKEN=$(krateoctl add-user -k "${JWT_SECRET}" -n "${NAMESPACE}" "${KRATEO_USER}")
+1. an **access token** — a plain HS256 JWT signed with the `--jwt-sign-key`
+   value (`AbbraCadabbra` here), carrying `username` and `groups` claims;
+2. a **`<user>-clientconfig` Secret** in the `--authn-namespace`
+   (`demo-system` here) holding the user's own Kubernetes credentials in the
+   [`Endpoint`](endpoints.md) format. Without it every `/call` returns `401`.
 
-echo "KRATEO_USER=${KRATEO_USER}" > .env
-echo "KRATEO_ACCESS_TOKEN=${KRATEO_ACCESS_TOKEN}" >> .env
-```
+Follow steps **4 and 5 of [install.md](install.md)** — the inline Python JWT
+mint and the CSR-signed client-certificate `clientconfig` Secret work
+identically here (use `JWT_SECRET=AbbraCadabbra` to match the dev flag). The
+created user belongs to the `devs` group.
 
-## 9. RBACs for the Krateo PlatformOps User
+## 9. RBAC for the Krateo PlatformOps user
 
-After creating a new user, you must assign them a minimal set of RBAC permissions.
-In this case, since we are testing [RESTActions][restactions], the user needs at least read access to this resource.
+After creating a new user, you must assign them a minimal set of RBAC
+permissions. Since we are testing [RESTActions][restactions], the user needs at
+least read access to that resource.
 > Write, create, or delete permissions can be granted at the discretion of the cluster administrator.
 
-Moreover, if the [RESTAction][restactions] invokes any internal cluster APIs (for example, to list other resources), the user must also have the necessary permissions to access those resources.
+Moreover, if the [RESTAction][restactions] invokes any internal cluster APIs
+(for example, to list other resources), the user must also have the necessary
+permissions to access those resources.
 
 For now, we will grant read-only permissions on [RESTActions][restactions].
-Since the user created earlier belongs to the _"devs"_ group, we will, for simplicity, assign these permissions to the entire _"devs"_ group:
+Since the user created earlier belongs to the _"devs"_ group, we will, for
+simplicity, assign these permissions to the entire _"devs"_ group:
 
 ```sh
 cat <<EOF | kubectl apply -f -
@@ -256,3 +211,16 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 EOF
 ```
+
+> `scripts/test-restactions.sh` applies a broader variant of this
+> (`testdata/rbac.yaml` + `testdata/rbac.restactions.yaml`, granting the
+> `devs` group full CRUD on restactions) together with the sample
+> RESTActions under `testdata/restactions/` — a fast way to get a populated
+> playground. `testdata/curl-samples.txt` collects ready-made `/call`, `/list`
+> and `/health` invocations.
+
+From here, continue with the [RESTAction walkthroughs](restactions.md):
+[list cluster namespaces](restactions/example-cluster-namespaces.md) and
+[invoke an external API](restactions/example-external-api.md).
+
+[restactions]: restactions.md

--- a/go/snowplow/howto/endpoints.md
+++ b/go/snowplow/howto/endpoints.md
@@ -1,3 +1,16 @@
+---
+type: Usage
+title: Endpoint — connection Secrets for RESTAction
+description: The Endpoint contract — a plain Kubernetes Secret holding connection details and credentials (server-url, auth, TLS, proxy, AWS SigV4) that RESTAction stages reference via endpointRef.
+resource: snowplow
+tags:
+  - snowplow
+  - endpoint
+  - restaction
+  - secret
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # `Endpoint`
 
 ## Overview
@@ -20,6 +33,10 @@ It is stored as a Kubernetes [`Secret`](https://kubernetes.io/docs/concepts/conf
 | `client-key-data` | `string (base64)` | Base64-encoded PEM private key associated with the client certificate. | ❌ |
 | `debug` | `boolean` | Enables verbose logging of HTTP requests/responses. | ❌ |
 | `insecure` | `boolean` | If `true`, disables TLS certificate verification. | ❌ |
+| `aws-access-key` | `string` | AWS access key id — enables AWS SigV4 request signing. | ❌ |
+| `aws-secret-key` | `string` | AWS secret access key (SigV4 signing). | ❌ |
+| `aws-region` | `string` | AWS region for SigV4 signing. | ❌ |
+| `aws-service` | `string` | AWS service name for SigV4 signing. | ❌ |
 
 ## Storage in Kubernetes
 
@@ -59,4 +76,9 @@ stringData:
 - if `certificate-authority-data` is provided, it’s added to the root CA pool
 - when `proxy-url` is set, outbound requests are routed through it
 - boolean values (`debug`, `insecure`) are parsed from strings via `strconv.ParseBool`
+- when `aws-access-key`, `aws-secret-key` and `aws-region` are all present, requests are signed with AWS SigV4 for `aws-service`
+
+(All parsing lives in the shared `plumbing` library — `endpoints.FromSecret`
+reads the keys above verbatim, and `http/request/transport.go` builds the TLS /
+proxy transport from them.)
 

--- a/go/snowplow/howto/export.md
+++ b/go/snowplow/howto/export.md
@@ -1,23 +1,33 @@
+---
+type: Usage
+title: Generic export (GET /export)
+description: Export any /call-resolvable list (RESTAction or Widget) as a CSV or JSON attachment — parameters, row auto-detection, full-list pagination and the truncation cap, CSV shaping, and the audit trail.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, export, csv, audit]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Generic export (`GET /export`)
 
 `/export` turns **any `/call`-resolvable list** — a `RESTAction` or a
 list/table `Widget` — into a downloadable **CSV** or **JSON** attachment.
-It is a pure serializer layered on the `/call` resolve lane: the request
-is re-dispatched **in-process** through the same dispatcher chain the
-`GET /call` route uses, so authentication, the RBAC gate and the
-serve-time user-aware filtering are identical. An export can never
-contain more than the caller's own `/call` would return.
+It is a pure serializer layered on the `/call` resolve lane
+(`internal/handlers/export.go`): the request is re-dispatched **in-process**
+through the same dispatcher chain the `GET /call` route uses, so
+authentication, the RBAC gate and the serve-time user-aware filtering are
+identical. An export can never contain more than the caller's own `/call`
+would return.
 
 Every export also emits an [`AuditEvent`](./audit-correlation.md)
-(structured log record, `action=export`) carrying the request session id
-(the W3C **`baggage`** member `session.id`), so data egress is auditable
-end-to-end. (The bespoke `X-Krateo-Correlation-Id` header is retired — the
-server ignores it; correlation now rides W3C baggage.)
+(a trace-correlated OTLP LogRecord, `krateo.action=export`) carrying the
+request session id (the W3C **`baggage`** member `session.id`), so data egress
+is auditable end-to-end. (There is no bespoke `X-Krateo-Correlation-Id`
+header — correlation rides W3C baggage.)
 
 ## Request
 
 ```
-GET /export?apiVersion=<gv>&resource=<plural>&name=<name>&namespace=<ns>[&format=...][&path=...][&fields=...][&filename=...]
+GET /export?apiVersion=<gv>&resource=<plural>&name=<name>&namespace=<ns>[&format=...][&path=...][&fields=...][&filename=...][&page=...&perPage=...]
 ```
 
 The `apiVersion` / `resource` / `name` / `namespace` parameters are the
@@ -29,10 +39,24 @@ standard `/call` ones. Authentication is the same JWT used for `/call`.
 | `path`     | auto    | Optional **jq expression** selecting the row array inside the resolved envelope, e.g. `.status.services`. |
 | `fields`   | all     | Comma-separated list of column **dot-paths** selecting and ordering the CSV columns, e.g. `name,health,usage.cpu`. |
 | `filename` | derived | Attachment file name (sanitized; extension appended). |
+| `page` / `perPage` | full list | Export exactly that `/call` window. When **both** are omitted, the handler exports the **full list** (below). |
+
+### Full-list pagination and the truncation cap
+
+An `/export` that carries no `page`/`perPage` of its own (the scheduled-export
+shape) does **not** inherit the target's default page size. The handler
+paginates the `/call` lane internally (`perPage=500`) and concatenates the
+extracted rows page by page until a short page signals exhaustion, bounded at
+100 pages — a documented cap of **50 000 rows** (`collectAllPages`,
+`export.go`). An export that hits the bound is truncated and the response
+carries **`X-Export-Truncated: true`**, so a consumer can tell a complete
+export from a capped one. A target that ignores the injected pagination is
+detected by page fingerprinting and exported once, never duplicated.
 
 ### Row auto-detection
 
-When `path` is omitted the rows are located by convention, in order:
+When `path` is omitted the rows are located by convention, in order
+(`autoDetectRows`):
 
 1. the resolved envelope itself, when it is an array;
 2. `.items`;
@@ -46,6 +70,10 @@ When `path` is omitted the rows are located by convention, in order:
 Nested objects are flattened to dot-path columns (`usage.cpu`); arrays
 and empty objects are JSON-encoded in place; the header row is the
 sorted union of all flattened keys (or the explicit `fields` order).
+String cells beginning with a spreadsheet formula trigger (`=`, `+`, `-`,
+`@`, tab, CR) are prefixed with a single quote so a spreadsheet renders
+them as literal text, not an executable formula (`neutralizeCSVCell` —
+OWASP CSV-injection guard; the JSON format is unaffected).
 
 ## Examples
 

--- a/go/snowplow/howto/extras.md
+++ b/go/snowplow/howto/extras.md
@@ -1,3 +1,12 @@
+---
+type: Usage
+title: extras — per-request context
+description: The ?extras= per-request JSON context for RESTAction and Widget resolves — precedence rules, identity injection, inline (author-declared) defaults, and how extras meet the cache key (spec.keyExtras).
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, restaction, widget, cache]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # `extras` — per-request context
 
 `extras` is a per-request JSON object you pass on the query string of a `/call`:
@@ -8,7 +17,7 @@ GET /call?resource=widgets&apiVersion=…&name=…&extras=%7B%22env%22%3A%22prod
 ```
 
 It is parsed once per request by `util.ParseExtras` into a `map[string]any`
-(`internal/handlers/util/extras.go:9-24`); a malformed value is a 400, an absent
+(`internal/handlers/util/extras.go`); a malformed value is a 400, an absent
 value is the empty map. The same `extras` mechanism works for **both**
 [`RESTAction`](restactions.md) and [`Widget`](widgets.md) dispatches.
 
@@ -24,7 +33,7 @@ pass a selected namespace, an environment, or a row id that the RESTAction's jq
 
 On a RESTAction resolve the run dict **starts as a deep copy of `extras`**, and
 the API stage outputs are then written on top
-(`internal/resolvers/restactions/api/resolve.go:228-230`):
+(`internal/resolvers/restactions/api/resolve.go`, the dict seed):
 
 ```go
 dict := map[string]any{}
@@ -37,7 +46,7 @@ So precedence is **API/apiRef result > extras**: an extras key collides with a
 stage output → the stage output wins. The widget side reaches the same ordering
 from the opposite direction — `ds` already holds the apiRef result, and
 `mergeExtras` only fills keys that are *absent*
-(`internal/resolvers/widgets/resolve.go:348-358`):
+(`internal/resolvers/widgets/resolve.go`):
 
 ```go
 for k, v := range extrasCopy {
@@ -46,7 +55,14 @@ for k, v := range extrasCopy {
 ```
 
 The pagination `slice` triple is treated like an API result — it also wins over
-`extras` (`resolve.go:88`, `:96`).
+`extras` (`injectSlice` runs before `mergeExtras`).
+
+**Identity injection wins over the client.** For a widget declaring
+`spec.identityContext`, the server overwrites the declared keys (`username` /
+`groups`) in the request extras with the authenticated JWT's own values
+*before* the resolve (`DeclaredIdentity` fold at the top of `widgets.Resolve`)
+— so a request carrying `extras.username=SOMEONE_ELSE` cannot spoof a declared
+widget's identity. Identity-free widgets (no declaration) are untouched.
 
 #### The per-stage `filter` also sees `extras` as a reserved sibling key
 
@@ -61,11 +77,8 @@ spec:
   api:
     - name: things
       path: /apis/.../things
-      filter: '[.things.items[] | select(.metadata.namespace == $__loc__) ]'
-      # …or read extras directly:
-      # filter: '.things.items | map(select(.spec.tenant == ($from_extras))) '
-      #   where the value comes from .extras.<key> in the envelope, e.g.
-      # filter: '{items: .things.items, tenant: .extras.tenant}'
+      # read extras directly in the step filter:
+      filter: '{items: .things.items, tenant: .extras.tenant}'
 ```
 
 The `extras` the filter sees is the **pure request extras** (`r.opts.Extras`),
@@ -73,8 +86,8 @@ not the accumulated run dict — at later stages the dict has stage outputs and 
 synthetic `slice` merged in, so it is no longer the request extras. The key is
 present only when the request carried a non-empty `extras` (mirrors the `slice`
 guard), so a no-extras resolve is byte-identical to before
-(`internal/resolvers/restactions/api/handler.go` — `pig["extras"]` written under
-the `len(opts.extras) > 0` guard).
+(`internal/resolvers/restactions/api/handler.go`, `jsonHandlerCore` —
+`pig["extras"]` written under the `len(opts.extras) > 0` guard).
 
 **Known asymmetry — `extras`-stage *wins*, `slice`-stage *loses*.** If a stage is
 literally named `extras`, the **stage response wins** the sibling-key collision:
@@ -93,33 +106,54 @@ considered acceptable (declaring a stage `extras` or `slice` is degenerate).
 raw `extras` object. Nothing in the resolvers copies `extras` into the emitted
 status.
 
-### 3. It is folded into the cache key
+### 3. It meets the cache key differently per lane
 
-`extras` is part of every L1 cache key, so two requests that differ only in
-`extras` land on **distinct cache entries** — no cross-request collision, and a
-warm entry for `extras=A` is never served to a request carrying `extras=B`.
+`ComputeKey` folds an extras map last, via `canonicaliseExtras`
+(`internal/cache/resolved.go`): a **recursively sorted-key JSON** surrogate.
+Sorting means two requests with the same content but different map iteration
+order hash to the *same* key (a cache hit), while different content hashes to a
+different key. On a marshal failure (cyclic / non-JSON value) it falls back to
+a deterministic `fmt.Sprintf("%v", …)` so the key still varies with content.
+*Which* extras reach that fold depends on the lane:
 
-`ComputeKey` folds `extras` last, via `canonicaliseExtras`
-(`internal/cache/resolved.go:679-688`, `:697`): a **recursively sorted-key JSON**
-surrogate. Sorting means two requests with the same content but different map
-iteration order hash to the *same* key (a cache hit), while different content
-hashes to a different key (`resolved.go:694-729`). On a marshal failure (cyclic /
-non-JSON value) it falls back to a deterministic `fmt.Sprintf("%v", …)` so the key
-still varies with content (`resolved.go:683-687`). This applies to the widget L1
-key, the RESTAction per-binding L1 key, and the identity-free `widgetContent` cell
-alike (`extras` is one of `widgetContent`'s key components,
-`resolved.go:652-660`).
+- **Direct RESTAction `/call`** — the full request `extras` is part of the L1
+  key (`handlers/dispatchers/restactions.go`), so two requests that differ
+  only in `extras` land on distinct cache entries.
+
+- **Widget `/call`** — the key folds the *effective key extras*
+  (`effectiveKeyExtras`, `handlers/dispatchers/helpers.go`), which is the
+  union of:
+  - the CR-fixed inline maps (`spec.apiRef.extras` ∪
+    `spec.resourcesRefsTemplateExtras`, request wins on collision),
+  - **only** the request-extras keys the author declared in
+    `spec.keyExtras` (`filterDeclaredKeyExtras`) — an absent/empty
+    declaration folds **nothing** from the request extras, so one cached
+    cell serves every route (the chrome-widget default),
+  - the declared identity (`spec.identityContext` → `username`/`groups`
+    from the JWT), and the full request identity for an inline-embedding
+    parent.
+
+  Undeclared request extras still reach the resolve's jq dict unchanged —
+  they affect the *body*, never the *key*. To keep that from polluting the
+  shared per-cohort cell, a request carrying extras the widget did **not**
+  declare (identity keys exempt) is served its own correct body but the
+  result is **not written to the cache** (`requestExtrasFullyDeclared` — the
+  self-quarantine guard). A widget whose output genuinely varies on a request
+  extra **must declare that key in `spec.keyExtras`**.
+
+  The same filtered union feeds all four key consumers — dispatch lookup,
+  the shared `widgetContent` cell, subscription arming, and the boot/keepwarm
+  seed — from the single `effectiveKeyExtras` site, so they cannot drift.
 
 > **Exception — resolves that touch an external endpoint are not cached.** If a
 > `RESTAction`'s resolve reaches a genuine **external** endpoint (an
 > `endpointRef` to a non-apiserver URL), its result is **never** written to L1 —
 > external data has no informer/dependency edge that could invalidate a stale
-> entry, so snowplow re-fetches it **live on every `/call`**. The `extras`
-> keying still applies to the *internal* (apiserver-backed) parts of a resolve;
-> it just means an external-touched outer result is not memoised under its
-> `extras`-derived key. A `${…}`-templated path that resolves at runtime to an
-> apiserver path is treated as **internal** (and cached); only genuinely
-> non-apiserver URLs are external.
+> entry, so snowplow re-fetches it **live on every `/call`**
+> (the external-touched sink Put-gate in `handlers/dispatchers/restactions.go`).
+> A `${…}`-templated path that resolves at runtime to an apiserver path is
+> treated as **internal** (and cached); only genuinely non-apiserver URLs are
+> external.
 
 ---
 
@@ -135,16 +169,18 @@ request always wins on collision):
 - `spec.resourcesRefsTemplateExtras` — scoped to the `resourcesRefsTemplate` jq
   **only**. Read by `GetResourcesRefsExtras`.
 
-The dispatcher folds the **union** of (apiRef-inline ∪ resourcesRefs-inline ∪
-request) into the L1 keys (`unionForKey`, `helpers.go`), and the prewarm seed
+The dispatcher folds the union of the two inline maps into the L1 keys
+(`unionForKey`, `helpers.go`) — inline maps are CR-fixed, so unlike request
+extras they are never filtered by `spec.keyExtras` — and the prewarm seed
 applies the same union so the first paint is a hit, not a miss. Precedence is
 request-wins via `mergeRequestWins` (`widgets/resolve.go`); both inline maps are
 input-only and deep-copied (they never alias the shared CR). A widget that
 declares neither is **byte-identical** to before.
 
-> The inline fields live on the **widget CRD**, which ships from the portal
-> chart — not snowplow. Until that CRD declares them the accessors read `{}`
-> (a no-op), so the feature is latent-but-safe on a snowplow-only upgrade.
+> The inline fields (like `identityContext` and `keyExtras`) live on the
+> **widget CRD**, which ships from the portal chart — not snowplow. Until that
+> CRD declares them the accessors read `{}`/nil (a no-op), so the features are
+> latent-but-safe on a snowplow-only upgrade.
 
 ---
 
@@ -154,36 +190,37 @@ declares neither is **byte-identical** to before.
 
 ```
 /call?resource=restactions&extras={…}
-   → restactions dispatcher: util.ParseExtras (restactions.go:79)
-   → L1 key includes extras (restactions.go:126/134, ComputeKey resolved.go:679)
-   → restactions.Resolve → api.Resolve: dict := DeepCopyJSON(extras) (api/resolve.go:228)
-   → API stages overwrite dict; spec.Filter projects; status.Raw emitted
+   → restactions dispatcher: util.ParseExtras
+   → L1 key includes the full request extras (ComputeKey → canonicaliseExtras)
+   → restactions.Resolve → api.Resolve: dict := DeepCopyJSON(extras)
+   → API stages overwrite dict; spec.Filter projects; status emitted
 ```
 
 ### Widget (`/call`)
 
 ```
 /call?resource=widgets&extras={…}
-   → widgets dispatcher: util.ParseExtras (widgets.go:64)
-   → L1 keys include extras (widgets.go:138/173/182)
-   → widgets.Resolve:
+   → widgets dispatcher: util.ParseExtras
+   → L1 keys fold effectiveKeyExtras (inline ∪ declared keyExtras ∪ declared identity)
+   → widgets.Resolve (receives the RAW request extras):
+       declared-identity injection (identityContext keys overwritten from the JWT)
        apiRef → apiref.Resolve → restactions.Resolve (extras seeds the RA dict)
        mergeExtras(ds, extras)  ← non-overwriting; covers apiRef-less widgets too
        widgetDataTemplate jq + resourcesRefsTemplate jq evaluate against ds
 ```
 
-The prewarm / seed / refresher callers never set `extras`, so a nil/empty
-`extras` is a no-op everywhere (the `if opts.Extras != nil` gate and the
-`len(extras) == 0` guard skip the copy), and a resolve without `extras` is
-byte-identical to the pre-extras behaviour
-(`api/resolve.go:228`, `resolve.go:349`).
+The prewarm / seed / refresher callers never set request `extras`, so a
+nil/empty `extras` is a no-op everywhere (the `if opts.Extras != nil` gate and
+the `len(extras) == 0` guard skip the copy), and a resolve without `extras` is
+byte-identical to the pre-extras behaviour.
 
 ---
 
 ## See also
 
-- [`widgets.md`](widgets.md) — how `extras` reaches each widget template path.
+- [`widgets.md`](widgets.md) — how `extras` reaches each widget template path,
+  and the `identityContext` / `keyExtras` spec fields.
 - [`restactions.md`](restactions.md) — the RESTAction `spec.api` resolve `extras`
   seeds.
-- [caching deep-dive](../docs/architecture/caching.md) §3.1 — `ComputeKey` /
+- [caching deep-dive](../docs/architecture/caching.md) — `ComputeKey` /
   `canonicaliseExtras` in the full key structure.

--- a/go/snowplow/howto/health-aggregation.md
+++ b/go/snowplow/howto/health-aggregation.md
@@ -1,10 +1,20 @@
+---
+type: Usage
+title: Health and usage aggregation (built-in health jq module)
+description: The embedded health jq module — normalize heterogeneous service health signals to OK/Warning/Critical/Unknown and roll them up in any RESTAction filter or widget expression via include "health".
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, restaction, jq, health]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Health & usage aggregation (built-in `health` jq module)
 
-Snowplow ships a **built-in jq module** (`internal/support/jq/modules/health.jq`)
-available to every `RESTAction` filter and widget expression via
-`include "health";` — no `JQ_MODULES_PATH` deployment configuration
-needed (filesystem modules with the same name still win, so operators
-can override it).
+Snowplow ships a **built-in jq module** (`internal/support/jq/modules/health.jq`,
+embedded in the binary and served by the layered loader in
+`internal/support/jq/modules.go`) available to every `RESTAction` filter and
+widget expression via `include "health";` — no `JQ_MODULES_PATH` deployment
+configuration needed (filesystem modules with the same name still win, so
+operators can override it).
 
 It defines the **normalized health vocabulary** used to aggregate
 heterogeneous per-service health signals into one uniform scale:
@@ -31,6 +41,14 @@ service.
 | `usage_pct(used; capacity)` | numbers | percentage (1 decimal) or `null` when capacity is unknown/0 |
 | `usage_health(pct; warnAt; critAt)` | percentage + thresholds | normalized status |
 | `usage_summary(fu; fc; warnAt; critAt)` | array of objects | `{used, capacity, pct, status}` |
+
+> **Numeric inputs.** `normalize_health` interprets a *number* as this module's
+> own severity code (`0`=OK, `1`=Unknown, `2`=Warning, `3`=Critical; any other
+> number degrades to Unknown) — the exact inverse of `health_severity`, so a
+> value round-trips. This is **not** the Nagios/Icinga plugin exit-code
+> convention; translate Nagios-shaped codes before aggregating. An
+> unreadable/absent signal degrades the rollup (`Unknown`), never silently
+> passes as healthy.
 
 ## Example — consolidated health RESTAction
 

--- a/go/snowplow/howto/install.md
+++ b/go/snowplow/howto/install.md
@@ -1,10 +1,12 @@
 # Installing `snowplow` on [Kind][kind]
 
-> **Production deploys** use the Helm chart `braghettos/krateo-snowplow-chart`
-> (chart name `krateo-snowplow`, image `ghcr.io/braghettos/krateo-snowplow`),
-> with `CACHE_ENABLED=true` and the runtime tuning described in
-> [operating.md](operating.md). This page is a single-node **quickstart** for
-> trying snowplow on a disposable [Kind][kind] cluster.
+> **Production deploys** use the Helm chart from this repo (`helm/snowplow`,
+> published as `oci://ghcr.io/krateo-platformops/charts/snowplow`, image
+> `ghcr.io/krateo-platformops/snowplow`), with `CACHE_ENABLED=true` and the
+> runtime tuning described in [operating.md](operating.md) — normally via the
+> Krateo installer (see [docs/usage.md](../../../docs/usage.md)). This page is a
+> single-node **quickstart** for trying snowplow on a disposable [Kind][kind]
+> cluster.
 
 If you have any Docker-compatible container runtime installed (including native Docker, Docker Desktop, or OrbStack), you can easily launch a disposable cluster just for this quickstart using [Kind][kind].
 
@@ -42,15 +44,37 @@ kubectl create secret generic jwt-sign-key \
 
 ## 4. Create a Krateo PlatformOps User
 
-To quickly create a Krateo PlatformOps user, install [`krateoctl`][krateoctl] and run the following command:
+A Krateo access token is a plain HS256 JWT signed with the `JWT_SIGN_KEY` above, carrying
+`username` and `groups` claims (the shape is defined by the shared auth library,
+`github.com/krateo-platformops/plumbing` `jwtutil` — `CreateToken` / `Validate`). You can mint
+one with nothing but Python's standard library:
 
 ```sh {name=create-krateo-user depends=create-jwt-secret}
 export KRATEO_USER=cyberjoker
-export KRATEO_ACCESS_TOKEN=$(krateoctl add-user -k "${JWT_SECRET}" -n "${NAMESPACE}" "${KRATEO_USER}")
+export KRATEO_ACCESS_TOKEN=$(python3 - "${JWT_SECRET}" "${KRATEO_USER}" <<'PYEOF'
+import base64, hashlib, hmac, json, sys, time
+def b64(d): return base64.urlsafe_b64encode(d).rstrip(b"=")
+key, user = sys.argv[1], sys.argv[2]
+now = int(time.time())
+header = b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+payload = b64(json.dumps({
+    "username": user, "groups": ["devs"],
+    "iss": "krateo.io", "sub": user,
+    "iat": now, "nbf": now, "exp": now + 8 * 3600,
+}).encode())
+sig = b64(hmac.new(key.encode(), header + b"." + payload, hashlib.sha256).digest())
+print((header + b"." + payload + b"." + sig).decode())
+PYEOF
+)
 
 echo "KRATEO_USER=${KRATEO_USER}" > .env
 echo "KRATEO_ACCESS_TOKEN=${KRATEO_ACCESS_TOKEN}" >> .env
 ```
+
+> The `krateoctl add-user` CLI (where you have it) mints the same token via the same shared
+> library — see [ADR 0001](../docs/adr/0001-decouple-authn.md). The inline mint above keeps this
+> quickstart free of extra tooling. The user belongs to the `devs` group, which the RBAC below
+> targets.
 
 ## 5. RBACs for the Krateo PlatformOps User
 
@@ -96,12 +120,26 @@ EOF
 
 ## 6. Deploy snowplow
 
-Finally, install `snowplow` using the Helm chart. The chart serves on the single
+First install the CRDs snowplow needs. The `snowplow-crds` chart ships the `RESTAction` CRD;
+the `authn-crds` chart ships the `serviceaccount.authn.krateo.io` CRD that the snowplow chart's
+prewarm-seed allowlist CR requires at install time (a hard dependency — without it the install
+fails fast on the unknown kind; see the `seedAuthn` notes in `helm/snowplow/values.yaml`):
+
+```sh {name=install-crds depends=kind-up}
+helm install snowplow-crds oci://ghcr.io/krateo-platformops/charts/snowplow-crds
+helm install authn-crds oci://ghcr.io/krateo-platformops/charts/authn-crds
+```
+
+> On a bare Kind cluster (no `authn` operator running) the prewarm seed's loopback token
+> exchange fails at runtime — that is fine here: the seed is best-effort warmth, not a
+> correctness gate, and `/call` serves normally.
+
+Then install `snowplow` itself. The chart serves on the single
 `http` port `8081` (there is no separate probe port — see
 [operating.md](operating.md)), so the NodePort maps to it:
 
-```sh {name=install depends=create-jwt-secret}
-helm install snowplow oci://ghcr.io/braghettos/krateo-snowplow-chart \
+```sh {name=install depends=install-crds}
+helm install snowplow oci://ghcr.io/krateo-platformops/charts/snowplow \
   --namespace ${NAMESPACE} \
   --set service.type=NodePort --set service.port=8081 --set service.nodePort=30081 \
   --set 'env.DEBUG=true' --set 'env.CACHE_ENABLED=true'
@@ -138,5 +176,4 @@ Experiment with creating, updating, and querying resources to get a hands-on und
 
 
 [kind]: https://kind.sigs.k8s.io/
-[krateoctl]: https://github.com/krateoplatformops/krateoctl/releases
 [restactions]: restactions.md

--- a/go/snowplow/howto/install.md
+++ b/go/snowplow/howto/install.md
@@ -1,3 +1,17 @@
+---
+type: Usage
+title: Installing snowplow on Kind
+description: Quickstart that installs the snowplow Helm chart on a disposable Kind cluster, mints a Krateo user (JWT + clientconfig Secret) and prepares RBAC for the RESTAction walkthroughs.
+resource: snowplow
+tags:
+  - snowplow
+  - install
+  - kind
+  - helm
+  - quickstart
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Installing `snowplow` on [Kind][kind]
 
 > **Production deploys** use the Helm chart from this repo (`helm/snowplow`,
@@ -76,7 +90,65 @@ echo "KRATEO_ACCESS_TOKEN=${KRATEO_ACCESS_TOKEN}" >> .env
 > quickstart free of extra tooling. The user belongs to the `devs` group, which the RBAC below
 > targets.
 
-## 5. RBACs for the Krateo PlatformOps User
+## 5. Create the user's `clientconfig` Secret
+
+The JWT alone is **not** enough. On every `/call`, after validating the JWT,
+snowplow loads the caller's per-user Kubernetes credentials from a
+**`<user>-clientconfig` Secret** in `AUTHN_NAMESPACE` — the chart sets
+`AUTHN_NAMESPACE` to the **release namespace** (`helm/snowplow/templates/configmap.yaml`).
+If the Secret is missing, `/call` returns **401** (`middleware.UserConfig`:
+Secret NotFound → Unauthorized). In production the `authn` service creates this
+Secret at login (a CSR-signed client certificate with `CN=<user>` /
+`O=<groups>` — the same thing `krateoctl add-user` does via the shared
+`signup` library). Here we mint the certificate by hand through the Kubernetes
+CSR API:
+
+```sh {name=create-clientconfig depends=create-krateo-user}
+openssl genrsa -out /tmp/${KRATEO_USER}.key 2048
+openssl req -new -key /tmp/${KRATEO_USER}.key \
+  -subj "/CN=${KRATEO_USER}/O=devs" -out /tmp/${KRATEO_USER}.csr
+
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${KRATEO_USER}
+spec:
+  request: $(base64 < /tmp/${KRATEO_USER}.csr | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
+  usages:
+  - digital signature
+  - key encipherment
+  - client auth
+EOF
+
+kubectl certificate approve ${KRATEO_USER}
+until CRT=$(kubectl get csr ${KRATEO_USER} -o jsonpath='{.status.certificate}') \
+  && [ -n "${CRT}" ]; do sleep 1; done
+CA=$(kubectl config view --raw --minify \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${KRATEO_USER}-clientconfig
+  namespace: ${NAMESPACE}
+stringData:
+  server-url: https://kubernetes.default.svc
+  certificate-authority-data: ${CA}
+  client-certificate-data: ${CRT}
+  client-key-data: $(base64 < /tmp/${KRATEO_USER}.key | tr -d '\n')
+EOF
+```
+
+> The Secret's key names and base64-encoded certificate values follow the
+> [`Endpoint`](endpoints.md) contract. The certificate identity (`CN`/`O`) is
+> what the Kubernetes apiserver enforces RBAC against on the cache-off
+> fallback path; keep it aligned with the JWT's `username`/`groups` claims so
+> cache-on (in-process RBAC over the JWT identity) and cache-off agree.
+
+## 6. RBACs for the Krateo PlatformOps User
 
 After creating a new user, you must assign them a minimal set of RBAC permissions.
 In this case, since we are testing [RESTActions][restactions], the user needs at least read access to this resource.
@@ -118,7 +190,7 @@ EOF
 ```
 
 
-## 6. Deploy snowplow
+## 7. Deploy snowplow
 
 First install the CRDs snowplow needs. The `snowplow-crds` chart ships the `RESTAction` CRD;
 the `authn-crds` chart ships the `serviceaccount.authn.krateo.io` CRD that the snowplow chart's
@@ -147,11 +219,13 @@ helm install snowplow oci://ghcr.io/krateo-platformops/charts/snowplow \
 
 > `env.*` values are rendered into the chart's `snowplow` ConfigMap and consumed
 > via `envFrom`; the container has no direct `env:` array. `CACHE_ENABLED=true`
-> turns on the in-process cache path; omit it (or set `false`) for the
-> transparent direct-apiserver fallback.
+> is the **chart default** (`helm/snowplow/values.yaml`) and turns on the
+> in-process cache path; set it explicitly to `false` for the transparent
+> direct-apiserver fallback. (The binary itself defaults to cache-off when the
+> variable is absent — only `"true"`, `"1"` or `"yes"` enable it.)
 
 
-## 7. Wait until the `snowplow` deployment is ready
+## 8. Wait until the `snowplow` deployment is ready
 
 Finally, wait for the `snowplow` deployment to become **available**.
 This ensures all pods are up and running before proceeding.

--- a/go/snowplow/howto/migrate-call-stage-to-direct-path.md
+++ b/go/snowplow/howto/migrate-call-stage-to-direct-path.md
@@ -1,22 +1,71 @@
-# How to migrate a RESTAction `/call` api-step to a direct apiserver path
+---
+type: Runbook
+title: RESTAction api-steps use direct apiserver paths (the /call loopback is retired)
+description: Current-state rules for referencing another RESTAction/Widget from a spec.api[] step — direct apiserver path + resolve (default false), the /call-to-path mapping for any legacy template, and the verification steps.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, restaction, migration, resolver]
+timestamp: 2026-08-06T00:00:00Z
+---
 
-**Audience:** whoever is editing RESTAction templates (portal-chart / composition-portal blueprints under the `krateo-platformops` org; portal is helm-only). **Apply in a separate session.**
+# RESTAction api-steps use direct apiserver paths (the `/call` loopback is retired)
 
-## Why (what changed in snowplow 1.4.x)
-snowplow 1.4.x **retired the in-process `/call` loopback for RESTAction *api steps*.** Before, a stage could set `path: /call?resource=…` and snowplow would resolve the referenced `RESTAction`/`Widget` in-process. That dispatch branch is **gone**. A stage whose `path` is still a `/call?…` URL now falls through to the **external HTTP fetch** → it needs an `endpointRef` or it errors/404s (and it is **not cached**).
+**Audience:** whoever is editing RESTAction templates (portal-chart /
+composition-portal blueprints under the `krateo-platformops` org; portal is
+helm-only).
 
-The supported replacement is a **direct apiserver path + `spec.api[].resolve`** (default `true`): point the stage `path` straight at the referenced CR's Kubernetes apiserver path; snowplow fetches it from the informer (cacheable, dependency-tracked) and **resolves it in-process — byte-identical to what the old `/call` returned, with no outbound round-trip.**
+**Status: the migration is complete.** The in-process `/call` loopback for
+RESTAction *api steps* was retired in the 2026-06-22 unified ship, after a
+corpus audit (`docs/corpus-audit-call-loopback-2026-06-22.md`) confirmed zero
+live RESTActions carried a `/call` api-step path. This document now describes
+the current contract, and keeps the `/call`→path mapping as a reference for
+anyone who finds a legacy `/call` stage in an out-of-tree template.
 
-> ⚠️ Only the **RESTAction-stage** `/call` loopback is retired. The `/call?resource=…` URL shape is **still used by the frontend SPA and the prewarm walker** for navigation (it appears in widget `status.resourcesRefs[].path`). **Do NOT rewrite those** — only rewrite `/call` paths that appear as a `spec.api[].path` inside a RESTAction.
+## The current contract
 
-## Step 1 — find the stages to migrate
-In the RA templates (e.g. `chart/templates/restaction.*.yaml`):
+A `spec.api[]` step that references another `RESTAction` or `Widget` points its
+`path` **straight at the referenced CR's Kubernetes apiserver path**. Snowplow
+fetches it internally (informer-served where possible — cacheable and
+dependency-tracked) and the step's `resolve` field decides what the stage
+output is (`apis/templates/v1/core.go`, applied in
+`internal/resolvers/restactions/api/resolve.go`):
+
+- **`resolve: true`** — snowplow runs the fetched `RESTAction`/`Widget` through
+  the resolver **in-process** and substitutes the **resolved envelope** —
+  byte-identical to what an HTTP `/call` of that CR would return, with no
+  outbound round-trip. Use this when the step consumes the referenced CR's
+  *resolved* output (e.g. a resolved-only `.status.<field>`).
+- **`resolve: false` — or OMITTED (the default)** — the stage output is the
+  **raw** stored CR (unresolved spec). The default was flipped to omit→false
+  on 2026-07-02 (see the `Resolve` field contract in
+  `apis/templates/v1/core.go`), aligned with
+  progressive rendering: the server returns raw refs/CRs unless a step
+  explicitly opts in. **A step that needs the resolved envelope MUST set
+  `resolve: true` explicitly.**
+- Non-`RESTAction`/`Widget` path (e.g. a ConfigMap, a composition CR):
+  `resolve` is a harmless no-op — the raw object is returned.
+
+There is **no** `/call` dispatch branch for api-steps any more: a stage whose
+`path` is still a `/call?…` URL falls through to the **external HTTP fetch**
+lane — it then needs an `endpointRef` or it errors, and it is **not cached**.
+
+> ⚠️ Only the **RESTAction-stage** `/call` loopback is retired. The
+> `/call?resource=…` URL shape is **still the navigation contract** for the
+> frontend SPA and the prewarm walker (it appears in widget
+> `status.resourcesRefs[].path`, emitted by `buildPath`). Do NOT rewrite
+> those — the rules here apply only to `/call` paths appearing as a
+> `spec.api[].path` inside a RESTAction.
+
+## Rewriting a legacy `/call` stage
+
+Find candidates in RA templates (e.g. `chart/templates/restaction.*.yaml`):
+
 ```
 grep -rnE 'path:.*\/call' chart/templates/
 ```
-Only hits where `/call` is a `spec.api[].path` value need migrating. Ignore `/call` in comments and in widget `resourcesRefs`/SPA-nav contexts.
 
-## Step 2 — rewrite the path
+Only hits where `/call` is a `spec.api[].path` value need rewriting. Ignore
+`/call` in comments and in widget `resourcesRefs`/SPA-nav contexts.
+
 `/call` query params map 1:1 to the apiserver path:
 
 | `/call?` param | apiserver path piece |
@@ -28,12 +77,13 @@ Only hits where `/call` is a `spec.api[].path` value need migrating. Ignore `/ca
 
 **Examples**
 ```yaml
-# BEFORE
+# BEFORE (legacy loopback)
 - name: inner
   path: /call?resource=restactions&apiVersion=templates.krateo.io/v1&namespace=krateo-system&name=my-ra
-# AFTER (resolve defaults to true — omit it)
+# AFTER — resolve:true is REQUIRED to keep the resolved output (omit→false)
 - name: inner
   path: /apis/templates.krateo.io/v1/namespaces/krateo-system/restactions/my-ra
+  resolve: true
 ```
 ```yaml
 # BEFORE (widget)
@@ -42,27 +92,47 @@ Only hits where `/call` is a `spec.api[].path` value need migrating. Ignore `/ca
 # AFTER
 - name: card
   path: /apis/widgets.templates.krateo.io/v1beta1/namespaces/krateo-system/cards/my-card
+  resolve: true
 ```
-Templated paths work the same — build the same apiserver URL with `${ … }` instead of a `/call` URL.
+Templated paths work the same — build the same apiserver URL with `${ … }`
+instead of a `/call` URL.
 
-## Step 3 — set `resolve` correctly
-- **`resolve: true` (the DEFAULT — you can omit it):** snowplow runs the fetched `RESTAction`/`Widget` through the resolver in-process and substitutes the **resolved envelope** — this is what the old `/call` returned. Use this for the normal case (you referenced another RA/widget to consume its resolved output).
-- **`resolve: false`:** returns the **raw** stored CR (unresolved spec). Set this **only** if the stage was consuming the raw CR spec, not the resolved output.
-- Non-`RESTAction`/`Widget` path (e.g. a ConfigMap, a composition CR): `resolve` is a no-op — the raw object is returned. No change needed.
+## Gotchas
 
-## Step 4 — gotchas (read these)
-1. **Use a SERVED apiVersion** (the RC-2 lesson, 2026-06-22). If you template the version from CRD data, select a **served** version — never `.status.storedVersions[0]` (the storage version may be `served:false`, e.g. a `vacuum` migration version → guaranteed 404 → uncacheable). Use `([.spec.versions[] | select(.served)][0]).name` (or storage-preferred-if-served). Hard-coded versions must be the served one.
-2. **`&extras={…}` does NOT migrate.** If a `/call` stage passed author-templated `?extras=`, the direct-path form has no equivalent (extras are a per-request concept of the *outer* `/call`, not of a CR fetch). Such stages need individual review — if the inner RA's jq reads those extras, a direct-path fetch won't supply them. Flag these rather than blind-rewrite.
-3. **RBAC is unchanged** — the in-process resolve is gated on the requesting identity being allowed to `get` the referenced CR (same as the old `/call`), and is depth-capped (cyclic refs terminate with a bounded error). Cache-off (`CACHE_ENABLED=false`) resolves the same data via the user's own token — transparent.
-4. **Pagination:** a `/call?…&page=N&perPage=M` LIST becomes a direct LIST path with `?limit=&continue=` (apiserver paging). Single-CR GET-by-name has no pagination.
+1. **Use a SERVED apiVersion.** If you template the version from CRD data,
+   select a **served** version — never `.status.storedVersions[0]` (the storage
+   version may be `served:false`, e.g. a `vacuum` migration version →
+   guaranteed 404 → uncacheable). Use
+   `([.spec.versions[] | select(.served)][0]).name` (or
+   storage-preferred-if-served). Hard-coded versions must be the served one.
+2. **`&extras={…}` does NOT map.** If a legacy `/call` stage passed
+   author-templated `?extras=`, the direct-path form has no equivalent (extras
+   are a per-request concept of the *outer* `/call`, not of a CR fetch). Such
+   stages need individual review — if the inner RA's jq reads those extras, a
+   direct-path fetch won't supply them. Flag these rather than blind-rewrite.
+3. **RBAC is unchanged** — the in-process resolve is gated on the requesting
+   identity being allowed to `get` the referenced CR (same as the old `/call`),
+   and is depth-capped (cyclic refs terminate with a bounded error; a
+   denied/depth-capped resolve surfaces a 403-class error, not empty content).
+   Cache-off (`CACHE_ENABLED=false`) resolves the same data via the user's own
+   token — transparent.
+4. **Pagination:** a `/call?…&page=N&perPage=M` LIST becomes a direct LIST path
+   with `?limit=&continue=` (apiserver paging). Single-CR GET-by-name has no
+   pagination.
 
-## Step 5 — verify (per stage)
-After the change, in the snowplow pod logs for a request that hits the stage:
+## Verify (per stage)
+
+In the snowplow pod logs for a request that hits the stage:
+
 - **No** `/call` outbound HTTP for the inner ref; the dispatch is in-process.
-- **No** `the server could not find the requested resource` and **no** `declining to cache the partial result` for that traceId (if you see these, the apiVersion is wrong — gotcha #1).
-- The stage output is byte-identical to the old `/call` resolution; the result is cacheable → 2nd navigation logs `l1_hit:"hit"`.
+- **No** `the server could not find the requested resource` and **no**
+  `declining to cache the partial result` for that traceId (if you see these,
+  the apiVersion is wrong — gotcha #1).
+- With `resolve: true`, the stage output is the resolved envelope (identical to
+  an HTTP `/call` of the referenced CR); the result is cacheable → 2nd
+  navigation logs `l1_hit:"hit"`.
 
-## Safety
-- Requires snowplow **≥ 1.4.1** on the cluster (the loopback is retired there; an un-migrated `/call` stage will break on 1.4.x — so migrate in lockstep with the 1.4.x rollout).
-- Portal changes are **helm-only** (chart template → helm upgrade), never `kubectl apply`.
-- See `howto/restactions.md` (the `resolve` field) and `docs/corpus-audit-call-loopback-2026-06-22.md` (the retirement scope).
+See `howto/restactions.md` (the `resolve` field) and
+`docs/corpus-audit-call-loopback-2026-06-22.md` (the retirement scope).
+Portal-chart changes remain **helm-only** (chart template → helm upgrade),
+never `kubectl apply`.

--- a/go/snowplow/howto/migrate-call-stage-to-direct-path.md
+++ b/go/snowplow/howto/migrate-call-stage-to-direct-path.md
@@ -1,6 +1,6 @@
 # How to migrate a RESTAction `/call` api-step to a direct apiserver path
 
-**Audience:** whoever is editing RESTAction templates (portal-chart / composition-portal blueprints — braghettos fork only, NEVER upstream krateoplatformops; portal is helm-only). **Apply in a separate session.**
+**Audience:** whoever is editing RESTAction templates (portal-chart / composition-portal blueprints under the `krateo-platformops` org; portal is helm-only). **Apply in a separate session.**
 
 ## Why (what changed in snowplow 1.4.x)
 snowplow 1.4.x **retired the in-process `/call` loopback for RESTAction *api steps*.** Before, a stage could set `path: /call?resource=…` and snowplow would resolve the referenced `RESTAction`/`Widget` in-process. That dispatch branch is **gone**. A stage whose `path` is still a `/call?…` URL now falls through to the **external HTTP fetch** → it needs an `endpointRef` or it errors/404s (and it is **not cached**).
@@ -64,5 +64,5 @@ After the change, in the snowplow pod logs for a request that hits the stage:
 
 ## Safety
 - Requires snowplow **≥ 1.4.1** on the cluster (the loopback is retired there; an un-migrated `/call` stage will break on 1.4.x — so migrate in lockstep with the 1.4.x rollout).
-- braghettos fork only; portal changes are **helm-only** (chart template → helm upgrade), never `kubectl apply`.
+- Portal changes are **helm-only** (chart template → helm upgrade), never `kubectl apply`.
 - See `howto/restactions.md` (the `resolve` field) and `docs/corpus-audit-call-loopback-2026-06-22.md` (the retirement scope).

--- a/go/snowplow/howto/operating.md
+++ b/go/snowplow/howto/operating.md
@@ -1,3 +1,17 @@
+---
+type: Runbook
+title: Operating snowplow
+description: Operator runbook for the snowplow Helm deployment — probe contract, GOMEMLIMIT/GOGC tuning at 50K scale, cache on/off semantics, observability surface and the incident table.
+resource: snowplow
+tags:
+  - snowplow
+  - runbook
+  - operations
+  - tuning
+  - observability
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Operating snowplow
 
 The operator runbook: deploy, tune at scale, and diagnose incidents. For the
@@ -31,17 +45,17 @@ re-templating the chart.
 ### The chart ⇄ binary probe contract
 
 On the **1.0.x ship line the binary serves everything on one port** — `PORT`
-(default `8081`, `main.go:73`), including `/health`, `/readyz`, `/debug/vars`, and
-`/debug/pprof/*` (`main.go:774-775`, `:837-869`). There is **no `PROBE_PORT`** and
-no second listener; a prototype probe-port split lived only on the abandoned
-0.25.x line and is not in the current binary. So all three probes target the
-single `http` port:
+(default `8081`, the `--port` flag in `main.go`), including `/health`, `/readyz`,
+`/debug/vars`, and `/debug/pprof/*` (all mounted on the same mux in `main.go`).
+There is **no `PROBE_PORT`** and no second listener; a prototype probe-port
+split lived only on the abandoned 0.25.x line and is not in the current binary.
+So all three probes target the single `http` port:
 
 | Probe | Path | Meaning |
 |---|---|---|
 | `startupProbe` | `/health` | binary is up and serving (binds early, before prewarm) |
-| `livenessProbe` | `/health` | always `200 {"status":"alive"}` — a still-warming pod is alive and must NOT be restarted (`handlers/health.go`) |
-| `readinessProbe` | `/readyz` | `200` once informers sync + `Phase1Done` flips; `503 {"status":"warming"}` until then (`handlers/readyz.go`) |
+| `livenessProbe` | `/health` | always `200 {"status":"alive"}` — a still-warming pod is alive and must NOT be restarted (`internal/handlers/health.go`) |
+| `readinessProbe` | `/readyz` | `200` once `Phase1Done` flips — informer sync **plus** the per-cohort prewarm seed complete (or its ~8min backstop; 1.5.29 prewarm-gated readiness, see `helm/snowplow/values.yaml`); `503 {"status":"warming"}` until then (`internal/handlers/readyz.go`) |
 
 The chart thresholds are **deliberately widened** beyond the k8s defaults
 (`timeout 1s / failure 3 / period 10s` ≈ a 30s window). Defaults are too tight for
@@ -88,7 +102,8 @@ rather than narrowing liveness.
 
 ### `CACHE_ENABLED` — a transparent fallback, not a degraded mode
 
-`CACHE_ENABLED=false` (`cache.Disabled()`, `internal/cache/cache.go:37`) turns off
+`CACHE_ENABLED=false` (`cache.Disabled()`, `internal/cache/cache.go` — only
+`"true"`, `"1"`, `"yes"` enable; anything else, including unset, disables) turns off
 all three cache tiers. The result is **the same data, same UI, same RBAC — only
 slower**: every read goes straight to the apiserver under the user's own token,
 and RBAC is enforced inline by the apiserver. It is a correctness-equivalent
@@ -96,7 +111,7 @@ fallback, safe to flip if you suspect a cache bug; it is not a reduced-capabilit
 mode. (`CACHE_ENABLED` is the single master gate; the fine-grained back-out knobs
 `RESOLVED_CACHE_ENABLED`, `WIDGET_CONTENT_L1_ENABLED`,
 `RESOLVED_CACHE_APISTAGE_ENABLED` exist only for narrow rollbacks —
-`cache.go:15-24`.)
+see the flag notes at the top of `internal/cache/cache.go`.)
 
 Under cache-off, most `snowplow_*` expvars are **absent** from `/debug/vars`
 (registered behind an `if cache.Disabled() { return }` init) — absent is expected,
@@ -107,7 +122,7 @@ cache-off contract.
 
 ## Observability
 
-Everything is on the single `http` port (`main.go:837-869`):
+Everything is on the single `http` port (mux registrations in `main.go`):
 
 - **`GET /debug/vars`** — expvars (lazy `expvar.Func`, zero per-`/call` cost).
   Full enumeration in [observability.md](../docs/architecture/observability.md).
@@ -133,8 +148,8 @@ What "healthy and warm" looks like:
 |---|---|---|
 | **OOM-kill** (pod `OOMKilled`, restart) | container memory limit vs `GOMEMLIMIT` env; `go tool pprof http://pod:8081/debug/pprof/heap` | `GOMEMLIMIT ≥ container limit` so the runtime never back-pressured (set it below); or genuine working-set growth → raise the limit *and* `GOMEMLIMIT` together. |
 | **Restart loop** | which probe is failing (`kubectl describe pod`); `/health` 200? `/readyz`? | liveness killing a *warming* pod = probe too tight (widen `startupProbe`/`progressDeadlineSeconds`); `/health` not answering at all = process wedged → goroutine dump `curl /debug/pprof/goroutine?debug=2`. |
-| **Stale content** (an object changed, UI didn't) | `snowplow_refresher_queue_depth` + `snowplow_refresher_completed_total`; `snowplow_refresher_dropped_total` / `..._failed_total` | dirty-mark only *enqueues* a re-resolve (stale-while-revalidate by design); a wedged/back-pressured refresher leaves stale content until TTL. A climbing `queue_depth` with flat `completed_total` = workers stuck. Dep-cap drop (`deps.cache.cap_reached`) → entries rely on TTL. |
-| **Convergence timeout** (a `/call` hangs, client gets HTTP 0) | cache on/off?; `snowplow_apiserver_fallthrough_total` climbing? CPU profile `/debug/pprof/profile` | under cache-OFF, heavy compute can approach the 300s `WriteTimeout` at 50K (`main.go:47-58`) — turn cache on. Under cache-ON, sustained fallthrough = prewarm not covering the live mix (check `snowplow_dispatch_l1_lookups` hit ratio + `snowplow_prewarm_engine_pending_depth`). |
+| **Stale content** (an object changed, UI didn't) | `snowplow_refresher_queue_depth` + `snowplow_refresher_completed_total`; `snowplow_refresher_dropped_total` / `..._failed_total` | dirty-mark only *enqueues* a re-resolve (stale-while-revalidate by design); a wedged/back-pressured refresher leaves stale content until TTL. A climbing `queue_depth` with flat `completed_total` = workers stuck. Dep-cap drop (`deps.record.cap_reached`) → entries rely on TTL. |
+| **Convergence timeout** (a `/call` hangs, client gets HTTP 0) | cache on/off?; `snowplow_apiserver_fallthrough_total` climbing? CPU profile `/debug/pprof/profile` | under cache-OFF, heavy compute can approach the 300s `WriteTimeout` at 50K (`writeTimeout`, `main.go`) — turn cache on. Under cache-ON, sustained fallthrough = prewarm not covering the live mix (check `snowplow_dispatch_l1_lookups` hit ratio + `snowplow_prewarm_engine_pending_depth`). |
 | **Everything hits the apiserver** (no cache serving) | `CACHE_ENABLED`; `snowplow_plurals_registered_gvrs.count`; `snowplow_apiserver_fallthrough_cells` | cache disabled, or an informer not yet `HasSynced`, or a specific GVR/reason — the per-cell breakdown attributes it. |
 | **403 for a resource the user expects** | `snowplow_rbac_publish_seq` (did a snapshot publish?); cache on/off | cache-on RBAC degrades-to-deny if the in-process snapshot isn't built yet — `seq == 0` means no snapshot (pre-readiness or cache-off). Confirm the RoleBinding exists and a snapshot has published. |
 | **Upstream looks broken, not snowplow** | `snowplow_upstream_controller_health` | an auto-discovered controller crash-looping / zero-ready endpoints, or a `Fail`-policy webhook on it (`snowplow_upstream_webhook_failurepolicy`) explaining apiserver write hangs. |

--- a/go/snowplow/howto/operating.md
+++ b/go/snowplow/howto/operating.md
@@ -10,8 +10,9 @@ internals behind these knobs see the architecture deep-dives:
 
 ## Deploy
 
-snowplow ships as a Helm chart, `braghettos/krateo-snowplow-chart`. The chart's
-defaults are pre-sized for the cache-enabled fork at 50K-composition scale; the
+snowplow ships as a Helm chart from this repo (`helm/snowplow`, published as
+`oci://ghcr.io/krateo-platformops/charts/snowplow`). The chart's
+defaults are pre-sized for cache-enabled operation at 50K-composition scale; the
 load-bearing values are below. The container takes **no direct `env:` array** —
 every value goes through the chart-managed `snowplow` ConfigMap and is consumed
 via `envFrom` (`values.yaml`, `env:` block).

--- a/go/snowplow/howto/restactions.md
+++ b/go/snowplow/howto/restactions.md
@@ -1,9 +1,22 @@
+---
+type: Usage
+title: RESTAction — declarative chained REST calls
+description: The RESTAction resource — declaratively define chained HTTP calls with jq filters, iterators, endpointRef credentials, in-process resolve of referenced CRs and per-item RBAC refiltering, executed via the snowplow /call endpoint.
+resource: snowplow
+tags:
+  - snowplow
+  - restaction
+  - jq
+  - call
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # `RESTAction`
 
 **API Group:** `templates.krateo.io`  
 **Kind:** `RESTAction`  
 **Version:** `v1`  
-**Scope:** Namespaced  
+**Scope:** Namespaced (short name: `ra`)  
 
 ## Overview
 
@@ -38,7 +51,7 @@ The `spec` field defines the configuration for the REST action workflow.
 
 | Field | Type | Description | Required |
 |--------|------|-------------|-----------|
-| `api` | `array` | List of API requests to execute. Each item defines one HTTP call. | ✅ |
+| `api` | `array` | List of API requests to execute. Each item defines one HTTP call. (Not enforced as required by the CRD schema, but a `RESTAction` without it resolves to nothing.) | ❌ |
 | `filter` | `string` | Optional filter to apply to the overall output or results. | ❌ |
 
 
@@ -59,7 +72,7 @@ Defines a single HTTP request and its dependencies.
 | `continueOnError` | `boolean` | If `true`, continues execution even if this call fails. | ❌ |
 | `endpointRef` | `object` | Reference (`name` + `namespace`) to a Kubernetes [`Endpoint`](endpoints.md) object defining the target service. | ❌ |
 | `dependsOn` | `object` | Declares a dependency on another API call defined in this spec. | ❌ |
-| `resolve` | `boolean` | When this stage's `path` is a **direct apiserver path to a `RESTAction` or `Widget` CR**, controls whether snowplow runs the fetched CR through the resolver in-process. **Defaults to `true`.** See [resolving a referenced RESTAction/Widget in-process](#resolving-a-referenced-restactionwidget-in-process). | ❌ |
+| `resolve` | `boolean` | When this stage's `path` is a **direct apiserver path to a `RESTAction` or `Widget` CR**, controls whether snowplow runs the fetched CR through the resolver in-process. **Opt-in — defaults to `false`** (the raw stored CR is returned). See [resolving a referenced RESTAction/Widget in-process](#resolving-a-referenced-restactionwidget-in-process). | ❌ |
 | `userAccessFilter` | `object` | Dispatch this read stage via snowplow's ServiceAccount and RBAC-refilter the result per item against the requesting user. Read-verb stages only. See below. | ❌ |
 
 ### `spec.api[].endpointRef`
@@ -91,22 +104,22 @@ api:
   - name: inner
     path: /apis/templates.krateo.io/v1/namespaces/krateo-system/restactions/my-inner-ra
     verb: GET
-    # resolve: true   # ← the default
+    resolve: true   # opt-in — omitted means false (raw CR)
 ```
 
-With `resolve: true` (the **default**) snowplow fetches that CR from the
-in-process informer (cacheable, dependency-tracked) and then **runs it through
-the resolver in-process** — `RESTAction`s through the RESTAction resolver,
-`Widget`s through the widget resolver — substituting the **resolved** envelope
-for the stage output. The result is byte-identical to what an HTTP `/call` of
-that referenced CR would return, but with **no outbound HTTP round-trip**. The
-referenced CR becomes a cache dependency of the entry, so editing it
-re-resolves the dependent entry.
+With `resolve: true` snowplow fetches that CR from the in-process informer
+(cacheable, dependency-tracked) and then **runs it through the resolver
+in-process** — `RESTAction`s through the RESTAction resolver, `Widget`s through
+the widget resolver — substituting the **resolved** envelope for the stage
+output. The result is byte-identical to what an HTTP `/call` of that referenced
+CR would return, but with **no outbound HTTP round-trip**. The referenced CR
+becomes a cache dependency of the entry, so editing it re-resolves the
+dependent entry.
 
 | `resolve` value | Behaviour |
 |---|---|
-| `true` (default) | Fetch the CR, then resolve it in-process; the stage output is the **resolved** envelope. |
-| `false` | Return the **raw** stored CR, unresolved (the pre-1.0 behaviour). |
+| `false` / omitted (**the default**) | Return the **raw** stored CR, unresolved. Aligned with the frontend's progressive rendering — the server returns raw refs/CRs unless a stage explicitly asks for resolution. |
+| `true` | Fetch the CR, then resolve it in-process; the stage output is the **resolved** envelope. |
 | any value, on a non-`RESTAction`/`Widget` path (e.g. a `ConfigMap`) | No-op — the raw fetched object is returned (resolution is meaningful only for `RESTAction`/`Widget`). |
 
 The in-process resolve is RBAC-gated (the requesting identity must be allowed
@@ -119,12 +132,11 @@ referenced CR is fetched over the requesting user's own token (the user's
 apiserver RBAC is the authoritative gate) and resolved in-process all the same —
 only slower (no informer serve, no memoisation), never a different result.
 
-> **Release note — `resolve` defaults to `true`.** If you have an existing
-> `RESTAction` that fetches another `RESTAction`/`Widget` CR by its direct
-> apiserver path and consumes the **raw** CR spec, set `resolve: false` on that
-> stage to preserve the old output. The common case — referencing another
-> `RESTAction` to consume its **resolved** data — is exactly what the default
-> gives you.
+> **Release note — `resolve` is opt-in (defaults to `false`).** A stage that
+> consumes a referenced `RESTAction`/`Widget`'s **resolved** data (e.g. reads a
+> child's resolved-only `.status.<field>`) MUST set `resolve: true` explicitly.
+> An omitted field is never persisted or defaulted by the apiserver; the
+> resolver treats `nil` as `false`.
 
 > **Note — the `/call?resource=…` loopback path is retired.** Earlier versions
 > let a stage reference another `RESTAction` by a `/call?resource=…&apiVersion=…`
@@ -140,7 +152,7 @@ read) and the returned items are **refiltered per item** through the in-process
 RBAC evaluator before being returned to the caller — so a narrow user sees only
 the items they may access. Allowed only on read verbs (`GET`/`HEAD`); admission
 CEL also forbids `exportJwt: true` on such a stage. Type `UserAccessFilterSpec`
-(`apis/templates/v1/core.go:112`).
+(`apis/templates/v1/core.go`).
 
 | Field | Type | Description | Required |
 |--------|------|-------------|-----------|
@@ -149,6 +161,7 @@ CEL also forbids `exportJwt: true` on such a stage. Type `UserAccessFilterSpec`
 | `resource` | `string` | Static plural resource name. Exactly one of `resource` / `resourcesFrom`. | conditional |
 | `resourcesFrom` | `string` | jq over the resolve dict yielding a `[]string` of plurals; an item is kept if the user may act on **any** of them (OR). | conditional |
 | `namespaceFrom` | `string` | jq evaluated per item to derive the namespace for the RBAC check. Defaults to `.metadata.namespace`. | ❌ |
+| `nameFrom` | `string` | jq evaluated per item to derive the object **name** for the RBAC check, so `resourceNames`-scoped grants are honoured on name-specific verbs. Defaults to `.metadata.name`; use `"."` when the items are bare name strings. No effect on collection verbs (`list`/`watch`/…). | ❌ |
 
 ## Passing per-request context
 
@@ -189,6 +202,15 @@ structure either way; a JSON body is passed through unchanged (byte-identical).
 This lets a `RESTAction` consume e.g. a Helm repo `index.yaml`. See
 [ADR 0006](../docs/adr/0006-snowplow-owned-external-fetch.md).
 
+## jq templating of `path`, `payload` and `headers`
+
+A stage's `path`, `payload` and each `headers` entry may embed a **jq template**
+delimited by `${ ... }`. The template is evaluated against the shared resolve
+dict (previous stage outputs + `extras`) before the request is issued; a plain
+string without the delimiter is passed through verbatim. (`endpointRef.name`
+supports the same templating, with a guardrail: a request-templated name may
+never resolve to a reserved `<user>-clientconfig` credential Secret.)
+
 ## Example
 
 ```yaml
@@ -204,8 +226,6 @@ spec:
         namespace: default
       verb: GET
       path: /users
-      headers:
-        - "Authorization: Bearer $(TOKEN)"
       continueOnError: false
 
     - name: update-user
@@ -215,7 +235,10 @@ spec:
         name: user-endpoint
         namespace: default
       verb: PUT
-      path: /users/123
-      payload: '{"status":"active"}'
+      path: '${ "/users/" + (.["get-user"].items[0].id | tostring) }'
+      headers:
+        - "Content-Type: application/json"
+      payload: '${ {status: "active"} }'
 
   filter: ""
+```

--- a/go/snowplow/howto/restactions/example-cluster-namespaces.md
+++ b/go/snowplow/howto/restactions/example-cluster-namespaces.md
@@ -1,17 +1,30 @@
+---
+type: Usage
+title: "RESTAction walkthrough: list cluster namespaces"
+description: Apply a RESTAction that lists Kubernetes namespaces through the apiserver, filter the response with jq, grant the required user RBAC and execute it via the snowplow /call endpoint.
+resource: snowplow
+tags:
+  - snowplow
+  - restaction
+  - walkthrough
+  - jq
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Example [`RESTAction`][restactions]: list _cluster-namespaces_
 
 ## Prerequisites
 
 Before you begin with this example, make sure you have **Snowplow** installed on a Kind cluster.
-Follow the guide here to set it up: [Installing `snowplow` on Kind](howto/install.md).
+Follow the guide here to set it up: [Installing `snowplow` on Kind](../install.md).
 
 ## Overview
 
 This `RESTAction` retrieves a list of Kubernetes namespaces by calling the Kubernetes API server at the `/api/v1/namespaces` endpoint.
 
-It then applies a [JSONPath/JQ-like][jq] filter to extract only the namespace names (`.metadata.name`) from the API response.
+It then applies a [jq][jq] filter to extract only the namespace names (`.metadata.name`) from the API response.
 
-The result can be consumed by other Krateo resources or displayed in the Karateo PlatformOps UI, depending on configuration.
+The result can be consumed by other Krateo resources or displayed in the Krateo PlatformOps UI, depending on configuration.
 
 ## Example
 
@@ -166,9 +179,11 @@ curl -sv -G \
 ```
 
 > The _.env_ file stores the environment variables required to authenticate with Snowplow.
-> In particular, it contains the _KRATEO_ACCESS_TOKEN_, which you obtained during the Snowplow [installation][install.md] process when > you created a user using the `krateoctl add-user` command, as [explained in the previous guide][install.md].
+> In particular, it contains the _KRATEO_ACCESS_TOKEN_ minted in step 4 of the
+> [installation guide](../install.md). The user's `<user>-clientconfig` Secret
+> (step 5 there) must also exist — without it snowplow answers `401`.
 
-Snowplow will fetch the corresponding CR, execute all the API calls, apply filters, iterators, and JQ expressions, and store the results in the resource's `status` field.
+Snowplow fetches the corresponding CR, executes all the API calls, applies filters, iterators, and jq expressions, and returns the results under the `status` field **of the HTTP response**. (Nothing is written back to the cluster — `kubectl get restaction` still shows the CR as stored.)
 
 ```json
 {

--- a/go/snowplow/howto/restactions/example-external-api.md
+++ b/go/snowplow/howto/restactions/example-external-api.md
@@ -1,14 +1,27 @@
+---
+type: Usage
+title: "RESTAction walkthrough: invoke an external API"
+description: Chain two dependent RESTAction stages against an external service (HTTPBin) through an Endpoint Secret, template the second payload with jq, and execute via the snowplow /call endpoint.
+resource: snowplow
+tags:
+  - snowplow
+  - restaction
+  - walkthrough
+  - endpoint
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Example [`RESTAction`][restactions]: Invoke external API
 
 ## Prerequisites
 
 Before you begin with this example, make sure you have **Snowplow** installed on a Kind cluster.
-Follow the guide here to set it up: [Installing `snowplow` on Kind](howto/install.md).
+Follow the guide here to set it up: [Installing `snowplow` on Kind](../install.md).
 
 
 ## Overview
 
-This [`RESTAction`][restactions] calls an external service. When you want to call a service other than the Kubernetes API server, you need to specify an [`Endpoint`][endpoints]. By default, the [`Endpoint`][endpoints] points to the Kubernetes API server, which is why it is not required when calling Kubernetes APIs.
+This [`RESTAction`][restactions] calls an external service. When you want to call a service other than the Kubernetes API server, you need to specify an [`Endpoint`][endpoints]. When `endpointRef` is omitted, snowplow resolves the calling user's own `<user>-clientconfig` Secret and targets the Kubernetes API server — which is why no `endpointRef` is needed when calling Kubernetes APIs.
 
 
 ```sh {name=create-endpoint}
@@ -104,10 +117,12 @@ curl -sv -G \
 
 
 > The _.env_ file stores the environment variables required to authenticate with Snowplow.
-> In particular, it contains the _KRATEO_ACCESS_TOKEN_, which you obtained during the Snowplow [installation][install.md] process when > you created a user using the `krateoctl add-user` command, as [explained in the previous guide][install.md].
+> In particular, it contains the _KRATEO_ACCESS_TOKEN_ minted in step 4 of the
+> [installation guide](../install.md). The user's `<user>-clientconfig` Secret
+> (step 5 there) must also exist — without it snowplow answers `401`.
 
 
-Snowplow will fetch the corresponding CR, execute all the API calls, apply filters, iterators, and JQ expressions, and store the results in the resource's `status` field.
+Snowplow fetches the corresponding CR, executes all the API calls, applies filters, iterators, and jq expressions, and returns the results under the `status` field **of the HTTP response** (nothing is written back to the cluster):
 
 ```json
 "status": {

--- a/go/snowplow/howto/widgets.md
+++ b/go/snowplow/howto/widgets.md
@@ -146,5 +146,5 @@ distinct extras resolve to distinct cache entries (`cache/resolved.go:679-688`).
 `resourcesRefs(+Template)` → CRD-schema validate (`resolve.go:69-170`). Each phase
 is wall-clocked for the seed-path timing log.
 
-Refer to the [Krateo Widgets documentation](https://github.com/krateoplatformops/frontend/blob/main/docs/docs.md)
+Refer to the [Krateo Widgets documentation](https://github.com/krateo-platformops/frontend/blob/main/docs/docs.md)
 for the frontend-side widget catalogue.

--- a/go/snowplow/howto/widgets.md
+++ b/go/snowplow/howto/widgets.md
@@ -1,3 +1,12 @@
+---
+type: Usage
+title: Understanding the Widget custom resource
+description: How snowplow resolves a Widget CR over /call — the spec contract (apiRef, widgetDataTemplate, resourcesRefs, identityContext, keyExtras), the status the frontend consumes, and how extras reach each template path.
+resource: oci://ghcr.io/krateo-platformops/charts/snowplow
+tags: [portal, widget, restaction, resolver]
+timestamp: 2026-08-06T00:00:00Z
+---
+
 # Understanding the `Widget` Custom Resource
 
 **API Group:** `*.widgets.templates.krateo.io`
@@ -12,32 +21,39 @@ the shape the frontend renders; the data itself comes from a [`RESTAction`](rest
 
 > See also: [`extras.md`](extras.md) (per-request context), the
 > [request lifecycle](../docs/architecture/request-lifecycle.md) deep-dive, and
-> the [caching](../docs/architecture/caching.md) deep-dive (the two widget L1
+> the [caching](../docs/architecture/caching.md) deep-dive (the widget L1
 > keys + per-binding-UID keying).
 
 ---
 
 ## The `spec` contract
 
-A widget's `spec` carries four resolver-facing fields plus the
+A widget's `spec` carries the resolver-facing fields below plus the
 frontend-authored `widgetData`. The resolver runs them in a fixed order
-(`resolve.go:38-173`):
+(`Resolve`, `resolve.go`):
 
 | `spec` field | Type | What the resolver does |
 |---|---|---|
-| `apiRef` | object ref | Fetches a `RESTAction` and resolves it into the widget's **data source** (`ds`). `GetApiRef` defaults `resource: restactions` + `apiVersion: templates.krateo.io/v1` (`widgets.go:82-100`). |
-| `widgetData` | object | The frontend-authored static base of `status.widgetData`. Read by `GetWidgetData` (`widgets.go:60-66`). |
+| `apiRef` | object ref | Fetches a `RESTAction` and resolves it into the widget's **data source** (`ds`). `GetApiRef` defaults `resource: restactions` + `apiVersion: templates.krateo.io/v1` (`widgets.go`). May carry an inline `extras` sub-key (see [`extras.md`](extras.md)). |
+| `widgetData` | object | The frontend-authored static base of `status.widgetData`. Read by `GetWidgetData`. |
 | `widgetDataTemplate` | `[]{forPath, expression}` | jq expressions evaluated against `ds`; each result is written into `status.widgetData` at `forPath`. Type `WidgetDataTemplate` (`apis/templates/v1/widgetdatatemplate.go`). |
-| `resourcesRefs.items` | `[]ResourceRef` | Static action references; each is RBAC-checked and emitted with an `allowed` flag. Type `ResourceRef` (`apis/templates/v1/resourcesrefs.go:11`). |
-| `resourcesRefsTemplate` | `[]{iterator, template}` | jq-templated action references expanded against `ds`, then merged with the static `resourcesRefs`. Type `ResourceRefTemplate` (`apis/templates/v1/resourcesrefstemplate.go`). |
+| `resourcesRefs.items` | `[]ResourceRef` | Static action references; each is RBAC-checked and emitted with an `allowed` flag. Type `ResourceRef` (`apis/templates/v1/resourcesrefs.go`). A `GET` ref may set `inline: true` to have its resolved child envelope embedded server-side (below). |
+| `resourcesRefsTemplate` | `[]{iterator, template}` | jq-templated action references expanded against `ds`, then merged with the static `resourcesRefs`. Type `ResourceRefTemplate` (`apis/templates/v1/resourcesrefstemplate.go`). A sibling `resourcesRefsTemplateExtras` map scopes inline extras to this jq only. |
+| `identityContext` | `[]string` | Declares which authenticated-principal keys (`username`, `groups` — the only honored values) the widget's output depends on. The server injects the *declared* subset of the JWT identity into the resolve extras (injection **wins** over any client-supplied value for those keys) and folds the same material into the cache key. Absent = identity-free (the default). `GetIdentityContext` / `DeclaredIdentity` (`widgets.go`). |
+| `keyExtras` | `[]string` | Declares which **request**-`extras` keys the widget's output depends on. Only the declared keys partition the L1 cache key; undeclared request extras still reach the jq dict but do not vary the key (see [caching note](#extras--per-request-context)). `GetKeyExtras` (`widgets.go`). |
 
 ### `apiRef`
 
-Points at a `RESTAction`; an empty `name`/`namespace` is a no-op that yields an
-empty data source (`apiref/resolve.go:26-28`). The referenced RESTAction is
-resolved under snowplow's ServiceAccount, and its output becomes the top-level
-`ds` the templates below evaluate against. Pagination (`?page` / `?perPage`) and
-`?extras` flow `widget → apiRef → RESTAction` (`resolve.go:181-201`).
+Points at a `RESTAction`; an empty `name` or `namespace` is a no-op that yields
+an empty data source (`apiref/resolve.go`, `Resolve`). The referenced RESTAction
+is resolved through the restactions resolver under snowplow's own
+ServiceAccount rest config (the dispatcher passes its `saRC`; dispatch of the
+RESTAction's own API steps then follows that RESTAction's rules, e.g.
+`userAccessFilter`). Its output becomes the top-level `ds` the templates below
+evaluate against. Pagination (`?page` / `?perPage`) and `?extras` flow
+`widget → apiRef → RESTAction` (`resolveApiRef`, `resolve.go`). An apiRef fetch
+error preserves the upstream apiserver status code (a 403 stays a 403 on the
+wire, not a 500).
 
 A widget needs no `apiRef`: a static widget (only `widgetData` + `resourcesRefs`)
 resolves against an empty `ds` (still seeded with `extras` — see below).
@@ -55,29 +71,37 @@ spec:
 
 Each entry's `expression` is evaluated against `ds` **only when wrapped in
 `${ … }`**: `jqutil.MaybeQuery` looks for the `${` marker and, finding none,
-returns the string unchanged (`widgetdatatemplate/resolve.go:50`, plumbing
+returns the string unchanged (`widgetdatatemplate/resolve.go`, plumbing
 `jqutil.MaybeQuery`) — an unwrapped value is then stored **verbatim as a literal**,
 not evaluated. The (wrapped) result is set into the static `widgetData` at
-`forPath` (`resolve.go:226-258`). A *read* error on
-`widgetDataTemplate` **fails soft** to the static-only `widgetData`
-(`resolve.go:220-224`) — a load-bearing invariant kept symmetric with the cache
-routing predicate so a read error can never land a ServiceAccount-maximal
-aggregate in the shared identity-free cell (`resolve.go:209-219`).
+`forPath`. A *read* error on `widgetDataTemplate` **fails soft** to the
+static-only `widgetData` (`resolveWidgetData`, `resolve.go`) — a load-bearing
+invariant kept symmetric with the cache routing predicate so a read error can
+never land a ServiceAccount-maximal aggregate in the shared identity-free cell.
 
 ### `resourcesRefs` and `resourcesRefsTemplate`
 
 Both produce `ResourceRef`s that become `status.resourcesRefs.items`. Static
-`resourcesRefs.items` are read verbatim (`widgets.go:102-114`);
+`resourcesRefs.items` are read verbatim (`GetResourcesRefs`, `widgets.go`);
 `resourcesRefsTemplate` entries are jq-expanded against `ds` (optionally over an
-`iterator`) and appended (`resolve.go:275-286`). Every resolved ref is then
-turned into a result with:
+`iterator`) and appended (`resolveResourceRefs`, `resolve.go`). Every resolved
+ref is then turned into a result with:
 
-- a `path` — a `/call` URL for the action (`resourcesrefs/resolve.go:151-172`),
+- a `path` — a `/call` URL for the action (`resourcesrefs/resolve.go`,
+  `buildPath`),
 - a `verb`, and
 - an **`allowed`** flag from `rbac.UserCan` under the requesting identity
-  (`resourcesrefs/resolve.go:108-112`).
+  (`resourcesrefs/resolve.go`, `resolveOne`).
 
 The frontend renders only `allowed == true` actions.
+
+**Inline-rendered children.** A `GET` ref carrying `inline: true` is
+additionally resolved server-side under the requesting user's identity, and the
+resolved child envelope is embedded into `items[i].rendered`
+(`embedInlineChildren`, `handlers/dispatchers/widgets.go`). Opt-in and
+default-off: a ref without `inline` is byte-identical to before. A non-GET or
+not-`allowed` inline ref is not embedded. An inline-embedding parent is always
+cached per-user, never in the shared content cell.
 
 **Example — `resourcesRefsTemplate` reading `extras`.** Only the *templated*
 variant is jq-expanded against `ds`, so only it can reference `extras`; static
@@ -106,17 +130,19 @@ Called as `/call?resource=widgets&…&extras={"names":["kube-system","default"]}
 
 ## The `status` the frontend consumes
 
-`Resolve` writes these `status` keys (`resolve.go:114`, `:151`, `:159`):
+`Resolve` writes these `status` keys (`resolve.go`; `traceId` is stamped by the
+dispatcher):
 
 | `status` key | Shape | Source |
 |---|---|---|
 | `status.widgetData` | object | static `widgetData` + `widgetDataTemplate` results |
-| `status.resourcesRefs.items[]` | `[]{id, path, verb, payload?, allowed}` | `resourcesRefs` + `resourcesRefsTemplate`; type `ResourceRefResult` (`resourcesrefs.go:29`) |
-| `status.resourcesRefs.slice` | `{perPage, page, continue}` | added only when the request is paginated (`resolve.go:131-142`) |
-| `status.error` | string | set on any resolve failure (`resolve.go:74`, `:103`, `:118`, `:162`) |
+| `status.resourcesRefs.items[]` | `[]{id, path, verb, payload?, allowed, inline?, rendered?}` | `resourcesRefs` + `resourcesRefsTemplate`; type `ResourceRefResult` (`resourcesrefs.go`) |
+| `status.resourcesRefs.slice` | `{perPage, page, continue}` | added only when the request is paginated |
+| `status.error` | string | set on any resolve failure |
+| `status.traceId` | string | the request's shortid trace id, for frontend log correlation |
 
 The final `status` is validated against the widget's own CRD schema before it is
-returned; a schema failure is a 400 `StatusError` (`resolve.go:159-170`).
+returned; a schema failure is a 400 `StatusError` (`Resolve`, `resolve.go`).
 
 ---
 
@@ -126,25 +152,41 @@ returned; a schema failure is a 400 `StatusError` (`resolve.go:159-170`).
 in a widget resolve (full story in [`extras.md`](extras.md)):
 
 - the `apiRef` RESTAction's own jq (its `path` / `payload`) can reference
-  `extras` keys — extras seed the RESTAction resolve dict
-  (`restactions/api/resolve.go:228-230`);
+  `extras` keys — extras seed the RESTAction resolve dict (the
+  `DeepCopyJSON(opts.Extras)` dict seed in `restactions/api/resolve.go`);
 - `widgetDataTemplate` **and** `resourcesRefsTemplate` jq can reference `extras`
-  keys — `mergeExtras` folds them into `ds` (`resolve.go:96`, `:348-358`);
+  keys — `mergeExtras` folds them into `ds` (`resolve.go`);
 - **apiRef-less** widgets get `extras` too — `mergeExtras` is the only thing that
-  puts them into `ds` when there is no apiRef result (`resolve.go:331-337`).
+  puts them into `ds` when there is no apiRef result;
+- for a widget declaring `spec.identityContext`, the server **overwrites** the
+  declared keys (`username` / `groups`) in `extras` with the authenticated
+  JWT's own values before the resolve — a client cannot spoof another user's
+  identity through `extras`.
 
 `extras` is **input-only** (never echoed to `status`) and **non-overwriting**:
 any apiRef-result key, or the pagination `slice` triple, wins on a key collision
-(`resolve.go:348-358`). `extras` is also folded into the widget's L1 cache key, so
-distinct extras resolve to distinct cache entries (`cache/resolved.go:679-688`).
+(`mergeExtras`, `resolve.go`).
+
+**Caching:** for the widget L1 keys, only the request-`extras` keys declared in
+`spec.keyExtras` (plus the CR-fixed inline extras and any declared identity)
+are folded into the cache key — an undeclared request extra does not create a
+new cache cell, and a request carrying undeclared non-identity extras is served
+correctly but its result is *not* written to the shared cache
+(`effectiveKeyExtras` / `requestExtrasFullyDeclared`,
+`internal/handlers/dispatchers/helpers.go`). A widget whose output genuinely
+varies on an extras key **must declare it in `spec.keyExtras`**, or a shared
+cached body may be served across requests with different extras. See
+[`extras.md`](extras.md) and the [caching](../docs/architecture/caching.md)
+deep-dive.
 
 ---
 
 ## Resolve order (summary)
 
-`apiRef` → `injectSlice` → `mergeExtras` → `widgetDataTemplate` →
-`resourcesRefs(+Template)` → CRD-schema validate (`resolve.go:69-170`). Each phase
-is wall-clocked for the seed-path timing log.
+declared-identity injection → `apiRef` → `injectSlice` → `mergeExtras` →
+`widgetDataTemplate` → fold `resourcesRefsTemplateExtras` →
+`resourcesRefs(+Template)` → CRD-schema validate (`Resolve`, `resolve.go`).
+Each phase is wall-clocked for the seed-path timing log.
 
 Refer to the [Krateo Widgets documentation](https://github.com/krateo-platformops/frontend/blob/main/docs/docs.md)
 for the frontend-side widget catalogue.


### PR DESCRIPTION
The **pilot conversion** for the org-wide Documentation Standard rollout — one repo, end-to-end, to calibrate content depth before the waves.

## The invariant file set (all delivered, `python3 lint_docs.py` → 0 errors, 0 warnings)

```
README.md                       rewritten to the thin skeleton (66 lines, was a link hub with ALL 8 links broken)
docs/index.md                   Component — the map: the core nine + a curated index into the deep corpus
docs/overview.md                Architecture — distilled from go/snowplow/ARCHITECTURE.md + the deep-dive suite (links, no duplication)
docs/usage.md                   Usage — the REAL install paths today: installer pin / CompositionDefinition / direct helm install oci://…
docs/configuration.md           Configuration — from helm/snowplow/values.yaml + values.schema.json + the deployment env contract
docs/api.md                     API — the RESTAction CRD (schema meaning, resolved-on-read lifecycle) + the HTTP surface from main.go/swagger
docs/examples.md                ExampleIndex
docs/release.md                 Runbook — grounded in the actual workflows (tag WITHOUT v prefix; image + 2 charts from one tag)
docs/log.md                     Log — 5 real entries (docs adoption, the 1.9.0 monorepo fold + v1.8.0 mis-tag lesson, 1.7.x hardening, 1.5.29 prewarm-gated readiness, the cache-invariant ADRs)
docs/llms.txt                   pinned to 1.9.0; bundle + curated deep-corpus entries
examples/cluster-namespaces/    RESTAction vs the k8s API (manifest + Example README)
examples/external-api/          chained GET→POST via an Endpoint Secret (manifest + Example README)
```

Both example manifests validated with `kubectl apply --dry-run=server` against a live cluster running snowplow.

## Authored vs fixed vs preserved

- **Authored**: the nine core files + two examples, every claim grounded in the tree (values.yaml, deployment.yaml, release workflows, main.go routes, the CRD, plumbing jwtutil). One spec-vs-code find surfaced honestly in api.md: `POST /convert` is in swagger but not wired in main.go.
- **Fixed (dead links / dead orgs)**: the README's 8 broken links; 15 dead-org references across 9 corpus files the bundle links — `howto/install.md` re-grounded on `oci://ghcr.io/krateo-platformops/charts/snowplow` (was the braghettos chart + image, and `krateoctl` from the dead org — replaced with a tool-free HS256 JWT mint traced to plumbing `jwtutil`), `operating.md`, `widgets.md`, `decoupling-authn…`, `migrate-call-stage…`, ADR 0001 + ADR 0006, `ARCHITECTURE.md` ("For agents" now points at this repo's helm/ + docs/), `CONTRIBUTING.md` (release process rewritten for the monorepo one-tag reality), and `go/snowplow/docs/llms.txt` (stale chart-repo-split self-references, broken README link).
- **Preserved in place (deliberate pilot calibration point)**: the deep corpus under `go/snowplow/` — 6 architecture deep dives, 6 ADRs, 14 howtos, ~40 design/RCA docs, the notes/ ship-log — stays **code-adjacent** and is *mapped* from `docs/index.md` + `docs/llms.txt` rather than mass-moved (~100 files). The standard's extension mechanism ("extra concept files under docs/ subdirs") is satisfied by linking; recommend the rollout waves adopt the same stance for repos with a rich in-tree corpus.

## CI wiring (ordering note)

`release-pullrequest.yaml` now calls `krateo-platformops/.github/.github/workflows/lint-docs.yaml@main`. That reusable lands with the standard's seed PR — **merge krateo-platformops/.github#2 first**, then this PR's `lint-docs` check resolves. (The lint was run locally from the repo root: exit 0.)

## Calibration feedback for the standard (from this pilot)

1. The banned-string rule collides with tools not yet migrated off the dead org (`krateoctl` has no `krateo-platformops` home) — the pilot resolved it by replacing the tool dependency; the standard may want a stated fallback.
2. `llms.txt` entries outside `docs/`/`examples/` (deep-corpus paths) are not link-checked by the linter — fine for now, worth noting.
3. Repos with placeholder `Chart.yaml` versions need the sed dance for local `helm template`; usage.md documents it — a candidate for the standard's chart-repo template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJsLqtryCgWwEt8FnPE1se
