### PR TITLE
security: document + accept snowplow RBAC broad-read (KSV-0041/0046, by design)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,27 @@
+# Trivy misconfiguration exceptions — reviewed, accepted-by-design (2026-08-14).
+#
+# KSV-0041 "Manage secrets" + KSV-0046 "Manage all resources" on the snowplow
+# ClusterRole (manifests/deploy.snowplow.yaml and the shipped helm/snowplow
+# chart) are DELIBERATE and functionally required, not an accidental over-grant:
+#
+#  - The `apiGroups:["*"] resources:["*"] verbs:[get,list,watch]` rule is
+#    READ-ONLY (no create/update/delete — the pod cannot mutate or escalate).
+#    snowplow dynamically discovers CRDs at runtime (autoDiscoverGroups cache
+#    warmup → informers on newly-observed CR types) because a portal widget /
+#    dashboard can reference ANY kind a customer registers. Enumerating the set
+#    is not possible ahead of time; broad READ is the intended default (see the
+#    rule's own comment in helm/snowplow/templates/clusterrole.yaml).
+#  - Secret read is required because RESTActions resolve endpointRef -> a
+#    credential Secret (internal/cache/secrets_informer.go,
+#    internal/resolvers/restactions/api/endpoints_cache.go) to call external
+#    APIs on the user's behalf. A #113 guardrail already blocks users from
+#    selecting per-user credential Secrets via query params.
+#
+# Residual risk (a compromised pod could read secrets cluster-wide) is inherent
+# to the dynamic-portal + RESTAction-gateway design and is NOT safely reducible
+# via RBAC narrowing (RBAC has no deny; narrowing breaks dynamic content +
+# RESTAction auth). Compensating controls live at the app layer (#113 guardrail,
+# PSA/audit). Revisit only via a product change that splits the discovery
+# identity from the content-serving identity.
+KSV-0041
+KSV-0046


### PR DESCRIPTION
> ⚠️ **Review decision, not a mechanical fix — please review before merging.** This does not auto-merge.

## What
Trivy flags snowplow's ClusterRole as **CRITICAL KSV-0041 (manage secrets)** + **KSV-0046 (manage all resources)**. After reading the chart + code, these are **deliberate and functionally required**, not an accidental over-grant. This accepts them via `.trivyignore` **with the full rationale in the file** (so the finding is signed-off, not lingering noise).

## Why they're by-design (not narrowable)
- The `apiGroups:["*"] resources:["*"]` rule is **READ-ONLY** (`get/list/watch`; no create/update/delete → cannot mutate or escalate). snowplow **discovers CRDs at runtime** (`autoDiscoverGroups` → informers on newly-observed kinds) because a portal widget can reference *any* customer-registered CRD. The chart's own comment documents this: broad read is the intended default.
- **Secret read is required**: RESTActions resolve `endpointRef` → a credential Secret to call external APIs on the user's behalf (`internal/cache/secrets_informer.go`, `internal/resolvers/restactions/api/endpoints_cache.go`). A `#113` guardrail already blocks user-selected per-user credential Secrets.

## Why not narrow it
RBAC has no deny rules, so you can't keep dynamic wildcard read while excluding secrets; enumerating groups breaks dynamic content, and removing secrets breaks RESTAction auth. The residual cluster-wide-secret-read risk is inherent to the dynamic-portal + RESTAction-gateway design. **Real reduction requires a product change** (split the discovery identity from the content-serving identity) — out of scope here.

Verified: `trivy fs --scanners misconfig` no longer reports KSV-0041/0046 (auto-detected `.trivyignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJsLqtryCgWwEt8FnPE1se