### PR TITLE
chore: pin CompositionDefinition chart to 1.12.0

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.11.1"
+    version: "1.12.0"


### PR DESCRIPTION
Bumps `compositiondefinition.yaml` `spec.chart.version` **1.11.1 → 1.12.0** to consume the freshly-published 1.12.0 release.

**1.12.0 contents (#163):** `--log-level` / `LOG_LEVEL` (debug|info|warn|error) as the single log-verbosity knob; `--debug`/`DEBUG` retained as a deprecated alias. The chart now **defaults `LOG_LEVEL=warn`**, cutting the ~54% otel_logs INFO firehose out of the box on every deploy.

**Artifacts (registry-verified before this PR):**
- image `ghcr.io/krateo-platformops/snowplow:1.12.0`
- chart `oci://ghcr.io/krateo-platformops/charts/snowplow` `version=1.12.0 appVersion=1.12.0`
- chart `oci://ghcr.io/krateo-platformops/charts/snowplow-crds` `version=1.12.0`

`preflight-refs` will live-resolve the pinned ref against the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)