### PR TITLE
bench: make the canonical GKE context overridable via BENCH_GKE_CONTEXT

### DIFF
--- a/go/snowplow/e2e/bench/bench/cli.py
+++ b/go/snowplow/e2e/bench/bench/cli.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 from bench import cluster
 from bench.cluster import (
-    CANONICAL_GKE_CONTEXT,
     NS,
     kubectl,
 )
@@ -473,8 +472,8 @@ def _gate_k8s_client() -> tuple[bool, str]:
                        "'kubernetes>=28.0.0' per requirements.txt)")
     if not cluster._k8s_init():
         return False, ("k8s_client: FAIL (lib present but client init "
-                       "failed — kubeconfig/context problem; canonical "
-                       f"context is {cluster.CANONICAL_GKE_CONTEXT!r})")
+                       "failed — kubeconfig/context problem; pinned "
+                       f"context is {cluster.canonical_gke_context()!r})")
     return True, "k8s_client: PASS (in-process client initialized)"
 
 

--- a/go/snowplow/e2e/bench/bench/cluster.py
+++ b/go/snowplow/e2e/bench/bench/cluster.py
@@ -41,6 +41,36 @@ import time
 
 CANONICAL_GKE_CONTEXT = "gke_neon-481711_us-central1-a_cluster-1"
 
+# Env override for the pinned context. The hard-coded CANONICAL_GKE_CONTEXT
+# above is the historical bench cluster, and it is GONE (the neon-481711
+# project 403s and no longer lists) — so as shipped the harness pins a
+# context that resolves to nothing on every live cluster.
+#
+# BENCH_GKE_CONTEXT retargets the pin. It does NOT weaken it: the resolved
+# context is still injected into every kubectl(), every `helm --kube-context`,
+# every direct-Popen `--context=`, and the in-process kubernetes client, and
+# gke_context_guard still refuses to run when current-context does not match
+# it. That is the whole point of the override — BENCH_ALLOW_NON_GKE=1 is the
+# only other way to reach a non-neon cluster today and it REMOVES all pinning,
+# which lets a `helm upgrade` land on whatever cluster current-context happens
+# to name (gcloud rewrites it; a teammate's kind run flips it). An operator
+# who needs a different GKE cluster must be able to say so without giving up
+# the safety rail.
+#
+# Resolved at CALL time, not import time, mirroring
+# expected.py:_resolve_overlay_path — so a test (or a caller that sets the
+# variable after importing bench.cluster) sees the change.
+ENV_GKE_CONTEXT = "BENCH_GKE_CONTEXT"
+
+
+def canonical_gke_context() -> str:
+    """The GKE context every bench kubectl/helm/client call pins.
+
+    Returns $BENCH_GKE_CONTEXT when set and non-empty, else the
+    CANONICAL_GKE_CONTEXT fallback.
+    """
+    return os.environ.get(ENV_GKE_CONTEXT, "").strip() or CANONICAL_GKE_CONTEXT
+
 
 def gke_context_guard(allow_non_gke: bool | None = None) -> None:
     """Exit non-zero if kubectl current-context is not the canonical GKE.
@@ -82,11 +112,13 @@ def gke_context_guard(allow_non_gke: bool | None = None) -> None:
         # the caller; we do not want module import to die on a transient.
         return
     ctx = (proc.stdout.decode() or "").strip()
-    if ctx != CANONICAL_GKE_CONTEXT:
+    want = canonical_gke_context()
+    if ctx != want:
         sys.stderr.write(
             f"bench: GKE context guard FAIL — current-context={ctx!r} "
-            f"(want {CANONICAL_GKE_CONTEXT!r}). Set BENCH_ALLOW_NON_GKE=1 "
-            f"to bypass (kind/minikube only).\n"
+            f"(want {want!r}). Set {ENV_GKE_CONTEXT} to pin a different GKE "
+            f"cluster, or BENCH_ALLOW_NON_GKE=1 to bypass pinning entirely "
+            f"(kind/minikube only).\n"
         )
         sys.exit(3)
 
@@ -96,7 +128,7 @@ def gke_context_guard(allow_non_gke: bool | None = None) -> None:
 def kubectl(*args, input_data=None, timeout_secs=120):
     """Run a kubectl invocation. Returns (returncode, stdout, stderr).
 
-    Injects `--context=CANONICAL_GKE_CONTEXT` UNLESS the caller already
+    Injects `--context=canonical_gke_context()` UNLESS the caller already
     passed an explicit `--context=...` flag OR `BENCH_ALLOW_NON_GKE=1` is
     set in the environment. This makes the bench hermetic against the
     user's kubectl current-context drifting between Bash invocations
@@ -111,7 +143,7 @@ def kubectl(*args, input_data=None, timeout_secs=120):
     caller_pinned_context = any(
         isinstance(a, str) and a.startswith("--context") for a in arg_list)
     if not allow_non_gke and not caller_pinned_context:
-        arg_list = [f"--context={CANONICAL_GKE_CONTEXT}"] + arg_list
+        arg_list = [f"--context={canonical_gke_context()}"] + arg_list
     try:
         proc = subprocess.run(
             ["kubectl"] + arg_list,
@@ -141,7 +173,7 @@ def helm_context_args():
     """
     if _allow_non_gke_env():
         return []
-    return ["--kube-context", CANONICAL_GKE_CONTEXT]
+    return ["--kube-context", canonical_gke_context()]
 
 
 def kubectl_context_args():
@@ -151,7 +183,7 @@ def kubectl_context_args():
     """
     if _allow_non_gke_env():
         return []
-    return [f"--context={CANONICAL_GKE_CONTEXT}"]
+    return [f"--context={canonical_gke_context()}"]
 
 
 # ─── Kubernetes-client helper layer (k8s_* prefix) ───────────────────────────
@@ -205,7 +237,7 @@ def _k8s_init():
                 env_flag = os.environ.get(
                     "BENCH_ALLOW_NON_GKE", "0").strip().lower()
                 pin = (None if env_flag in ("1", "true", "yes")
-                       else CANONICAL_GKE_CONTEXT)
+                       else canonical_gke_context())
                 _k8s_config_mod.load_kube_config(context=pin)
             except Exception:
                 # Fall back to in-cluster config (when running in a pod)
@@ -1315,6 +1347,8 @@ gke_context_guard()
 __all__ = [
     # Constants
     "CANONICAL_GKE_CONTEXT",
+    "ENV_GKE_CONTEXT",
+    "canonical_gke_context",
     "NS",
     "COMPDEF_NAME",
     "COMP_GVR",

--- a/go/snowplow/e2e/bench/tests/conftest.py
+++ b/go/snowplow/e2e/bench/tests/conftest.py
@@ -22,6 +22,13 @@ import pytest
 # Bypass the GKE context guard — tests should never contact a real cluster.
 os.environ.setdefault("BENCH_ALLOW_NON_GKE", "1")
 
+# BENCH_GKE_CONTEXT retargets the pinned context (cluster.canonical_gke_context).
+# An operator who exports it in their shell to drive a real bench run would
+# otherwise change what the context-pinning tests assert. Clear it so the suite
+# is hermetic against the operator's environment; the tests that exercise the
+# override set it explicitly via monkeypatch.
+os.environ.pop("BENCH_GKE_CONTEXT", None)
+
 # Add e2e/bench/ to sys.path so `import bench.cluster` works without install.
 _E2E_BENCH_DIR = Path(__file__).resolve().parent.parent
 if str(_E2E_BENCH_DIR) not in sys.path:

--- a/go/snowplow/e2e/bench/tests/test_cluster.py
+++ b/go/snowplow/e2e/bench/tests/test_cluster.py
@@ -194,6 +194,164 @@ def test_kubectl_no_inject_when_env_bypass_set(monkeypatch, with_env):
     assert contexts == []
 
 
+# ─── BENCH_GKE_CONTEXT override (H-1) ───────────────────────────────────────
+#
+# The shipped CANONICAL_GKE_CONTEXT names a cluster whose GCP project no
+# longer exists, so the harness as written pins a dead context on every live
+# cluster. BENCH_GKE_CONTEXT retargets that pin. These arms exist to prove the
+# override RETARGETS the pin rather than WEAKENING it — the distinction that
+# matters, because the only pre-existing way to reach a non-neon cluster was
+# BENCH_ALLOW_NON_GKE=1, which removes pinning entirely and would let a
+# `helm upgrade` land on whatever current-context happens to name.
+
+_OVERRIDE_CTX = "gke_operations-dev-krateo-io_europe-west3-a_krateo-057"
+
+
+def _fake_run_factory(seen, stdout=b""):
+    """subprocess.run stub that records argv and returns a success result."""
+
+    class _Fake:
+        returncode = 0
+        stderr = b""
+
+    def _run(argv, **kwargs):
+        seen["argv"] = list(argv)
+        result = _Fake()
+        result.stdout = stdout
+        return result
+
+    return _run
+
+
+def test_canonical_gke_context_falls_back_to_constant(with_env):
+    """Unset (or blank) BENCH_GKE_CONTEXT → the hard-coded constant."""
+    with_env(BENCH_GKE_CONTEXT=None)
+    assert cluster_mod.canonical_gke_context() == CANONICAL_GKE_CONTEXT
+    # Whitespace-only is treated as unset, not as a context named "  ".
+    with_env(BENCH_GKE_CONTEXT="   ")
+    assert cluster_mod.canonical_gke_context() == CANONICAL_GKE_CONTEXT
+
+
+def test_canonical_gke_context_env_override(with_env):
+    """BENCH_GKE_CONTEXT wins, and is read at CALL time (not import time)."""
+    with_env(BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+    assert cluster_mod.canonical_gke_context() == _OVERRIDE_CTX
+    assert cluster_mod.canonical_gke_context() != CANONICAL_GKE_CONTEXT
+
+
+def test_kubectl_injects_overridden_context(monkeypatch, with_env):
+    """kubectl() pins the OVERRIDE — still position 1, still exactly one."""
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+
+    seen = {}
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(seen))
+    kubectl("get", "ns")
+
+    assert seen["argv"][1] == f"--context={_OVERRIDE_CTX}"
+    contexts = [a for a in seen["argv"]
+                if isinstance(a, str) and a.startswith("--context")]
+    assert contexts == [f"--context={_OVERRIDE_CTX}"]
+    # The dead constant must NOT survive anywhere in the invocation.
+    assert CANONICAL_GKE_CONTEXT not in " ".join(seen["argv"])
+
+
+def test_helm_context_args_use_override(with_env):
+    """helm pins the override too — an unpinned `helm upgrade` is the
+    scenario that would mutate the wrong cluster."""
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+    assert cluster_mod.helm_context_args() == ["--kube-context", _OVERRIDE_CTX]
+
+
+def test_kubectl_context_args_use_override(with_env):
+    """The direct-Popen streamers (port-forward, logs -f) pin the override."""
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+    assert cluster_mod.kubectl_context_args() == [f"--context={_OVERRIDE_CTX}"]
+
+
+def test_gke_context_guard_passes_on_overridden_context(monkeypatch, with_env):
+    """current-context == the override → guard returns silently."""
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+
+    seen = {}
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(seen, stdout=(_OVERRIDE_CTX + "\n").encode()))
+    gke_context_guard()  # must not raise
+
+
+def test_gke_context_guard_still_exits_on_stale_constant(monkeypatch, with_env):
+    """THE safety arm: with the override set, sitting on the OLD canonical
+    context must still exit 3.
+
+    A "fix" that merely widened the guard into an allow-anything check would
+    pass every other arm here and fail this one.
+    """
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+
+    seen = {}
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(seen, stdout=(CANONICAL_GKE_CONTEXT + "\n").encode()))
+
+    with pytest.raises(SystemExit) as exc_info:
+        gke_context_guard()
+    assert exc_info.value.code == 3
+
+
+def test_allow_non_gke_still_bypasses_with_override_set(monkeypatch, with_env):
+    """The kind/minikube escape hatch is unchanged: BENCH_ALLOW_NON_GKE=1
+    removes pinning even when BENCH_GKE_CONTEXT names a cluster."""
+    with_env(BENCH_ALLOW_NON_GKE="1", BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+
+    seen = {}
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(seen))
+    kubectl("get", "ns")
+
+    contexts = [a for a in seen["argv"]
+                if isinstance(a, str) and a.startswith("--context")]
+    assert contexts == []
+    assert cluster_mod.helm_context_args() == []
+    assert cluster_mod.kubectl_context_args() == []
+
+
+def test_k8s_client_pins_overridden_context(monkeypatch, with_env,
+                                            reset_k8s_state):
+    """The in-process kubernetes client pins the override, so it and the
+    subprocess kubectl calls cannot diverge onto two different clusters."""
+    with_env(BENCH_ALLOW_NON_GKE=None, BENCH_GKE_CONTEXT=_OVERRIDE_CTX)
+    cluster_mod = reset_k8s_state
+
+    seen = {}
+
+    class _FakeConfigMod:
+        @staticmethod
+        def load_kube_config(context=None):
+            seen["context"] = context
+
+        @staticmethod
+        def load_incluster_config():
+            raise AssertionError("must not fall back to in-cluster config")
+
+    class _FakeApi:
+        def __init__(self, *a, **kw):
+            pass
+
+    class _FakeClientMod:
+        CoreV1Api = _FakeApi
+        RbacAuthorizationV1Api = _FakeApi
+        CustomObjectsApi = _FakeApi
+        ApiextensionsV1Api = _FakeApi
+
+    monkeypatch.setattr(cluster_mod, "_K8S_LIB_AVAILABLE", True)
+    monkeypatch.setattr(cluster_mod, "_k8s_config_mod", _FakeConfigMod)
+    monkeypatch.setattr(cluster_mod, "_k8s_client_mod", _FakeClientMod)
+    monkeypatch.setattr(cluster_mod, "K8S_CLIENT_AVAILABLE", False)
+    monkeypatch.setattr(cluster_mod, "_k8s_init_attempted", False)
+
+    assert cluster_mod._k8s_init() is True
+    assert seen["context"] == _OVERRIDE_CTX
+
+
 # ─── Case 4/5: _k8s_init idempotence + one-shot retry semantics ─────────────
 
 def test_k8s_init_short_circuits_when_lib_missing(reset_k8s_state):


### PR DESCRIPTION
## bench: make the canonical GKE context overridable (BENCH_GKE_CONTEXT)

`bench/cluster.py` pinned `CANONICAL_GKE_CONTEXT` to a context in a GCP project that no longer exists (403, absent from `gcloud projects list`), so the Phase-6 harness could not be pointed at any live cluster without `BENCH_ALLOW_NON_GKE=1` — which does not retarget, it removes every kubectl/helm pin and is unsafe for a scored run.

### Change
- New `canonical_gke_context()` returns `$BENCH_GKE_CONTEXT` when set, else the unchanged constant. All five pin sites route through it (the guard, `kubectl()`'s injected flag, `helm_context_args`, `kubectl_context_args`, the in-process client's `load_kube_config`). Call-time resolution, same pattern as `_resolve_overlay_path`.
- The override **retargets** the pin; it does not weaken it. `BENCH_ALLOW_NON_GKE=1` keeps its old meaning.
- Not changed on purpose: the calibration overlay path. It is a regenerable cache whose freshness gate reads `st_mtime`; an env redirect would let a just-written file forge freshness. The loud `--allow-stale-overlay` bypass already exists.

### Verification
- Falsifiers run both ways: a resolver that ignores the env reds 5 of the 9 new arms; a guard widened to accept any `gke_*` context reds exactly `test_gke_context_guard_still_exits_on_stale_constant` (the arm that separates "retargeted" from "weakened").
- 372 passed in the harness fast suite (`tests/` minus the `test_browser.py` stall tracked in #178), re-run on the clean committed tree.
- No Go code touched.

Found while preparing the 1.12.4 observability bench (PM gate C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzQNKfRDhnXQzuMoCybUo3
