### PR TITLE
chore: pin CompositionDefinition chart to 1.11.1

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.11.0"
+    version: "1.11.1"


### PR DESCRIPTION
Bumps the CompositionDefinition chart pin **1.11.0 → 1.11.1** now that `1.11.1` is published (image + charts `snowplow`/`snowplow-crds` at 1.11.1, verified resolving).

Sequenced after publish so `preflight-refs` (live registry resolve) passes.

Contents vs 1.11.0: **plumbing v1.14.2** — the jqutil `json.Number` encoder fix (#160), closing the RESTAction empty-reply panic that broke the portal composition Edit form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)