### PR TITLE
fix: point brand logo at the canonical .github home (off the dead org)

### DIFF
--- a/helm/snowplow/Chart.yaml
+++ b/helm/snowplow/Chart.yaml
@@ -27,7 +27,7 @@ appVersion: APP_VERSION
 # Bundling it makes the app release try to own the CRDs and collide with the
 # snowplow-crd release ("cannot be imported into the current release").
 home: https://krateo.io
-icon: https://raw.githubusercontent.com/krateoplatformops/krateo/main/docs/media/logo.svg
+icon: https://raw.githubusercontent.com/krateo-platformops/.github/main/brand/logo.svg
 keywords:
   - krateo
   - platformops


### PR DESCRIPTION
Repoints the brand logo off the dead one-word `krateoplatformops` org to the canonical org brand home `krateo-platformops/.github/brand/logo.svg` (verified 200 image/svg+xml). Part of an org-wide sweep — the hyphenated `krateo-platformops/krateo` repo 404s and `krateo.io/logo.svg` is an HTML soft-404, so this canonical `.github` asset is the stable replacement. Files: helm/snowplow/Chart.yaml. Cosmetic/brand-only.