### PR TITLE
feat: declare service.nodePort in values.schema.json

### DIFF
--- a/helm/snowplow/values.schema.json
+++ b/helm/snowplow/values.schema.json
@@ -141,7 +141,11 @@
           "title": "Port"
         },
         "nodePort": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 30000,
+          "maximum": 32767,
+          "description": "Explicit NodePort (only honored when service.type=NodePort). Set by the installer to pin a deterministic, host-mappable port.",
+          "title": "Node Port"
         }
       },
       "description": "Kubernetes Service configuration.",

--- a/helm/snowplow/values.yaml
+++ b/helm/snowplow/values.yaml
@@ -73,6 +73,9 @@ securityContext: {}
 service:
   type: LoadBalancer
   port: 8081
+  # nodePort: explicit NodePort (30000-32767), only honored when type=NodePort.
+  # Set by the installer to pin a deterministic, host-mappable port.
+  # nodePort: 31002
 
 # NOTE: the snowplow binary (1.0.x ship line) has NO dedicated probe
 # listener -- it serves /health + /readyz on the single `http` port


### PR DESCRIPTION
The chart Service template already renders `spec.ports[].nodePort` when `service.type=NodePort`:

```yaml
{{- if eq .Values.service.type "NodePort" }}
nodePort: {{ .Values.service.nodePort }}
{{- end }}
```

However `helm/snowplow/values.schema.json` carried only a bare `{"type":"integer"}` stub for `service.nodePort`. Krateo core-provider **crdgen** generates the `Snowplow` composition CRD from `values.schema.json`, so with an under-specified property the generated CRD did not properly expose `spec.service.nodePort`. When the installer pins a deterministic NodePort, the apiserver then **prunes** the unmodeled field, and the NodePort is silently dropped.

## Change
Fully declare `service.nodePort` in the schema:
- `type: integer` with `minimum: 30000` / `maximum: 32767` (valid Kubernetes NodePort range)
- a `description`/`title` so the generated CRD documents the field

Also add a commented `nodePort` reference under `service:` in `values.yaml` for discoverability. The default `service.type` remains `LoadBalancer`, so default render behavior is unchanged.

## Validation
- `python3 -c "import json; json.load(...)"` — schema is valid JSON.
- `helm template x helm/snowplow --set service.type=NodePort --set service.nodePort=31002` renders `nodePort: 31002` on the Service.
- `--set service.nodePort=80` is now correctly rejected: `at '/service/nodePort': minimum: got 80, want 30,000`.

Touches only `values.schema.json` and `values.yaml`; the Service template already rendered nodePort and was not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)