### PR TITLE
fix(chart): cpu int-or-string via x-kubernetes-int-or-string (crdgen form-1)

### DIFF
--- a/helm/snowplow/values.schema.json
+++ b/helm/snowplow/values.schema.json
@@ -227,7 +227,7 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": ["integer", "string"],
+              "x-kubernetes-int-or-string": true,
               "description": "CPU limit — a Kubernetes Quantity: integer cores or a string like \"500m\"/\"1\".",
               "title": "CPU"
             },
@@ -245,7 +245,7 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": ["integer", "string"],
+              "x-kubernetes-int-or-string": true,
               "description": "CPU request — a Kubernetes Quantity: integer cores or a string like \"500m\"/\"1\".",
               "title": "CPU"
             },


### PR DESCRIPTION
## The bug behind the bug (caught on a fresh installer 0.3.12 install)
[#140](https://github.com/krateo-platformops/snowplow/pull/140) typed `resources.cpu` as `{"type": ["integer","string"]}` to fix the MAP wedge (krateo-core-provider#66). **It doesn't work.** Production CRD generation is core-provider → `plumbing/crdgen` (`transpile.go`), whose `primaryType()` keeps only the **first** type of a bare union — so cpu generates as `type: integer` and the composition CRD still rejects Quantity strings. A fresh `helm install …/installer:0.3.12` reproduced it: `snowplows.composition.krateo.io` CRD cpu = `integer`, no int-or-string.

## Fix (crdgen form-1)
Express the quantity the supported way: `{"x-kubernetes-int-or-string": true}` — `transpile.go:234-236` carries it verbatim as a typeless int-or-string node. This is what the **installer chart uses throughout**, and its generated CRD already carries int-or-string on the same field (verified live on a running 0.3.12 cluster). crdgen's own `docs/api.md` documents all three constructs and prescribes form-1; the bare-union is documented as dropping to the first type.

Verified: plumbing `crdgen/transpile.go` (XIntOrString passthrough) + the live installer CRD equivalence; `helm template` passes with string and integer cpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)