### PR TITLE
chore(cd): pin snowplow composition to 1.12.3

### DIFF
--- a/compositiondefinition.yaml
+++ b/compositiondefinition.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   chart:
     url: oci://ghcr.io/krateo-platformops/charts/snowplow
-    version: "1.12.2"
+    version: "1.12.3"


### PR DESCRIPTION
## CD pin 1.12.2 → 1.12.3

Artifacts verified before opening:
- image `ghcr.io/krateo-platformops/snowplow:1.12.3` (manifest present)
- charts `oci://ghcr.io/krateo-platformops/charts/snowplow` and `snowplow-crds` @ 1.12.3

Release: #173 (security mitigations: UAF-touched resolves uncached, /debug/* JWT-gated, identity-extras sanitiser, UAF verb warn, chart UAF TTL plumbing). Follow-ups #174–#180.

This file is a mirror, not the deploy trigger — the live rollout goes through the Krateo Installer component pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzQNKfRDhnXQzuMoCybUo3