### PR TITLE
chore: pin CompositionDefinition chart to 1.11.0

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.10.1"
+    version: "1.11.0"


### PR DESCRIPTION
Bumps the CompositionDefinition chart pin **1.10.1 → 1.11.0** now that the `1.11.0` release is published (image `ghcr.io/krateo-platformops/snowplow:1.11.0` + charts `snowplow`/`snowplow-crds` at 1.11.0, all verified resolving in the registry).

Sequenced after publish so **`preflight-refs`** (the live registry resolve) passes — the exact guard #154 added after a pin pointed at an unpublished version.

Release contents vs 1.10.1: #157 `/call` cluster-scoped read+write (closes #156) + #158 `internal/rbac/evaltest` de-flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)