### PR TITLE
chore: pin CompositionDefinition chart to 1.12.1

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.12.0"
+    version: "1.12.1"


### PR DESCRIPTION
Bumps `compositiondefinition.yaml` `spec.chart.version` **1.12.0 → 1.12.1** to consume the 1.12.1 release.

**1.12.1 contents (#166):** demote benign high-frequency WARN/ERROR diagnostics to DEBUG — ~74% of the WARN-floor firehose removed (chiefly `empty request options` ~50% and the benign gojq nil-iteration ERROR), while every genuine fault/config/cache-effectiveness signal is preserved (and all noise remains visible at `LOG_LEVEL=debug`).

**Artifacts (registry-verified before this PR):**
- image `ghcr.io/krateo-platformops/snowplow:1.12.1`
- chart `oci://ghcr.io/krateo-platformops/charts/snowplow` `version=1.12.1 appVersion=1.12.1`
- chart `oci://ghcr.io/krateo-platformops/charts/snowplow-crds` `version=1.12.1`

`preflight-refs` live-resolves the pinned ref against the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)