### PR TITLE
fix: repoint live braghettos references; leave historical records alone

### DIFF
--- a/go/snowplow/e2e/bench/bench/lifecycle.py
+++ b/go/snowplow/e2e/bench/bench/lifecycle.py
@@ -194,7 +194,7 @@ def _set_cache_via_helm(value):
 
     str_value = "true" if value else "false"
     helm_repo = os.environ.get(
-        "SNOWPLOW_HELM_REPO", "oci://ghcr.io/braghettos/charts/snowplow")
+        "SNOWPLOW_HELM_REPO", "oci://ghcr.io/krateo-platformops/charts/snowplow")
     helm_version = os.environ.get("SNOWPLOW_HELM_VERSION")  # optional
     chart_path = os.environ.get("SNOWPLOW_HELM_CHART_PATH")
 
@@ -288,7 +288,7 @@ def disable_cache():
 def cleanup_rogue_rbac():
     """Remove rogue RBAC left by previous test runs.
 
-    All user/group RBAC is defined by the braghettos/portal helm chart.
+    All user/group RBAC is defined by the krateo-platformops/portal helm chart.
     The test must NOT create custom roles — previous versions mistakenly
     created cluster-wide roles that defeated the chart's namespace-scoped
     permissions.

--- a/go/snowplow/e2e/bench/tests/test_cli_check.py
+++ b/go/snowplow/e2e/bench/tests/test_cli_check.py
@@ -223,7 +223,7 @@ def test_verify_deployed_image_matches(monkeypatch):
 
     def fake_kubectl(*args, **kwargs):
         # The function calls `kubectl get deployment snowplow ... -o jsonpath=...`
-        return (0, "ghcr.io/braghettos/snowplow:0.30.232", "")
+        return (0, "ghcr.io/krateo-platformops/snowplow:0.30.232", "")
 
     monkeypatch.setattr(cli_mod, "kubectl", fake_kubectl)
     assert verify_deployed_image(expected_tag="0.30.232") is True
@@ -235,7 +235,7 @@ def test_verify_deployed_image_mismatch_returns_false(monkeypatch, capsys):
     monkeypatch.delenv("SKIP_IMAGE_CHECK", raising=False)
 
     def fake_kubectl(*args, **kwargs):
-        return (0, "ghcr.io/braghettos/snowplow:0.30.999", "")
+        return (0, "ghcr.io/krateo-platformops/snowplow:0.30.999", "")
 
     monkeypatch.setattr(cli_mod, "kubectl", fake_kubectl)
     assert verify_deployed_image(expected_tag="0.30.232") is False

--- a/go/snowplow/e2e/bench/tests/test_lifecycle.py
+++ b/go/snowplow/e2e/bench/tests/test_lifecycle.py
@@ -308,7 +308,7 @@ def test_widget_kinds_includes_panels_and_restactions():
 # ─── #320: _flush_snowplow_cache — verifier-only, the bench NEVER deploys ────
 
 
-def _flush_kubectl_recorder(live_image="ghcr.io/braghettos/snowplow:0.30.258"):
+def _flush_kubectl_recorder(live_image="ghcr.io/krateo-platformops/snowplow:0.30.258"):
     """Recording kubectl stub: GET deployment returns `live_image`; every
     other call (rollout restart/status) succeeds."""
     calls = []
@@ -342,7 +342,7 @@ def test_flush_raises_on_image_mismatch_before_any_mutation(monkeypatch):
     """Live image behind the expected tag → RuntimeError directing the
     operator to helm-upgrade; nothing mutated (no set-image, no restart)."""
     calls, fake = _flush_kubectl_recorder(
-        live_image="ghcr.io/braghettos/snowplow:0.30.257")
+        live_image="ghcr.io/krateo-platformops/snowplow:0.30.257")
     monkeypatch.setattr(lifecycle_mod, "kubectl", fake)
     monkeypatch.setattr(lifecycle_mod, "log", lambda *a, **k: None)
     monkeypatch.setenv("EXPECTED_IMAGE_TAG", "0.30.258")

--- a/go/snowplow/internal/resolvers/restactions/api/handler.go
+++ b/go/snowplow/internal/resolvers/restactions/api/handler.go
@@ -48,7 +48,7 @@ type jsonHandlerOptions struct {
 	// NOT opts.dict: dict starts as a DeepCopy of Extras (resolve.go) but then
 	// accumulates stage outputs + a synthetic `slice`, so at later stages it
 	// is no longer the pure extras. The reference is SHARED, not deep-copied:
-	// gojq is the braghettos COW fork, so the filter cannot mutate the input
+	// gojq is the krateo-platformops COW fork, so the filter cannot mutate the input
 	// (mirrors the existing pig["slice"] shared-map pattern).
 	extras map[string]any
 }

--- a/go/snowplow/internal/resolvers/restactions/api/handler_extras_test.go
+++ b/go/snowplow/internal/resolvers/restactions/api/handler_extras_test.go
@@ -98,7 +98,7 @@ func TestStepFilter_NoExtras_NoExtrasKey(t *testing.T) {
 // (`.extras + {seen:.x}`, `del(.extras.foo)`) AND reads `.extras.foo`. Every
 // goroutine must observe the ORIGINAL extras.foo unchanged, and `go test
 // -race` must be clean. This proves the COW share-reference decision: gojq is
-// the braghettos COW fork; input maps are never allocated() so mutating ops
+// the krateo-platformops COW fork; input maps are never allocated() so mutating ops
 // copy-on-write and reads can't mutate the shared input.
 func TestStepFilter_ConcurrentSharedExtras_Race(t *testing.T) {
 	ctx := context.Background()

--- a/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_nullcollapse_test.go
+++ b/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_nullcollapse_test.go
@@ -122,7 +122,7 @@ func TestPathHasNullPathSegment_Discriminates(t *testing.T) {
 		},
 		{
 			// A SEPARATE null class (disc-architect #118 caveat, confirmed
-			// against braghettos/gojq v0.12.21): when a downstream step's jq
+			// against krateo-platformops/gojq v0.12.21): when a downstream step's jq
 			// `split()` hits a null it THROWS, and evalJQ swallows the error
 			// into the path string (setup.go:92-94), so out.Path becomes the
 			// literal jq error message. It has NO slash / no `//`, so


### PR DESCRIPTION
> **Heads-up:** this repo is owned by another session. Changes are surgical — dead-org references only, no logic touched. Diego asked for every remaining reference to be repointed.

Rewrote **6 files**, deliberately left **27** untouched.

## Fixed (these were wrong, not historical)

- **gojq COW fork comments** — three comments in `internal/resolvers/restactions/api/` say "the braghettos COW fork". `go.mod:119` has read `replace github.com/itchyny/gojq => github.com/krateo-platformops/gojq v0.13.0` for some time, so the comments named an org that is not the one actually vendored.
- **`e2e/bench/bench/lifecycle.py`** — `SNOWPLOW_HELM_REPO` defaulted to `oci://ghcr.io/braghettos/charts/snowplow`, which returns **403**. Now `oci://ghcr.io/krateo-platformops/charts/snowplow`, which returns **200**.

`go build ./...` clean.

## Deliberately left alone

- `docs/notes/*` and dated `bench/*.json` snapshots — records of what was true on a given date. Rewriting them would falsify the history.
- `testdata/.../github_runs.json` — a GitHub API fixture where `braghettos` is a **username**, not the org.

## ⚠️ Needs a decision — not mine to make

`go/snowplow/.claude/agents/{cache-team-lead,cache-architect,cache-developer}.md` encode a **pre-migration workflow rule**:

> `braghettos fork only — NEVER krateoplatformops upstream`
> `any snowplow tag MUST be lockstep-tagged on braghettos/snowplow-chart`

That rule is now **inverted**: snowplow *is* `krateo-platformops`, not a fork of it. As written it would tell an agent to push to a dead account and explicitly forbid the real upstream. I did not rewrite it — these are operating instructions, and mechanically find-replacing them would silently change agent behaviour and invert a rule that was originally a deliberate safety guard. Please decide the intended rule and update them.