### PR TITLE
test(rbac): de-flake internal/rbac/evaltest — publish RBAC snapshot in shared harness

### DIFF
--- a/go/snowplow/internal/rbac/evaltest/evaluate_test.go
+++ b/go/snowplow/internal/rbac/evaltest/evaluate_test.go
@@ -73,6 +73,20 @@ func newTestWatcher(t *testing.T, seed ...runtime.Object) {
 
 	cache.SetGlobal(rw)
 	t.Cleanup(func() { cache.SetGlobal(nil) })
+
+	// Deterministically publish the typed RBAC snapshot before returning.
+	// NewResourceWatcher publishes the FIRST snapshot from an ASYNC goroutine
+	// (waitAndPublishInitialRBACSnapshot) that races WaitForCacheSync's
+	// informer-HasSynced signal: HasSynced can fire before that goroutine has
+	// run rebuildRBACSnapshot + rbacSnap.Store. Without forcing it here,
+	// EvaluateRBAC may observe rbacSnap.Load()==nil and degrade-to-deny
+	// ("snapshot not yet published — denying"), flaking ANY test in this
+	// package under CI load (the -p1 + parallel-workflow contention delays the
+	// publish goroutine). Mirrors what f3_convergence / snapshot_authz_memo
+	// already do by hand — centralised in the shared harness so no future test
+	// can reintroduce the race. Idempotent + synchronous; production's async
+	// publish path is unchanged (this is a test-only seam).
+	cache.RebuildRBACSnapshotForTest(rw)
 }
 
 func clusterRole(name string, rules ...rbacv1.PolicyRule) *rbacv1.ClusterRole {


### PR DESCRIPTION
## Problem
`checks / test` intermittently reds on `internal/rbac/evaltest` — a **different test fails each run** (`TestEvaluateRBAC_ResourceNamesWildcardVerb`, `…_ServiceAccountSubjectMatch`, `…_AllowByRoleBindingToClusterRole`, …). It's not tied to any code change; it flakes on unrelated PRs under CI load.

## Root cause
The shared harness `newTestWatcher` (used by **9** test files) waits for informer sync (`WaitForCacheSync` → `Informer().HasSynced`) but **not** for the typed RBAC snapshot publish. `NewResourceWatcher` publishes the *first* snapshot from an **async goroutine** (`waitAndPublishInitialRBACSnapshot`) that races the `HasSynced` signal. Under CI contention (`-p 1` + the parallel workflow delays that goroutine), the test calls `EvaluateRBAC` before the publish → `rbacSnap.Load()==nil` → the `AC-B.8` **degrade-to-deny** fires (`"snapshot not yet published — denying"`) → the `should grant` assertion fails. Whichever test loses the race that run is the one that reds.

## Fix
Call the **existing** `cache.RebuildRBACSnapshotForTest(rw)` seam in `newTestWatcher` after `WaitForCacheSync`, so the typed snapshot deterministically reflects the seed before any test evaluates. This is exactly what `f3_convergence_test.go` and `snapshot_authz_memo_test.go` already do by hand — now centralised in the shared harness so no future test can reintroduce the race. **Test-only** (14 lines, one call); production's async publish path is untouched.

## Evidence (before → after)
- **Baseline (unfixed):** `-race -count=3` full-package flaked **1/3** — three *distinct* tests failed across runs.
- **After fix:** **0/8** at the same `-race -count=3` setting (24 effective package-runs), plus the code-level root cause is definitive.

The real acceptance gate is CI's loaded `-tags=unit,integration -p 1 ./...` run going clean; this also stops evaltest red-ing unrelated PRs (it just flaked #157 on its first run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)