### PR TITLE
fix(logging): demote paged_list.completed + apiserver_fallthrough WARN→DEBUG (#170)

### DIFF
--- a/go/snowplow/internal/cache/fallthrough_meter.go
+++ b/go/snowplow/internal/cache/fallthrough_meter.go
@@ -349,14 +349,22 @@ func RecordApiserverFallthrough(ctx context.Context, reason FallthroughReason, g
 	c.(*atomic.Uint64).Add(1)
 	fallthroughTotal.Add(1)
 
-	// 1%-sampled WARN — deterministic via mod 100 on a monotonic
+	// 1%-sampled DEBUG echo — deterministic via mod 100 on a monotonic
 	// counter. Allocation-free: the counter is package-level atomic.
 	// Two goroutines incrementing at the same tick both pass the gate
-	// — the duplicate WARN is informational only (PM-accepted as
-	// per the sampling spec — counter accuracy is per-cell, sampling
-	// is loose by design).
+	// — the duplicate line is informational only (counter accuracy is
+	// per-cell, sampling is loose by design).
+	//
+	// LEVEL — DEBUG (#170). The authoritative cache-effectiveness signal
+	// is the snowplow_apiserver_fallthrough_total / _cells expvar counters
+	// (updated unconditionally above); this sampled log is only a
+	// convenience echo of an already-exported metric. Even 1%-sampled it
+	// is ~14K/week at the WARN floor (#163), so it belongs at DEBUG — the
+	// counters remain the source of truth, and the echo stays available at
+	// LOG_LEVEL=debug. Consistent with the discovery soft-fail sibling
+	// (resolve.go: "apiserver_fallthrough metrics. DEBUG, not WARN.").
 	if fallthroughWarnSampleCounter.Add(1)%fallthroughWarnSampleEvery == 0 {
-		slog.Warn("apiserver_fallthrough",
+		slog.Debug("apiserver_fallthrough",
 			slog.String("subsystem", "cache"),
 			slog.String("path", scope.Path),
 			slog.String("gvr", gvr),

--- a/go/snowplow/internal/resolvers/restactions/api/internal_dispatch.go
+++ b/go/snowplow/internal/resolvers/restactions/api/internal_dispatch.go
@@ -535,20 +535,18 @@ func dispatchViaInternalRESTConfig(ctx context.Context, call httpcall.RequestOpt
 	resultList.SetRemainingItemCount(nil)
 
 	// Falsifier event — proves the paged path executed (per
-	// feedback_falsifier_first_before_ship). WARN level so it is
-	// retained in pod logs at default verbosity; one event per served
-	// LIST, not per page (to keep the log volume bounded at scale).
+	// feedback_falsifier_first_before_ship). One event per served LIST,
+	// not per page (to keep the log volume bounded at scale).
 	//
-	// R2 — VERBOSITY NOTE (architect 0.30.250 review): WARN deliberately,
-	// NOT INFO. The pod ships with `DEBUG=false` by default which sets
-	// the slog handler level to INFO — at INFO this event would still
-	// fire, but a future log-volume-driven downgrade (e.g. raising the
-	// handler to WARN under high load) would silently lose the
-	// observability handle the ship relies on. WARN keeps the event
-	// available at every level the pod will ever ship with. The event
-	// fires once per served LIST so even at 50K-composition scale the
-	// volume is bounded by the /call rate, not the item count.
-	xcontext.Logger(ctx).Warn("internal_dispatch.paged_list.completed",
+	// LEVEL — DEBUG (#170). This is a success/completion event, not a
+	// fault. It fires once per served paged LIST, i.e. at the /call rate,
+	// which on a healthy portal at scale is ~253K/week — a firehose that
+	// drowns real warnings now that LOG_LEVEL=warn is the steady-state prod
+	// floor (#163). The old R2 note kept it at WARN to survive a floor
+	// raise, but LOG_LEVEL is now an explicit knob: this event stays fully
+	// visible (with its pages/items/total_ms fields) at LOG_LEVEL=debug when
+	// you actually need it, and the per-cell counters/metrics are unaffected.
+	xcontext.Logger(ctx).Debug("internal_dispatch.paged_list.completed",
 		slog.String("subsystem", "cache"),
 		slog.String("gvr", gvr.String()),
 		slog.String("namespace", namespace),

--- a/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_informer_serve_1a_test.go
+++ b/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_informer_serve_1a_test.go
@@ -340,7 +340,10 @@ func TestServe1a_C1_NeverWorse_FallsThroughToLiveList(t *testing.T) {
 	}
 
 	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	// LevelDebug: internal_dispatch.paged_list.completed is a DEBUG event
+	// (#170) — capture it so the fall-through assertion below still verifies
+	// the live paged LIST completed (the level dropped WARN→DEBUG).
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	ctx := cache.WithInternalRESTConfig(context.Background(), rc)
 	ctx = cache.WithServeWatcher(ctx, rw)

--- a/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_paged_test.go
+++ b/go/snowplow/internal/resolvers/restactions/api/internal_dispatch_paged_test.go
@@ -240,7 +240,10 @@ func TestInternalRESTConfigDispatch_PagedList_FullWalk(t *testing.T) {
 	// Capture the WARN-level slog falsifier event by attaching a
 	// custom slog.Handler to the request context.
 	var logBuf bytes.Buffer
-	logHandler := slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	// LevelDebug: internal_dispatch.paged_list.completed is a DEBUG event
+	// (#170) — capture it so the FALSIFIER-D assertion below still verifies
+	// the paged path fired (the level dropped WARN→DEBUG, the event did not).
+	logHandler := slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logger := slog.New(logHandler)
 
 	ctx := cache.WithInternalRESTConfig(context.Background(), rc)
@@ -345,13 +348,13 @@ func TestInternalRESTConfigDispatch_PagedList_FullWalk(t *testing.T) {
 			envelope.Metadata.Continue)
 	}
 
-	// FALSIFIER-D — the WARN-level slog falsifier event MUST fire ONCE,
+	// FALSIFIER-D — the DEBUG-level slog falsifier event MUST fire ONCE,
 	// carrying the expected pages / items / page_limit / total_ms.
 	logOut := logBuf.String()
 	if !strings.Contains(logOut, `"msg":"internal_dispatch.paged_list.completed"`) {
-		t.Fatalf("FALSIFIER-D FAIL: the WARN-level falsifier event "+
+		t.Fatalf("FALSIFIER-D FAIL: the DEBUG-level falsifier event "+
 			"`internal_dispatch.paged_list.completed` did NOT fire. "+
-			"A future code edit that drops the slog.Warn call would "+
+			"A future code edit that drops the slog.Debug call would "+
 			"silently regress the paged path's observability. Log "+
 			"buffer:\n%s", logOut)
 	}


### PR DESCRIPTION
Closes #170. Finishes the log-hygiene pass #166 started.

## Why
With `LOG_LEVEL=warn` the steady-state prod floor (#163), two benign high-frequency events dominate `otel_logs` on krateo-057 (7-day counts) and drown real warnings:

| message | 7d volume | change |
|---|---|---|
| `internal_dispatch.paged_list.completed` | ~253K | **WARN → DEBUG** |
| `apiserver_fallthrough` (1%-sampled) | ~14K | **WARN → DEBUG** |

Both are the same class #166 handled; they were left at WARN then. #170 supplied the production volumes that overturn the earlier "keep the signal" calls:

- **`paged_list.completed`** is a per-served-LIST **success/completion** event, not a fault. Its old R2 note kept it at WARN to survive a floor raise — but `LOG_LEVEL` is now an explicit knob, so it stays fully visible (with `pages`/`items`/`total_ms`) at `LOG_LEVEL=debug`, and the per-cell counters are unaffected.
- **`apiserver_fallthrough`** is a convenience echo of the `snowplow_apiserver_fallthrough_total`/`_cells` expvar counters, which remain the authoritative cache-effectiveness signal. This also fixes the inconsistency where #166 demoted the discovery soft-fail *citing these very metrics* but left this echo at WARN.

## Tests
The two `paged_list.completed` falsifier handlers were pinned at `LevelWarn`; bumped to `LevelDebug` so the falsifiers still verify the paged path fired (the event moved level, it did not disappear). `apiserver_fallthrough` tests assert on the **expvar counters**, not the log, so they're unaffected.

No behavior change beyond log level. Verified: `build` + `-race -tags=unit,integration` on `internal/resolvers/restactions/api` + `internal/cache`.

## Not included (deliberately)
#170 also references `internal_dispatch.list.unintended_collapse` indirectly via #169 — that one is a **behavior change** (guard vs. serve the wrong cluster LIST), tracked separately in #169 and under investigation. Not in this log-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)