### PR TITLE
chore: pin CompositionDefinition chart to 1.12.2

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.12.1"
+    version: "1.12.2"


### PR DESCRIPTION
Bumps `compositiondefinition.yaml` `spec.chart.version` **1.12.1 → 1.12.2** to consume the 1.12.2 release.

**1.12.2 (#170):** demote `internal_dispatch.paged_list.completed` (~253K/wk) + `apiserver_fallthrough` (~14K/wk) WARN→DEBUG — finishes the #166/#170 log-hygiene pass. No behavior change beyond log level.

**Artifacts (registry-verified):** image `1.12.2`, chart `snowplow` `1.12.2`/appVersion `1.12.2`, chart `snowplow-crds` `1.12.2`.

Note: the live krateo-057 rollout is driven by the platform **installer** bump (component pin), not this repo's `compositiondefinition.yaml` — this PR keeps the repo's declared pin in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)