### PR TITLE
fix(logging): demote benign high-frequency WARN/ERROR diagnostics to DEBUG

### DIFF
--- a/go/snowplow/internal/handlers/dispatchers/resolve_populate.go
+++ b/go/snowplow/internal/handlers/dispatchers/resolve_populate.go
@@ -273,7 +273,11 @@ func resolveAndPopulateL1(ctx context.Context, inputs cache.ResolvedKeyInputs, s
 	// entry; TTL is the outer net) exactly as the stage-error gate does.
 	if extTouchedSink.Count() > 0 {
 		cache.BumpExternalSkippedPut()
-		log.Warn("resolveAndPopulateL1: re-resolve touched an external endpoint; declining to overwrite entry",
+		// Not a fault: a designed defense-in-depth decline (external data has no
+		// dep edge to invalidate it, so keep the prior entry; TTL is the outer
+		// net). Fires on every refresh of an external-touching entry — DEBUG.
+		// The BumpExternalSkippedPut counter carries the rate for operators.
+		log.Debug("resolveAndPopulateL1: re-resolve touched an external endpoint; declining to overwrite entry",
 			slog.String("subsystem", "cache"),
 			slog.String("key_hash", key),
 			slog.String("handler", inputs.CacheEntryClass),

--- a/go/snowplow/internal/resolvers/restactions/api/resolve.go
+++ b/go/snowplow/internal/resolvers/restactions/api/resolve.go
@@ -462,7 +462,10 @@ func (r *resolveRun) evalEndpointRef(ref *templates.Reference) (*templates.Refer
 func (r *resolveRun) collapseOrFanoutPlan(id string, apiCall *templates.API, ep endpoints.Endpoint, st *cache.PIPStageTiming) []httpcall.RequestOptions {
 	tmp := createRequestOptions(r.ctx, r.log, apiCall, r.dict)
 	if len(tmp) == 0 {
-		r.log.Warn("empty request options for http call", slog.Any("name", id))
+		// C-3 (a normal "continue" condition): an iterator stage evaluated to
+		// zero items, so there is nothing to call. Benign and per-resolve —
+		// DEBUG, not the WARN that dominates the healthy-cluster firehose.
+		r.log.Debug("empty request options for http call", slog.Any("name", id))
 		return tmp
 	}
 
@@ -1775,7 +1778,12 @@ func lazyRegisterInnerCallPaths(ctx context.Context, log *slog.Logger, opts []ht
 					if rcAny, ok := cache.InternalRESTConfigFromContext(ctx); ok {
 						if cfg, ok := rcAny.(*rest.Config); ok && cfg != nil {
 							if _, err := discoverGroupResourcesFn(ctx, cfg, grp); err != nil {
-								log.Warn("cache.discovery.group_resources_fetch_failed",
+								// Soft-fail: discovery is an optimization; the
+								// dispatch falls through to the apiserver and a
+								// subsequent walk retries. No operator action —
+								// cache-effectiveness is tracked by the
+								// apiserver_fallthrough metrics. DEBUG, not WARN.
+								log.Debug("cache.discovery.group_resources_fetch_failed",
 									slog.String("subsystem", "cache"),
 									slog.String("group", grp),
 									slog.Any("err", err),

--- a/go/snowplow/internal/resolvers/restactions/api/setup.go
+++ b/go/snowplow/internal/resolvers/restactions/api/setup.go
@@ -48,7 +48,15 @@ func createRequestOptions(ctx context.Context, log *slog.Logger, in *templates.A
 
 	err := jqutil.ForEach(ctx, jqutil.EvalOptions{Query: it, Unquote: true, Data: dict}, action)
 	if err != nil {
-		log.Error("unable to execute iterator", slog.String("query", it), slog.Any("err", err))
+		if jqsupport.IsBenignNilIteration(err) {
+			// Iterator walked a null/absent upstream value → zero request
+			// options; the stage continues exactly as the empty-iterator case
+			// (C-3). Data-dependent and benign — DEBUG, not the ERROR that would
+			// flood the WARN-floor firehose on a healthy cluster.
+			log.Debug("iterator yielded no items (nil upstream)", slog.String("query", it), slog.Any("err", err))
+		} else {
+			log.Error("unable to execute iterator", slog.String("query", it), slog.Any("err", err))
+		}
 	}
 
 	return all

--- a/go/snowplow/internal/resolvers/widgets/resourcesrefstemplate/resolve.go
+++ b/go/snowplow/internal/resolvers/widgets/resourcesrefstemplate/resolve.go
@@ -44,7 +44,10 @@ func createResourceReferencesFromTemplate(ctx context.Context, in *templatesv1.R
 	q, ok := jqutil.MaybeQuery(it)
 	if !ok || q == "" {
 		log := xcontext.Logger(ctx)
-		log.Warn("bad or empty iterator", slog.String("iterator", it))
+		// Iterator is optional (omitempty): an absent/non-jq value is the
+		// supported non-iterated mode — produce exactly one ResourceRef from
+		// the template. Not a fault; fires per-template — DEBUG, not WARN.
+		log.Debug("bad or empty iterator", slog.String("iterator", it))
 
 		all = make([]templatesv1.ResourceRef, 0, 1)
 		el := createResourceRef(in, ds)
@@ -65,7 +68,14 @@ func createResourceReferencesFromTemplate(ctx context.Context, in *templatesv1.R
 	}, action)
 	if err != nil {
 		log := xcontext.Logger(ctx)
-		log.Error("unable to execute iterator", slog.String("iterator", it), slog.Any("err", err))
+		if jqsupport.IsBenignNilIteration(err) {
+			// Iterator walked a null/absent upstream value → zero refs, exactly
+			// like an empty iterator. Data-dependent and benign — DEBUG, not the
+			// ERROR that would flood the WARN-floor firehose on a healthy cluster.
+			log.Debug("iterator yielded no items (nil upstream)", slog.String("iterator", it), slog.Any("err", err))
+		} else {
+			log.Error("unable to execute iterator", slog.String("iterator", it), slog.Any("err", err))
+		}
 	}
 
 	return

--- a/go/snowplow/internal/support/jq/iteration.go
+++ b/go/snowplow/internal/support/jq/iteration.go
@@ -1,0 +1,27 @@
+package jq
+
+import "strings"
+
+// gojqNilIterationMarker is the exact message gojq renders when a jq iterator
+// (`.[]`, `.foo[]`) is applied to a null value — e.g. `.found[]` when the
+// upstream data dictionary has no "found" key. gojq's iteratorError formats it
+// as "cannot iterate over: " + typeErrorPreview(v), and typeErrorPreview(nil)
+// is "null" (itchyny/gojq error.go:35,373-375; pinned by gojq's own
+// query_test.go:221). A non-null non-iterable renders a different preview
+// ("cannot iterate over: number (5)", …), so this marker matches ONLY the
+// nil case and never a genuine data-shape mismatch.
+const gojqNilIterationMarker = "cannot iterate over: null"
+
+// IsBenignNilIteration reports whether err is the benign "iterator over a null
+// value" case: an upstream stage produced no data for the key the iterator
+// walks, so the fan-out yields zero items. This is semantically identical to an
+// empty iterator (zero request options / zero refs; the stage simply
+// continues) and is NOT an authoring fault — callers log it at DEBUG so it does
+// not flood the WARN-floor firehose on a healthy cluster.
+//
+// Any OTHER jqutil.ForEach error — a malformed jq query, iterating over a
+// non-null scalar, or a non-array result — is a genuine fault the caller MUST
+// keep at ERROR so it is not buried.
+func IsBenignNilIteration(err error) bool {
+	return err != nil && strings.Contains(err.Error(), gojqNilIterationMarker)
+}

--- a/go/snowplow/internal/support/jq/iteration_test.go
+++ b/go/snowplow/internal/support/jq/iteration_test.go
@@ -1,0 +1,84 @@
+package jq
+
+import (
+	"context"
+	"testing"
+
+	"github.com/krateo-platformops/plumbing/jqutil"
+)
+
+// TestIsBenignNilIteration drives REAL gojq (via jqutil.ForEach, the same call
+// the resolvers use) so the discriminator is validated against gojq's actual
+// error strings, not a hand-written approximation. If a gojq upgrade changes
+// the "cannot iterate over: null" phrasing, the nilIteration case reds here —
+// which is exactly when the setup.go / resourcesrefstemplate ERROR→DEBUG gates
+// would silently start mis-classifying, so this test is the tripwire.
+func TestIsBenignNilIteration(t *testing.T) {
+	ctx := context.Background()
+	forEachErr := func(query string, data map[string]any) error {
+		return jqutil.ForEach(ctx, jqutil.EvalOptions{Query: query, Unquote: true, Data: data}, func(any) error { return nil })
+	}
+
+	cases := []struct {
+		name  string
+		query string
+		data  map[string]any
+		want  bool
+	}{
+		{
+			// The observed production case: `.found[]` where "found" is absent
+			// → gojq "cannot iterate over: null". Benign (zero items), DEBUG.
+			name:  "iterate over absent key (null)",
+			query: ".found[]",
+			data:  map[string]any{},
+			want:  true,
+		},
+		{
+			// Explicit null value, same benign nil-iteration.
+			name:  "iterate over explicit null",
+			query: ".found[]",
+			data:  map[string]any{"found": nil},
+			want:  true,
+		},
+		{
+			// Iterating a non-null scalar is a genuine data-shape fault
+			// ("cannot iterate over: number") — must stay ERROR.
+			name:  "iterate over a number",
+			query: ".n[]",
+			data:  map[string]any{"n": 5},
+			want:  false,
+		},
+		{
+			// A malformed jq query is an authoring fault — must stay ERROR.
+			name:  "malformed query",
+			query: ".[",
+			data:  map[string]any{},
+			want:  false,
+		},
+		{
+			// A query that yields a non-array (jqutil.ForEach requires an
+			// array result) is a genuine fault — must stay ERROR.
+			name:  "non-array result",
+			query: ".n",
+			data:  map[string]any{"n": 5},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := forEachErr(tc.query, tc.data)
+			if err == nil {
+				t.Fatalf("query %q: expected a ForEach error to classify, got nil", tc.query)
+			}
+			if got := IsBenignNilIteration(err); got != tc.want {
+				t.Errorf("IsBenignNilIteration(%v) = %v, want %v (query %q)", err, got, tc.want, tc.query)
+			}
+		})
+	}
+
+	// Nil error is never a benign-nil-iteration (no error to classify).
+	if IsBenignNilIteration(nil) {
+		t.Error("IsBenignNilIteration(nil) = true, want false")
+	}
+}


### PR DESCRIPTION
## Why
1.12.0 made `LOG_LEVEL=warn` the chart default (#163), cutting the ~54% INFO firehose. **Verified live on krateo-057**, but with INFO gone, WARN became the dominant volume: in a 2000-line window, `empty request options for http call` alone was ~50%, plus a 143-line/window ERROR (`unable to execute iterator`) that was actually the benign nil-iteration case.

## What
Triaged **every** high-frequency WARN/ERROR site (each analyzed for its firing condition + volume-on-a-healthy-cluster, then adversarially re-checked). Demoted **only** those that fire during normal healthy operation with **zero functional impact**; **kept every genuine fault / config-error / cache-effectiveness signal**.

**Demoted WARN → DEBUG** (per-resolve/per-call, not faults):
| message | why benign |
|---|---|
| `empty request options for http call` | C-3 empty-iterator "continue" — iterator yielded 0 items (~50% of firehose) |
| `bad or empty iterator` | `Iterator` is `omitempty` → non-iterated single ResourceRef (designed path) |
| `cache.discovery.group_resources_fetch_failed` | soft-fail; apiserver fallthrough + `apiserver_fallthrough` metric cover it |
| `resolveAndPopulateL1: re-resolve touched an external endpoint` | designed re-Put decline (no dep edge), not an error; `BumpExternalSkippedPut` counts it |

**Demoted ERROR → DEBUG _conditionally_** (`setup.go` + `resourcesrefstemplate`):
- `unable to execute iterator` → DEBUG **only** when the error is gojq's benign `cannot iterate over: null` (upstream key absent → 0 items, same as an empty iterator). A **malformed query / non-null-scalar / non-array result STAYS ERROR.** New shared `IsBenignNilIteration` discriminator in `internal/support/jq`, tested against **real gojq** so a gojq message change reds the tripwire test.

**Kept as-is** (genuine signals — explicitly _not_ touched): `internal_dispatch.list.unintended_collapse` (Class-3 by-name→cluster-LIST defect handle, documented WARN), `internal_dispatch.paged_list.completed` (ship falsifier, deliberately WARN to survive a floor raise), `apiserver_fallthrough` (1%-sampled cache-effectiveness signal), `prewarm.engine.seed.operational_failure` (real transient seed fault), `resolveAndPopulateL1` stage-error, `cache.watch.broken`, `phase1.roots.entry_point_empty`, `cluster_list.shape_fallback`.

## Safety
No behavior change beyond log level. No test asserts on these messages. Verified: `go build`, `go vet`, and `-race -tags=unit,integration` on all affected packages (`support/jq`, `restactions/api`, `resourcesrefstemplate`, `dispatchers`).

Net: ~74% of the current WARN-floor firehose removed while every fault signal is preserved (and remains visible at `LOG_LEVEL=debug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)